### PR TITLE
ref(flags): move min version requirements from index to integration docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`), version 8.43.0 or higher.
+This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
 
 </Alert>
 
@@ -37,7 +37,8 @@ If you are using an external feature flag provider, refer to the [supported list
 
 The Feature Flags integration allows you to manually track feature flag evaluations through an API.
 These evaluations are held in memory and sent to Sentry when an error occurs.
-**At the moment, we only support boolean flag evaluations.**
+**At the moment, we only support boolean flag evaluations.** This integration is available in
+Sentry SDK **versions 8.43.0 or higher.**
 
 _Import names: `Sentry.featureFlagsIntegration` and `type Sentry.FeatureFlagsIntegration`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
+This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`), version 8.43.0 or higher.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
+This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`), version 8.43.0 or higher.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -25,11 +25,12 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`), version 8.43.0 or higher.
+This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
 
 </Alert>
 
-The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag evaluations produced by the LaunchDarkly SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.**
+The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag evaluations produced by the LaunchDarkly SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.** This integration is available in
+Sentry SDK **versions 8.43.0 or higher.**
 
 _Import names: `Sentry.launchDarklyIntegration` and `Sentry.buildLaunchDarklyFlagUsedHandler`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -25,11 +25,12 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`), version 8.43.0 or higher.
+This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
 
 </Alert>
 
-The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.**
+The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.** This integration is available in
+Sentry SDK **versions 8.43.0 or higher.**
 
 _Import name: `Sentry.openFeatureIntegration` and `Sentry.OpenFeatureIntegrationHook`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -25,7 +25,7 @@ notSupported:
 
 <Alert level="info">
 
-This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
+This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`), version 8.43.0 or higher.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -26,7 +26,7 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 
 ## Prerequisites
 
-* You have the <PlatformLink to="/">JavaScript SDK installed</PlatformLink> (version 8.43.0 or higher).
+* You have the <PlatformLink to="/">JavaScript SDK installed</PlatformLink>.
 
 ## Enable Evaluation Tracking
 

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -8,7 +8,7 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 
 ## Prerequisites
 
-* You have the <PlatformLink to="/">Python SDK installed</PlatformLink> (version 2.19.2 or higher).
+* You have the <PlatformLink to="/">Python SDK installed</PlatformLink>.
 
 ## Enable Evaluation Tracking
 

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -9,7 +9,7 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 
 ## Install
 
-Install [`sentry-sdk` from PyPI](https://pypi.org/project/sentry-sdk/). The minimum version for this integration is 2.19.2.
+Install `sentry-sdk` from PyPI. The minimum version for this integration is 2.19.2.
 
 ```bash
 pip install --upgrade 'sentry-sdk'

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -9,7 +9,7 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 
 ## Install
 
-Install `sentry-sdk` from PyPI. The minimum version for this integration is 2.19.2.
+Install `sentry-sdk` (>=2.19.2) from PyPI.
 
 ```bash
 pip install --upgrade 'sentry-sdk'

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -9,7 +9,7 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 
 ## Install
 
-Install `sentry-sdk` from PyPI.
+Install [`sentry-sdk` from PyPI](https://pypi.org/project/sentry-sdk/). The minimum version for this integration is 2.19.2.
 
 ```bash
 pip install --upgrade 'sentry-sdk'
@@ -41,7 +41,7 @@ import sentry_sdk
 
 client = ldclient.get()
 client.variation("hello", Context.create("test-context"), False)
-    
+
 sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -9,7 +9,7 @@ The [OpenFeature](https://openfeature.dev/) integration tracks feature flag eval
 
 ## Install
 
-Install `sentry-sdk` from PyPI.
+Install [`sentry-sdk` from PyPI](https://pypi.org/project/sentry-sdk/). The minimum version for this integration is 2.19.2.
 
 ```bash
 pip install --upgrade 'sentry-sdk'
@@ -41,7 +41,7 @@ import sentry_sdk
 
 client = api.get_client()
 client.get_boolean_value("hello", default_value=False)
-    
+
 sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -9,7 +9,7 @@ The [OpenFeature](https://openfeature.dev/) integration tracks feature flag eval
 
 ## Install
 
-Install [`sentry-sdk` from PyPI](https://pypi.org/project/sentry-sdk/). The minimum version for this integration is 2.19.2.
+Install `sentry-sdk` from PyPI. The minimum version for this integration is 2.19.2.
 
 ```bash
 pip install --upgrade 'sentry-sdk'

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -9,7 +9,7 @@ The [OpenFeature](https://openfeature.dev/) integration tracks feature flag eval
 
 ## Install
 
-Install `sentry-sdk` from PyPI. The minimum version for this integration is 2.19.2.
+Install `sentry-sdk` (>=2.19.2) from PyPI.
 
 ```bash
 pip install --upgrade 'sentry-sdk'


### PR DESCRIPTION
As we add and release more integrations, the versioning will be different for each one, so we should not specify it in the list of integrations.