### PR TITLE
fix(self-hosted): Add difference btw SaaS for iOS symbolication

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -19,6 +19,7 @@ The difference only resides on a few things that are impossible to be hosted by 
 - [Spend Allocation](https://docs.sentry.io/pricing/quotas/spend-allocation/), as it is tightly coupled with Billing Quotas.
 - AI & ML features (such as autofix), although the code is open at [getsentry/seer](https://github.com/getsentry/seer).
 - [Data Storage Location](https://docs.sentry.io/organization/data-storage-location/), because you own your data.
+- [iOS Symbolication](https://docs.sentry.io/platforms/apple/data-management/debug-files/symbol-servers#built-in-repositories), because Apple does not provide a public symbol server, nor do they allow us to distribute the Debug Information Files (DIFs) ourselves.
 
 To put things simply, consider self-hosted as the Business plan without any software limitations and no paid tier.
 


### PR DESCRIPTION
Fixes getsentry/self-hosted#3441.
