### PR TITLE
chore: add redirect from api-server to backend

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -115,6 +115,10 @@ const developerDocsRedirects = [
     destination: '/backend/api/:path*',
   },
   {
+    source: '/api-server/:path*',
+    destination: '/backend/:path*'
+  },
+  {
     source: '/application/serializers/',
     destination: '/backend/serializers/',
   },


### PR DESCRIPTION
[After we reverted the name change from api-server to backend](https://github.com/getsentry/sentry-docs/pull/12141), links on google, etc. don't work for the time being. This PR adds a redirect from api-server to backend to restore functionality. 
