### PR TITLE
feat(sdk): Request compression with `zstd` is supported

### DIFF
--- a/develop-docs/sdk/overview.mdx
+++ b/develop-docs/sdk/overview.mdx
@@ -262,6 +262,7 @@ and Sentry:
 - `deflate`: Using [zlib](http://tools.ietf.org/html/rfc1950) structure with the
   [deflate](http://tools.ietf.org/html/rfc1951) compression algorithm.
 - `br`: Using the [Brotli](https://en.wikipedia.org/wiki/Brotli) algorithm.
+- `zstd`: Using the [zstd](https://datatracker.ietf.org/doc/html/rfc8878) algorithm.
 
 ## Transfer Encoding
 


### PR DESCRIPTION
See https://github.com/getsentry/relay/pull/4089


