### PR TITLE
docs: fix queue custom instrumentation code

### DIFF
--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
@@ -48,7 +48,7 @@ with sentry_sdk.start_transaction(
     # Create the span
     with sentry_sdk.start_span(
         op="queue.publish",
-        name="queue_producer",
+        description="queue_producer",
     ) as span:
         # Set span data
         span.set_data("messaging.message.id", message_id)
@@ -118,7 +118,7 @@ with sentry_sdk.start_transaction(transaction):
     # Create the span
     with sentry_sdk.start_span(
         op="queue.process",
-        name="queue_consumer",
+        description="queue_consumer",
     ) as span:
         # Set span data
         span.set_data("messaging.message.id", message["message_id"])


### PR DESCRIPTION
Hey, when following the [doc](https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module/) I encountered the following error:
```
Span.__init__() got an unexpected keyword argument 'name'
```

It works with `description` instead.