### PR TITLE
Moved configuration pages to where it belongs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: detect-private-key
         exclude: |
           (?x)^(
-              develop-docs/application-architecture/config.mdx|
+              develop-docs/api-server/config.mdx|
               develop-docs/integrations/github.mdx|
               develop-docs/self-hosted/sso.mdx
           )$

--- a/develop-docs/api-server/config.mdx
+++ b/develop-docs/api-server/config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_order: 30
+sidebar_order: 10
 ---
 
 This document describes configuration available to the Sentry server itself.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3656,6 +3656,10 @@ const DEVELOPER_DOCS_REDIRECTS: Redirect[] = [
     to: '/application-architecture/config/',
   },
   {
+    from: '/application-architecture/config/',
+    to: '/api-server/config/',
+  },
+  {
     from: '/application/sentry-vs-getsentry/',
     to: '/application-architecture/sentry-vs-getsentry/',
   },


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The "Configuration" page did not make sense in Application Architecture, because it documentas the configuration options one can set for the API server. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
