### PR TITLE
ref(flags): reduce heading size and fix platform icons on python/integrations/

### DIFF
--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -59,12 +59,12 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 | <LinkWithPlatformIcon platform="python.rq"       label="RQ"             url="/platforms/python/integrations/rq" />       |        ✓         |
 | <LinkWithPlatformIcon platform="python.ray"      label="Ray"            url="/platforms/python/integrations/ray" />      |                  |
 
-## Feature Flags
+### Feature Flags
 
 |                                                                                                                         | **Auto-enabled** |
 | ----------------------------------------------------------------------------------------------------------------------- | :--------------: |
-| <LinkWithPlatformIcon platform="launchdarkly" label="LaunchDarkly" url="/platforms/python/integrations/launchdarkly" /> |                  |
-| <LinkWithPlatformIcon platform="openfeature"  label="OpenFeature"  url="/platforms/python/integrations/openfeature" />  |                  |
+| <LinkWithPlatformIcon platform="python" label="LaunchDarkly" url="/platforms/python/integrations/launchdarkly" /> |                  |
+| <LinkWithPlatformIcon platform="python"  label="OpenFeature"  url="/platforms/python/integrations/openfeature" />  |                  |
 
 ### Cloud Computing
 


### PR DESCRIPTION
Fixes a discrepancy with other integration headings. There's no platform icon for FF provider so let's just use Python for now

Before:
<img width="925" alt="Screenshot 2024-12-26 at 11 55 09 PM" src="https://github.com/user-attachments/assets/2dd46a6a-96c3-4521-a016-e7491dcf2060" />

After:
<img width="918" alt="Screenshot 2024-12-26 at 11 55 23 PM" src="https://github.com/user-attachments/assets/eec33eef-ecd7-498f-a1d7-7ba9654887f6" />
