### PR TITLE
docs(profiling): add SDK logger as a step to troubleshooting

### DIFF
--- a/docs/platforms/php/common/profiling/troubleshooting.mdx
+++ b/docs/platforms/php/common/profiling/troubleshooting.mdx
@@ -9,3 +9,4 @@ If you don't see any profiling data in [sentry.io](https://sentry.io), you can t
 - Ensure that <PlatformLink to="/tracing/">Tracing is enabled</PlatformLink>.
 - Ensure that the <PlatformLink to="/tracing/instrumentation/custom-instrumentation">custom instrumentation</PlatformLink> is sending performance data to Sentry by going to the **Performance** page in [sentry.io](https://sentry.io).
 - Ensure the <PlatformLink to="/integrations/#environmentintegration">`Sentry\Integration\EnvironmentIntegration`</PlatformLink> is enabled.
+- Enable the <PlatformLink to="/configuration/options/#logger">logger</PlatformLink> and see what the SDK is doing under the hood.

--- a/docs/platforms/php/common/profiling/troubleshooting.mdx
+++ b/docs/platforms/php/common/profiling/troubleshooting.mdx
@@ -9,4 +9,4 @@ If you don't see any profiling data in [sentry.io](https://sentry.io), you can t
 - Ensure that <PlatformLink to="/tracing/">Tracing is enabled</PlatformLink>.
 - Ensure that the <PlatformLink to="/tracing/instrumentation/custom-instrumentation">custom instrumentation</PlatformLink> is sending performance data to Sentry by going to the **Performance** page in [sentry.io](https://sentry.io).
 - Ensure the <PlatformLink to="/integrations/#environmentintegration">`Sentry\Integration\EnvironmentIntegration`</PlatformLink> is enabled.
-- Enable the <PlatformLink to="/configuration/options/#logger">logger</PlatformLink> and see what the SDK is doing under the hood.
+- Enable the <PlatformLink to="/configuration/options/#logger">logger</PlatformLink> to see what the SDK is doing under the hood.


### PR DESCRIPTION
## DESCRIBE YOUR PR

I have been trying to get tracing and profiling to work. I followed the guide, including the troubleshooting guide, but I still didn't see any traces in the performance tab. I ended up [asking on Discord](https://discord.com/channels/621778831602221064/1245295898594902077/1313882179121446954) where I got a quick reply to try to enable logger. From there, I could quickly see that the transactions were being dropped due to an exceeded quota. From there, it was easy to see that some other projects under our organization have used up the quota.


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
