### PR TITLE
feat(flags): document python FeatureFlagsIntegration for custom flag …

### DIFF
--- a/docs/platforms/python/integrations/feature_flags/index.mdx
+++ b/docs/platforms/python/integrations/feature_flags/index.mdx
@@ -1,0 +1,50 @@
+---
+title: Feature Flags
+description: "Learn how to attach custom feature flag data to Sentry error events."
+---
+
+<PlatformContent includePath="feature-flags/prerelease-alert" />
+
+The Feature Flags integration allows you to manually track feature flag evaluations through an API. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis.
+**At the moment, we only support boolean flag evaluations.**
+
+## Install
+
+Install `sentry-sdk` from PyPI.
+
+```bash
+pip install --upgrade 'sentry-sdk'
+```
+
+## Configure
+
+Add `FeatureFlagsIntegration()` to your `integrations` list:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.feature_flags import FeatureFlagsIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[
+        FeatureFlagsIntegration(),
+    ],
+)
+```
+
+## Verify
+
+The integration is tested by calling the `add_feature_flag` API before capturing an exception.
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.feature_flags import add_feature_flag
+
+add_feature_flag('hello', False)
+
+sentry_sdk.capture_exception(Exception("Something went wrong!"))
+```
+
+Visit the Sentry website and confirm that your error event has recorded the feature flag "hello" and its value "false".
+
+<PlatformContent includePath="feature-flags/next-steps" />

--- a/docs/platforms/python/integrations/featureflags/index.mdx
+++ b/docs/platforms/python/integrations/featureflags/index.mdx
@@ -22,7 +22,7 @@ Add `FeatureFlagsIntegration()` to your `integrations` list:
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.feature_flags import FeatureFlagsIntegration
+from sentry_sdk.integrations.featureflags import FeatureFlagsIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
@@ -38,7 +38,7 @@ The integration is tested by calling the `add_feature_flag` API before capturing
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.feature_flags import add_feature_flag
+from sentry_sdk.integrations.featureflags import add_feature_flag
 
 add_feature_flag('hello', False)
 


### PR DESCRIPTION
This is live as of release 8.43. This doc follows the structure of python/integrations/launchdarkly/ and openfeature/