### PR TITLE
Add documentation on how to check-in to an environment with CheckInUtils

### DIFF
--- a/platform-includes/crons/setup/java.mdx
+++ b/platform-includes/crons/setup/java.mdx
@@ -54,6 +54,29 @@ CheckInUtils.withCheckIn("<monitor-slug>", monitorConfig) {
 }
 ```
 
+You can also check-in to a specific environment.
+
+```java
+import io.sentry.MonitorSchedule;
+import io.sentry.MonitorScheduleUnit;
+import io.sentry.util.CheckInUtils;
+
+String result = CheckInUtils.withCheckIn("<monitor-slug>", "<environment-name>", () -> {
+    // Execute your scheduled task here...
+    return "computed result";
+});
+```
+
+```kotlin
+import io.sentry.MonitorSchedule
+import io.sentry.MonitorScheduleUnit
+import io.sentry.util.CheckInUtils
+
+CheckInUtils.withCheckIn("<monitor-slug>", "<environment-name>") {
+    // Execute your scheduled task here...
+}
+```
+
 ### Manually sending check-ins
 
 It is also possible to manually send check-ins.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Adding documentation on how to check-in to an environment with `CheckInUtils` on Java platforms. Follows a change in the following PR: https://github.com/getsentry/sentry-java/pull/3889

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
