### PR TITLE
fix(js): Correct function names for `startProfiler`

### DIFF
--- a/docs/platforms/javascript/guides/node/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/node/profiling/index.mdx
@@ -101,7 +101,7 @@ _(New in version 8.28.0)_
 
 The current profiling implementation stops the profiler automatically after 30 seconds (unless you manually stop it earlier). Naturally, this limitation makes it difficult to get full coverage of your app's execution. We now offer an experimental continuous mode, where profiling data is periodically uploaded while running, with no limit on how long the profiler may run.
 
-To get started with continuous profiling, you can start and stop the profiler directly with `Sentry.profiler.startProfiling` and `Sentry.profiler.stopProfiling`.
+To get started with continuous profiling, you can start and stop the profiler directly with `Sentry.profiler.startProfiler` and `Sentry.profiler.stopProfiler`.
 
 <Note>
 
@@ -116,11 +116,11 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
 });
 
-Sentry.profiler.startProfiling();
+Sentry.profiler.startProfiler();
 
 // run some code here
 
-Sentry.profiler.stopProfiling();
+Sentry.profiler.stopProfiler();
 ```
 
 These new APIs do not offer any sampling functionality—every call to start the profiler will run and start sending profiling data. If you are interested in reducing the amount of profiles that run, you must take care to do it at the callsites.


### PR DESCRIPTION
`Sentry.profiler.startProfiling` is not a function:

	TypeError: Sentry.profiler.startProfiling is not a function
		at file:///root/workspace/meteogram/instrument.mjs:46:17
		at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
		at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
		at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:118:9)

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->
