### PR TITLE
fix(flags): rm link to custom integration for python

### DIFF
--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -16,6 +16,5 @@ Evaluation tracking requires enabling an SDK integration. Integrations are provi
 
 - [OpenFeature](/platforms/python/integrations/openfeature/)
 - [LaunchDarkly](/platforms/python/integrations/launchdarkly/)
-- [Manual Tracking](/platforms/javascript/configuration/integrations/featureflags/) - if you use an unsupported or in-house provider, you may track evaluations through an API.
 
 <PlatformContent includePath="feature-flags/enable-change-tracking" />


### PR DESCRIPTION
This links to the wrong platform. We shouldn't mention this integration at all until it's live, https://github.com/getsentry/sentry-docs/pull/12152 is on standby for this