### PR TITLE
docs(flags): add index flag docs for python

### DIFF
--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -22,6 +22,6 @@ Please read the note below to ensure that you also complete one additional step.
 
 <Alert level="warning" title="Note">
 
-In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/). 
+In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/#set-up-your-integration-specific-webhook). 
 
 </Alert>

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Set Up Feature Flags
+sidebar_order: 5200
+description: "Learn how to enable Feature Flags in your app if it is not already set up."
+---
+
+Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
+
+Learn more about the integrations available for Python and how to set them up:
+- [OpenFeature](/platforms/python/integrations/openfeature/)
+- [LaunchDarkly](/platforms/python/integrations/launchdarkly/)

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -10,7 +10,9 @@ description: With Feature Flags, Sentry tracks flag evaluations in your applicat
 
 </Alert>
 
-Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
+## Prerequisites
+
+* You have the <PlatformLink to="/">Python SDK installed</PlatformLink> (version 2.18.0 or higher).
 
 ## Enable Evaluation Tracking
 

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -1,27 +1,24 @@
 ---
 title: Set Up Feature Flags
 sidebar_order: 5200
-description: Learn how to set up feature flag evaluation tracking and feature flag change tracking.
+description: With Feature Flags, Sentry tracks flag evaluations in your application and reports their state on error. Sentry will also record an audit log of feature flag changes and report any suspicious changes that may have triggered an error.
 ---
 
 <Alert level="info" title="Currently in Beta">
 
-The support for **feature flag change tracking** and **feature flag evaluation tracking** is currently in beta.
+**Feature flag change tracking** and **feature flag evaluation tracking** is currently in closed beta. If you'd like to be added to the beta, please fill out [this form](https://forms.gle/EeNwTepvVwt7poAJ8).
 
 </Alert>
 
 Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
 
-To set up **feature flag evaluation tracking**, you will need to set up your language-specific SDK to include Sentry's feature flag integration. 
+## Enable Evaluation Tracking
 
-Learn more about the integrations available for Python and how to set them up:
+Evaluation tracking requires enabling an SDK integration. Integrations are provider specific. Documentation for supported providers is listed below.
+
 - [OpenFeature](/platforms/python/integrations/openfeature/)
 - [LaunchDarkly](/platforms/python/integrations/launchdarkly/)
 
-Please read the note below to ensure that you also complete one additional step.
+## Enable Change Tracking
 
-<Alert level="warning" title="Note">
-
-In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/#set-up-your-integration-specific-webhook). 
-
-</Alert>
+Change tracking requires registering a Sentry webhook with your feature flag provider. Set up varies by provider and is documented in detail [here](/product/explore/feature-flags/#set-up-your-integration-specific-webhook).

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -1,8 +1,14 @@
 ---
 title: Set Up Feature Flags
 sidebar_order: 5200
-description: "Learn how to enable Feature Flags in your app if it is not already set up."
+description: Learn how to set up feature flag evaluation tracking and feature flag change tracking.
 ---
+
+<Alert level="info" title="Currently in Beta">
+
+The support for **feature flag change tracking** and **feature flag evaluation tracking** is currently in beta.
+
+</Alert>
 
 Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
 

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -12,6 +12,16 @@ The support for **feature flag change tracking** and **feature flag evaluation t
 
 Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
 
+To set up **feature flag evaluation tracking**, you will need to set up your language-specific SDK to include Sentry's feature flag integration. 
+
 Learn more about the integrations available for Python and how to set them up:
 - [OpenFeature](/platforms/python/integrations/openfeature/)
 - [LaunchDarkly](/platforms/python/integrations/launchdarkly/)
+
+Please read the note below to ensure that you also complete one additional step.
+
+<Alert level="warning" title="Note">
+
+In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/). 
+
+</Alert>


### PR DESCRIPTION
create a index page for feature flags under the python platform (currently we only have specific instructions under each of the integrations, e.g. https://docs.sentry.io/platforms/python/integrations/openfeature/)

url will be: https://docs.sentry.io/platforms/python/feature-flags/

[figjam ref](https://www.figma.com/board/ZFPJSbpTYyjMzkp0qqWAgp/Feature-Flag-Docs-Map?node-id=1-596&node-type=shape_with_text&t=gMvrvhNpF7u073HY-0) mapping out the docs

![localhost_3000_platforms_python_feature-flags_ (1)](https://github.com/user-attachments/assets/ba411264-3963-4557-9273-11d9ed629658)
