### PR TITLE
Suggest not to use `SentryGlobalGraphQLFilter` in newer SDK versions

### DIFF
--- a/platform-includes/getting-started-use/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-use/javascript.nestjs.mdx
@@ -72,11 +72,6 @@ import { SentryGlobalFilter } from "@sentry/nestjs/setup";
 export class AppModule {}
 ```
 
-{/* TODO(v9): Remove this note. */}
-
-**Note:** If you have a NestJS + GraphQL application and you are using the `@sentry/nestjs` SDK version `8.38.0` or earlier, replace the `SentryGlobalFilter` with the `SentryGlobalGraphQLFilter`.
-In SDK versions `8.39.0` and above, the `SentryGlobalFilter` will handle GraphQL contexts automatically.
-
 By default, exceptions with status code 4xx are not sent to Sentry. If you still want to capture these exceptions, you can do so manually with `Sentry.captureException()`:
 
 ```javascript {9}

--- a/platform-includes/getting-started-use/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-use/javascript.nestjs.mdx
@@ -1,10 +1,10 @@
 ```javascript {filename: main.ts}
 // Import this first!
-import './instrument';
+import "./instrument";
 
 // Now import other modules
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -17,15 +17,15 @@ bootstrap();
 Afterwards, add the `SentryModule` as a root module to your main module:
 
 ```javascript {filename: app.module.ts} {2, 8}
-import { Module } from '@nestjs/common';
-import { SentryModule } from '@sentry/nestjs/setup';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { Module } from "@nestjs/common";
+import { SentryModule } from "@sentry/nestjs/setup";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
 
 @Module({
   imports: [
-      SentryModule.forRoot(),
-      // ...other modules
+    SentryModule.forRoot(),
+    // ...other modules
   ],
   controllers: [AppController],
   providers: [AppService],
@@ -56,9 +56,9 @@ module. This filter will report all unhandled errors to Sentry that are not caug
 **Important:** The `SentryGlobalFilter` needs to be registered before any other exception filters.
 
 ```javascript {3, 9}
-import { Module } from '@nestjs/common';
-import { APP_FILTER } from '@nestjs/core';
-import { SentryGlobalFilter } from '@sentry/nestjs/setup';
+import { Module } from "@nestjs/common";
+import { APP_FILTER } from "@nestjs/core";
+import { SentryGlobalFilter } from "@sentry/nestjs/setup";
 
 @Module({
   providers: [
@@ -72,7 +72,10 @@ import { SentryGlobalFilter } from '@sentry/nestjs/setup';
 export class AppModule {}
 ```
 
-**Note:** In NestJS + GraphQL applications replace the `SentryGlobalFilter` with the `SentryGlobalGraphQLFilter`.
+{/* TODO(v9): Remove this note. */}
+
+**Note:** If you have a NestJS + GraphQL application and you are using the `@sentry/nestjs` SDK version `8.38.0` or earlier, replace the `SentryGlobalFilter` with the `SentryGlobalGraphQLFilter`.
+In SDK versions `8.39.0` and above, the `SentryGlobalFilter` will handle GraphQL contexts automatically.
 
 By default, exceptions with status code 4xx are not sent to Sentry. If you still want to capture these exceptions, you can do so manually with `Sentry.captureException()`:
 

--- a/platform-includes/getting-started-use/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-use/javascript.nestjs.mdx
@@ -72,6 +72,11 @@ import { SentryGlobalFilter } from "@sentry/nestjs/setup";
 export class AppModule {}
 ```
 
+{/* TODO(v9): Remove this note. */}
+
+**Note:** If you have a NestJS + GraphQL application and you are using the `@sentry/nestjs` SDK version `8.38.0` or earlier, replace the `SentryGlobalFilter` with the `SentryGlobalGenericFilter`.
+In SDK versions `8.39.0` and above, the `SentryGlobalGenericFilter` is deprecated because the `SentryGlobalFilter` will handle GraphQL contexts automatically.
+
 By default, exceptions with status code 4xx are not sent to Sentry. If you still want to capture these exceptions, you can do so manually with `Sentry.captureException()`:
 
 ```javascript {9}


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Ref: https://github.com/getsentry/sentry-javascript/issues/14292

We don't want to suggest using this class because it is problematic. Also `SentryGlobalGenericFilter` is deprecated but necessary for now.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+