### PR TITLE
Keep platform selector in sync with pathname

### DIFF
--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -13,6 +13,7 @@ import {CaretRightIcon, CaretSortIcon, MagnifyingGlassIcon} from '@radix-ui/reac
 import * as RadixSelect from '@radix-ui/react-select';
 import {matchSorter} from 'match-sorter';
 import {usePathname} from 'next/navigation';
+import {useRouter} from 'next/router';
 
 import {PlatformIcon} from 'sentry-docs/components/platformIcon';
 import {Platform, PlatformGuide, PlatformIntegration} from 'sentry-docs/types';
@@ -21,7 +22,6 @@ import {uniqByReference} from 'sentry-docs/utils';
 import styles from './style.module.scss';
 
 import {SidebarLink} from '../sidebarLink';
-import {useRouter} from 'next/router';
 
 export function PlatformSelector({
   platforms,

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -12,7 +12,7 @@ import {Combobox, ComboboxItem, ComboboxList, ComboboxProvider} from '@ariakit/r
 import {CaretRightIcon, CaretSortIcon, MagnifyingGlassIcon} from '@radix-ui/react-icons';
 import * as RadixSelect from '@radix-ui/react-select';
 import {matchSorter} from 'match-sorter';
-import {usePathname,useRouter} from 'next/navigation';
+import {usePathname, useRouter} from 'next/navigation';
 
 import {PlatformIcon} from 'sentry-docs/components/platformIcon';
 import {Platform, PlatformGuide, PlatformIntegration} from 'sentry-docs/types';

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -25,7 +25,10 @@ import {SidebarLink} from '../sidebarLink';
 export function PlatformSelector({
   platforms,
   currentPlatform,
+  // do nothing with path for now
+  path: _path,
 }: {
+  path: string;
   platforms: Array<Platform>;
   currentPlatform?: Platform | PlatformGuide;
 }) {

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -25,10 +25,7 @@ import {SidebarLink} from '../sidebarLink';
 export function PlatformSelector({
   platforms,
   currentPlatform,
-  // do nothing with path for now
-  path: _path,
 }: {
-  path: string[];
   platforms: Array<Platform>;
   currentPlatform?: Platform | PlatformGuide;
 }) {

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -28,9 +28,9 @@ export function PlatformSelector({
   // do nothing with path for now
   path: _path,
 }: {
-  path: string;
   platforms: Array<Platform>;
   currentPlatform?: Platform | PlatformGuide;
+  path: string[];
 }) {
   // humanize the title for a more natural sorting
   const humanizeTitle = (title: string) =>

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -21,6 +21,7 @@ import {uniqByReference} from 'sentry-docs/utils';
 import styles from './style.module.scss';
 
 import {SidebarLink} from '../sidebarLink';
+import {useRouter} from 'next/router';
 
 export function PlatformSelector({
   platforms,
@@ -93,13 +94,12 @@ export function PlatformSelector({
     return matches_;
   }, [searchValue, currentPlatformKey, platformsAndGuides]);
 
+  const router = useRouter();
   const onPlatformChange = (platformKey: string) => {
     const platform_ = platformsAndGuides.find(platform => platform.key === platformKey);
     if (platform_) {
       localStorage.setItem('active-platform', platform_.key);
-      // feels wrong to use window.location here,
-      // but router.push is not working on mobile for some reason
-      window.location.href = platform_.url;
+      router.push(platform_.url);
     }
   };
 

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -12,8 +12,7 @@ import {Combobox, ComboboxItem, ComboboxList, ComboboxProvider} from '@ariakit/r
 import {CaretRightIcon, CaretSortIcon, MagnifyingGlassIcon} from '@radix-ui/react-icons';
 import * as RadixSelect from '@radix-ui/react-select';
 import {matchSorter} from 'match-sorter';
-import {usePathname} from 'next/navigation';
-import {useRouter} from 'next/router';
+import {usePathname,useRouter} from 'next/navigation';
 
 import {PlatformIcon} from 'sentry-docs/components/platformIcon';
 import {Platform, PlatformGuide, PlatformIntegration} from 'sentry-docs/types';

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -28,9 +28,9 @@ export function PlatformSelector({
   // do nothing with path for now
   path: _path,
 }: {
+  path: string[];
   platforms: Array<Platform>;
   currentPlatform?: Platform | PlatformGuide;
-  path: string[];
 }) {
   // humanize the title for a more natural sorting
   const humanizeTitle = (title: string) =>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -91,7 +91,6 @@ export async function Sidebar({path, versions}: SidebarProps) {
             <PlatformSelector
               platforms={platforms}
               currentPlatform={currentGuide || currentPlatform}
-              path={path}
             />
           </div>
           {versions && versions.length >= 1 && (

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -91,6 +91,7 @@ export async function Sidebar({path, versions}: SidebarProps) {
             <PlatformSelector
               platforms={platforms}
               currentPlatform={currentGuide || currentPlatform}
+              path={path}
             />
           </div>
           {versions && versions.length >= 1 && (


### PR DESCRIPTION
fixes #11973

`router.push()` works on mobile Next 15