### PR TITLE
Deprecate `SessionTiming` and `Debug` integrations

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/debug.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/debug.mdx
@@ -1,7 +1,16 @@
 ---
 title: Debug
-description: "Allows you to inspect the contents of a processed event and hint object that gets passed to beforeSend or beforeSendTransaction."
+description: "Allows you to inspect the contents of a processed event and hint object that gets passed to beforeSend or beforeSendTransaction. (deprecated)"
 ---
+
+{/* TODO(v9): Remove this page and all references to it */}
+
+<Alert title="Deprecation Notice">
+
+The `Debug` Integration is deprecated and will be removed in the next major version of the SDK.
+To log outgoing events, we recommend using <PlatformLink to="/configuration/options/#hooks">Hook Options</PlatformLink> in `Sentry.init()`.
+
+</Alert>
 
 _Import name: `Sentry.debugIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/sessiontiming.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/sessiontiming.mdx
@@ -8,7 +8,7 @@ description: "Adds session timing data to events. (deprecated)"
 <Alert title="Deprecation Notice">
 
 The `SessionTiming` Integration is deprecated and will be removed in the next major version of the SDK.
-To capture session durations alongside events we recommend using <PlatformLink to="/enriching-events/context/">Context</PlatformLink>.
+To capture session durations alongside events, we recommend using <PlatformLink to="/enriching-events/context/">Context</PlatformLink>.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/sessiontiming.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/sessiontiming.mdx
@@ -1,7 +1,16 @@
 ---
 title: SessionTiming
-description: "Adds session timing data to events."
+description: "Adds session timing data to events. (deprecated)"
 ---
+
+{/* TODO(v9): Remove this page and all references to it */}
+
+<Alert title="Deprecation Notice">
+
+The `SessionTiming` Integration is deprecated and will be removed in the next major version of the SDK.
+To capture session durations alongside events we recommend using <PlatformLink to="/enriching-events/context/">Context</PlatformLink>.
+
+</Alert>
 
 _Import name: `Sentry.sessionTimingIntegration`_
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

These integrations are going to get removed soon.

https://github.com/getsentry/sentry-javascript/issues/14272

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+