### PR TITLE
docs(tracing) clarify span_id attribute

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -628,7 +628,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 `span_id`
 
-: _Required_. The ID of the span or transaction. If there's none available (e.g. in tracing without performance mode), a random span ID must be provided. [See the TwP docs](/sdk/telemetry/traces/tracing-without-performance/#attaching-trace-data-to-events-and-envelopes) for more details.
+: _Required_. The ID of the span or transaction. For non-transaction events, and if performance monitoring is disabled, it may still be desired to attach events to a trace via a trace ID. In these cases, you still need to provide a span ID. This span ID can effectively be entirely random and doesn't need to relate to an actual span, however, it is recommended to consider using the same span ID for multiple events within the same unit-of-execution (e.g. a request). [See the TwP docs](/sdk/telemetry/traces/tracing-without-performance/#attaching-trace-data-to-events-and-envelopes) for more details.
 
 - Example: `"bb8f278130535c3c"`
 

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -628,7 +628,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 `span_id`
 
-: _Required_. The ID of the span or transaction. If there's none available (e.g. in tracing without performance mode), a random span ID must be provided.
+: _Required_. The ID of the span or transaction. If there's none available (e.g. in tracing without performance mode), a random span ID must be provided. [See the TwP docs](/sdk/telemetry/traces/tracing-without-performance/#attaching-trace-data-to-events-and-envelopes) for more details.
 
 - Example: `"bb8f278130535c3c"`
 

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -628,7 +628,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 `span_id`
 
-: _Required_. The ID of the span.
+: _Required_. The ID of the span or transaction. If there's none available (e.g. in tracing without performance mode), a random span ID must be provided.
 
 - Example: `"bb8f278130535c3c"`
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

As discussed `span_id` is always required. Update docs to clarify a random span_id can be provided if none is available.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
