### PR TITLE
docs(flags): update python onboarding docs to include second step

### DIFF
--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -44,3 +44,11 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 
 Visit the Sentry website and confirm that your error event has recorded the feature flag "hello" and its value "false".
+
+Please read the note below to ensure that you also complete one additional step.
+
+<Alert level="warning" title="Note">
+
+In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/#set-up-your-integration-specific-webhook). 
+
+</Alert>

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -44,3 +44,11 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 
 Visit the Sentry website and confirm that your error event has recorded the feature flag "hello" and its value "false".
+
+Please read the note below to ensure that you also complete one additional step.
+
+<Alert level="warning" title="Note">
+
+In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/#set-up-your-integration-specific-webhook). 
+
+</Alert>


### PR DESCRIPTION
add info to the python-specific launchdarkly & openfeature onboarding docs to let users know that there's a second step needed to set up feature flags completely!