### PR TITLE
fix(js): Fix docs for using feedback with the Loader

### DIFF
--- a/platform-includes/user-feedback/install/javascript.mdx
+++ b/platform-includes/user-feedback/install/javascript.mdx
@@ -10,7 +10,9 @@ window.sentryOnLoad = function () {
 
   Sentry.lazyLoadIntegration("feedbackIntegration")
     .then((feedbackIntegration) => {
-      Sentry.addIntegration(feedbackIntegration());
+      Sentry.addIntegration(feedbackIntegration({
+      	// User Feedback configuration options
+      }));
     })
     .catch(() => {
       // this can happen if e.g. a network error occurs,

--- a/platform-includes/user-feedback/install/javascript.mdx
+++ b/platform-includes/user-feedback/install/javascript.mdx
@@ -21,7 +21,7 @@ window.sentryOnLoad = function () {
 };
 ```
 
-If you're using CDN bundles instead of NPM packages, you need to load the User Feedback integration CDN bundle in addition to your browser bundle:
+If you're using CDN bundles instead of NPM packages, you need to use a respective bundle that includes user feedback:
 
 ```html {tabTitle: CDN}
 <!-- Recommended: Use this bundle for feedback, replay, error, and tracing -->

--- a/platform-includes/user-feedback/install/javascript.mdx
+++ b/platform-includes/user-feedback/install/javascript.mdx
@@ -1,13 +1,4 @@
-The User Feedback integration is **already included** in your NPM packages. You can enable it by adding it to your `integrations` in your `init` config:
-
-```javascript {tabTitle: NPM}
-import * as Sentry from "@sentry/browser";
-
-Sentry.init({
-  dsn: "___DSN___",
-  integrations: [Sentry.feedbackIntegration()],
-});
-```
+The User Feedback integration is **already included** in your NPM packages. You don't need to install anything else to use it.
 
 If you're using the Loader Script, you can lazy load the User Feedback integration like this:
 

--- a/platform-includes/user-feedback/install/javascript.mdx
+++ b/platform-includes/user-feedback/install/javascript.mdx
@@ -1,16 +1,34 @@
-The User Feedback integration is **already included** in your browser or framework SDK NPM packages. If you're using CDN bundles instead of NPM packages, you need to load the User Feedback integration CDN bundle in addition to your browser bundle:
+The User Feedback integration is **already included** in your NPM packages. You can enable it by adding it to your `integrations` in your `init` config:
 
-```bash {tabTitle:npm}
-npm install @sentry/browser --save
+```javascript {tabTitle: NPM}
+import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "___DSN___",
+  integrations: [Sentry.feedbackIntegration()],
+});
 ```
 
-```bash {tabTitle:yarn}
-yarn add @sentry/browser
+If you're using the Loader Script, you can lazy load the User Feedback integration like this:
+
+```javascript {tabTitle: Loader}
+window.sentryOnLoad = function () {
+  Sentry.init({
+    // add other configuration here
+  });
+
+  Sentry.lazyLoadIntegration("feedbackIntegration")
+    .then((feedbackIntegration) => {
+      Sentry.addIntegration(feedbackIntegration());
+    })
+    .catch(() => {
+      // this can happen if e.g. a network error occurs,
+      // in this case User Feedback will not be enabled
+    });
+};
 ```
 
-```bash {tabTitle:pnpm}
-pnpm add @sentry/browser
-```
+If you're using CDN bundles instead of NPM packages, you need to load the User Feedback integration CDN bundle in addition to your browser bundle:
 
 ```html {tabTitle: CDN}
 <!-- Recommended: Use this bundle for feedback, replay, error, and tracing -->


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-docs/issues/12138

We did not really document well how to use user feedback with the loader. So I expanded this section in the docs to properly explain how it can be used.