### PR TITLE
fix(ruby): Fix missing require for ParameterFilter

### DIFF
--- a/platform-includes/configuration/before-send/ruby.rails.mdx
+++ b/platform-includes/configuration/before-send/ruby.rails.mdx
@@ -1,4 +1,6 @@
 ```ruby
+require "active_support/parameter_filter"
+
 Sentry.init do |config|
   #...
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-docs/issues/12082