### PR TITLE
docs(releases): Clarify behavior for "Resolved in next release"

### DIFF
--- a/docs/product/releases/index.mdx
+++ b/docs/product/releases/index.mdx
@@ -66,7 +66,7 @@ The "Resolved in the current release" option records the current release that's 
 
 ### Resolved in the Next Release
 
-The "Resolved in the next release" option works in a similar way to resolved in the current release. But because we can't record the resolution version since it hasn't been created yet, we record the current release version and update it when a newer release is created.
+The "Resolved in the next release" option works in a similar way to resolved in the current release. But because we can't record the resolution version since it hasn't been created yet, we record the latest release version the group was seen in and update it when a newer release is created.
 
 ### Resolved in a Commit
 

--- a/docs/product/releases/index.mdx
+++ b/docs/product/releases/index.mdx
@@ -66,7 +66,7 @@ The "Resolved in the current release" option records the current release that's 
 
 ### Resolved in the Next Release
 
-The "Resolved in the next release" option works in a similar way to resolved in the current release. But because we can't record the resolution version since it hasn't been created yet, we record the latest release version the group was seen in and update it when a newer release is created.
+The "Resolved in the next release" option works similarly to resolving in the current release. But because we can't record the resolution version since it hasn't been created yet, we record the latest release version the group was seen in and update it when a newer release is created. When using semantic versioned releases, the group will be resolved with the next release which is greater than all existing ones.
 
 ### Resolved in a Commit
 

--- a/docs/product/releases/index.mdx
+++ b/docs/product/releases/index.mdx
@@ -66,7 +66,7 @@ The "Resolved in the current release" option records the current release that's 
 
 ### Resolved in the Next Release
 
-The "Resolved in the next release" option works similarly to resolving in the current release. But because we can't record the resolution version since it hasn't been created yet, we record the latest release version the group was seen in and update it when a newer release is created. When using semantic versioned releases, the group will be resolved with the next release which is greater than all existing ones.
+The "Resolved in the next release" option works like resolving in the current release, but since the next release doesn’t exist yet, we record the latest version where the issue was seen. This updates automatically when a new release is created. For semantic versioning, the issue is resolved in the next newest of all current versions.
 
 ### Resolved in a Commit
 


### PR DESCRIPTION
Clarify the behavior for "resolved in next release", addressing feedback from [#78325](https://github.com/getsentry/sentry/issues/78325)