### PR TITLE
ref(docs): add info about mimetype in docs

### DIFF
--- a/docs/platforms/android/enriching-events/attachments/index.mdx
+++ b/docs/platforms/android/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 <PlatformContent includePath="enriching-events/add-attachment" />

--- a/docs/platforms/apple/common/enriching-events/attachments/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.

--- a/docs/platforms/dart/enriching-events/attachments/index.mdx
+++ b/docs/platforms/dart/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.

--- a/docs/platforms/dotnet/common/enriching-events/attachments/index.mdx
+++ b/docs/platforms/dotnet/common/enriching-events/attachments/index.mdx
@@ -33,6 +33,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.

--- a/docs/platforms/flutter/enriching-events/attachments/index.mdx
+++ b/docs/platforms/flutter/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.

--- a/docs/platforms/java/common/enriching-events/attachments/index.mdx
+++ b/docs/platforms/java/common/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 <PlatformContent includePath="enriching-events/add-attachment" />

--- a/docs/platforms/kotlin-multiplatform/enriching-events/attachments/index.mdx
+++ b/docs/platforms/kotlin-multiplatform/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 <PlatformContent includePath="enriching-events/add-attachment" />

--- a/docs/platforms/powershell/enriching-events/attachments/index.mdx
+++ b/docs/platforms/powershell/enriching-events/attachments/index.mdx
@@ -27,6 +27,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.

--- a/docs/platforms/unity/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unity/enriching-events/attachments/index.mdx
@@ -33,6 +33,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Unity features a global <PlatformLink to="/enriching-events/scopes/">scope</PlatformLink> to which you add an attachment that will be sent with every event.

--- a/docs/platforms/unreal/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unreal/enriching-events/attachments/index.mdx
@@ -54,6 +54,20 @@ The filename is the name of the file to display in Sentry. When using bytes you 
 
 The type of content stored in this attachment. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Uploading Attachments
 
 Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</PlatformLink>. You can either add an attachment on the global scope to be sent with every event or add it on the <PlatformLink to="/enriching-events/scopes/#local-scopes">local Scope</PlatformLink> to just send the attachment with one specific event.

--- a/platform-includes/enriching-events/add-attachment/javascript.mdx
+++ b/platform-includes/enriching-events/add-attachment/javascript.mdx
@@ -27,6 +27,20 @@ The type of content stored in this attachment. Any [MIME
 type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be
 used; the default is `application/octet-stream`.
 
+`mimetype`
+
+The specific media content type that determines how the attachment is rendered in the Sentry UI. We currently support and can render the following MIME types:
+
+- `text/plain`
+- `text/css`
+- `text/csv`
+- `text/html`
+- `text/javascript`
+- `text/json` or `text/x-json` or `application/json` or `application/ld+json`
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+
 ## Add or Modify Attachments Before Sending
 
 It's possible to add, remove, or modify attachments before an event is sent by way of


### PR DESCRIPTION
add specific info in the docs about which MIME types are supported / renderable for event attachments.

based on `previewAttachmentTypes.tsx`:

https://github.com/getsentry/sentry/blob/bf167f9145882b76bc1f38eb4b7f62bedf6d9b71/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx#L7-L32

closes https://github.com/getsentry/sentry-docs/issues/8471