### PR TITLE
feat(platform): Add CI scope to auth token creation

### DIFF
--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -258,7 +258,10 @@ export async function createOrgAuthToken({
 }): Promise<string | null> {
   const url = `${getHost()}/api/0/organizations/${orgSlug}/org-auth-tokens/`;
 
-  const body = {name};
+  const body = {
+    name,
+    scopes: ['org:ci'],
+  };
 
   try {
     const resp = await fetch(url, {


### PR DESCRIPTION
This PR adds the `org:ci` scope to the `createOrgAuthToken` request that is used for creating auth tokens within docs. With this the token should be both eligible for creating releases and uploading source maps.

(potentially) closes https://github.com/getsentry/sentry-docs/issues/11999