### PR TITLE
fix(insights): links were pointing to old dashboards

### DIFF
--- a/docs/platforms/dotnet/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/dotnet/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -6,7 +6,7 @@ description: "Learn how to manually instrument your code to use Sentry's Caches 
 
 A cache can be used to speed up data retrieval, thereby improving application performance. Because instead of getting data from a potentially slow data layer, your application will be getting data from memory (in a best case scenario). Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 
-Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/caches/) for getting an overview of your application's caches.
+Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) for getting an overview of your application's caches.
 
 To make it possible for Sentry to give you an overview of your cache performance, you'll need to create two spans - one indicating that something is being put into the cache, and a second one indicating that something is being fetched from the cache.
 
@@ -102,4 +102,4 @@ public class MyCachingService
 }
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) to see how your cache is performing.

--- a/docs/platforms/go/common/tracing/instrumentation/caches-module.mdx
+++ b/docs/platforms/go/common/tracing/instrumentation/caches-module.mdx
@@ -91,4 +91,4 @@ if parentSpan != nil {
 }
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches) to see how your cache is performing.

--- a/docs/platforms/go/common/tracing/instrumentation/caches-module.mdx
+++ b/docs/platforms/go/common/tracing/instrumentation/caches-module.mdx
@@ -91,4 +91,4 @@ if parentSpan != nil {
 }
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) to see how your cache is performing.

--- a/docs/platforms/java/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/java/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -5,7 +5,7 @@ description: "Learn how to manually instrument your code to use Sentry's Caches 
 ---
 A cache can be used to speed up data retrieval, thereby improving application performance. Because instead of getting data from a potentially slow data layer, your application will be getting data from memory (in a best case scenario). Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 
-Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/caches/). For now you can manually instrument your caching solution and use Sentry to get a look into how it is performing by following the setup instructions below. We might be adding integrations to do this automatically, please head over to [GitHub](https://github.com/getsentry/sentry-java) and let us know which caching solution you'd like us to support.
+Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/). For now you can manually instrument your caching solution and use Sentry to get a look into how it is performing by following the setup instructions below. We might be adding integrations to do this automatically, please head over to [GitHub](https://github.com/getsentry/sentry-java) and let us know which caching solution you'd like us to support.
 
 To make it possible for Sentry to give you an overview of your cache performance, you'll need to create two spans - one indicating that something is being put into the cache, and a second one indicating that something is being fetched from the cache.
 
@@ -15,7 +15,7 @@ For detailed information about which data can be set, see the [Cache Module Deve
 
 ## Manual Instrumentation
 
-For now you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/insights/caches/) by following the steps below.
+For now you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) by following the steps below.
 
 <PlatformSection supported={["java.spring", "java.spring-boot"]}>
 If you are using Spring caching, please take a look at our [proof of concept PR](https://github.com/getsentry/sentry-java/pull/3457) as it shows how to register a cache listener and report cache spans to Sentry.

--- a/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -26,7 +26,7 @@ supported:
 
 A cache can be used to speed up data retrieval, thereby improving application performance. Because instead of getting data from a potentially slow data layer, your application will be getting data from memory (in a best case scenario). Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 
-Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) that can be auto-instrumented using Sentry's Redis integration (more coming soon).
+Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) that can be auto-instrumented using Sentry's Redis integration (more coming soon).
 
 ## Instrumentation with Redis Clients
 
@@ -44,7 +44,7 @@ Sentry.init({
 
 ## Manual Instrumentation
 
-If you're using anything other than Sentry's Redis integration, you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) by following the steps below.
+If you're using anything other than Sentry's Redis integration, you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) by following the steps below.
 
 You'll need to create two spans - one indicating that something is being put into the cache, and a second one indicating that something is being fetched from the cache.
 
@@ -129,4 +129,4 @@ Sentry.startSpan(
 );
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) to see how your cache is performing.

--- a/docs/platforms/php/common/tracing/instrumentation/caches-module.mdx
+++ b/docs/platforms/php/common/tracing/instrumentation/caches-module.mdx
@@ -3,7 +3,7 @@ title: Instrument Caches
 sidebar_order: 1000
 description: "Learn how to manually instrument your code to use Sentry's Caches module. "
 ---
-Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/caches/) that can be auto-instrumented by our [Laravel SDK](/platforms/php/guides/laravel/).
+Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) that can be auto-instrumented by our [Laravel SDK](/platforms/php/guides/laravel/).
 
 If you're using something else, you can manually instrument your cache operations and use Sentry to get a look into how your caching solution is performing by following the setup instructions below.
 
@@ -15,7 +15,7 @@ For detailed information about which data can be set, see the [Cache Module deve
 
 ## Custom Instrumentation
 
-If you're using anything other than our [Laravel SDK](/platforms/php/guides/laravel/), you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) by following the steps below.
+If you're using anything other than our [Laravel SDK](/platforms/php/guides/laravel/), you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) by following the steps below.
 
 ### Add Span When Putting Data Into the Cache
 
@@ -120,4 +120,4 @@ if ($parentSpan !== null) {
 }
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) to see how your cache is performing.

--- a/docs/platforms/php/common/tracing/instrumentation/queues-module.mdx
+++ b/docs/platforms/php/common/tracing/instrumentation/queues-module.mdx
@@ -3,7 +3,7 @@ title: Instrument Queues
 sidebar_order: 3000
 description: "Learn how to manually instrument your code to use Sentry's Queues module. "
 ---
-Sentry comes with a [queue-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/queues/) that can be auto-instrumented by our [Laravel SDK](/platforms/php/guides/laravel/).
+Sentry comes with a [queue-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/queues/) that can be auto-instrumented by our [Laravel SDK](/platforms/php/guides/laravel/).
 
 If you're using something else, you can manually instrument your queue producers and consumers to ensure that you have performance data about your messaging queues.
 

--- a/docs/platforms/php/common/tracing/instrumentation/requests-module.mdx
+++ b/docs/platforms/php/common/tracing/instrumentation/requests-module.mdx
@@ -3,7 +3,7 @@ title: Instrument HTTP Requests
 sidebar_order: 2000
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
-Sentry offers a [requests monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/http/) that can be auto-instrumented by our [Laravel SDK](/platforms/php/guides/laravel/) and [Symfony SDK](/platforms/php/guides/symfony/).
+Sentry offers a [requests monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/http/) that can be auto-instrumented by our [Laravel SDK](/platforms/php/guides/laravel/) and [Symfony SDK](/platforms/php/guides/symfony/).
 
 If you're using something else, you can manually instrument your requests and use Sentry to get a look into how your requests to APIs are performing by following the setup instructions below.
 

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -5,7 +5,7 @@ description: "Learn how to manually instrument your code to use Sentry's Caches 
 ---
 A cache can be used to speed up data retrieval, thereby improving application performance. Because instead of getting data from a potentially slow data layer, your application will be getting data from memory (in a best case scenario). Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 
-Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/caches/) that can be auto-instrumented for popular Python caching setups (like <PlatformLink to="/integrations/django/">Django</PlatformLink>, <PlatformLink to="/integrations/redis/">Redis</PlatformLink>, and memcached (coming soon)).
+Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) that can be auto-instrumented for popular Python caching setups (like <PlatformLink to="/integrations/django/">Django</PlatformLink>, <PlatformLink to="/integrations/redis/">Redis</PlatformLink>, and memcached (coming soon)).
 
 If you're using a custom caching solution that doesn't have auto instrumentation, you can manually instrument it and use Sentry to get a look into how your caching solution is performing by following the setup instructions below.
 
@@ -17,7 +17,7 @@ For detailed information about which data can be set, see the [Cache Module Deve
 
 ## Manual Instrumentation
 
-If you're using anything other than <PlatformLink to="/integrations/django/">Django</PlatformLink>, <PlatformLink to="/integrations/redis/">Redis</PlatformLink>,  memcached (coming soon), you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) by following the steps below.
+If you're using anything other than <PlatformLink to="/integrations/django/">Django</PlatformLink>, <PlatformLink to="/integrations/redis/">Redis</PlatformLink>,  memcached (coming soon), you'll need to manually instrument the [Cache Module](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) by following the steps below.
 
 ### Add Span When Putting Data Into the Cache
 
@@ -94,4 +94,4 @@ with sentry_sdk.start_span(op="cache.get") as span:
         span.set_data("cache.hit", False)
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches) to see how your cache is performing.

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
@@ -3,7 +3,7 @@ title: Instrument Queues
 sidebar_order: 3000
 description: "Learn how to manually instrument your code to use Sentry's Queues module. "
 ---
-Sentry comes with a [queue-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/queues/) that can be auto-instrumented for popular Python queue setups (like <PlatformLink to="/integrations/celery/">Celery</PlatformLink>).
+Sentry comes with a [queue-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/queues/) that can be auto-instrumented for popular Python queue setups (like <PlatformLink to="/integrations/celery/">Celery</PlatformLink>).
 
 In case yours isn't supported, you can still instrument custom spans and transactions around your queue producers and consumers to ensure that you have performance data about your messaging queues.
 

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/requests-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/requests-module.mdx
@@ -3,7 +3,7 @@ title: Instrument HTTP Requests
 sidebar_order: 2000
 description: "Learn how to manually instrument your code to use Sentry's Requests module."
 ---
-As a prerequisite to setting up [Requests](/product/insights/requests/), you’ll need to first <PlatformLink to="/tracing/">set up tracing</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection` and show the data in the [requests-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/http/). If that doesn't fit your use case, you can set up using custom instrumentation described below.
+As a prerequisite to setting up [Requests](/product/insights/requests/), you’ll need to first <PlatformLink to="/tracing/">set up tracing</PlatformLink>. Once this is done, the Python SDK will automatically instrument outgoing HTTP requests made via `HTTPConnection` and show the data in the [requests-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/http/). If that doesn't fit your use case, you can set up using custom instrumentation described below.
 
 ## Custom Instrumentation
 

--- a/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/caches-module.mdx
@@ -5,7 +5,7 @@ description: "Learn how to manually instrument your code to use Sentry's Caches 
 ---
 A cache can be used to speed up data retrieval, thereby improving application performance. Because instead of getting data from a potentially slow data layer, your application will be getting data from memory (in a best case scenario). Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 
-Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/caches/) for getting an overview of your application's caches.
+Sentry offers a [cache-monitoring dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) for getting an overview of your application's caches.
 
 To make it possible for Sentry to give you an overview of your cache performance, you'll need to create two spans - one indicating that something is being put into the cache, and a second one indicating that something is being fetched from the cache.
 
@@ -85,4 +85,4 @@ Sentry.with_child_span(op: 'cache.get') do |span|
 end
 ```
 
-You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/performance/caches/) to see how your cache is performing.
+You should now have the right spans in place. Head over to the [Cache dashboard](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/caches/) to see how your cache is performing.

--- a/docs/product/insights/index.mdx
+++ b/docs/product/insights/index.mdx
@@ -6,7 +6,7 @@ description: Sentry's Insights for frontend, backend, mobile, and AI, provide cu
 
 <Include name="feature-limited-on-team-retention.mdx" />
 
-Sentry’s frontend, backend, mobile, and AI performance insights (all under the [**Insights**](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend) heading in Sentry), give you a clear summary of the telemetry and events impacting the performance of individual parts of your application. Each section shows a high-level overview of your application's health with widgets for "Best Page Opportunities" (improvement that will be most helpful for boosting your performance score), most time-consuming events, and so on. You can also drill deeper into specific workflows to see specific traces, errors, and releases. This helps you identify potential problems and spot trends, fix bugs, and ultimately boost application performance.
+Sentry’s frontend, backend, mobile, and AI performance insights (all under the [**Insights**](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend/) heading in Sentry), give you a clear summary of the telemetry and events impacting the performance of individual parts of your application. Each section shows a high-level overview of your application's health with widgets for "Best Page Opportunities" (improvement that will be most helpful for boosting your performance score), most time-consuming events, and so on. You can also drill deeper into specific workflows to see specific traces, errors, and releases. This helps you identify potential problems and spot trends, fix bugs, and ultimately boost application performance.
 
 
 

--- a/docs/product/insights/index.mdx
+++ b/docs/product/insights/index.mdx
@@ -6,7 +6,7 @@ description: Sentry's Insights for frontend, backend, mobile, and AI, provide cu
 
 <Include name="feature-limited-on-team-retention.mdx" />
 
-Sentry’s frontend, backend, mobile, and AI performance insights (all under the [**Insights**](https://sentry.io/orgredirect/organizations/:orgslug/insights/) heading in Sentry), give you a clear summary of the telemetry and events impacting the performance of individual parts of your application. Each section shows a high-level overview of your application's health with widgets for "Best Page Opportunities" (improvement that will be most helpful for boosting your performance score), most time-consuming events, and so on. You can also drill deeper into specific workflows to see specific traces, errors, and releases. This helps you identify potential problems and spot trends, fix bugs, and ultimately boost application performance.
+Sentry’s frontend, backend, mobile, and AI performance insights (all under the [**Insights**](https://sentry.io/orgredirect/organizations/:orgslug/insights/backend) heading in Sentry), give you a clear summary of the telemetry and events impacting the performance of individual parts of your application. Each section shows a high-level overview of your application's health with widgets for "Best Page Opportunities" (improvement that will be most helpful for boosting your performance score), most time-consuming events, and so on. You can also drill deeper into specific workflows to see specific traces, errors, and releases. This helps you identify potential problems and spot trends, fix bugs, and ultimately boost application performance.
 
 
 

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -20,9 +20,9 @@ export function PageGrid({header, exclude}: Props) {
   }
 
   const children: DocNode[] = parentNode.frontmatter.next_steps?.length
-    ? (parentNode.frontmatter.next_steps
+    ? parentNode.frontmatter.next_steps
         .map(p => nodeForPath(rootNode, path.join(parentNode.path, p)))
-        .filter(isNotNil) ?? [])
+        .filter(isNotNil) ?? []
     : parentNode.children;
 
   return (

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -20,9 +20,9 @@ export function PageGrid({header, exclude}: Props) {
   }
 
   const children: DocNode[] = parentNode.frontmatter.next_steps?.length
-    ? parentNode.frontmatter.next_steps
+    ? (parentNode.frontmatter.next_steps
         .map(p => nodeForPath(rootNode, path.join(parentNode.path, p)))
-        .filter(isNotNil) ?? []
+        .filter(isNotNil) ?? [])
     : parentNode.children;
 
   return (


### PR DESCRIPTION
We missed migrating some links with the new Insights menu.