### PR TITLE
feat: Add better docs for setting the user

### DIFF
--- a/docs/platforms/javascript/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/identify-user/index.mdx
@@ -26,22 +26,30 @@ Serverside SDKs that instrument incoming requests will attempt to pull the IP ad
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server.
 
-If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
+If the field is omitted, the default value is `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To ensure your users' IP addresses are never stored in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 
 Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.
 
-You'll first need to import the SDK, as usual:
+## Setting the User
 
-<PlatformContent includePath="enriching-events/import" />
-
-To identify the user:
+You can set the user by calling the `setUser` method on the Sentry SDK:
 
 <PlatformContent includePath="enriching-events/set-user" />
 
 You can also clear the currently set user:
 
 <PlatformContent includePath="enriching-events/unset-user" />
+
+<PlatformCategorySection supported={["server"]}>
+`Sentry.setUser()` will set the user for the currently active request - see <PlatformLink to="/enriching-events/request-isolation">Request Isolation</PlatformLink> for more information. For example, if you want to set the user for a single request, you can do this like this:
+
+<PlatformContent includePath="enriching-events/set-user-request" />
+
+Or if you want to set the user for all requests, you could do this with a middleware like this:
+
+<PlatformContent includePath="enriching-events/set-user-middleware" />
+</PlatformCategorySection>

--- a/platform-includes/enriching-events/set-user-middleware/javascript.mdx
+++ b/platform-includes/enriching-events/set-user-middleware/javascript.mdx
@@ -1,0 +1,20 @@
+```javascript
+// Add a middleware, for example:
+app.use((req, res, next) => {
+  // Get the user from somewhere
+  const user = req.user;
+
+  // Set the user data for all requests
+  if (user) {
+    Sentry.setUser({
+      id: user.id,
+      email: user.email,
+      username: user.username,
+    });
+  } else {
+    Sentry.setUser(null);
+  }
+
+  next();
+});
+```

--- a/platform-includes/enriching-events/set-user-middleware/javascript.node.mdx
+++ b/platform-includes/enriching-events/set-user-middleware/javascript.node.mdx
@@ -1,0 +1,22 @@
+```javascript
+const Sentry = require("@sentry/node");
+
+// Add a middleware, for example:
+app.use((req, res, next) => {
+  // Get the user from somewhere
+  const user = req.user;
+
+  // Set the user data for all requests
+  if (user) {
+    Sentry.setUser({
+      id: user.id,
+      email: user.email,
+      username: user.username,
+    });
+  } else {
+    Sentry.setUser(null);
+  }
+
+  next();
+});
+```

--- a/platform-includes/enriching-events/set-user-request/javascript.mdx
+++ b/platform-includes/enriching-events/set-user-request/javascript.mdx
@@ -1,0 +1,16 @@
+```javascript
+// Your route handler, for example:
+app.get("/my-route", (req, res) => {
+  // Get the user from somewhere
+  const user = req.user;
+
+  // Set the user data for this request only
+  Sentry.setUser({
+    id: user.id,
+    email: user.email,
+    username: user.username,
+  });
+
+  res.send("Hello World");
+});
+```

--- a/platform-includes/enriching-events/set-user-request/javascript.node.mdx
+++ b/platform-includes/enriching-events/set-user-request/javascript.node.mdx
@@ -1,0 +1,18 @@
+```javascript
+const Sentry = require("@sentry/node");
+
+// Your route handler, for example:
+app.get("/my-route", (req, res) => {
+  // Get the user from somewhere
+  const user = req.user;
+
+  // Set the user data for this request only
+  Sentry.setUser({
+    id: user.id,
+    email: user.email,
+    username: user.username,
+  });
+
+  res.send("Hello World");
+});
+```

--- a/platform-includes/enriching-events/set-user/javascript.node.mdx
+++ b/platform-includes/enriching-events/set-user/javascript.node.mdx
@@ -1,0 +1,5 @@
+```javascript
+const Sentry = require("@sentry/node");
+
+Sentry.setUser({ email: "john.doe@example.com" });
+```


### PR DESCRIPTION
This PR improves the docs for setting the user in JS SDKs.

1. Updates the text about the default value for ip_address. This was more generic than needed, we can just make this JS specific. I _think_ this is correct, but TBH not quite sure what the behavior is there actually 😓 
2. Add docs for server-side JS about how to set the user, concretely, for a single request or for all requests, e.g. in a middleware. For now I made this generic, we may add more specific examples for sub-guides that show specifically how to do this with a next.js middleware, etc. But IMHO we can do that in a follow up.