### PR TITLE
Fix code example for Sentry JavaScript DataLoader()

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/dataloader.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/dataloader.mdx
@@ -33,7 +33,7 @@ The `dataloaderIntegration` adds instrumentation for the `dataloader` library to
 
 ```javascript
 Sentry.init({
-  integrations: [new Sentry.dataloaderIntegration()],
+  integrations: [Sentry.dataloaderIntegration()],
 });
 ```
 


### PR DESCRIPTION
It used a constructor syntax but this throws a `TypeError: Sentry.dataloaderIntegration is not a constructor`.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
