### PR TITLE
docs(dotnet): valid value for RequestSize

### DIFF
--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -175,7 +175,7 @@ This option can be overridden using <PlatformIdentifier name="in-app-include" />
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
-- `never`: Request bodies are never sent.
+- `none`: Request bodies are never sent.
 - `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
 - `medium`: Medium and small requests will be captured (typically 10KB).
 - `always`: The SDK will always capture the request body as long as Sentry can make sense of it.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Correct the dotnet docs regarding the valid values for `MaxRequestBodySize`.

Based on `sentry-dotnet` code:
https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Extensibility/RequestSize.cs
`None` is a valid

I encountered the following error:
`"Message":"Failed to convert configuration value at 'Sentry:MaxRequestBodySize' to type 'Sentry.Extensibility.RequestSize'`
when setting the `appsettings.json` value `Sentry:MaxRequestBodySize` to `never`

## IS YOUR CHANGE URGENT?  
- [x] None: Not urgent, can wait up to 1 week+
