### PR TITLE
Troubleshoot android minified libraries autoinstrumentation

### DIFF
--- a/docs/platforms/android/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/android/tracing/instrumentation/automatic-instrumentation.mdx
@@ -443,5 +443,5 @@ Sentry.reportFullyDisplayed()
 
 Time to full display is dependent on having an active transaction bound to the scope. Ideally, it should be used along with [Activity Instrumentation](/platforms/android/tracing/instrumentation/automatic-instrumentation/#activity-instrumentation), which starts a transaction and binds it to the scope automatically.
 
-If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 30 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
+If the span finishes through the API, its `status` is set to `SpanStatus.OK`. If the span doesn't finish after 25 seconds, it is finished by the SDK automatically, and its `status` is set to `SpanStatus.DEADLINE_EXCEEDED`.
 If the span finishes before the Activity is first drawn and displayed as measured by the `Time to initial display`, the reported time will be shifted to `Time to initial display` measured time.

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -194,7 +194,7 @@ With this information, it might be more clear what's happening. If not, please c
 
 The [Sentry Android Gradle plugin](/platforms/android/configuration/gradle/) uses bytecode manipulation to automatically measure the performance of your application. This process requires looking at the dependencies of the application, which can potentially break the build process if there are libraries which have been compiled/minified with a non-default java compiler, like R8/D8.
 
-If you experience a "[sentry] Error while instrumenting <class.method>" error message, it could be that you are using a minified library that cannot be instrumented, as the bytecode is not compliant with the JVM spec. You can exclude such library from instrumentation as follows:
+If you experience a "[sentry] Error while instrumenting MyClassName" error message, it could be that you are using a minified library that cannot be instrumented, as the bytecode is not compliant with the JVM spec. You can exclude such library from instrumentation as follows:
 
 ```groovy
 sentry {

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -194,7 +194,27 @@ With this information, it might be more clear what's happening. If not, please c
 
 The [Sentry Android Gradle plugin](/platforms/android/configuration/gradle/) uses bytecode manipulation to automatically measure the performance of your application. This process requires looking at the dependencies of the application, which can potentially break the build process if there are libraries which have been compiled/minified with a non-default java compiler, like R8/D8.
 
-The culprit is usually our [File I/O instrumentation](/platforms/android/integrations/file-io/), which can be disabled as follows:
+If you experience a "[sentry] Error while instrumenting <class.method>" error message, it could be that you are using a minified library that cannot be instrumented, as the bytecode is not compliant with the JVM spec. You can exclude such library from instrumentation as follows:
+
+```groovy
+sentry {
+  tracingInstrumentation {
+    enabled = true
+    excludes = ['com/example/donotinstrument/**']
+  }
+}
+```
+
+```kotlin
+sentry {
+  tracingInstrumentation {
+    enabled.set(true)
+    excludes.set(setOf("com/example/donotinstrument/**"))
+  }
+}
+```
+
+You may also disable one of our instrumentations, like our [File I/O instrumentation](/platforms/android/integrations/file-io/), which is usually the culprit, as follows:
 
 ```groovy
 import io.sentry.android.gradle.extensions.InstrumentationFeature


### PR DESCRIPTION
## DESCRIBE YOUR PR
added gradle plugin auto-instrumentation issue with minified libraries to troubleshooting page
changed Android TTFD timeout from 30 to 25 seconds

Closes https://github.com/getsentry/sentry-android-gradle-plugin/issues/768
Relates to https://github.com/getsentry/sentry-java/issues/3831

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
