### PR TITLE
Update automatic-instrumentation.mdx

### DIFF
--- a/docs/platforms/react-native/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/automatic-instrumentation.mdx
@@ -186,7 +186,7 @@ Currently, by default, the React Native SDK will only create child spans for fet
 
 ### React Profiler
 
-We export the React Profiler from our React Native SDK as well. Learn more in [React Component Tracking](/platforms/javascript/guides/react/features/component-tracking/).
+We export the React Profiler from our React Native SDK as well. Learn more in [React Component Tracking](/platforms/javascript/guides/react/features/component-monitoring/).
 
 After you instrument your app's routing, if you wrap a component that renders on one of the routes with `withProfiler`, you will be able to track the component's lifecycle as a child span of the route transaction.
 


### PR DESCRIPTION
Embedded URL in "Learn more in [React Component Tracking](https://docs.sentry.io/platforms/javascript/guides/react/features/component-tracking/)." is https://docs.sentry.io/platforms/javascript/guides/react/features/component-tracking/ (which goes to https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/), but should be https://docs.sentry.io/platforms/javascript/guides/react/features/component-monitoring/