### PR TITLE
docs(relay): update the data scrubbing default values

### DIFF
--- a/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx
+++ b/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx
@@ -20,15 +20,13 @@ With it enabled, Sentry will scrub the following:
   - passwd
   - api_key
   - apikey
-  - access_token
   - auth
   - credentials
   - mysql_pwd
-  - stripetoken
-  - card[number]
-  - github_token
   - privatekey
   - private_key
+  - token
+  - bearer
 - Values that contain strings in, or whose keynames are listed in, [Project] > Settings > Security & Privacy in "Additional Sensitive Fields".
   - An entry in "Additional Sensitive Fields" such as `mysekret`, for example, will cause the removal of any field named `mysekret`, but also removes any field _value_ that contains `mysekret`. Sentry does this to protect against sensitive data leaking as part of structured data that has been sent as a single string to Sentry (such as a JSON object that is stringified and embedded as JSON string in another JSON structure).
   - As an extreme example where this behavior can become surprising, the string `"Unexpected error"` will be removed from events if the entry `exp` is in "Additional Sensitive Fields".


### PR DESCRIPTION
## Update the data scrubbing default values

After investigating a data scrubbing issue I found out, that the list in the docs differs from the list defined in the relay code.

[list in the current docs](https://github.com/getsentry/sentry-docs/blob/d92a2eba3798e43c824456d1ef55ddc802d607aa/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx?plain=1#L18-L31):
```
  - password
  - secret
  - passwd
  - api_key
  - apikey
  - access_token
  - auth
  - credentials
  - mysql_pwd
  - stripetoken
  - card[number]
  - github_token
  - privatekey
  - private_key
```

[list in the current relay code](https://github.com/getsentry/relay/blob/a2f9e1100100c93b3a680a45a46379655e4d7f15/relay-pii/src/regexes.rs#L289):
``` rs
password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|token|bearer
```

comparing these two lists I updated the docs and removed:
```
- access_token
- stripetoken
- card[number]
- github_token
```

and added these:
```
- token
- bearer
```

@iambriccardo can you have a look and verify that my assumptions are correct?

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
