### PR TITLE
feat(docs): add Linux distribution name and version to searchable properties

### DIFF
--- a/docs/concepts/search/searchable-properties/events.mdx
+++ b/docs/concepts/search/searchable-properties/events.mdx
@@ -472,6 +472,18 @@ The independent kernel version string. This is typically the entire output of th
 
 - **Type:** string
 
+### `os.distribution_name`
+
+The Linux distribution name. This maps to `ID` in [`/etc/os-release/`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html).
+
+- **Type:** string
+
+### `os.distribution_version`
+
+The Linux distribution version. This maps to `VERSION_ID` in  [`/etc/os-release/`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html).
+
+- **Type:** string
+
 ### `percentile(field,level)`
 
 Returns results with an approximate percentile of the field to the level. The level can be between `0` and `1`. For example, if you wanted to find the 50th percentile of transaction durations, you would enter `percentile(transaction.duration, 0.5)`.

--- a/docs/concepts/search/searchable-properties/issues.mdx
+++ b/docs/concepts/search/searchable-properties/issues.mdx
@@ -292,6 +292,18 @@ The independent kernel version string. This is typically the entire output of th
 
 - **Type:** string
 
+### `os.distribution_name`
+
+The Linux distribution name. This maps to `ID` in [`/etc/os-release/`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html).
+
+- **Type:** string
+
+### `os.distribution_version`
+
+The Linux distribution version. This maps to `VERSION_ID` in  [`/etc/os-release/`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html).
+
+- **Type:** string
+
 ### `platform.name`
 
 Name of the platform


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->
## DESCRIBE YOUR PR
Prompted by changes in Sentry (https://github.com/getsentry/sentry/pull/81656) where we added `os.distribution_name` and `os.distribution_version` to the searchable properties.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
