### PR TITLE
ref(develop): Clarify `synthetic` flag in exception mechanism

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/exception.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/exception.mdx
@@ -88,8 +88,9 @@ Furthermore, if this flag is set, Sentry will ignore the exception `type` when g
 exception into issues.
 : This flag should be set for all "segfaults" for instance as every single error group would
 look very similar otherwise. Also, errors the SDK creates to add a stack trace to events
-that don't have one themselves should be marked as `synthetic`. For example, when users
-set `attachStackTrace: true` and capture a string message via `captureException` or `captureMessage`.
+that don't have one themselves should be marked as `synthetic` (This happens, for example, 
+when users set `attachStackTrace: true` and capture a string message via `captureException` 
+or `captureMessage`.)
 
 `exception_id`
 

--- a/develop-docs/sdk/data-model/event-payloads/exception.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/exception.mdx
@@ -121,10 +121,9 @@ mechanism (see [meta information](#meta-information)).
 this mechanism.
 
 <Alert title="Note" level="warning">
-  The <code>type</code> attribute is required to send any exception mechanism
-  attribute, even if the SDK cannot determine the specific mechanism. In this
-  case, set the <code>type</code>
-  to <code>generic</code>. See below for an example.
+The <code>type</code> attribute is required to send any exception mechanism attribute, even
+if the SDK cannot determine the specific mechanism. In this case, set the <code>type</code>
+to <code>generic</code>. See below for an example.
 </Alert>
 
 ### Meta information
@@ -375,5 +374,4 @@ Exception group:
   ]
 }
 ```
-
 `;

--- a/develop-docs/sdk/data-model/event-payloads/exception.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/exception.mdx
@@ -79,14 +79,17 @@ from the operating system or runtime APIs, as well as mechanism-specific values.
 
 `synthetic`
 
-: An optional flag indicating that this error is synthetic. Synthetic errors
-are errors that carry little meaning by themselves. This may be because they
-are created at a central place (like a crash handler), and are all
-called the same: `Error`, `Segfault` etc. When the flag is set, Sentry will then
-try to use other information (top in-app frame function) rather than exception
-type and value in the UI for the primary event display. This flag should be set
-for all "segfaults" for instance as every single error group would look very
-similar otherwise.
+: An optional flag indicating that this error is synthetic. Synthetic errors are errors that
+carry little meaning by themselves. This may be because they are created at a central
+place (like a crash handler), and are all called the same: `Error`, `Segfault` etc.
+When the flag is set, Sentry will then try to use other information (top in-app frame
+function) rather than the exception type and value in the UI for the primary event display.
+Furthermore, if this flag is set, Sentry will ignore the exception `type` when grouping the
+exception into issues.
+: This flag should be set for all "segfaults" for instance as every single error group would
+look very similar otherwise. Also, errors the SDK creates to add a stack trace to events
+that don't have one themselves should be marked as `synthetic`. For example, when users
+set `attachStackTrace: true` and capture a string message via `captureException` or `captureMessage`.
 
 `exception_id`
 
@@ -118,9 +121,10 @@ mechanism (see [meta information](#meta-information)).
 this mechanism.
 
 <Alert title="Note" level="warning">
-The <code>type</code> attribute is required to send any exception mechanism attribute, even
-if the SDK cannot determine the specific mechanism. In this case, set the <code>type</code>
-to <code>generic</code>. See below for an example.
+  The <code>type</code> attribute is required to send any exception mechanism
+  attribute, even if the SDK cannot determine the specific mechanism. In this
+  case, set the <code>type</code>
+  to <code>generic</code>. See below for an example.
 </Alert>
 
 ### Meta information
@@ -371,4 +375,5 @@ Exception group:
   ]
 }
 ```
+
 `;


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR clarifies/expands on the impact and applicability of the `synthetic` flag in the exception `mechanism`:
- adds impact on issue grouping
- adds another concrete use case when to set the flag

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
