### PR TITLE
docs(flags): add product index page for feature flags

### DIFF
--- a/docs/product/explore/feature-flags/index.mdx
+++ b/docs/product/explore/feature-flags/index.mdx
@@ -29,7 +29,7 @@ In order to take advantage of the full feature flag experience available, there 
 In order to gain access to **feature flag evaluation tracking**, you need to set up your SDK to include Sentry's feature flag integration.
 
 Learn more about the languages we currently support and how to set up the SDK:
-* JavaScript
+* [JavaScript](/platforms/javascript/feature-flags/)
 * [Python](/platforms/python/feature-flags/)
 
 ## Set Up Your Integration-Specific Webhook

--- a/docs/product/explore/feature-flags/index.mdx
+++ b/docs/product/explore/feature-flags/index.mdx
@@ -6,35 +6,27 @@ description: "Learn how to set up and interact with Sentry's feature flag evalua
 
 <Alert level="info" title="Currently in Beta">
 
-The support for **feature flag change tracking** and **feature flag evaluation tracking** is currently in beta.
+**Feature flag change tracking** and **feature flag evaluation tracking** is currently in closed beta. If you'd like to be added to the beta, please fill out [this form](https://forms.gle/EeNwTepvVwt7poAJ8).
 
 </Alert>
 
-Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
+Enabling a feature flag integration gives you deep insights into the state of your application prior to failure. A list of flags and their evaluation results are displayed on each error event. Integrating Sentry with your feature flag provider enables Sentry to correlate feature flag changes with new error events and mark certain changes as suspicious.
 
-## Touchpoints
+## Evaluation Tracking
 
-Feature flag insights can be found by navigating to the Issue Details page for any error event. There are two places where you can interact with flag data:
-* Flag updates (changes, deletions, and additions) will appear as a series on the event and user volume chart.
-* Flag evaluations will appear in the Feature Flag section in Issue Details as a table, with "suspect" flag predictions highlighted in yellow.
+Flag evaluations will appear in the "Feature Flag" section of Issue Details page as a table, with "suspect" flag predictions highlighted in yellow. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details docs](/product/issues/issue-details/#feature-flags/).
 
-Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details docs](/product/issues/issue-details/#feature-flags/).
+### Set Up Evaluation Tracking
 
-## Setup
-
-In order to take advantage of the full feature flag experience available, there are two steps necessary to set up **feature flag evaluation tracking** and **feature flag change tracking**. The first step — setting up the language-specific SDK — is necessary for evaluation tracking, and the second step — setting up your integration-specific webhook — is necessary for change tracking.
-
-## Set Up Your Language-Specific SDK
-
-In order to gain access to **feature flag evaluation tracking**, you need to set up your SDK to include Sentry's feature flag integration.
-
-Learn more about the languages we currently support and how to set up the SDK:
+Supported Platforms:
 * [JavaScript](/platforms/javascript/feature-flags/)
 * [Python](/platforms/python/feature-flags/)
 
-## Set Up Your Integration-Specific Webhook
+## Change Tracking
 
-In order to gain access to **feature flag change tracking**, you need to set up a webhook with your specific integration, so that it may communicate feature flag changes with Sentry.
+Change tracking enables Sentry to listen for updates to your feature flags' definitions. On change, we'll record the event in an audit log. The audit log appears in the "event volume" chart and presents itself as a "release" line. If the change is responsible for a new error event, we'll notify you by marking the feature flag as "suspect" on the issue details page. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details page documentation](/product/issues/issue-details/#feature-flags/).
 
-Learn more about the integrations we currently support and how to set up the webhook:
+### Set Up Change Tracking
+
+Supported Feature Flag Providers:
 * [LaunchDarkly](/organization/integrations/feature-flag/launchdarkly/)

--- a/docs/product/explore/feature-flags/index.mdx
+++ b/docs/product/explore/feature-flags/index.mdx
@@ -1,0 +1,40 @@
+---
+title: "Feature Flags"
+sidebar_order: 100
+description: "Learn how to set up and interact with Sentry's feature flag evaluation tracking and feature flag change tracking."
+---
+
+<Alert level="info" title="Currently in Beta">
+
+The support for **feature flag change tracking** and **feature flag evaluation tracking** is currently in beta.
+
+</Alert>
+
+Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
+
+## Touchpoints
+
+Feature flag insights can be found by navigating to the Issue Details page for any error event. There are two places where you can interact with flag data:
+* Flag updates (changes, deletions, and additions) will appear as a series on the event and user volume chart.
+* Flag evaluations will appear in the Feature Flag section in Issue Details as a table, with "suspect" flag predictions highlighted in yellow.
+
+Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details docs](/product/issues/issue-details/#feature-flags/).
+
+## Setup
+
+In order to take advantage of the full feature flag experience available, there are two steps necessary to set up **feature flag evaluation tracking** and **feature flag change tracking**. The first step — setting up the language-specific SDK — is necessary for evaluation tracking, and the second step — setting up your integration-specific webhook — is necessary for change tracking.
+
+## Set Up Your Language-Specific SDK
+
+In order to gain access to **feature flag evaluation tracking**, you need to set up your SDK to include Sentry's feature flag integration.
+
+Learn more about the languages we currently support and how to set up the SDK:
+* JavaScript
+* [Python](/platforms/python/feature-flags/)
+
+## Set Up Your Integration-Specific Webhook
+
+In order to gain access to **feature flag change tracking**, you need to set up a webhook with your specific integration, so that it may communicate feature flag changes with Sentry.
+
+Learn more about the integrations we currently support and how to set up the webhook:
+* [LaunchDarkly](/organization/integrations/feature-flag/launchdarkly/)


### PR DESCRIPTION
add a product landing page for feature flags!

url will be https://docs.sentry.io/product/explore/feature-flags/

[figjam ref](https://www.figma.com/board/ZFPJSbpTYyjMzkp0qqWAgp/Feature-Flag-Docs-Map?node-id=1-596&node-type=shape_with_text&t=gMvrvhNpF7u073HY-0) mapping out the docs

![localhost_3000_product_explore_feature-flags_ (1)](https://github.com/user-attachments/assets/8580c8e6-ab2f-4ce0-a181-ffb1c5b028f8)
