### PR TITLE
dotnet: remove note on legacy sdk

### DIFF
--- a/docs/platforms/dotnet/index.mdx
+++ b/docs/platforms/dotnet/index.mdx
@@ -14,8 +14,6 @@ If you don't already have an account and Sentry project established, head over t
 
 </Note>
 
-This <PlatformLink to="/compatibility/">SDK is compatible</PlatformLink> with the latest .NET and .NET Core platforms, as well as .NET Standard 2.0 and .NET Framework 4.6.2 or newer. You can use it with applications written in C#, VB.NET, F#, and other .NET programming languages. For older versions, such as .NET Framework 3.5, you may continue to use our <Link rel={`nofollow`} to={`/platforms/dotnet/legacy-sdk/`}>legacy SDK</Link>, until further notice. Check out related guides in the dropdown menu on the left.
-
 ## Features
 
 In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](/product/explore/profiling/).
@@ -48,7 +46,7 @@ Install the **NuGet** package to add the Sentry dependency:
 
   <Note>
 
-  Sentry profiling for .NET is available in Alpha on .NET 6.0+ (tested on .NET 7.0 & .NET 8.0 as well).
+  Sentry profiling for .NET is available in Alpha on .NET 6.0 and newer.
 
   </Note>
 


### PR DESCRIPTION
To simplify things (referring to .NET Framework 3.5 at the top of the docs isn't helpful)