### PR TITLE
docs(v9/js): Update beforeSendSpan documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -229,7 +229,7 @@ Learn more about <PlatformLink to="/configuration/sampling/">configuring the sam
 
 Available since Javascript SDK version `8.2.0`.
 
-To prevent certain spans from being reported to Sentry, use the <PlatformIdentifier name="before-send-span" /> configuration option which allows you to provide a function to modify and drop a child span.
-This function is only called for child spans of the root span. If you want to modify or drop the root span, including its child spans, use [`beforeSendTransaction`](#using-beforesendtransaction) instead.
+Use the <PlatformIdentifier name="before-send-span" /> configuration option which allows you to provide a function to modify a span.
+This function is called for the root span and all child spans. If you want to drop the root span, including its child spans, use [`beforeSendTransaction`](#using-beforesendtransaction) instead.
 
 <PlatformContent includePath="configuration/before-send-span" />

--- a/includes/platforms/configuration/options/warn-before-send-span.mdx
+++ b/includes/platforms/configuration/options/warn-before-send-span.mdx
@@ -1,5 +1,0 @@
-{/* TODO(v9): Remove this alert in js sdk v9 */}
-
-<Alert level="warning">
-  In the Sentry JavaScript SDK v9.0.0, the ability to drop spans via `beforeSendSpan` by returning `null` will be removed. The callback will only allow modifying span attributes.
-</Alert>

--- a/platform-includes/configuration/before-send-span/javascript.mdx
+++ b/platform-includes/configuration/before-send-span/javascript.mdx
@@ -1,15 +1,12 @@
-<Include name="platforms/configuration/options/warn-before-send-span.mdx" />
-
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // Called for spans
+  // Called for all spans
   beforeSendSpan(span) {
-    // Modify or drop the span here
-    if (span.description === 'unimportant span') {
-      // Don't send the span to Sentry
-      return null;
+    // Modify the span here
+    if (span.description === 'should be renamed') {
+      span.description = 'renamed span';
     }
     return span;
   },


### PR DESCRIPTION
## 🚨 DO NOT MERGE THIS BEFORE JS SDK V9 has shipped

This pr updates the documentation of the behaviour of `beforeSendSpan` in the v9 JS SDK.

documents https://github.com/getsentry/sentry-javascript/pull/14831