### PR TITLE
docs(flags): add index flag docs for javascript

### DIFF
--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -19,27 +19,26 @@ notSupported:
   - javascript.nestjs
   - javascript.nodejs
   - javascript.wasm
-description: "Learn how to set up feature flag evaluation tracking and feature flag change tracking."
+description: With Feature Flags, Sentry tracks flag evaluations in your application and reports their state on error. Sentry will also record an audit log of feature flag changes and report any suspicious changes that may have triggered an error.
 ---
 
 <Alert level="info" title="Currently in Beta">
 
-The support for **feature flag change tracking** and **feature flag evaluation tracking** is currently in beta.
+**Feature flag change tracking** and **feature flag evaluation tracking** is currently in closed beta. If you'd like to be added to the beta, please fill out [this form](https://forms.gle/EeNwTepvVwt7poAJ8).
 
 </Alert>
 
-Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
+## Prerequisites
 
-To set up **feature flag evaluation tracking**, you will need to set up your language-specific SDK to include Sentry's feature flag integration. 
+* You have the <PlatformLink to="/">Javascript SDK installed</PlatformLink> (version 8.41.0-beta.0 or higher).
 
-Learn more about the integrations available for JavaScript and how to set them up:
+## Enable Evaluation Tracking
+
+Evaluation tracking requires enabling an SDK integration. Integrations are provider specific. Documentation for supported providers is listed below.
+
 - [OpenFeature](/platforms/javascript/integrations/openfeature/)
 - [LaunchDarkly](/platforms/javascript/integrations/launchdarkly/)
 
-Please read the note below to ensure that you also complete one additional step.
+## Enable Change Tracking
 
-<Alert level="warning" title="Note">
-
-In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/#set-up-your-integration-specific-webhook). 
-
-</Alert>
+Change tracking requires registering a Sentry webhook with your feature flag provider. Set up varies by provider and is documented in detail [here](/product/explore/feature-flags/#set-up-your-integration-specific-webhook).

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Set Up Feature Flags
+sidebar_order: 7000
+notSupported:
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.bun
+  - javascript.capacitor
+  - javascript.cloudflare
+  - javascript.connect
+  - javascript.cordova
+  - javascript.deno
+  - javascript.electron
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.koa
+  - javascript.nestjs
+  - javascript.nodejs
+  - javascript.wasm
+description: "Learn how to set up feature flag evaluation tracking and feature flag change tracking."
+---
+
+<Alert level="info" title="Currently in Beta">
+
+The support for **feature flag change tracking** and **feature flag evaluation tracking** is currently in beta.
+
+</Alert>
+
+Link your external feature flag integrations with Sentry to provide feature flag insights right inside the Sentry UI. Linking one or more integrations will allow you to view recent flag evaluations in one place and identify potential suspect flags related to errors. In addition, Sentry will provide insights on feature flag updates relative to error event timelines.
+
+To set up **feature flag evaluation tracking**, you will need to set up your language-specific SDK to include Sentry's feature flag integration. 
+
+Learn more about the integrations available for JavaScript and how to set them up:
+- [OpenFeature](/platforms/javascript/integrations/openfeature/)
+- [LaunchDarkly](/platforms/javascript/integrations/launchdarkly/)
+
+Please read the note below to ensure that you also complete one additional step.
+
+<Alert level="warning" title="Note">
+
+In order to take full advantage of the feature flag capabilities Sentry offers, there is an additional setup step needed, which is setting up your integration-specific webhook. This is needed to enable **feature flag change tracking**, so that your integration may communicate feature flag changes to Sentry. Learn how to set this up by [reading the docs](/product/explore/feature-flags/#set-up-your-integration-specific-webhook). 
+
+</Alert>


### PR DESCRIPTION
create a index page for feature flags under the javascript platform. mirrors python index page: https://github.com/getsentry/sentry-docs/pull/11879

url will be: https://docs.sentry.io/platforms/javascript/feature-flags/

[figjam ref](https://www.figma.com/board/ZFPJSbpTYyjMzkp0qqWAgp/Feature-Flag-Docs-Map?node-id=1-596&node-type=shape_with_text&t=gMvrvhNpF7u073HY-0) mapping out the docs

![localhost_3000_platforms_javascript_feature-flags_](https://github.com/user-attachments/assets/cec5d20f-9b10-4efc-9e37-5a4849c145d2)

closes https://github.com/getsentry/team-replay/issues/503
