### PR TITLE
Add new "Unknown" check-in status to Crons monitor details docs

### DIFF
--- a/docs/product/crons/monitor-details.mdx
+++ b/docs/product/crons/monitor-details.mdx
@@ -23,6 +23,7 @@ Sentry's Cron Monitoring service can notify you and store a timeline of the foll
   - An invalid request format.
 - **Failed check-in:** The job has reported its execution as unsuccessful.
 - **Successful check-in:** The job has reported its execution as successful.
+- **Unknown check-in:** In rare occasions, it is possible that Sentry is unable to identify a check-in status. This can happen during outages or maintenance periods.
 
 To see information about your cron monitor, select "Crons" from the sidebar menu and click on your cron monitor's name.
 

--- a/docs/product/crons/monitor-details.mdx
+++ b/docs/product/crons/monitor-details.mdx
@@ -1,8 +1,18 @@
 ---
-title: Job Monitoring
+title: Monitor Details
 sidebar_order: 1
-description: "Learn how to set up monitor notifications, monitor the same job in multiple environments, and manage your monitor in the Sentry UI."
+description: "Learn how to navigate the Monitor Details page to help you understand your recurring job's overall health."
 ---
+
+The **Monitor Details** page is where you'll find a daily historical bar chart showing successful, failed, and missed check-ins and a line chart of the runtime average for the job execution.
+
+The "Issues" section shows the issues created from this Cron Monitor. Issues are created when a cron monitor job execution is missed or failed. If you have configured the Sentry SDK for your job, any errors thrown during the job runtime will be shown here as well.
+
+The table of recent check-ins lists previously scheduled jobs and their statuses.
+
+<Arcade src="https://demo.arcade.software/7XmPfL0l2pp6KmBUXwMc?embed" />
+
+## Check-in Statuses
 
 Sentry's Cron Monitoring service can notify you and store a timeline of the following check-in events:
 
@@ -15,16 +25,6 @@ Sentry's Cron Monitoring service can notify you and store a timeline of the foll
 - **Successful check-in:** The job has reported its execution as successful.
 
 To see information about your cron monitor, select "Crons" from the sidebar menu and click on your cron monitor's name.
-
-## Cron Monitor Details
-
-This is where you'll find a daily historical bar chart showing successful, failed, and missed check-ins and a line chart of the runtime average for the job execution.
-
-The "Issues" section shows the issues created from this Cron Monitor. Issues are created when a cron monitor job execution is missed or failed. If you have configured the Sentry SDK for your job, any errors thrown during the job runtime will be shown here as well.
-
-The table of recent check-ins lists previously scheduled jobs and their statuses.
-
-<Arcade src="https://demo.arcade.software/7XmPfL0l2pp6KmBUXwMc?embed" />
 
 ## Multiple Environments
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3351,6 +3351,10 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     from: '/clients/cordova/',
     to: '/platforms/javascript/guides/cordova/',
   },
+  {
+    from: '/product/crons/job-monitoring/',
+    to: '/product/crons/monitor-details/',
+  },
 ];
 
 const DEVELOPER_DOCS_REDIRECTS: Redirect[] = [


### PR DESCRIPTION
## DESCRIBE YOUR PR
Renames the job monitoring page to monitor details and adds a new description for the "Unknown" check-in status.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
