### PR TITLE
feat: Scrubbing HTTP Data from HTTP Spans

### DIFF
--- a/docs/platforms/android/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/android/data-management/sensitive-data/index.mdx
@@ -54,7 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/android/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/android/data-management/sensitive-data/index.mdx
@@ -54,6 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/apple/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/apple/common/data-management/sensitive-data/index.mdx
@@ -48,7 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/apple/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/apple/common/data-management/sensitive-data/index.mdx
@@ -48,6 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/dart/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/dart/data-management/sensitive-data/index.mdx
@@ -48,7 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/dart/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/dart/data-management/sensitive-data/index.mdx
@@ -48,6 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/dotnet/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/dotnet/common/data-management/sensitive-data/index.mdx
@@ -54,7 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/dotnet/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/dotnet/common/data-management/sensitive-data/index.mdx
@@ -54,6 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/elixir/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/elixir/data-management/sensitive-data/index.mdx
@@ -48,7 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/elixir/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/elixir/data-management/sensitive-data/index.mdx
@@ -48,6 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/flutter/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/flutter/data-management/sensitive-data/index.mdx
@@ -48,7 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/flutter/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/flutter/data-management/sensitive-data/index.mdx
@@ -48,6 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/go/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/go/common/data-management/sensitive-data/index.mdx
@@ -48,7 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/go/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/go/common/data-management/sensitive-data/index.mdx
@@ -48,6 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/java/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/java/common/data-management/sensitive-data/index.mdx
@@ -54,7 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/java/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/java/common/data-management/sensitive-data/index.mdx
@@ -54,6 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
@@ -49,7 +49,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
@@ -49,6 +49,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/php/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/php/common/data-management/sensitive-data/index.mdx
@@ -54,7 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/php/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/php/common/data-management/sensitive-data/index.mdx
@@ -54,6 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/powershell/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/powershell/data-management/sensitive-data/index.mdx
@@ -54,7 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/powershell/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/powershell/data-management/sensitive-data/index.mdx
@@ -54,6 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/python/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/python/data-management/sensitive-data/index.mdx
@@ -60,6 +60,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/python/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/python/data-management/sensitive-data/index.mdx
@@ -60,7 +60,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/react-native/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/react-native/data-management/sensitive-data/index.mdx
@@ -48,7 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/react-native/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/react-native/data-management/sensitive-data/index.mdx
@@ -48,6 +48,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
@@ -50,7 +50,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
@@ -50,6 +50,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/rust/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/rust/common/data-management/sensitive-data/index.mdx
@@ -54,7 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/rust/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/rust/common/data-management/sensitive-data/index.mdx
@@ -54,6 +54,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/platform-includes/sensitive-data/scrubbing-data/native.mdx
+++ b/platform-includes/sensitive-data/scrubbing-data/native.mdx
@@ -13,7 +13,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
-- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
+- HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/platform-includes/sensitive-data/scrubbing-data/native.mdx
+++ b/platform-includes/sensitive-data/scrubbing-data/native.mdx
@@ -13,6 +13,7 @@ Sensitive data may appear in the following areas:
 - User context → Automated behavior is controlled via <PlatformIdentifier name="send-default-pii" />.
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
+- HTTP Spans → Most SDKs will add the HTTP query string and fragment as a data attribute to the span, which may need to be scrubbed.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Explain that most SDKs will add the HTTP query string and fragment as a data attribute to spans, as pointed out in the [develop docs](https://develop.sentry.dev/sdk/expected-features/data-handling/#spans).

Related to https://github.com/getsentry/sentry-docs/pull/12025.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

