### PR TITLE
feat: Link to Replay Issues when we mention Perf Issues as well

### DIFF
--- a/includes/only-error-issues-note.mdx
+++ b/includes/only-error-issues-note.mdx
@@ -1,5 +1,5 @@
 <Note>
 
-This feature is only applicable for [error issues](/product/issues/issue-details/error-issues/) with debug information files, excluding source maps. Other categories of issues (such as [performance issues](/product/issues/issue-details/performance-issues/)) do not support this feature.
+This feature is only applicable for [error issues](/product/issues/issue-details/error-issues/) with debug information files, excluding source maps. Other categories of issues (such as [performance issues](/product/issues/issue-details/performance-issues/) or [replay issues](/product/issues/issue-details/replay-issues/)) do not support this feature.
 
 </Note>


### PR DESCRIPTION
On `/product/releases/associate-commits/` we mention:
>This feature is only applicable for [error issues](https://docs.sentry.io/product/issues/issue-details/error-issues/) with debug information files, excluding source maps. Other categories of issues (such as [performance issues](https://docs.sentry.io/product/issues/issue-details/performance-issues/)) do not support this feature.

This change adds `Replay Issues` to the list in parens.


**Before**
<img width="766" alt="SCR-20241125-ryna" src="https://github.com/user-attachments/assets/b5b15feb-62aa-4245-9a20-73b58dd10f2a">

**After**
<img width="759" alt="SCR-20241125-rzah" src="https://github.com/user-attachments/assets/dbbb5008-1dad-40b6-ba74-e4dd00e3df57">
