### PR TITLE
feat(js): Re-org js integrations and add missing node integrations

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
@@ -38,7 +38,6 @@ The `amqplibIntegration` adds instrumentation for the `amqplib` library to captu
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.amqplibIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
@@ -26,7 +26,7 @@ supported:
 
 <Alert level="info">
 
-This integration only works inside server environments (Node.js, Bun, Deno). Requires SDK version `8.32.0` or higher.
+This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.32.0` or higher.
 
 </Alert>
 
@@ -35,3 +35,14 @@ _Import name: `Sentry.amqplibIntegration`_
 This integration is enabled by default when performance monitoring is enabled. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 The `amqplibIntegration` adds instrumentation for the `amqplib` library to capture spans using [`@opentelemetry/instrumentation-amqplib`](https://www.npmjs.com/package/@opentelemetry/instrumentation-amqplib).
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new Sentry.amqplibIntegration()],
+});
+```
+
+## Supported Versions
+
+- `amqplib`: `>=0.5.5 <1`

--- a/docs/platforms/javascript/common/configuration/integrations/anr.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anr.mdx
@@ -30,3 +30,10 @@ This integration only works in the Node.js runtime.
 _Import name: `Sentry.anrIntegration`_
 
 The `anrIntegration` captures Application Not Responding (ANR)/Event Loop Stall errors and reports them as Sentry events. For more details, see the documentation on [ANR](../../application-not-responding).
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/anr.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anr.mdx
@@ -33,7 +33,6 @@ The `anrIntegration` captures Application Not Responding (ANR)/Event Loop Stall 
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/aws.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/aws.mdx
@@ -15,7 +15,6 @@ Adds instrumentation for aws-sdk v2 and v3 to automatically create spans. Powere
 import * as Sentry from '@sentry/aws-serverless';
 
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.awsIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/aws.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/aws.mdx
@@ -10,3 +10,12 @@ _Import name: `Sentry.awsIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 Adds instrumentation for aws-sdk v2 and v3 to automatically create spans. Powered by [`@opentelemetry/instrumentation-aws-sdk`](https://www.npmjs.com/package/@opentelemetry/instrumentation-aws-sdk).
+
+```JavaScript
+import * as Sentry from '@sentry/aws-serverless';
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.awsIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/awslambda.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/awslambda.mdx
@@ -15,7 +15,6 @@ Adds instrumentation for AWS Lambda to automatically create spans. Powered by [`
 import * as Sentry from '@sentry/aws-serverless';
 
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.awsIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/awslambda.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/awslambda.mdx
@@ -10,3 +10,12 @@ _Import name: `Sentry.awsLambdaIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 Adds instrumentation for AWS Lambda to automatically create spans. Powered by [`@opentelemetry/instrumentation-aws-lambda`](https://www.npmjs.com/package/@opentelemetry/instrumentation-aws-lambda).
+
+```JavaScript
+import * as Sentry from '@sentry/aws-serverless';
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.awsIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -34,6 +34,7 @@ By default, the Sentry SDK wraps the `console`, `dom`, `fetch`, `history`, and `
 
 ```JavaScript
 Sentry.init({
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.breadcrumbsIntegration({
       console: true,

--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -34,7 +34,6 @@ By default, the Sentry SDK wraps the `console`, `dom`, `fetch`, `history`, and `
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.breadcrumbsIntegration({
       console: true,

--- a/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
@@ -32,6 +32,7 @@ This integration wraps native time and event APIs (`setTimeout`, `setInterval`, 
 
 ```JavaScript
 Sentry.init({
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.browserApiErrorsIntegration({
       setTimeout: true,

--- a/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
@@ -32,7 +32,6 @@ This integration wraps native time and event APIs (`setTimeout`, `setInterval`, 
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.browserApiErrorsIntegration({
       setTimeout: true,

--- a/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
@@ -31,3 +31,10 @@ _Import name: `Sentry.browserProfilingIntegration`_
 The BrowserProfiling integration sets up automatic performance profiling for your frontend applications. It captures profiles via the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) from the browser and sends them to Sentry. To use this integration, you also need to have the [BrowserTracing integration](../browsertracing) enabled.
 
 Read more about [setting up BrowserProfiling](./../../../profiling/).
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [new Sentry.browserProfilingIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
@@ -34,7 +34,6 @@ Read more about [setting up BrowserProfiling](./../../../profiling/).
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [new Sentry.browserProfilingIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
@@ -31,3 +31,9 @@ With [tracing](/product/performance/), Sentry tracks your software performance, 
 The BrowserTracing integration sets up automatic tracing for your frontend applications. It captures transactions and spans from the browser and sends them to Sentry.
 
 Read more about [setting up BrowserTracing](./../../../tracing/).
+
+```JavaScript
+Sentry.init({
+  integrations: [new Sentry.browserTracingIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/bunserver.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/bunserver.mdx
@@ -16,3 +16,11 @@ _Import name: `Sentry.bunServerIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 The `bunServerIntegration` instruments [`Bun.serve` API](https://bun.sh/docs/api/http) to automatically create transactions and capture errors.
+
+```JavaScript
+import * as Sentry from '@sentry/bun';
+
+Sentry.init({
+  integrations: [new Sentry.bunServerIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/connect.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/connect.mdx
@@ -20,6 +20,12 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `connectIntegration` adds instrumentation for the Hapi framework to capture spans using [`@opentelemetry/instrumentation-connect`](https://www.npmjs.com/package/@opentelemetry/instrumentation-connect).
 
+```JavaScript
+Sentry.init({
+  integrations: [new Sentry.connectIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `connect`: `^3.0.0`

--- a/docs/platforms/javascript/common/configuration/integrations/connect.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/connect.mdx
@@ -22,4 +22,4 @@ The `connectIntegration` adds instrumentation for the Hapi framework to capture 
 
 ## Supported Versions
 
-- Connect `^3.0.0`
+- `connect`: `^3.0.0`

--- a/docs/platforms/javascript/common/configuration/integrations/console.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/console.mdx
@@ -36,3 +36,10 @@ _Import name: `Sentry.consoleIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 The `consoleIntegration` generates breadcrumbs for console logs.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.consoleIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/console.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/console.mdx
@@ -39,7 +39,6 @@ The `consoleIntegration` generates breadcrumbs for console logs.
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.consoleIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/dataloader.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/dataloader.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dataloader
-description: "Adds instrumentation for Dataloader. (default)"
+description: "Adds instrumentation for Dataloader."
 supported:
   - javascript.node
   - javascript.aws-lambda
@@ -29,9 +29,13 @@ This integration only works in the Node.js and Bun runtimes. Requires SDK versio
 
 _Import name: `Sentry.dataloaderIntegration`_
 
-This integration is enabled by default when performance monitoring is enabled. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
-
 The `dataloaderIntegration` adds instrumentation for the `dataloader` library to capture spans using [`@opentelemetry/instrumentation-dataloader`](https://www.npmjs.com/package/@opentelemetry/instrumentation-dataloader).
+
+```javascript
+Sentry.init({
+  integrations: [new Sentry.dataloaderIntegration()],
+});
+```
 
 ## Supported Versions
 

--- a/docs/platforms/javascript/common/configuration/integrations/denocontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/denocontext.mdx
@@ -16,3 +16,10 @@ _Import name: `Sentry.denoContextIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 Adds Deno related context to events. This includes contexts about `app`, `device`, `os`, `v8`, and `TypeScript`.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.denoContextIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/denocontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/denocontext.mdx
@@ -19,7 +19,6 @@ Adds Deno related context to events. This includes contexts about `app`, `device
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.denoContextIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/denocron.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/denocron.mdx
@@ -18,3 +18,10 @@ _Import name: `Sentry.denoCronIntegration`_
 The DenoCron integration sets up automatic monitoring for your cron jobs created by [`Deno.cron`](https://docs.deno.com/deploy/kv/manual/cron). It captures check-ins and sends them to Sentry.
 
 Read more about [setting up Cron Monitoring for Deno](./../../../crons/).
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.denoCronIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/denocron.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/denocron.mdx
@@ -21,7 +21,6 @@ Read more about [setting up Cron Monitoring for Deno](./../../../crons/).
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.denoCronIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/fastify.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fastify.mdx
@@ -20,6 +20,12 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `fastifyIntegration` adds instrumentation for the Fastify framework to capture spans using [`@opentelemetry/instrumentation-fastify`](https://www.npmjs.com/package/@opentelemetry/instrumentation-fastify).
 
+```JavaScript
+Sentry.init({
+  integrations: [new Sentry.fastifyIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `fastify`: `^3.0.0 || ^4.0.0`

--- a/docs/platforms/javascript/common/configuration/integrations/fs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fs.mdx
@@ -40,7 +40,6 @@ The `fsIntegration` creates spans for `fs` API operations, like reading and writ
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.fsIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/fs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fs.mdx
@@ -38,6 +38,13 @@ The `fsIntegration` creates spans for `fs` API operations, like reading and writ
   down your application.
 </Alert>
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.fsIntegration()],
+});
+```
+
 ## Options
 
 ### `recordFilePaths`

--- a/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
@@ -8,3 +8,10 @@ _Import name: `Sentry.functionToStringIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 This integration allows the SDK to provide original functions and method names, even when those functions or methods are wrapped by our error or breadcrumb handlers.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.functionToStringIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/functiontostring.mdx
@@ -11,7 +11,6 @@ This integration allows the SDK to provide original functions and method names, 
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.functionToStringIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/genericpool.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/genericpool.mdx
@@ -33,6 +33,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `genericPoolIntegration` adds instrumentation for the `generic-pool` library to capture spans using [`@opentelemetry/instrumentation-generic-pool`](https://www.npmjs.com/package/@opentelemetry/instrumentation-generic-pool).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.genericPoolIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `generic-pool`: `>=2.0.0 <4`

--- a/docs/platforms/javascript/common/configuration/integrations/genericpool.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/genericpool.mdx
@@ -35,7 +35,6 @@ The `genericPoolIntegration` adds instrumentation for the `generic-pool` library
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.genericPoolIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
@@ -30,7 +30,6 @@ This integration attaches global handlers to capture uncaught exceptions and unh
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.globalHandlersIntegration({ onerror: true, onunhandledrejection: true })],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
@@ -28,6 +28,13 @@ This integration is enabled by default. If you'd like to modify your default int
 
 This integration attaches global handlers to capture uncaught exceptions and unhandled rejections. It captures errors and unhandled promise rejections by default.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.globalHandlersIntegration({ onerror: true, onunhandledrejection: true })],
+});
+```
+
 ## Options
 
 ### `onerror`

--- a/docs/platforms/javascript/common/configuration/integrations/googlecloudgrpc.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/googlecloudgrpc.mdx
@@ -13,7 +13,6 @@ Adds instrumentation for GRPC APIs on Google Cloud to automatically create spans
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.googleCloudGrpcIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/googlecloudgrpc.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/googlecloudgrpc.mdx
@@ -10,3 +10,10 @@ _Import name: `Sentry.googleCloudGrpcIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 Adds instrumentation for GRPC APIs on Google Cloud to automatically create spans.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.googleCloudGrpcIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/googlecloudhttp.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/googlecloudhttp.mdx
@@ -13,7 +13,6 @@ Adds instrumentation for RESTful APIs on Google Cloud to automatically create sp
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.googleCloudHttpIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/googlecloudhttp.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/googlecloudhttp.mdx
@@ -10,3 +10,10 @@ _Import name: `Sentry.googleCloudHttpIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 Adds instrumentation for RESTful APIs on Google Cloud to automatically create spans.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.googleCloudHttpIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/graphql.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/graphql.mdx
@@ -34,6 +34,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `graphqlIntegration` adds instrumentation for the `graphql` library to capture spans using [`@opentelemetry/instrumentation-graphql`](https://www.npmjs.com/package/@opentelemetry/instrumentation-graphql).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.graphqlIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `graphql`: `>=14.0.0 <17`

--- a/docs/platforms/javascript/common/configuration/integrations/graphql.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/graphql.mdx
@@ -36,7 +36,6 @@ The `graphqlIntegration` adds instrumentation for the `graphql` library to captu
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.graphqlIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/hapi.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/hapi.mdx
@@ -20,6 +20,12 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `hapiIntegration` adds instrumentation for the Hapi framework to capture spans using [`@opentelemetry/instrumentation-hapi`](https://www.npmjs.com/package/@opentelemetry/instrumentation-hapi).
 
+```JavaScript
+Sentry.init({
+  integrations: [new Sentry.hapiIntegration()],
+});
+```
+
 ## Supported Versions
 
 - Hapi: `>=17.0.0 <22`

--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -37,6 +37,13 @@ The `httpIntegration` does two things:
 1. It captures breadcrumbs for HTTP requests.
 2. It captures spans for outgoing HTTP requests.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.httpIntegration()],
+});
+```
+
 ## Options
 
 ### `breadcrumbs`

--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -39,7 +39,6 @@ The `httpIntegration` does two things:
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.httpIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
@@ -33,7 +33,6 @@ It allows us to correctly catalog and tag events with specific OS, browser, and 
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.httpContextIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
@@ -30,3 +30,10 @@ This integration is enabled by default. If you'd like to modify your default int
 
 This integration attaches HTTP request information, such as URL, user-agent, referrer, and other headers, to the event.
 It allows us to correctly catalog and tag events with specific OS, browser, and version information.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.httpContextIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/kafka.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/kafka.mdx
@@ -35,7 +35,6 @@ The `kafkaIntegration` adds instrumentation for the `kafkajs` library to capture
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.kafkaIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/kafka.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/kafka.mdx
@@ -33,6 +33,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `kafkaIntegration` adds instrumentation for the `kafkajs` library to capture spans using [`@opentelemetry/instrumentation-kafkajs`](https://www.npmjs.com/package/@opentelemetry/instrumentation-kafkajs).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.kafkaIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `kafkajs`: `>=0.1.0 <3`

--- a/docs/platforms/javascript/common/configuration/integrations/knex.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/knex.mdx
@@ -29,7 +29,7 @@ This integration only works in the Node.js and Bun runtimes. Requires SDK versio
 
 _Import name: `Sentry.knexIntegration`_
 
-The `knexIntegration` adds instrumentation for the `dataloader` library to capture spans using [`@opentelemetry/instrumentation-knex`](https://www.npmjs.com/package/@opentelemetry/instrumentation-knex).
+The `knexIntegration` adds instrumentation for the `knex` library to capture spans using [`@opentelemetry/instrumentation-knex`](https://www.npmjs.com/package/@opentelemetry/instrumentation-knex).
 
 ```javascript
 Sentry.init({

--- a/docs/platforms/javascript/common/configuration/integrations/knex.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/knex.mdx
@@ -1,0 +1,42 @@
+---
+title: Knex
+description: "Adds instrumentation for Knex."
+supported:
+  - javascript.node
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+  - javascript.electron
+  - javascript.nextjs
+  - javascript.nuxt
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.astro
+  - javascript.bun
+---
+
+<Alert level="info">
+
+This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.38.0` or higher.
+
+</Alert>
+
+_Import name: `Sentry.knexIntegration`_
+
+The `knexIntegration` adds instrumentation for the `dataloader` library to capture spans using [`@opentelemetry/instrumentation-knex`](https://www.npmjs.com/package/@opentelemetry/instrumentation-knex).
+
+```javascript
+Sentry.init({
+  integrations: [new Sentry.knexIntegration()],
+});
+```
+
+## Supported Versions
+
+- `dataloader`: `>=0.10.0 <4`

--- a/docs/platforms/javascript/common/configuration/integrations/koa.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/koa.mdx
@@ -20,6 +20,12 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `koaIntegration` adds instrumentation for the Koa framework to capture spans using [`@opentelemetry/instrumentation-koa`](https://www.npmjs.com/package/@opentelemetry/instrumentation-koa).
 
+```JavaScript
+Sentry.init({
+  integrations: [new Sentry.koaIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `koa`: `^2.0.0`

--- a/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
@@ -11,7 +11,6 @@ This integration allows you to configure linked errors. They'll be recursively r
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.linkedErrorsIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/linkederrors.mdx
@@ -9,6 +9,13 @@ This integration is enabled by default. If you'd like to modify your default int
 
 This integration allows you to configure linked errors. They'll be recursively read up to a specified limit, then lookup will be performed by a specific key. By default, the Sentry SDK sets the limit to five and the key used is `"cause"`.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.linkedErrorsIntegration()],
+});
+```
+
 ## Options
 
 ### `key`

--- a/docs/platforms/javascript/common/configuration/integrations/lrumemoizer.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/lrumemoizer.mdx
@@ -1,18 +1,20 @@
 ---
-title: MySQL
-description: "Adds instrumentation for MySQL. (default)"
+title: LRU Memoizer
+description: "Adds instrumentation for LRU Memoizer. (default)"
 supported:
   - javascript.node
+  - javascript.astro
   - javascript.aws-lambda
   - javascript.azure-functions
   - javascript.connect
+  - javascript.deno
   - javascript.express
   - javascript.fastify
   - javascript.gcp-functions
   - javascript.hapi
   - javascript.koa
-  - javascript.nestjs
   - javascript.electron
+  - javascript.nestjs
   - javascript.nextjs
   - javascript.nuxt
   - javascript.solidstart
@@ -24,23 +26,22 @@ supported:
 
 <Alert level="info">
 
-This integration only works in the Node.js and Bun runtimes.
+This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.33.0` or higher.
 
 </Alert>
 
-_Import name: `Sentry.mysqlIntegration`_
+_Import name: `Sentry.lruMemoizerIntegration`_
 
 This integration is enabled by default when performance monitoring is enabled. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
-The `mysqlIntegration` adds instrumentation for the `mysql` library to capture spans using [`@opentelemetry/instrumentation-mysql`](https://www.npmjs.com/package/@opentelemetry/instrumentation-mysql).
+The `lruMemoizerIntegration` adds instrumentation for the `lru-memoizer` library to capture spans using [`@opentelemetry/instrumentation-lru-memoizer`](https://www.npmjs.com/package/@opentelemetry/instrumentation-lru-memoizer).
 
-```JavaScript
+```javascript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [Sentry.mysqlIntegration()],
+  integrations: [new Sentry.lruMemoizerIntegration()],
 });
 ```
 
 ## Supported Versions
 
-- `mysql`: `2.x`
+- `lru-memoizer`: `>=1.3.0 <3`

--- a/docs/platforms/javascript/common/configuration/integrations/modules.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modules.mdx
@@ -35,3 +35,10 @@ _Import name: `Sentry.modulesIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 The `modulesIntegration` captures information about the installed node modules/packages to the event.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.modulesIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/modules.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modules.mdx
@@ -38,7 +38,6 @@ The `modulesIntegration` captures information about the installed node modules/p
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.modulesIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/mongo.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mongo.mdx
@@ -36,7 +36,6 @@ The `mongoIntegration` adds instrumentation for the `mongodb` library to capture
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.mongoIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/mongo.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mongo.mdx
@@ -34,6 +34,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `mongoIntegration` adds instrumentation for the `mongodb` library to capture spans using [`@opentelemetry/instrumentation-mongodb`](https://www.npmjs.com/package/@opentelemetry/instrumentation-mongodb).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.mongoIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `mongodb`: `>=3.3 <7`

--- a/docs/platforms/javascript/common/configuration/integrations/mongoose.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mongoose.mdx
@@ -35,7 +35,6 @@ The `mongooseIntegration` adds instrumentation for the `mongoose` library to cap
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.mongooseIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/mongoose.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mongoose.mdx
@@ -33,6 +33,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `mongooseIntegration` adds instrumentation for the `mongoose` library to capture spans using [`@opentelemetry/instrumentation-mongoose`](https://www.npmjs.com/package/@opentelemetry/instrumentation-mongoose).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.mongooseIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `mongoose`: `>=5.9.7 <9`

--- a/docs/platforms/javascript/common/configuration/integrations/mysql.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mysql.mdx
@@ -36,7 +36,6 @@ The `mysqlIntegration` adds instrumentation for the `mysql` library to capture s
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.mysqlIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/mysql2.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mysql2.mdx
@@ -36,7 +36,6 @@ The `mysql2Integration` adds instrumentation for the `mysql2` library to capture
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.mysql2Integration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/mysql2.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mysql2.mdx
@@ -34,6 +34,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `mysql2Integration` adds instrumentation for the `mysql2` library to capture spans using [`@opentelemetry/instrumentation-mysql2`](https://www.npmjs.com/package/@opentelemetry/instrumentation-mysql2).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.mysql2Integration()],
+});
+```
+
 ## Supported Versions
 
 - `mysql2`: `>= 1.4.2, < 4.0`

--- a/docs/platforms/javascript/common/configuration/integrations/nest.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nest.mdx
@@ -20,6 +20,12 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `nestIntegration` adds instrumentation for the Nest.js framework to capture spans using [`@opentelemetry/instrumentation-nestjs-core`](https://www.npmjs.com/package/@opentelemetry/instrumentation-nestjs-core).
 
+```JavaScript
+Sentry.init({
+  integrations: [new Sentry.nestIntegration()],
+});
+```
+
 ## Supported Versions
 
 - Nest.js `>=4.0.0`

--- a/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
@@ -34,6 +34,13 @@ This integration is enabled by default. If you'd like to modify your default int
 
 The `nodeContextIntegration` captures context about the environment and the device that the SDK is running on, and attaches this information to events.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.nodeContextIntegration()],
+});
+```
+
 ## Options
 
 ### `app`

--- a/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
@@ -36,7 +36,6 @@ The `nodeContextIntegration` captures context about the environment and the devi
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.nodeContextIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
@@ -40,7 +40,6 @@ The `nativeNodeFetchIntegration` does two things:
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.nativeNodeFetchIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
@@ -38,6 +38,13 @@ The `nativeNodeFetchIntegration` does two things:
 1. It captures spans for fetch requests.
 2. It captures breadcrumbs for fetch requests.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.nativeNodeFetchIntegration()],
+});
+```
+
 ## Options
 
 ### `breadcrumbs`

--- a/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
@@ -34,3 +34,23 @@ This integration only works in the Node.js runtime.
 The NodeProfiling integration sets up automatic performance profiling for your Node.js applications. It captures profiles via v8 and sends them to Sentry. To use this integration, you also need to have the performance monitoring enabled.
 
 Read more about [setting up NodeProfiling](./../../../profiling/).
+
+```JavaScript {tabTitle:CJS}
+const Sentry = require("@sentry/node");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [nodeProfilingIntegration()],
+});
+```
+
+```JavaScript {tabTitle:ESM}
+import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [nodeProfilingIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
@@ -40,7 +40,6 @@ const Sentry = require("@sentry/node");
 const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [nodeProfilingIntegration()],
 });
 ```
@@ -50,7 +49,6 @@ import * as Sentry from "@sentry/node";
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
 
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [nodeProfilingIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/normalizepath.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/normalizepath.mdx
@@ -19,7 +19,6 @@ Normalises paths to the app root directory so that error stack frames can be pro
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.normalizePathsIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/normalizepath.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/normalizepath.mdx
@@ -16,3 +16,10 @@ _Import name: `Sentry.normalizePathsIntegration`_
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
 Normalises paths to the app root directory so that error stack frames can be processed by Sentry.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.normalizePathsIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
@@ -40,7 +40,6 @@ This integration _does not_ prevent the process from exiting! If you want to pre
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.onUncaughtExceptionIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
@@ -38,6 +38,13 @@ The `onUncaughtExceptionIntegration` registers handlers to capture global uncaug
 
 This integration _does not_ prevent the process from exiting! If you want to prevent the process from exiting, you should register your own uncaught exception handler and configure `exitEvenIfOtherHandlersAreRegistered: false` in the integration options.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.onUncaughtExceptionIntegration()],
+});
+```
+
 ## Options
 
 ### `exitEvenIfOtherHandlersAreRegistered`

--- a/docs/platforms/javascript/common/configuration/integrations/postgres.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/postgres.mdx
@@ -34,6 +34,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `postgresIntegration` adds instrumentation for the `pg` library to capture spans using [`@opentelemetry/instrumentation-pg`](https://www.npmjs.com/package/@opentelemetry/instrumentation-pg).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.postgresIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `pg`: `>=8 <9`

--- a/docs/platforms/javascript/common/configuration/integrations/postgres.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/postgres.mdx
@@ -36,7 +36,6 @@ The `postgresIntegration` adds instrumentation for the `pg` library to capture s
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.postgresIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/processThreadsBreadcrumb.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/processThreadsBreadcrumb.mdx
@@ -34,7 +34,6 @@ The `processThreadBreadcrumbIntegration` adds breadcrumbs for `child_process` an
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.processThreadBreadcrumbIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/processThreadsBreadcrumb.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/processThreadsBreadcrumb.mdx
@@ -22,18 +22,22 @@ supported:
 
 <Alert level="info">
 
-This integration only works in Node.js and requires SDK version `8.36.0` or
-higher.
+This integration only works in Node.js and requires SDK version `8.36.0` or higher.
 
 </Alert>
 
 _Import name: `Sentry.processThreadBreadcrumbIntegration`_
 
-This integration is enabled by default. If you'd like to modify your default
-integrations, read [this](./../#modifying-default-integrations).
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
-The `processThreadBreadcrumbIntegration` adds breadcrumbs for `child_process`
-and `worker_threads` errors and `child_process` non-zero exit codes.
+The `processThreadBreadcrumbIntegration` adds breadcrumbs for `child_process` and `worker_threads` errors and `child_process` non-zero exit codes.
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.processThreadBreadcrumbIntegration()],
+});
+```
 
 ## Options
 
@@ -41,5 +45,4 @@ and `worker_threads` errors and `child_process` non-zero exit codes.
 
 _Type: `boolean`_
 
-If set to `true`, the integration will include the arguments used to start child
-processes.
+If set to `true`, the integration will include the arguments used to start child processes.

--- a/docs/platforms/javascript/common/configuration/integrations/redis.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/redis.mdx
@@ -36,7 +36,6 @@ The `redisIntegration` adds instrumentation for the `ioredis` and `redis` librar
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.redisIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/redis.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/redis.mdx
@@ -34,6 +34,13 @@ This integration is enabled by default when performance monitoring is enabled. I
 
 The `redisIntegration` adds instrumentation for the `ioredis` and `redis` library to capture spans using [`@opentelemetry/instrumentation-ioredis`](https://www.npmjs.com/package/@opentelemetry/instrumentation-ioredis) and [`@opentelemetry/instrumentation-redis-4`](https://www.npmjs.com/package/@opentelemetry/instrumentation-redis-4).
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.redisIntegration()],
+});
+```
+
 ## Supported Versions
 
 - `ioredis`: `>=2.0.0 <6`

--- a/docs/platforms/javascript/common/configuration/integrations/replay.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replay.mdx
@@ -30,3 +30,10 @@ _Import name: `Sentry.replayIntegration`_
 [Session Replay](/product/explore/session-replay/) helps you get to the root cause of an error or latency issue faster by providing you with a video-like reproduction of what was happening in the user's browser before, during, and after the issue. You can rewind and replay your application's DOM state and see key user interactions, like mouse clicks, scrolls, network requests, and console entries, in a single combined UI inspired by your browser's DevTools.
 
 Read more about [setting up Session Replay](./../../../session-replay/).
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.replayIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/replay.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replay.mdx
@@ -33,7 +33,6 @@ Read more about [setting up Session Replay](./../../../session-replay/).
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.replayIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/replaycanvas.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replaycanvas.mdx
@@ -39,7 +39,6 @@ Read more about [setting up Session Replay with the Canvas integration](./../../
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.replayCanvasIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/replaycanvas.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replaycanvas.mdx
@@ -36,3 +36,10 @@ There is currently no PII scrubbing in canvas recordings!
 </Alert>
 
 Read more about [setting up Session Replay with the Canvas integration](./../../../session-replay#canvas-recording).
+
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.replayCanvasIntegration()],
+});
+```

--- a/docs/platforms/javascript/common/configuration/integrations/rewriteframes.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/rewriteframes.mdx
@@ -7,7 +7,7 @@ _Import name: `Sentry.rewriteFramesIntegration`_
 
 This integration allows you to apply a transformation to each frame of the stack trace. In the streamlined scenario, it can be used to change the name of the file frame it originates from, or it can be fed with an iterated function to apply any arbitrary transformation.
 
-On Windows machines, you have to use Unix paths and skip the volume letter in the `root` option to enable it. For example, `C:\\Program Files\\Apache\\www` won’t work, however, `/Program Files/Apache/www` will.
+On Windows machines, you have to use Unix paths and skip the volume letter in the `root` option to enable it. For example, `C:\\Program Files\\Apache\\www` won't work, however, `/Program Files/Apache/www` will.
 
 <PlatformContent includePath="configuration/rewrite-frames" />
 

--- a/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
@@ -1,18 +1,20 @@
 ---
-title: MySQL
-description: "Adds instrumentation for MySQL. (default)"
+title: Tedious
+description: "Adds instrumentation for Tedious. (default)"
 supported:
   - javascript.node
+  - javascript.astro
   - javascript.aws-lambda
   - javascript.azure-functions
   - javascript.connect
+  - javascript.deno
   - javascript.express
   - javascript.fastify
   - javascript.gcp-functions
   - javascript.hapi
   - javascript.koa
-  - javascript.nestjs
   - javascript.electron
+  - javascript.nestjs
   - javascript.nextjs
   - javascript.nuxt
   - javascript.solidstart
@@ -24,23 +26,22 @@ supported:
 
 <Alert level="info">
 
-This integration only works in the Node.js and Bun runtimes.
+This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.38.0` or higher.
 
 </Alert>
 
-_Import name: `Sentry.mysqlIntegration`_
+_Import name: `Sentry.tediousIntegration`_
 
 This integration is enabled by default when performance monitoring is enabled. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
 
-The `mysqlIntegration` adds instrumentation for the `mysql` library to capture spans using [`@opentelemetry/instrumentation-mysql`](https://www.npmjs.com/package/@opentelemetry/instrumentation-mysql).
+The `tediousIntegration` adds instrumentation for the `tedious` library to capture spans using [`@opentelemetry/instrumentation-tedious`](https://www.npmjs.com/package/@opentelemetry/instrumentation-tedious).
 
-```JavaScript
+```javascript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [Sentry.mysqlIntegration()],
+  integrations: [new Sentry.tediousIntegration()],
 });
 ```
 
 ## Supported Versions
 
-- `mysql`: `2.x`
+- `tedious`: `>=1.11.0 <20`

--- a/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
@@ -38,7 +38,6 @@ The `onUnhandledRejectionIntegration` registers handlers to capture global unhan
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.onUnhandledRejectionIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
@@ -36,6 +36,12 @@ This integration is enabled by default. If you'd like to modify your default int
 
 The `onUnhandledRejectionIntegration` registers handlers to capture global unhandled promise rejections.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.onUnhandledRejectionIntegration()],
+});
+```
 
 <PlatformSection supported={["javascript.aws-lambda"]}>
 

--- a/docs/platforms/javascript/common/configuration/integrations/wintercgfetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/wintercgfetch.mdx
@@ -18,6 +18,13 @@ This integration is enabled by default. If you'd like to modify your default int
 
 The `winterCGFetchIntegration` creates spans and attaches tracing headers to fetch requests on the Edge runtime.
 
+```JavaScript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.winterCGFetchIntegration()],
+});
+```
+
 ## Options
 
 ### `breadcrumbs`

--- a/docs/platforms/javascript/common/configuration/integrations/wintercgfetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/wintercgfetch.mdx
@@ -20,7 +20,6 @@ The `winterCGFetchIntegration` creates spans and attaches tracing headers to fet
 
 ```JavaScript
 Sentry.init({
-  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.winterCGFetchIntegration()],
 });
 ```

--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -8,61 +8,66 @@ Depending on whether an integration enhances the functionality of a particular r
 
 ### Common Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |           ✓            |
 
 ### Browser Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |        ✓        |            |           ✓            |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 
 ### Node.js Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
@@ -1,40 +1,44 @@
 ### Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`awsIntegration`](./aws)                                 |        ✓         |            |        ✓        |                        |
-| [`awsLambdaIntegration`](./awslambda)                     |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |                 |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)           |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                             |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |                 |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |                  |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |                  |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |                  |            |        ✓        |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`mongoIntegration`](./mongo)                             |                  |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |                  |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |                  |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |                  |            |        ✓        |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`postgresIntegration`](./postgres)                       |                  |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |                  |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |                  |            |        ✓        |                        |
-| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`awsIntegration`](./aws)                                 |        ✓         |            |      ✓      |                        |
+| [`awsLambdaIntegration`](./awslambda)                     |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`amqplibIntegration`](./amqplib)                         |                  |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
+| [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`genericPoolIntegration`](./genericpool)                 |                  |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |                  |            |      ✓      |                        |
+| [`kafkaIntegration`](./kafka)                             |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |                  |            |      ✓      |                        |
+| [`mongoIntegration`](./mongo)                             |                  |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |                  |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |                  |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |                  |            |      ✓      |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`postgresIntegration`](./postgres)                       |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |                  |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |                  |            |      ✓      |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
+| [`tediousIntegration`](./tedious)                         |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.bun.mdx
+++ b/platform-includes/configuration/integrations/javascript.bun.mdx
@@ -1,36 +1,39 @@
 ### Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`bunServerIntegration`](./bunserver)                     |        ✓         |     ✓      |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |                 |                        |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |                 |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`captureConsoleIntegration`](./captureconsole)           |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                             |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`bunServerIntegration`](./bunserver)                     |        ✓         |     ✓      |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.cloudflare.mdx
+++ b/platform-includes/configuration/integrations/javascript.cloudflare.mdx
@@ -1,15 +1,15 @@
 ### Integrations
 
-|                                                      | **Auto Enabled** | **Errors** | **Performance** | **Cron** | **Additional Context** |
-| ---------------------------------------------------- | :--------------: | :--------: | :-------------: | :------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                      |        ✓         |     ✓      |                 |          |                        |
-| [`fetchIntegration`](./fetchIntegration)             |        ✓         |     ✓      |        ✓        |          |                        |
-| [`functionToStringIntegration`](./functiontostring)  |        ✓         |            |                 |          |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)      |        ✓         |     ✓      |                 |          |                        |
-| [`linkedErrorsIntegration`](./linkederrors)          |        ✓         |     ✓      |                 |          |                        |
-| [`requestDataIntegration`](./requestDataIntegration) |        ✓         |            |                 |          |           ✓            |
-| [`captureConsoleIntegration`](./captureconsole)      |                  |            |                 |          |           ✓            |
-| [`debugIntegration`](./debug)                        |                  |            |                 |          |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)      |                  |            |                 |          |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)        |                  |     ✓      |                 |          |                        |
-| [`sessionTimingIntegration`](./sessiontiming)        |                  |            |                 |          |           ✓            |
+|                                                      | **Auto Enabled** | **Errors** | **Tracing** | **Cron** | **Additional Context** |
+| ---------------------------------------------------- | :--------------: | :--------: | :---------: | :------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                      |        ✓         |     ✓      |             |          |                        |
+| [`fetchIntegration`](./fetchIntegration)             |        ✓         |     ✓      |      ✓      |          |                        |
+| [`functionToStringIntegration`](./functiontostring)  |        ✓         |            |             |          |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)      |        ✓         |     ✓      |             |          |                        |
+| [`linkedErrorsIntegration`](./linkederrors)          |        ✓         |     ✓      |             |          |                        |
+| [`requestDataIntegration`](./requestDataIntegration) |        ✓         |            |             |          |           ✓            |
+| [`captureConsoleIntegration`](./captureconsole)      |                  |            |             |          |           ✓            |
+| [`debugIntegration`](./debug)                        |                  |            |             |          |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)      |                  |            |             |          |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)        |                  |     ✓      |             |          |                        |
+| [`sessionTimingIntegration`](./sessiontiming)        |                  |            |             |          |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.connect.mdx
+++ b/platform-includes/configuration/integrations/javascript.connect.mdx
@@ -2,43 +2,42 @@
 
 |                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
 | --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
 | [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`connectIntegration`](./connect)                         |        ✓         |            |      ✓      |                        |
 | [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
 | [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
 | [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
-| [`googleCloudGrpcIntegration`](./googlecloudgrpc)         |        ✓         |            |      ✓      |                        |
-| [`googleCloudHttpIntegration`](./googlecloudhttp)         |        ✓         |            |      ✓      |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
 | [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
 | [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
 | [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
 | [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
 | [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
 | [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
 | [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
 | [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
-| [`amqplibIntegration`](./amqplib)                         |                  |            |      ✓      |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
-| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
 | [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
-| [`genericPoolIntegration`](./genericpool)                 |                  |            |      ✓      |                        |
-| [`graphqlIntegration`](./graphql)                         |                  |            |      ✓      |                        |
-| [`kafkaIntegration`](./kafka)                             |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
-| [`lruMemoizerIntegration`](./lrumemoizer)                 |                  |            |      ✓      |                        |
-| [`mongoIntegration`](./mongo)                             |                  |            |      ✓      |                        |
-| [`mongooseIntegration`](./mongoose)                       |                  |            |      ✓      |                        |
-| [`mysqlIntegration`](./mysql)                             |                  |            |      ✓      |                        |
-| [`mysql2Integration`](./mysql2)                           |                  |            |      ✓      |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
-| [`postgresIntegration`](./postgres)                       |                  |            |      ✓      |                        |
 | [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
-| [`redisIntegration`](./redis)                             |                  |            |      ✓      |                        |
-| [`requestDataIntegration`](./requestdata)                 |                  |            |      ✓      |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
 | [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
-| [`tediousIntegration`](./tedious)                         |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.cordova.mdx
+++ b/platform-includes/configuration/integrations/javascript.cordova.mdx
@@ -1,20 +1,20 @@
 ### Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |                 |            |                        |
-| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |                 |            |                        |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |                 |            |                        |
-| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |                 |            |                        |
-| [`captureConsoleIntegration`](./captureconsole)       |                  |            |                 |            |           ✓            |
-| [`debugIntegration`](./debug)                         |                  |            |                 |            |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |                 |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |                 |            |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
-| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |                 |            |           ✓            |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |             |            |                        |
+| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |             |            |                        |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
+| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
+| [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
+| [`debugIntegration`](./debug)                         |                  |            |             |            |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.deno.mdx
+++ b/platform-includes/configuration/integrations/javascript.deno.mdx
@@ -1,20 +1,19 @@
 ### Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Cron** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :------: | :--------------------: |
-| [`amqplib`](./amqplib)                              |        ✓         |            |        ✓        |          |                        |
-| [`breadcrumbsIntegration`](./breadcrumbs)           |        ✓         |            |                 |          |           ✓            |
-| [`contextLinesIntegration`](./contextlines)         |        ✓         |     ✓      |                 |          |                        |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |          |                        |
-| [`denoContextIntegration`](./denocontext)           |        ✓         |            |                 |          |           ✓            |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |          |                        |
-| [`globalHandlersIntegration`](./globalhandlers)     |        ✓         |     ✓      |                 |          |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |          |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |          |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |          |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |          |                        |
-| [`denoCronIntegration`](./denocron)                 |                  |            |                 |    ✓     |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |          |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |          |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |          |           ✓            |
-| [`trpcMiddleware`](./trpc)                          |                  |     ✓      |        ✓        |          |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Cron** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)           |        ✓         |            |             |          |           ✓            |
+| [`contextLinesIntegration`](./contextlines)         |        ✓         |     ✓      |             |          |                        |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |          |                        |
+| [`denoContextIntegration`](./denocontext)           |        ✓         |            |             |          |           ✓            |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |          |                        |
+| [`globalHandlersIntegration`](./globalhandlers)     |        ✓         |     ✓      |             |          |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |          |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |          |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |          |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |          |                        |
+| [`denoCronIntegration`](./denocron)                 |                  |            |             |    ✓     |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |          |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |          |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |          |           ✓            |
+| [`trpcMiddleware`](./trpc)                          |                  |     ✓      |      ✓      |          |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.fastify.mdx
+++ b/platform-includes/configuration/integrations/javascript.fastify.mdx
@@ -1,37 +1,43 @@
 ### Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |                 |                        |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |                 |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)           |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                             |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |                 |           ✓            |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
+| [`fastifyIntegration`](./fastify)                         |        ✓         |            |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.gatsby.mdx
+++ b/platform-includes/configuration/integrations/javascript.gatsby.mdx
@@ -1,25 +1,25 @@
 ### Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |                 |            |                        |
-| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |                 |            |                        |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |                 |            |                        |
-| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |                 |            |                        |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |                  |            |        ✓        |            |           ✓            |
-| [`captureConsoleIntegration`](./captureconsole)       |                  |            |                 |            |           ✓            |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`debugIntegration`](./debug)                         |                  |            |                 |            |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |                 |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |                 |            |                        |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
-| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |                 |            |           ✓            |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |             |            |                        |
+| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |             |            |                        |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
+| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
+| [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`debugIntegration`](./debug)                         |                  |            |             |            |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.hapi.mdx
+++ b/platform-includes/configuration/integrations/javascript.hapi.mdx
@@ -2,43 +2,42 @@
 
 |                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
 | --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
 | [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
 | [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
 | [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
 | [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
-| [`googleCloudGrpcIntegration`](./googlecloudgrpc)         |        ✓         |            |      ✓      |                        |
-| [`googleCloudHttpIntegration`](./googlecloudhttp)         |        ✓         |            |      ✓      |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`hapiIntegration`](./hapi)                               |        ✓         |            |      ✓      |                        |
 | [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
 | [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
 | [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
 | [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
 | [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
 | [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
 | [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
 | [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
-| [`amqplibIntegration`](./amqplib)                         |                  |            |      ✓      |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
-| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
 | [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
-| [`genericPoolIntegration`](./genericpool)                 |                  |            |      ✓      |                        |
-| [`graphqlIntegration`](./graphql)                         |                  |            |      ✓      |                        |
-| [`kafkaIntegration`](./kafka)                             |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
-| [`lruMemoizerIntegration`](./lrumemoizer)                 |                  |            |      ✓      |                        |
-| [`mongoIntegration`](./mongo)                             |                  |            |      ✓      |                        |
-| [`mongooseIntegration`](./mongoose)                       |                  |            |      ✓      |                        |
-| [`mysqlIntegration`](./mysql)                             |                  |            |      ✓      |                        |
-| [`mysql2Integration`](./mysql2)                           |                  |            |      ✓      |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
-| [`postgresIntegration`](./postgres)                       |                  |            |      ✓      |                        |
 | [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
-| [`redisIntegration`](./redis)                             |                  |            |      ✓      |                        |
-| [`requestDataIntegration`](./requestdata)                 |                  |            |      ✓      |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
 | [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
-| [`tediousIntegration`](./tedious)                         |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.mdx
+++ b/platform-includes/configuration/integrations/javascript.mdx
@@ -1,25 +1,25 @@
 ### Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |                 |            |                        |
-| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |                 |            |                        |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |                 |            |                        |
-| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |                 |            |                        |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |                  |            |        ✓        |            |           ✓            |
-| [`captureConsoleIntegration`](./captureconsole)       |                  |            |                 |            |           ✓            |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`debugIntegration`](./debug)                         |                  |            |                 |            |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |                 |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |                 |            |                        |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
-| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |                 |            |           ✓            |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |             |            |                        |
+| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |             |            |                        |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
+| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
+| [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`debugIntegration`](./debug)                         |                  |            |             |            |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nestjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nestjs.mdx
@@ -1,38 +1,43 @@
 ### Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |                 |                        |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |                 |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |                 |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)           |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                             |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |                 |           ✓            |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nestIntegration`](./nest)                               |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -9,72 +9,78 @@ Depending on whether an integration enhances the functionality of a particular r
 
 ### Common Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |           ✓            |
 
 ### Browser Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |        ✓        |            |           ✓            |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 
 ### Server (Node.js, Edge) Integrations
 
-|                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| ----------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`requestDataIntegration`](./requestdata) |        ✓         |            |        ✓        |                        |
+|                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| ----------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`requestDataIntegration`](./requestdata) |        ✓         |            |      ✓      |                        |
 
 ### Node.js Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
 
 ### Edge Integrations
 
-|                                               | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`winterCGFetchIntegration`](./wintercgfetch) |        ✓         |            |        ✓        |           ✓            |
+|                                               | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`winterCGFetchIntegration`](./wintercgfetch) |        ✓         |            |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.node.mdx
+++ b/platform-includes/configuration/integrations/javascript.node.mdx
@@ -1,38 +1,42 @@
 ### Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |                 |                        |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |                 |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |                 |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)           |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                             |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |                 |           ✓            |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |                 |           ✓            |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`dedupeIntegration`](./dedupe)                           |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring)       |        ✓         |            |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)           |        ✓         |     ✓      |             |                        |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`linkedErrorsIntegration`](./linkederrors)               |        ✓         |     ✓      |             |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                             |                  |            |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)             |                  |            |             |           ✓            |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -8,61 +8,66 @@ Depending on whether an integration enhances the functionality of a particular r
 
 ### Common Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |           ✓            |
 
 ### Browser Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |        ✓        |            |           ✓            |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 
 ### Node.js Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -8,61 +8,66 @@ Depending on whether an integration enhances the functionality of a particular r
 
 ### Common Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |           ✓            |
 
 ### Browser Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |        ✓        |            |           ✓            |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 
 ### Node.js Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -8,60 +8,66 @@ Depending on whether an integration enhances the functionality of a particular r
 
 ### Common Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |           ✓            |
 
 ### Browser Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |        ✓        |            |           ✓            |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 
 ### Node.js Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -8,61 +8,66 @@ Depending on whether an integration enhances the functionality of a particular r
 
 ### Common Integrations
 
-|                                                     | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |                 |                        |
-| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |                 |                        |
-| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |                 |                        |
-| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |                 |                        |
-| [`captureConsoleIntegration`](./captureconsole)     |                  |            |                 |           ✓            |
-| [`debugIntegration`](./debug)                       |                  |            |                 |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |                 |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |                 |                        |
-| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |                 |           ✓            |
+|                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |                        |
+| [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |                        |
+| [`inboundFiltersIntegration`](./inboundfilters)     |        ✓         |     ✓      |             |                        |
+| [`linkedErrorsIntegration`](./linkederrors)         |        ✓         |     ✓      |             |                        |
+| [`captureConsoleIntegration`](./captureconsole)     |                  |            |             |           ✓            |
+| [`debugIntegration`](./debug)                       |                  |            |             |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)     |                  |            |             |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |                        |
+| [`sessionTimingIntegration`](./sessiontiming)       |                  |            |             |           ✓            |
 
 ### Browser Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |        ✓        |            |           ✓            |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 
 ### Node.js Integrations
 
-|                                                           | **Auto Enabled** | **Errors** | **Performance** | **Additional Context** |
-| --------------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------------------: |
-| [`amqplib`](./amqplib)                                    |        ✓         |            |        ✓        |                        |
-| [`consoleIntegration`](./console)                         |        ✓         |            |                 |           ✓            |
-| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |                 |                        |
-| [`httpIntegration`](./http)                               |        ✓         |     ✓      |        ✓        |           ✓            |
-| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |        ✓        |                        |
-| [`graphqlIntegration`](./graphql)                         |        ✓         |            |        ✓        |                        |
-| [`kafkaIntegration`](./kafka)                             |        ✓         |            |        ✓        |                        |
-| [`modulesIntegration`](./modules)                         |        ✓         |            |                 |           ✓            |
-| [`mongoIntegration`](./mongo)                             |        ✓         |            |        ✓        |                        |
-| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |        ✓        |                        |
-| [`mysqlIntegration`](./mysql)                             |        ✓         |            |        ✓        |                        |
-| [`mysql2Integration`](./mysql2)                           |        ✓         |            |        ✓        |                        |
-| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |                 |           ✓            |
-| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |        ✓        |           ✓            |
-| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |                 |                        |
-| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |                 |                        |
-| [`postgresIntegration`](./postgres)                       |        ✓         |            |        ✓        |                        |
-| [`prismaIntegration`](./prisma)                           |                  |            |        ✓        |                        |
-| [`redisIntegration`](./redis)                             |        ✓         |            |        ✓        |                        |
-| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |        ✓        |                        |
-| [`anrIntegration`](./anr)                                 |                  |     ✓      |                 |                        |
-| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |                 |                        |
-| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |        ✓        |                        |
-| [`fsIntegration`](./fs)                                   |                  |            |        ✓        |                        |
-| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |        ✓        |           ✓            |
+|                                                           | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| --------------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
+| [`amqplibIntegration`](./amqplib)                         |        ✓         |            |      ✓      |                        |
+| [`consoleIntegration`](./console)                         |        ✓         |            |             |           ✓            |
+| [`contextLinesIntegration`](./contextlines)               |        ✓         |     ✓      |             |                        |
+| [`genericPoolIntegration`](./genericpool)                 |        ✓         |            |      ✓      |                        |
+| [`graphqlIntegration`](./graphql)                         |        ✓         |            |      ✓      |                        |
+| [`httpIntegration`](./http)                               |        ✓         |     ✓      |      ✓      |           ✓            |
+| [`kafkaIntegration`](./kafka)                             |        ✓         |            |      ✓      |                        |
+| [`lruMemoizerIntegration`](./lrumemoizer)                 |        ✓         |            |      ✓      |                        |
+| [`modulesIntegration`](./modules)                         |        ✓         |            |             |           ✓            |
+| [`mongoIntegration`](./mongo)                             |        ✓         |            |      ✓      |                        |
+| [`mongooseIntegration`](./mongoose)                       |        ✓         |            |      ✓      |                        |
+| [`mysqlIntegration`](./mysql)                             |        ✓         |            |      ✓      |                        |
+| [`mysql2Integration`](./mysql2)                           |        ✓         |            |      ✓      |                        |
+| [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
+| [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
+| [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
+| [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
+| [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |
+| [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
+| [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
+| [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
+| [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
+| [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
+| [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
+| [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
+| [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.vue.mdx
+++ b/platform-includes/configuration/integrations/javascript.vue.mdx
@@ -1,26 +1,26 @@
 ### Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |                 |            |                        |
-| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |                 |            |                        |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |                 |            |                        |
-| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |                 |            |                        |
-| [`vueIntegration`](./vue)                             |        ✓         |     ✓      |        ✓        |            |                        |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |                  |            |        ✓        |            |           ✓            |
-| [`captureConsoleIntegration`](./captureconsole)       |                  |            |                 |            |           ✓            |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`debugIntegration`](./debug)                         |                  |            |                 |            |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |                 |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |                 |            |                        |
-| [`replayIntegration`](./replay)                       |                  |            |                 |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |                 |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
-| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |                 |            |           ✓            |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |             |            |                        |
+| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |             |            |                        |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
+| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
+| [`vueIntegration`](./vue)                             |        ✓         |     ✓      |      ✓      |            |                        |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
+| [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`debugIntegration`](./debug)                         |                  |            |             |            |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.wasm.mdx
+++ b/platform-includes/configuration/integrations/javascript.wasm.mdx
@@ -1,23 +1,23 @@
 ### Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Performance** | **Replay** | **Additional Context** |
-| ----------------------------------------------------- | :--------------: | :--------: | :-------------: | :--------: | :--------------------: |
-| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |                 |            |           ✓            |
-| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |                 |            |                        |
-| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |                 |            |                        |
-| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |                 |            |                        |
-| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |                 |            |                        |
-| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |                 |            |           ✓            |
-| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |                 |            |                        |
-| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |                 |            |                        |
-| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |        ✓        |            |                        |
-| [`browserTracingIntegration`](./browsertracing)       |                  |            |        ✓        |            |           ✓            |
-| [`captureConsoleIntegration`](./captureconsole)       |                  |            |                 |            |           ✓            |
-| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |                 |            |                        |
-| [`debugIntegration`](./debug)                         |                  |            |                 |            |                        |
-| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |                 |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |                 |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |                 |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |                 |            |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |                 |            |                        |
-| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |                 |            |           ✓            |
+|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
+| [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
+| [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |             |            |                        |
+| [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |             |            |                        |
+| [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
+| [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
+| [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
+| [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
+| [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
+| [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
+| [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
+| [`debugIntegration`](./debug)                         |                  |            |             |            |                        |
+| [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`sessionTimingIntegration`](./sessiontiming)         |                  |            |             |            |           ✓            |


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/13317

1. Add `Sentry.init` snippets to all relevant node integrations
2. Add supported versions where missing in node integrations
3. Add node integration entries for `dataloader`, `knex,` and `lrumemorizer` integrations
4. Make sure dataloader is not marked as default
5. Alpha-order and add missing entries to js integrations table