### PR TITLE
feat(feedback): Add requirement note for Dialog element

### DIFF
--- a/platform-includes/user-feedback/pre-requisites/javascript.mdx
+++ b/platform-includes/user-feedback/pre-requisites/javascript.mdx
@@ -1,3 +1,3 @@
 For the User Feedback integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser), or an equivalent framework SDK (for example, [@sentry/react](https://www.npmjs.com/package/@sentry/react)) installed. The minimum version required for the SDK is [7.85.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.85.0). If you're on an older version of the SDK, please check this [migration document](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md).
 
-User Feedback requires browsers that support [Shadow DOM](https://caniuse.com/shadowdomv1).
+User Feedback requires browsers that support [Shadow DOM](https://caniuse.com/shadowdomv1) and [the Dialog element](https://caniuse.com/mdn-html_elements_dialog).


### PR DESCRIPTION
This adds a note that User Feedback requires browsers that support the [Dialog element](https://caniuse.com/mdn-html_elements_dialog) as we use the element + its APIs to show the feedback modal.
