### PR TITLE
docs(js): Add note for shorthand margin

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -142,7 +142,7 @@ The following values are only available as CSS variables, and apply to both dark
 | `--font-size`   | `14px`                                             | The font size.                                                                |
 | `--z-index`     | `100000`                                           | The z-index of the widget.                                                    |
 | `--inset`       | `auto 0 0 auto`                                    | By default, the widget has fixed position, and is in the bottom right corner. |
-| `--page-margin` | `16px`                                             | The margin from the edge of the screen that the widget should be positioned.  |
+| `--page-margin` | `16px`                                             | The margin from the edge of the screen that the widget should be positioned. This also accepts shorthand values like `10px 20px 30px 10px` for top/right/bottom/left margins.   |
 
 Colors can be customized by by defining CSS variables that override the default values, or by passing `themeLight` and/or `themeDark` to `feedbackIntegration({})`.
 


### PR DESCRIPTION
Adds a note that shorthand margin values can be passed to feedback css customization
ref https://github.com/getsentry/sentry-javascript/issues/14539