### PR TITLE
feat(js): Add docs for `updateSpanName`

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -235,7 +235,7 @@ Sentry maintains a [list of well known span operations](https://develop.sentry.d
 
 ### Updating the Span Name
 
-_Available since: v8.44.0_
+_Available since: v8.46.0_
 
 You can update the name of a span at any time:
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -235,7 +235,7 @@ Sentry maintains a [list of well known span operations](https://develop.sentry.d
 
 ### Updating the Span Name
 
-_Available since: v8.46.0_
+_Available since: v8.47.0_
 
 You can update the name of a span at any time:
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -246,11 +246,11 @@ if (span) {
 }
 ```
 
-Prior to v8.39.0, you had to use `span.updateName('New Name')`, which had some limitations in `@sentry/node` and SDKs depending on it (e.g. `@sentry/nextjs`):
+Prior to v8.39.0, you had to use `span.updateName('New Name')`, which had some limitations in `@sentry/node` and SDKs depending on it (for example, `@sentry/nextjs`):
 
-- Spans with `http.method` or `http.request.method` attributes would automatically have their name set to the method + the URL path
-- Spans with `db.system` attributes would automatically have their name set to the system + the statement
+- Spans with `http.method` or `http.request.method` attributes would automatically have their name set to the method + the URL path.
+- Spans with `db.system` attributes would automatically have their name set to the system + the statement.
 
-Using `Sentry.updateSpanName()` instead of `span.updateName()` ensures that the name is updated correctly and no longer overwritten in these cases.
+Using `Sentry.updateSpanName()` ensures that the name is updated correctly and no longer overwritten in these cases.
 
-In browser environments (if you use `@sentry/browser`, `@sentry/react`, etc), `span.updateName()` and `Sentry.updateSpanName()` are identical and you can use either of them.
+If you use `@sentry/browser`, `@sentry/react`, and so on in browser environments, `span.updateName()` and `Sentry.updateSpanName()` will function identically, so you can use either one of them.

--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -235,7 +235,7 @@ Sentry maintains a [list of well known span operations](https://develop.sentry.d
 
 ### Updating the Span Name
 
-_Available since: v8.39.0_
+_Available since: v8.44.0_
 
 You can update the name of a span at any time:
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -235,16 +235,22 @@ Sentry maintains a [list of well known span operations](https://develop.sentry.d
 
 ### Updating the Span Name
 
+_Available since: v8.39.0_
+
 You can update the name of a span at any time:
 
 ```javascript
 const span = Sentry.getActiveSpan();
 if (span) {
-  span.updateName("New Name");
+  Sentry.updateSpanName(span, "New Name");
 }
 ```
 
-Please note that in certain scenarios, the span name will be overwritten by the SDK. This is the case for spans with any of the following attribute combinations:
+Prior to v8.39.0, you had to use `span.updateName('New Name')`, which had some limitations in `@sentry/node` and SDKs depending on it (e.g. `@sentry/nextjs`):
 
-* Spans with `http.method` or `http.request.method` attributes will automatically have their name set to the method + the URL path
-* Spans with `db.system` attributes will automatically have their name set to the system + the statement
+- Spans with `http.method` or `http.request.method` attributes would automatically have their name set to the method + the URL path
+- Spans with `db.system` attributes would automatically have their name set to the system + the statement
+
+Using `Sentry.updateSpanName()` instead of `span.updateName()` ensures that the name is updated correctly and no longer overwritten in these cases.
+
+In browser environments (if you use `@sentry/browser`, `@sentry/react`, etc), `span.updateName()` and `Sentry.updateSpanName()` are identical and you can use either of them.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

To be merged only once https://github.com/getsentry/sentry-javascript/pull/14291 was released

This PR:

- adds documentation for `Sentry.updateSpanName`, a helper function we (unfortunately) had to add to the JS SDK
- rewords the previous `span.updateName` documentation, leaving the shortcomings of the previous way to update a span name in Node in place
- does not touch the React Native docs because I think it's fine for RN users (given it's based on `@sentry/react`) to continue using `span.updateName`. Happy to change this if reviewers have different opinions

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
