### PR TITLE
docs(js): Add warning for usage of beforeSendSpan

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -288,6 +288,8 @@ This function is called with an SDK-specific transaction event object, and can r
 
 <ConfigKey name="before-send-span">
 
+<Include name="platforms/configuration/options/warn-before-send-span.mdx" />
+
 This function is called with a serialized span object, and can return a modified span object, or `null` to skip sending the span. This might be useful for manually stripping PII from spans or to remove individual spans from the span tree.
 This function is only called for child spans of the root span. If you want to modify or drop the root span, including all of its child spans, use [`beforeSendTransaction`](#before-send-transaction) instead.
 

--- a/includes/platforms/configuration/options/warn-before-send-span.mdx
+++ b/includes/platforms/configuration/options/warn-before-send-span.mdx
@@ -1,0 +1,5 @@
+{/* TODO(v9): Remove this alert in js sdk v9 */}
+
+<Alert level="warning">
+  In the Sentry JavaScript SDK v9.0.0, the ability to drop spans via `beforeSendSpan` will be removed. The callback will only allow modifying span attributes.
+</Alert>

--- a/includes/platforms/configuration/options/warn-before-send-span.mdx
+++ b/includes/platforms/configuration/options/warn-before-send-span.mdx
@@ -1,5 +1,5 @@
 {/* TODO(v9): Remove this alert in js sdk v9 */}
 
 <Alert level="warning">
-  In the Sentry JavaScript SDK v9.0.0, the ability to drop spans via `beforeSendSpan` will be removed. The callback will only allow modifying span attributes.
+  In the Sentry JavaScript SDK v9.0.0, the ability to drop spans via `beforeSendSpan` by returning `null` will be removed. The callback will only allow modifying span attributes.
 </Alert>

--- a/platform-includes/configuration/before-send-span/javascript.mdx
+++ b/platform-includes/configuration/before-send-span/javascript.mdx
@@ -1,3 +1,5 @@
+<Include name="platforms/configuration/options/warn-before-send-span.mdx" />
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",


### PR DESCRIPTION
documents https://github.com/getsentry/sentry-javascript/issues/14335

