### PR TITLE
docs(nextjs): Add troubleshooting for OOM

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -454,14 +454,6 @@ shamefully-hoist=true
   **Note**: While `shamefully-hoist=true` usually isn't the ideal solution from a dependency management perspective, it's sometimes necessary for compatibility with certain packages that expect Node.js module resolution behavior similar to npm or yarn.
 </Alert>
 
-{" "}
-<Alert level="warning">
-  **Note**: While `shamefully-hoist=true` usually isn't the ideal solution from
-  a dependency management perspective, it's sometimes necessary for
-  compatibility with certain packages that expect Node.js module resolution
-  behavior similar to npm or yarn.
-</Alert>
-
   </Expandable>
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -431,29 +431,32 @@ Learn more about fixing these caching issues in the <PlatformLink to="/sourcemap
 
 </Expandable>
 
-
 </PlatformSection>
 
 <PlatformSection notSupported={['javascript.nuxt']}>
   <Expandable permalink title="pnpm: Resolving 'import-in-the-middle' external package errors">
 
-  When using pnpm, you might encounter errors related to packages that can't be external, particularly with packages like `import-in-the-middle` and `require-in-the-middle`. These errors typically occur due to pnpm's strict dependency management and hoisting behavior.
+When using pnpm, you might encounter errors related to packages that can't be external, particularly with packages like `import-in-the-middle` and `require-in-the-middle`. These errors typically occur due to pnpm's strict dependency management and hoisting behavior.
 
-  While adding these packages as direct dependencies might remove the warning messages, it often doesn't resolve the underlying functionality issues:
+While adding these packages as direct dependencies might remove the warning messages, it often doesn't resolve the underlying functionality issues:
 
-  ```bash
-  pnpm add import-in-the-middle require-in-the-middle
-  ```
+```bash
+pnpm add import-in-the-middle require-in-the-middle
+```
 
-  As a workaround, create or modify `.npmrc` in your project root:
+As a workaround, create or modify `.npmrc` in your project root:
 
-  ```npmrc
-  shamefully-hoist=true
-  ```
-  <Alert level="warning">
-  **Note**: While `shamefully-hoist=true` usually isn't the ideal solution from a dependency management perspective, it's sometimes necessary for compatibility with certain packages that expect Node.js module resolution behavior similar to npm or yarn.
-  </Alert>
+```npmrc
+shamefully-hoist=true
+```
 
+{" "}
+<Alert level="warning">
+  **Note**: While `shamefully-hoist=true` usually isn't the ideal solution from
+  a dependency management perspective, it's sometimes necessary for
+  compatibility with certain packages that expect Node.js module resolution
+  behavior similar to npm or yarn.
+</Alert>
 
   </Expandable>
 </PlatformSection>
@@ -463,7 +466,6 @@ Learn more about fixing these caching issues in the <PlatformLink to="/sourcemap
     After adding `sentry.server.config.ts` and building the project, you might get an error like this:
     `Failed to register ESM hook import-in-the-middle/hook.mjs`. You can add an override (npm/pnpm) or a resolution (yarn)
     for `@vercel/nft` to fix this. This will add the `hook.mjs` file to your build output. See the [underlying issue in the UnJS Nitro project](https://github.com/unjs/nitro/issues/2703).
-
 
     Nitro updated `@vercel/nft` in Nitro version `2.10.0`, so you might not get this error anymore, and you don't need to
     add this override/resolution.
@@ -500,6 +502,7 @@ Learn more about fixing these caching issues in the <PlatformLink to="/sourcemap
     ```bash
     pnpm add import-in-the-middle
     ```
+
   </Expandable>
 
   <Expandable permalink title="Nuxt: Server-side Nitro is not sending events">
@@ -537,6 +540,25 @@ Learn more about fixing these caching issues in the <PlatformLink to="/sourcemap
       }
     }
     ```
+
+  </Expandable>
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+  <Expandable permalink title="Out of Memory (OOM) errors during build">
+    The problem is related to memory consumption during the build process, especially when generating source maps. Here are some potential solutions and workarounds:
+    
+    - Update your `@sentry/nextjs` package to the latest version.
+    - Increase Node.js memory limit: You can try increasing the memory limit for Node.js during the build process. Add this to your build command: `NODE_OPTIONS="--max-old-space-size=4096" next build`
+    - Disable source maps entirely: As a last resort, you can disable source map generation completely:
+    ```js {filename:next.config.js}
+      module.exports = withSentryConfig(module.exports, {
+        sourcemaps: {
+          disable: true,
+        },
+      }
+    ```
+
   </Expandable>
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -550,7 +550,7 @@ shamefully-hoist=true
 
 <PlatformSection supported={['javascript.nextjs']}>
   <Expandable permalink title="Out of Memory (OOM) errors during build">
-    The problem is related to memory consumption during the build process, especially when generating source maps. Here are some potential solutions and workarounds:
+    The problem here is related to memory consumption during the build process, especially when generating source maps. Here are some potential solutions and workarounds:
     
     - Update your `@sentry/nextjs` package to the latest version.
     - Increase Node.js memory limit: You can try increasing the memory limit for Node.js during the build process. Add this to your build command: `NODE_OPTIONS="--max-old-space-size=8192" next build`. This flag will increase the memory available to the node process to 8 GB. We have found that Next.js consumes around 4 GB in most cases. Decrease the size depending on your memory availability.

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -549,7 +549,7 @@ shamefully-hoist=true
     The problem is related to memory consumption during the build process, especially when generating source maps. Here are some potential solutions and workarounds:
     
     - Update your `@sentry/nextjs` package to the latest version.
-    - Increase Node.js memory limit: You can try increasing the memory limit for Node.js during the build process. Add this to your build command: `NODE_OPTIONS="--max-old-space-size=4096" next build`
+    - Increase Node.js memory limit: You can try increasing the memory limit for Node.js during the build process. Add this to your build command: `NODE_OPTIONS="--max-old-space-size=8192" next build`. This flag will increase the memory available to the node process to 8 GB. We have found that Next.js consumes around 4 GB in most cases. Decrease the size depending on your memory availability.
     - Disable source maps entirely: As a last resort, you can disable source map generation completely:
     ```js {filename:next.config.js}
       module.exports = withSentryConfig(module.exports, {


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10468

Adds a troubleshooting section to nextjs for the OOM issue while building.