### PR TITLE
chore(webvitals): Updates text around required Webvitals for Performance Score

### DIFF
--- a/docs/product/insights/frontend/web-vitals/index.mdx
+++ b/docs/product/insights/frontend/web-vitals/index.mdx
@@ -96,6 +96,5 @@ You can find out how to set up Sentry on your web application in the [installati
 Although Sentry provides auto instrumentation for many frontend frameworks, there are some environments and scenarios that may not be fully supported. If you are unable to find your pages in the **Web Vitals** page, check to see if your page loads are meeting the following conditions:
 
 - **Performance Scores** only support **Chrome**, **Firefox**, **Safari**, **Opera**, and **Edge** desktop and mobile browsers.
-- A page load must capture a minimum set of web vitals in order to be eligible for **Performance Score** calculation. For example, Chrome page loads must contain LCP, FCP, CLS, and TTFB; otherwise they will not appear in the Web Vitals page.
-    - This requirement varies depending on the client browser. Find out the full list of required web vitals in the [Browser Support](/product/insights/web-vitals/web-vitals-concepts/#browser-support) table.
-    - Some web vitals may not be captured as frequently depending on the unique behavior of your web page or your user's browser.
+- Some pageloads may not capture all web vitals supported by Sentry. This may depending on the client browser and/or the unique behavior of your web page. **Performance Score** are calculated based on available web vitals. 
+    - Find out the full list of web vitals in the [Browser Support](/product/insights/web-vitals/web-vitals-concepts/#browser-support) table.


### PR DESCRIPTION
Performance Scores no longer require a minimum set of webvitals to calculate. Removes this text to accurately reflect this.