### PR TITLE
feat(native): docs on extending performance API with explicit timings

### DIFF
--- a/docs/platforms/native/common/tracing/instrumentation/custom-instrumentation.mdx
+++ b/docs/platforms/native/common/tracing/instrumentation/custom-instrumentation.mdx
@@ -19,6 +19,21 @@ To capture transactions and spans customized to your organization's needs, you m
 
 <PlatformContent includePath="performance/add-spans-example" />
 
+## Custom Timestamps
+Sometimes systems don't provide a reliable system time. For these cases, the following explicitly timed functions can be used.
+- `sentry_transaction_start_ts`
+- `sentry_transaction_finish_ts`
+- `sentry_transaction_start_child_ts`
+- `sentry_transaction_start_child_ts_n`
+- `sentry_span_start_child_ts`
+- `sentry_span_start_child_ts_n`
+- `sentry_span_finish_ts`
+
+They only differ from their non-timestamped counterparts by taking an additional timestamp parameter, which is the unix epoch offset in microseconds.
+
+When using these functions, you should ensure that the provided timestamps are consistent. It is recommended to use the normal interface with automatic timestamping, and to only use the explicitly timed interface when absolutely necessary.
+
+
 <PlatformContent includePath="performance/concurrency" />
 
 <PlatformContent includePath="performance/connect-errors-spans" />

--- a/docs/platforms/native/common/tracing/instrumentation/custom-instrumentation.mdx
+++ b/docs/platforms/native/common/tracing/instrumentation/custom-instrumentation.mdx
@@ -20,7 +20,7 @@ To capture transactions and spans customized to your organization's needs, you m
 <PlatformContent includePath="performance/add-spans-example" />
 
 ## Custom Timestamps
-Sometimes systems don't provide a reliable system time. For these cases, the following explicitly timed functions can be used.
+Sometimes you want to measure timings in code that cannot call Native SDK functions directly (like GPU shaders). For these cases, the following explicitly timed functions can be used.
 - `sentry_transaction_start_ts`
 - `sentry_transaction_finish_ts`
 - `sentry_transaction_start_child_ts`


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Related to the changes in sentry-native https://github.com/getsentry/sentry-native/pull/1093
Updating the docs to reflect the additional explicit timing API for transactions/spans.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
