### PR TITLE
ref(flags): clarify 'integration documentation' links on product index page

### DIFF
--- a/docs/product/explore/feature-flags/index.mdx
+++ b/docs/product/explore/feature-flags/index.mdx
@@ -14,7 +14,7 @@ Flag evaluations will appear in the "Feature Flag" section of Issue Details page
 
 ### Set Up Evaluation Tracking
 
-To set up evaluation tracking visit your provider's integration documentation page:
+To set up evaluation tracking, visit the SDK integration documentation for your platform:
 * [JavaScript](/platforms/javascript/feature-flags/)
 * [Python](/platforms/python/feature-flags/)
 
@@ -24,5 +24,5 @@ Change tracking enables Sentry to listen for additions, removals, and modificati
 
 ### Set Up Change Tracking
 
-To set up change tracking visit your provider's integration documentation page:
+To set up change tracking, visit the webhook integration documentation for your provider:
 * [LaunchDarkly](/organization/integrations/feature-flag/launchdarkly/#change-tracking)


### PR DESCRIPTION
<img width="838" alt="Screenshot 2024-12-03 at 12 04 18 PM" src="https://github.com/user-attachments/assets/2fd22c52-12bc-4725-9b9a-92f449c7e84d">
