### PR TITLE
Fixed used data type for setting cache key 

### DIFF
--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -45,8 +45,8 @@ with sentry_sdk.start_span(op="cache.put") as span:
     span.set_data("network.peer.address", "cache.example.com/supercache")
     span.set_data("network.peer.port", 9000)
 
-    # Add the key you want to set
-    span.set_data("cache.key", key)
+    # Add the key(s) you want to set.
+    span.set_data("cache.key", [key])
 
     # Add the size of the value you stored in the cache
     span.set_data("cache.item_size", len(value))  # Warning: if value is very big this could use lots of memory
@@ -80,8 +80,8 @@ with sentry_sdk.start_span(op="cache.get") as span:
     span.set_data("network.peer.address", "cache.example.com/supercache")
     span.set_data("network.peer.port", 9000)
 
-    # Add the key you just retrieved from the cache
-    span.set_data("cache.key", key)
+    # Add the key(s) you just retrieved from the cache
+    span.set_data("cache.key", [key])
 
     if value is not None:
         # If you retrieved a value, the cache was hit

--- a/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -38,8 +38,8 @@ Sentry.with_child_span(op: 'cache.put') do |span|
   span.set_data('network.peer.address', 'cache.example.com/supercache')
   span.set_data('network.peer.port', 9000)
 
-  # Add the key you want to set
-  span.set_data('cache.key', key)
+  # Add the key(s) you want to set
+  span.set_data('cache.key', [key])
 
   # Add the size of the value you stored in the cache
   span.set_data('cache.item_size', value.size)  # Warning: if value is very big this could use lots of memory
@@ -69,8 +69,8 @@ Sentry.with_child_span(op: 'cache.get') do |span|
   span.set_data('network.peer.address', 'cache.example.com/supercache')
   span.set_data('network.peer.port', 9000)
 
-  # Add the key you just retrieved from the cache
-  span.set_data('cache.key', key)
+  # Add the key(s) you just retrieved from the cache
+  span.set_data('cache.key', [key])
 
   if value
     # If you retrieved a value, the cache was hit


### PR DESCRIPTION
For the Caches insights module to work, the `cache.key` data attribute of a spans needs to be an array, not a string. 

Fixing this in the code snippets for:
- [x] Python 
- [x] Ruby
- [ ] .NET

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
