### PR TITLE
feat(python): Add Typer integration docs

### DIFF
--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -116,10 +116,11 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 | <LinkWithPlatformIcon platform="python.asyncio"       label="asyncio"         url="/platforms/python/integrations/asyncio" />       |                  |
 | <LinkWithPlatformIcon platform="python.pure_eval"     label="Enhanced Locals" url="/platforms/python/integrations/pure_eval" />     |                  |
 | <LinkWithPlatformIcon platform="python.gnu_backtrace" label="GNU Backtrace"   url="/platforms/python/integrations/gnu_backtrace" /> |                  |
-| <LinkWithPlatformIcon platform="python.rust_tracing"                 label="Rust Tracing"    url="/platforms/python/integrations/rust_tracing" />  |                  |
+| <LinkWithPlatformIcon platform="python.rust_tracing"  label="Rust Tracing"    url="/platforms/python/integrations/rust_tracing" />  |                  |
 | <LinkWithPlatformIcon platform="python.socket"        label="Socket"          url="/platforms/python/integrations/socket" />        |                  |
 | <LinkWithPlatformIcon platform="python.sys_exit"      label="sys.exit"        url="/platforms/python/integrations/sys_exit" />      |                  |
 | <LinkWithPlatformIcon platform="python.tryton"        label="Tryton"          url="/platforms/python/integrations/tryton" />        |                  |
+| <LinkWithPlatformIcon platform="python.typer"         label="Typer"           url="/platforms/python/integrations/typer" />         |                  |
 | <LinkWithPlatformIcon platform="python.wsgi"          label="WSGI"            url="/platforms/python/integrations/wsgi" />          |                  |
 
 ### Default Integrations

--- a/docs/platforms/python/integrations/typer/index.mdx
+++ b/docs/platforms/python/integrations/typer/index.mdx
@@ -7,8 +7,10 @@ The `TyperIntegration` captures exceptions raised when using Typer CLI applicati
 
 ## Install
 
+Install Typer and the Sentry SDK.
+
 ```bash
-pip install --upgrade "sentry-sdk"
+pip install --upgrade "sentry-sdk" typer
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/typer/index.mdx
+++ b/docs/platforms/python/integrations/typer/index.mdx
@@ -1,0 +1,53 @@
+---
+title: Typer
+description: Learn how to use Sentry to capture Typer exceptions.
+---
+
+The `TyperIntegration` captures exceptions raised when using Typer CLI applications.
+
+## Install
+
+```bash
+pip install --upgrade "sentry-sdk"
+```
+
+## Configure
+
+To enable the `TyperIntegration`, add it to the `integrations` list of your `sentry_sdk.init`. 
+
+<SignInNote />
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.typer import TyperIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[TyperIntegration()],
+)
+```
+
+
+## Verify
+
+Create a small CLI application:
+
+```python
+import typer
+import sentry_sdk
+from sentry_sdk.integrations.typer import TyperIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    integrations=[TyperIntegration()],
+)
+
+def main():
+    1 / 0
+
+if __name__ == "__main__":
+    typer.run(main)
+```
+
+When you run this, Sentry will capture the `ZeroDivisionError` from the `main()`
+function and you will be able to see it on [sentry.io](https://sentry.io).

--- a/docs/platforms/python/integrations/typer/index.mdx
+++ b/docs/platforms/python/integrations/typer/index.mdx
@@ -3,7 +3,7 @@ title: Typer
 description: Learn how to use Sentry to capture Typer exceptions.
 ---
 
-The `TyperIntegration` captures exceptions raised when using Typer CLI applications.
+The `TyperIntegration` captures exceptions raised when using [Typer CLI](https://typer.tiangolo.com/) applications.
 
 ## Install
 
@@ -49,4 +49,4 @@ if __name__ == "__main__":
 ```
 
 When you run this, Sentry will capture the `ZeroDivisionError` from the `main()`
-function and you will be able to see it on [sentry.io](https://sentry.io).
+function and you'll be able to see it on [sentry.io](https://sentry.io).

--- a/docs/platforms/python/integrations/typer/index.mdx
+++ b/docs/platforms/python/integrations/typer/index.mdx
@@ -7,7 +7,7 @@ The `TyperIntegration` captures exceptions raised when using Typer CLI applicati
 
 ## Install
 
-Install Typer and the Sentry SDK.
+Install Typer and the Sentry Python SDK.
 
 ```bash
 pip install --upgrade "sentry-sdk" typer
@@ -16,8 +16,6 @@ pip install --upgrade "sentry-sdk" typer
 ## Configure
 
 To enable the `TyperIntegration`, add it to the `integrations` list of your `sentry_sdk.init`. 
-
-<SignInNote />
 
 ```python
 import sentry_sdk
@@ -28,7 +26,6 @@ sentry_sdk.init(
     integrations=[TyperIntegration()],
 )
 ```
-
 
 ## Verify
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

https://github.com/getsentry/sentry-python/pull/3869 adds the Typer integration to the Python SDK. Adding docs.

**Note:** This is not released yet, so please don't merge yet. It can however be reviewed already.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
