### PR TITLE
Remove old constructor keywords in JS integration options that can ca…

### DIFF
--- a/docs/platforms/javascript/guides/electron/configuration/integrations/browserwindowsession.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/integrations/browserwindowsession.mdx
@@ -20,7 +20,7 @@ import * as Sentry from "@sentry/electron/main";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  integrations: [new Sentry.browserWindowSessionIntegration()],
+  integrations: [Sentry.browserWindowSessionIntegration()],
 });
 ```
 
@@ -33,7 +33,7 @@ import * as Sentry from "@sentry/electron/main";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
-    new Sentry.browserWindowSessionIntegration({
+    Sentry.browserWindowSessionIntegration({
       backgroundTimeoutSeconds: 120,
     }),
   ],

--- a/docs/platforms/javascript/guides/electron/configuration/integrations/mainprocesssession.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/integrations/mainprocesssession.mdx
@@ -32,7 +32,7 @@ import * as Sentry from "@sentry/electron/main";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
-    new Sentry.mainProcessSessionIntegration({ sendOnCreate: true }),
+    Sentry.mainProcessSessionIntegration({ sendOnCreate: true }),
   ],
 });
 ```

--- a/docs/product/sentry-basics/integrate-frontend/initialize-sentry-sdk.mdx
+++ b/docs/product/sentry-basics/integrate-frontend/initialize-sentry-sdk.mdx
@@ -54,7 +54,7 @@ Sentry captures data by using a platform-specific SDK that you add to your appli
 
    Sentry.init({
      dsn: "<your_DSN_key>",
-     integrations: [new Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+     integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
 
      // Set tracesSampleRate to 1.0 to capture 100%
      // of transactions for performance monitoring.

--- a/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.electron.mdx
@@ -10,7 +10,7 @@ Sentry.init({
 
   // This enables automatic instrumentation (highly recommended), but is not
   // necessary for purely manual usage
-  integrations: [new Sentry.browserTracingIntegration()],
+  integrations: [Sentry.browserTracingIntegration()],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/platform-includes/performance/enable-automatic-instrumentation/javascript.electron.mdx
+++ b/platform-includes/performance/enable-automatic-instrumentation/javascript.electron.mdx
@@ -10,7 +10,7 @@ import * as Sentry from "@sentry/electron/renderer";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  integrations: [new Sentry.browserTracingIntegration()],
+  integrations: [Sentry.browserTracingIntegration()],
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
@@ -7,8 +7,8 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
     // Add browser profiling integration to the list of integrations
-    new Sentry.browserTracingIntegration(),
-    new Sentry.browserProfilingIntegration(),
+    Sentry.browserTracingIntegration(),
+    Sentry.browserProfilingIntegration(),
   ],
 
   // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
…use browser errors

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The constructor functions used in some code examples for JS integrations are deprecated and can cause errors in the new sdk, this PR cleans them up.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [X ] Other deadline: <!-- ASAP, fixing broken code examples in the docs -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
