### PR TITLE
chore: Remove example values from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,5 @@
 # warning: variables prefixed with NEXT_PUBLIC_ will be made available to client-side code
 # be careful not to expose sensitive data (in this case your Algolia admin key)
 
-NEXT_PUBLIC_ALGOLIA_APP_ID=OOK48W9UCL
-NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=ca98597f559459c216891b75989832f8  #trufflehog:ignore
+NEXT_PUBLIC_ALGOLIA_APP_ID=
+NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=


### PR DESCRIPTION
These values are being set in ci anyway, no need have these in the example file.