### PR TITLE
devenv: internal troubleshooting

### DIFF
--- a/develop-docs/development-infrastructure/environment/index.mdx
+++ b/develop-docs/development-infrastructure/environment/index.mdx
@@ -187,7 +187,9 @@ SENTRY_SILO_DEVSERVER=1 SENTRY_SILO_MODE=REGION SENTRY_REGION=us getsentry djang
 
 ## Troubleshooting
 
-You might also be interested in <Link to="/development/continuous-integration/#troubleshooting-ci">troubleshooting CI</Link>.
+The more up-to-date troubleshooting docs for the internal development environment on MacOS are <Link to="https://www.notion.so/sentry/devenv-troubleshooting-1448b10e4b5d8080ba04f452e33de48d">here</Link>.
+
+You might also be interested in <Link to="/development/continuous-integration/#troubleshooting-ci">Troubleshooting CI</Link>.
 
 ---
 
@@ -210,7 +212,7 @@ following in getsentry:
 
 **Problem:** You see an error that mentions something like `pkg_resources.DistributionNotFound: The 'some_dependency<0.6.0,>=0.5.5' distribution was not found and is required by sentry`
 
-**Solution:** Your virtualenv needs to be updated. Run `make install-py-dev`.
+**Solution:** Your virtualenv needs to be updated. Run `devenv sync`.
 
 ---
 

--- a/develop-docs/development-infrastructure/python-dependencies.mdx
+++ b/develop-docs/development-infrastructure/python-dependencies.mdx
@@ -23,7 +23,7 @@ To add or manually update a dependency:
 5. In that repo, add to or update `requirements-base.txt` or `requirements-dev.txt`, as appropriate. Note that many of our dependencies are pinned with lower bounds only, to encourage updating to latest versions, though we do use exact pins for certain core dependencies like `django`. Choose whichever one feels most appropriate in your case.
 6. Run `make freeze-requirements`. You might need to wait a few minutes for the changes to `getsentry/pypi` to be deployed before this will work without erroring.
 7. Commit your changes (which should consist of changes to both one of the `requirements` files and its corresponding lockfile) to a branch and open a PR in the relevant repo. If it's not obvious, explain why you're adding or updating the dependency. Tag `owners-python-build` if they haven't already been auto-tagged.
-8. Merge your PR, pull `master`, and run `make install-py-dev`.
+8. Merge your PR, pull `master`, and run `devenv sync`.
 
 To update a dependency using GitHub Actions:
 


### PR DESCRIPTION
adds a link to internal troubleshooting doc + updates the obsoleted `make install-py-dev` with `devenv sync`