### PR TITLE
Fix spacing on the Android Profiling docs

### DIFF
--- a/docs/platforms/android/profiling/index.mdx
+++ b/docs/platforms/android/profiling/index.mdx
@@ -19,8 +19,8 @@ In `AndroidManifest.xml`:
 
 ```xml
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
-    <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+  <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
+  <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
 </application>
 ```
 
@@ -42,10 +42,10 @@ In `AndroidManifest.xml`:
 
 ```xml
 <application>
-    <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
-    <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-    <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
-    <meta-data android:name="io.sentry.traces.profiling.enable-app-start" android:value="true" />
+  <meta-data android:name="io.sentry.dsn" android:value="___PUBLIC_DSN___" />
+  <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+  <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
+  <meta-data android:name="io.sentry.traces.profiling.enable-app-start" android:value="true" />
 </application>
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
I believe the spacing on the docs is incorrect. 
It is correct on the [Tracing page](https://docs.sentry.io/platforms/android/tracing/):
![Screenshot 2024-12-19 at 9 44 34 PM](https://github.com/user-attachments/assets/70a64eef-2113-4fd1-9832-05e1c6c28174)
But incorrect on the [Profiling page](https://docs.sentry.io/platforms/android/profiling/):
![Screenshot 2024-12-19 at 9 45 20 PM](https://github.com/user-attachments/assets/4da3571e-ca70-42ce-91db-568f3342b904)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+


## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
