### PR TITLE
ref(flags): temporarily mention beta release version in JS integration docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (This is temporary. The integration will be included in the next 8.43 release).
+This integration only works inside a browser environment. To use it, please install @sentry/browser v8.43.0 when it's available, or [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) in the interim.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. To use it, please install @sentry/browser v8.43.0 when it's available, or [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) in the interim.
+This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1).
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment.
+This integration only works inside a browser environment. Please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (this is temporary. This integration will be included in the next 8.43 release).
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. Please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (This is temporary. The integration will be included in the next 8.43 release).
+This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (This is temporary. The integration will be included in the next 8.43 release).
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. Please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (this is temporary. This integration will be included in the next 8.43 release).
+This integration only works inside a browser environment. Please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (This is temporary. The integration will be included in the next 8.43 release).
 
 </Alert>
 
@@ -35,7 +35,7 @@ _Import names: `Sentry.launchDarklyIntegration` and `Sentry.buildLaunchDarklyFla
 
 ## Install
 
-Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser) and [`launchdarkly-js-client-sdk`](https://www.npmjs.com/package/launchdarkly-js-client-sdk) from npm.
+Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) and [`launchdarkly-js-client-sdk`](https://www.npmjs.com/package/launchdarkly-js-client-sdk) from npm.
 
 ## Configure
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (This is temporary. The integration will be included in the next 8.43 release).
+This integration only works inside a browser environment. To use it, please install @sentry/browser v8.43.0 when it's available, or [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) in the interim.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. To use it, please install @sentry/browser v8.43.0 when it's available, or [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) in the interim.
+This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1).
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment.
+This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) (This is temporary. The integration will be included in the next 8.43 release).
 
 </Alert>
 
@@ -35,7 +35,7 @@ _Import name: `Sentry.openFeatureIntegration` and `Sentry.OpenFeatureIntegration
 
 ## Install
 
-Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser) and [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) from npm.
+Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) and [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) from npm.
 
 ## Configure
 


### PR DESCRIPTION
Clarify for open beta users they have to use this specific version of @sentry/browser, before 8.43 comes out

Example (banner is same for OpenFeature + every platform):
![Screenshot 2024-12-06 at 3 14 57 PM](https://github.com/user-attachments/assets/847c4773-118f-4183-97c8-31d2bdaba7dd)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

