### PR TITLE
chore(Profiling): Add callouts and links to Android Profiling troubleshooting info

### DIFF
--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -30,9 +30,20 @@ Select which Sentry features you'd like to install in addition to Error Monitori
   options={[
     'error-monitoring',
     'performance',
-    'profiling',
+    {
+      id: 'profiling',
+      checked: false
+    },
   ]}
 />
+
+<OnboardingOption optionId="profiling">
+
+<Alert level="warning">
+  Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
+</Alert>
+
+</OnboardingOption>
 
 ## Install
 

--- a/docs/platforms/android/profiling/index.mdx
+++ b/docs/platforms/android/profiling/index.mdx
@@ -7,6 +7,10 @@ sidebar_order: 5000
 <PlatformContent includePath="profiling/index/preface" />
 <PlatformContent includePath="profiling/index/why-profiling" />
 
+<Alert level="warning" title="Important">
+  Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
+</Alert>
+
 ## Enable Tracing
 
 Profiling depends on Sentry’s Tracing product being enabled beforehand. To enable tracing in the SDK:

--- a/docs/platforms/android/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/android/profiling/troubleshooting/index.mdx
@@ -4,6 +4,16 @@ description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---
 
+## I see elevated number of crashes in the Android Runtime when profiling is activated
+
+Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. Read on for more information, and subscribe to this <Link to="https://github.com/getsentry/sentry-java/issues/3679">GitHub issue</Link> for updates.
+
+As of October 2024, two of these crashes (see <Link to="https://github.com/getsentry/sentry-java/issues/3561#issuecomment-2361054644">1</Link>, <Link to="https://github.com/getsentry/sentry-java/issues/3653">2</Link>) have been acknowledged and fixed by Google. The fixes are being rolled out to affected devices by Google, but the crashing behaviur might still be present on devices that didn't receive the fix.
+
+There is one <Link to="https://github.com/getsentry/sentry-java/issues/2604">other issue</Link>, where the likely root cause is incorrect native thread handling by app code or third party code. This means that it can also not be fixed in the Sentry SDK. If you experience this, please comment on the <Link to="https://github.com/getsentry/sentry-java/issues/2604">GitHub issue</Link>.
+
+## I don't see any profiling data in [sentry.io](https://sentry.io)
+
 If you don't see any profiling data in [sentry.io](https://sentry.io), you can try the following:
 
 - Ensure that <PlatformLink to="/tracing/">Tracing is enabled</PlatformLink>.

--- a/docs/platforms/android/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/android/profiling/troubleshooting/index.mdx
@@ -8,7 +8,7 @@ sidebar_order: 9000
 
 Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. Read on for more information, and subscribe to this <Link to="https://github.com/getsentry/sentry-java/issues/3679">GitHub issue</Link> for updates.
 
-As of October 2024, two of these crashes (see <Link to="https://github.com/getsentry/sentry-java/issues/3561#issuecomment-2361054644">1</Link>, <Link to="https://github.com/getsentry/sentry-java/issues/3653">2</Link>) have been acknowledged and fixed by Google. The fixes are being rolled out to affected devices by Google, but the crashing behaviur might still be present on devices that didn't receive the fix.
+As of October 2024, two of these crashes (see <Link to="https://github.com/getsentry/sentry-java/issues/3561#issuecomment-2361054644">1</Link>, <Link to="https://github.com/getsentry/sentry-java/issues/3653">2</Link>) have been acknowledged and fixed by Google. The fixes are being rolled out to affected devices by Google, but the crashing behavior might still be present on devices that didn't receive the fix yet.
 
 There is one <Link to="https://github.com/getsentry/sentry-java/issues/2604">other issue</Link>, where the likely root cause is incorrect native thread handling by app code or third party code. This means that it can also not be fixed in the Sentry SDK. If you experience this, please comment on the <Link to="https://github.com/getsentry/sentry-java/issues/2604">GitHub issue</Link>.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

- Add callouts to [Android](https://docs.sentry.io/platforms/android/) and [Android Profiling](https://docs.sentry.io/platforms/android/profiling) landing pages about current issues with Android Runtime `tracer`
- Make `Profiling` option **off by default** on [Android](https://docs.sentry.io/platforms/android/) landing page
- Add entry to [Android Profiling Troubleshooting](https://docs.sentry.io/platforms/android/profiling/troubleshooting/) page and link to that from the callouts

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: no specific date, but want to publish in the next few days
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
