### PR TITLE
Update Java SDK v8 deprecation removals

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -260,7 +260,7 @@ Default: set to `android.content.Context.getCacheDir()/sentry`.
 
 <ConfigKey name="shutdown-timeout-millis">
 
-Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
+Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from the application. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 
 </ConfigKey>
 

--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -258,7 +258,7 @@ Default: set to `android.content.Context.getCacheDir()/sentry`.
 
 </ConfigKey>
 
-<ConfigKey name="shutdown-timeout">
+<ConfigKey name="shutdown-timeout-millis">
 
 Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 

--- a/docs/platforms/java/common/configuration/index.mdx
+++ b/docs/platforms/java/common/configuration/index.mdx
@@ -265,18 +265,18 @@ sentry.traces-sample-rate=0.2
 
 ### Tracing Origins
 
-To set tracing origins, use the `tracing-origins` option:
+To set tracing origins, use the `trace-propagation-targets` option:
 
 ```properties {tabTitle:sentry.properties}
-tracing-origins=localhost,^(http|https)://api\\..*$
+trace-propagation-targets=localhost,^(http|https)://api\\..*$
 ```
 
 ```properties {tabTitle:environment variable}
-SENTRY_TRACING_ORIGINS=localhost,^(http|https)://api\\..*$
+SENTRY_TRACE_PROPAGATION_TARGETS=localhost,^(http|https)://api\\..*$
 ```
 
 ```properties {tabTitle:system property}
-sentry.tracing-origins=localhost,^(http|https)://api\\..*$
+sentry.trace-propagation-targets=localhost,^(http|https)://api\\..*$
 ```
 
 ### Debug

--- a/docs/platforms/java/common/configuration/options.mdx
+++ b/docs/platforms/java/common/configuration/options.mdx
@@ -213,7 +213,7 @@ When set, a proxy can be configured that should be used for outbound requests. T
 
 </ConfigKey>
 
-<ConfigKey name="shutdown-timeout">
+<ConfigKey name="shutdown-timeout-millis">
 
 Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 
@@ -236,12 +236,6 @@ A number between 0 and 1, controlling the percentage chance a given transaction 
 <ConfigKey name="traces-sampler">
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or <PlatformIdentifier name="traces-sample-rate" /> must be defined to enable tracing.
-
-</ConfigKey>
-
-<ConfigKey name="tracing-origins">
-
-An optional property that configures which downstream services receive the `sentry-trace` header attached to HTTP requests. It contains a list of URLs or regex against which URLs are matched. If not set, the `sentry-trace` header is attached to every request executed from an instrumented client.
 
 </ConfigKey>
 

--- a/platform-includes/configuration/auto-session-tracking/android.mdx
+++ b/platform-includes/configuration/auto-session-tracking/android.mdx
@@ -30,7 +30,7 @@ If you'd like to opt-out of this feature, you can do it via options.
 
 ```xml {filename:AndroidManifest.xml}
 <application>
-  <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
+  <meta-data android:name="io.sentry.auto-session-tracking.enable" android:value="true" />
 </application>
 ```
 
@@ -40,7 +40,7 @@ Or, if you are manually instrumenting Sentry:
 import io.sentry.android.core.SentryAndroid;
 
 SentryAndroid.init(this, options -> {
-  options.setEnableSessionTracking(true);
+  options.setEnableAutoSessionTracking(true);
 });
 ```
 
@@ -48,7 +48,7 @@ SentryAndroid.init(this, options -> {
 import io.sentry.android.core.SentryAndroid
 
 SentryAndroid.init(this) { options ->
-  options.isEnableSessionTracking = true
+  options.isEnableAutoSessionTracking = true
 }
 ```
 

--- a/platform-includes/configuration/drain-example/java.mdx
+++ b/platform-includes/configuration/drain-example/java.mdx
@@ -1,1 +1,1 @@
-The Java SDK automatically shuts down on JVM exit and waits `shutdownTimeout` milliseconds before that happens.
+The Java SDK automatically shuts down on JVM exit and waits `shutdownTimeoutMillis` milliseconds before that happens.


### PR DESCRIPTION
We've removed some APIs in Java SDK v8. This PR replaces / removes docs for those.

Here's the changelog: https://github.com/getsentry/sentry-java/blob/8.x.x/CHANGELOG.md

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
