### PR TITLE
Fix the snippet from the example on how to set up the browser tracing integration

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
@@ -34,6 +34,6 @@ Read more about [setting up BrowserTracing](./../../../tracing/).
 
 ```JavaScript
 Sentry.init({
-  integrations: [new Sentry.browserTracingIntegration()],
+  integrations: [Sentry.browserTracingIntegration()],
 });
 ```


### PR DESCRIPTION
This PR fixes one JS snippet from the chapter on the browser tracing integration. `Sentry.browserTracingIntegration()` is a function, not a constructor. like [here](https://docs.sentry.io/platforms/javascript/tracing/).

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
