### PR TITLE
ref(flags): Revert "temporarily mention beta release version in JS integration docs"

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1).
+This integration only works inside a browser environment.
 
 </Alert>
 
@@ -35,7 +35,7 @@ _Import names: `Sentry.launchDarklyIntegration` and `Sentry.buildLaunchDarklyFla
 
 ## Install
 
-Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) and [`launchdarkly-js-client-sdk`](https://www.npmjs.com/package/launchdarkly-js-client-sdk) from npm.
+Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser) and [`launchdarkly-js-client-sdk`](https://www.npmjs.com/package/launchdarkly-js-client-sdk) from npm.
 
 ## Configure
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -35,7 +35,7 @@ _Import names: `Sentry.launchDarklyIntegration` and `Sentry.buildLaunchDarklyFla
 
 ## Install
 
-Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser) and [`launchdarkly-js-client-sdk`](https://www.npmjs.com/package/launchdarkly-js-client-sdk) from npm.
+Install your platform's Sentry SDK and [`launchdarkly-js-client-sdk`](https://www.npmjs.com/package/launchdarkly-js-client-sdk) from npm.
 
 ## Configure
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -35,7 +35,7 @@ _Import name: `Sentry.openFeatureIntegration` and `Sentry.OpenFeatureIntegration
 
 ## Install
 
-Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser) and [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) from npm.
+Install your platform's Sentry SDK and [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) from npm.
 
 ## Configure
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. To use it, please install @sentry/browser [v8.41.0-beta.1](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1).
+This integration only works inside a browser environment.
 
 </Alert>
 
@@ -35,7 +35,7 @@ _Import name: `Sentry.openFeatureIntegration` and `Sentry.OpenFeatureIntegration
 
 ## Install
 
-Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser/v/8.41.0-beta.1) and [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) from npm.
+Install [`@sentry/browser`](https://www.npmjs.com/package/@sentry/browser) and [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) from npm.
 
 ## Configure
 


### PR DESCRIPTION
Reverts getsentry/sentry-docs#12073 now that release 8.43 is live and linked in the sidebar. Also removes the npm links to @sentry/browser - these pages are for specific platforms, so users should refer to the side bar "Package Details"