### PR TITLE
chore(Apple): Show Profiling only on supported platforms' landing pages

### DIFF
--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -49,8 +49,6 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 
 Sentry captures data by using an SDK within your application's runtime. These are platform-specific and allow Sentry to have a deep understanding of how your application works.
 
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](https://docs.sentry.io/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](https://docs.sentry.io/product/explore/profiling/). To enable tracing and/or profiling, click the corresponding checkmarks to get the code snippets.
-
 We recommend installing the SDK through our [Sentry Wizard](https://github.com/getsentry/sentry-wizard) by running the following command inside your project directory:
 
 ```bash

--- a/docs/platforms/apple/common/index.mdx
+++ b/docs/platforms/apple/common/index.mdx
@@ -34,8 +34,6 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 
 Sentry captures data by using an SDK within your application's runtime. These are platform-specific and allow Sentry to have a deep understanding of how your application works.
 
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](https://docs.sentry.io/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](https://docs.sentry.io/product/profiling/). To enable tracing and/or profiling, click the corresponding checkmarks to get the code snippets.
-
 <PlatformSection notSupported={["apple.ios"]}>
 
 We recommend installing the SDK with Swift Package Manager (SPM), but we also support alternate [installation methods](install/). To integrate Sentry into your Xcode project, open your App in Xcode and open **File > Add Packages**. Then add the SDK by entering the git repo url in the top right search field:

--- a/docs/platforms/apple/common/index.mdx
+++ b/docs/platforms/apple/common/index.mdx
@@ -18,19 +18,34 @@ The support for [visionOS](https://developer.apple.com/visionos/) is currently e
 
 ## Features
 
+<PlatformSection notSupported={["apple.tvos", "apple.watchos", "apple.visionos"]}>
+
 In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](/product/explore/profiling/).
+
+</PlatformSection>
+
+<PlatformSection notSupported={["apple.ios", "apple.macos"]}>
+
+In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
+
+</PlatformSection>
 
 Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-    'profiling',
-  ]}
-/>
+<PlatformSection notSupported={["apple.tvos", "apple.watchos", "apple.visionos"]}>
+
+<OnboardingOptionButtons options={['error-monitoring', 'performance', 'profiling']}/>
+
+</PlatformSection>
+
+<PlatformSection notSupported={["apple.ios", "apple.macos"]}>
+
+<OnboardingOptionButtons options={['error-monitoring', 'performance']}/>
+
+</PlatformSection>
+
 
 Sentry captures data by using an SDK within your application's runtime. These are platform-specific and allow Sentry to have a deep understanding of how your application works.
 
@@ -70,8 +85,9 @@ If you prefer, you can also [set up the SDK manually](/platforms/apple/guides/io
 
 To capture all errors, initialize the SDK as soon as possible, such as in your `AppDelegate` `application:didFinishLaunchingWithOptions` method:
 
+<PlatformSection notSupported={["apple.tvos", "apple.watchos", "apple.visionos"]}>
 
-```swift {tabTitle:Swift} {"onboardingOptions": {"performance": "9-12", "profiling": "13-16"}}
+```swift {tabTitle:Swift} {"onboardingOptions": {"performance": "9-12", "profiling": "14-24"}}
 import Sentry
 
 func application(_ application: UIApplication,
@@ -86,22 +102,22 @@ func application(_ application: UIApplication,
         options.tracesSampleRate = 1.0
     }
 
-     // Manually call startProfiler and stopProfiler to profile any code that runs in between.
-     SentrySDK.startProfiler()
+    // Manually call startProfiler and stopProfiler to profile any code that runs in between.
+    SentrySDK.startProfiler()
 
-     //
-     // ...anything here will be profiled...
-     //
+    //
+    // ...anything here will be profiled...
+    //
 
-     // Calls to stopProfiler are optional - if you don't stop the profiler, it will keep profiling
-     // your application until the process exits, the app goes to the background, or stopProfiling is called.
-     SentrySDK.stopProfiler()
+    // Calls to stopProfiler are optional - if you don't stop the profiler, it will keep profiling
+    // your application until the process exits, the app goes to the background, or stopProfiling is called.
+    SentrySDK.stopProfiler()
 
     return true
 }
 ```
 
-```objc {tabTitle:Objective-C} {"onboardingOptions": {"performance": "8-11", "profiling": "12-15"}}
+```objc {tabTitle:Objective-C} {"onboardingOptions": {"performance": "8-11", "profiling": "13-23"}}
 @import Sentry;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -115,16 +131,16 @@ func application(_ application: UIApplication,
         options.tracesSampleRate = @1.0;
     }];
 
-     // Manually call startProfiler and stopProfiler to profile any code that runs in between.
-     [SentrySDK startProfiler];
+    // Manually call startProfiler and stopProfiler to profile any code that runs in between.
+    [SentrySDK startProfiler];
 
-     //
-     // ...anything here will be profiled...
-     //
+    //
+    // ...anything here will be profiled...
+    //
 
-     // Calls to stopProfiler are optional - if you don't stop the profiler, it will keep profiling
-     // your application until the process exits, the app goes to the background, or stopProfiling is called.
-     [SentrySDK stopProfiler];
+    // Calls to stopProfiler are optional - if you don't stop the profiler, it will keep profiling
+    // your application until the process exits, the app goes to the background, or stopProfiling is called.
+    [SentrySDK stopProfiler];
 
     return YES;
 }
@@ -151,6 +167,66 @@ struct SwiftUIApp: App {
     }
 }
 ```
+</PlatformSection>
+
+<PlatformSection notSupported={["apple.ios", "apple.macos"]}>
+
+```swift {tabTitle:Swift} {"onboardingOptions": {"performance": "9-12"}}
+import Sentry
+
+func application(_ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    SentrySDK.start { options in
+        options.dsn = "___PUBLIC_DSN___"
+        options.debug = true // Enabled debug when first installing is always helpful
+
+        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+        // We recommend adjusting this value in production.
+        options.tracesSampleRate = 1.0
+    }
+
+    return true
+}
+```
+
+```objc {tabTitle:Objective-C} {"onboardingOptions": {"performance": "8-11"}}
+@import Sentry;
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+
+    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+        options.dsn = @"___PUBLIC_DSN___";
+        options.debug = YES; // Enabled debug when first installing is always helpful
+
+        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+        // We recommend adjusting this value in production.
+        options.tracesSampleRate = @1.0;
+    }];
+
+    return YES;
+}
+```
+
+```swift {tabTitle:SwiftUI with App conformer} {"onboardingOptions": {"performance": "9-12"}}
+import Sentry
+
+@main
+struct SwiftUIApp: App {
+    init() {
+        SentrySDK.start { options in
+            options.dsn = "___PUBLIC_DSN___"
+            options.debug = true // Enabled debug when first installing is always helpful
+
+            // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            options.tracesSampleRate = 1.0
+        }
+    }
+}
+```
+
+</PlatformSection>
 
 ## Verify
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Ensures that Profiling (feature description, feature selector, config snippet) is only shown on supported platforms (iOS, macOS). Also fixes a small glitch with incorrect line highlights in snippets.

This PR is based on the changes in https://github.com/getsentry/sentry-docs/pull/12191, so we should get the other one merged first.

fixes https://github.com/getsentry/sentry-docs/issues/12089

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
