### PR TITLE
ref(profiling): add note for profiles stack trace rules

### DIFF
--- a/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
+++ b/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
@@ -6,25 +6,27 @@ description: "Learn how to use stack trace rules to group incoming events based 
 
 <Include name="only-error-issues-note.mdx" />
 
-<Note>
-A subset of stack trace rules, when defined, will also be applied to incoming profiles in order to improve the frames classification (in-app vs system).
+Stack trace rules improve issue tracking by ensuring accurate grouping and better classification of stack frames as in-app or system. This helps focus on relevant code, reduces noise, and minimizes false positives. By tailoring rules to your project, you can streamline debugging and maintain consistency across teams or multiple applications.
 
-More specifically, only the rules with any of these matchers and actions (below) will be applied to profiles.
+When you set stack trace rules (previously known as _grouping enhancements_) for grouping in Sentry, they influence the data that's fed into the grouping algorithm. These rules can be configured on a per-project basis by going to your project settings and then clicking on "Issue Grouping". 
 
-Matchers allowed:
+Here are a few things to note about stack trace rules:
+
+- Each rule is written on a single line.
+- Rules consist of one or more match expressions followed by one or more actions triggered when all expressions match.
+- Rules are applied sequentially, from top to bottom, across all frames in the stack trace.
+
+In addition, the stack trace rules using the below matchers and actions can also be applied to incoming profiles to improve frame classification (in-app vs system, for example). 
+
+Allowed Matchers:
   * `stack.abs_path`
   * `stack.module`
   * `stack.function`
   * `stack.package`
- 
-Actions allowed:
+  
+Allowed Actions:
   * `+app`
   * `-app`
-</Note>
-
-If you use stack traces for grouping, the stack trace rules (previously known as _grouping enhancements_) influence the data that's fed into the grouping algorithm. These rules can be configured on a per-project basis in **[Project] > Settings > Issue Grouping > Stack Trace Rules**.
-
-Each line is a single rule; one or multiple match expressions are followed by one or multiple actions to be executed when all expressions match. All rules are executed from top to bottom on all frames in the stack trace.
 
 The syntax for stack trace rules is similar to:
 

--- a/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
+++ b/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
@@ -6,6 +6,22 @@ description: "Learn how to use stack trace rules to group incoming events based 
 
 <Include name="only-error-issues-note.mdx" />
 
+<Note>
+A subset of stack trace rules, when defined, will also be applied to incoming profiles in order to improve the frames classification (in-app vs system).
+
+More specifically, only the rules with any of these matchers and actions (below) will be applied to profiles.
+
+Matchers allowed:
+  `stack.abs_path`
+  `stack.module`
+  `stack.function`
+  `stack.package`
+ 
+Actions allowed:
+  `+app`
+  `-app`
+</Note>
+
 If you use stack traces for grouping, the stack trace rules (previously known as _grouping enhancements_) influence the data that's fed into the grouping algorithm. These rules can be configured on a per-project basis in **[Project] > Settings > Issue Grouping > Stack Trace Rules**.
 
 Each line is a single rule; one or multiple match expressions are followed by one or multiple actions to be executed when all expressions match. All rules are executed from top to bottom on all frames in the stack trace.

--- a/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
+++ b/docs/concepts/data-management/event-grouping/stack-trace-rules.mdx
@@ -12,14 +12,14 @@ A subset of stack trace rules, when defined, will also be applied to incoming pr
 More specifically, only the rules with any of these matchers and actions (below) will be applied to profiles.
 
 Matchers allowed:
-  `stack.abs_path`
-  `stack.module`
-  `stack.function`
-  `stack.package`
+  * `stack.abs_path`
+  * `stack.module`
+  * `stack.function`
+  * `stack.package`
  
 Actions allowed:
-  `+app`
-  `-app`
+  * `+app`
+  * `-app`
 </Note>
 
 If you use stack traces for grouping, the stack trace rules (previously known as _grouping enhancements_) influence the data that's fed into the grouping algorithm. These rules can be configured on a per-project basis in **[Project] > Settings > Issue Grouping > Stack Trace Rules**.


### PR DESCRIPTION
Add note to the stack trace rules to explain that a subset of those rules will now be applied to profiles as well.

----------

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
