### PR TITLE
ref(migrations): Add instructions for hybrid cloud foreign key

### DIFF
--- a/develop-docs/api-server/application-domains/database-migrations/index.mdx
+++ b/develop-docs/api-server/application-domains/database-migrations/index.mdx
@@ -287,7 +287,7 @@ Extra care is needed here if the table is referenced as a foreign key in other t
 
 - Make a pull request to remove all uses of the model in the codebase in a separate pull request. This mostly helps with code cleanliness. This should be merged ahead of the migration pull requests, but we don't need to worry about whether it is deployed first.
 - Make another pull request to:
-    - Remove any database level foreign key constraints from this table to other tables by setting `db_constraint=False` on the columns.
+    - Remove any database level foreign key constraints from this table to other tables by setting `db_constraint=False` on the columns. If it's a hybrid cloud foreign key, set `null=True` instead.
     - Remove the model and in the generated migration use `SafeDeleteModel(..., deletion_action=DeletionAction.MOVE_TO_PENDING)` to replace `DeleteModel(...)`. This only marks the state for the model as removed.
 - Deploy. It's important that all previous pull requests are in production before we remove the actual table.
 - Make a pull request that creates a new migration that has the same `SafeDeleteModel` operation as before, but set `deletion_action=DeletionAction.DELETE` instead. This deletes the actual table from Postgres.


### PR DESCRIPTION
When removing a model that has a hybrid cloud foreign key you can't set `db_constraint` to False, but instead you need to make the column nullable.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
