### PR TITLE
feat(api) Add ability for endpoint specific domains

### DIFF
--- a/src/build/open-api/types.ts
+++ b/src/build/open-api/types.ts
@@ -36,6 +36,11 @@ type Tag = {
   'x-sidebar-name': string;
 };
 
+type ServerMeta = {
+  description: string;
+  url: string;
+};
+
 export type DeRefedOpenAPI = {
   paths: {
     [key: string]: {
@@ -66,6 +71,7 @@ export type DeRefedOpenAPI = {
         tags: string[];
         description?: string;
         security?: any;
+        servers?: ServerMeta[];
       };
     };
   };

--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -70,6 +70,7 @@ export type API = {
   pathParameters: APIParameter[];
   queryParameters: APIParameter[];
   responses: APIResponse[];
+  server: string;
   slug: string;
   bodyContentType?: string;
   descriptionMarkdown?: string;
@@ -120,11 +121,16 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
 
   Object.entries(data.paths).forEach(([apiPath, methods]) => {
     Object.entries(methods).forEach(([method, apiData]) => {
+      let server = 'https://sentry.io';
+      if (apiData.servers && apiData.servers[0]) {
+        server = apiData.servers[0].url;
+      }
       apiData.tags.forEach(tag => {
         categoryMap[tag].apis.push({
           apiPath,
           method,
           name: apiData.operationId,
+          server,
           slug: slugify(apiData.operationId),
           summary: apiData.summary,
           descriptionMarkdown: apiData.description,

--- a/src/components/apiExamples/apiExamples.tsx
+++ b/src/components/apiExamples/apiExamples.tsx
@@ -38,7 +38,7 @@ const codeToJsx = (code: string, lang = 'json') => {
 
 export function ApiExamples({api}: Props) {
   const apiExample = [
-    `curl https://sentry.io${api.apiPath}`,
+    `curl ${api.server}${api.apiPath}`,
     ` -H 'Authorization: Bearer <auth_token>'`,
   ];
   if (['put', 'options', 'delete'].includes(api.method.toLowerCase())) {


### PR DESCRIPTION
## DESCRIBE YOUR PR

Some of our endpoints require customers to use region domains in order to have APIs work correctly across DE and US regions. I've already updated those endpoints in getsentry/sentry#82159.

Refs getsentry/sentry#81232

## Screenshot

![Screenshot 2024-12-17 at 2 14 30 PM](https://github.com/user-attachments/assets/92d3e010-106a-491d-b09f-49ac6f7df307)


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
