### PR TITLE
add reporting-endpoints header for maximum compatibility

### DIFF
--- a/docs/security-legal-pii/security/security-policy-reporting.mdx
+++ b/docs/security-legal-pii/security/security-policy-reporting.mdx
@@ -21,11 +21,12 @@ Content-Security-Policy: ...;
     report-to csp-endpoint
 
 Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
+Reporting-Endpoints: csp-endpoint="https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"
 ```
 
 <Alert level="note" title="Compatibility Recommendation">
 
-Though the `report-to` directive is intended to replace the deprecated `report-uri` directive, `report-to` isn't supported in most browsers yet. So for compatibility with current browsers while also adding forward compatibility when browsers get `report-to` support, you can specify both `report-uri` and `report-to` in your Content-Security-Policy (CSP).
+Though the `report-to` directive is intended to replace the deprecated `report-uri` directive, `report-to` isn't supported in most browsers yet. So for compatibility with current browsers while also adding forward compatibility when browsers get `report-to` support, you can specify both `report-uri` and `report-to` in your Content-Security-Policy (CSP), as well as [Report-To](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Report-To) and [Reporting-Endpoints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Reporting-Endpoints) headers.
 
 </Alert>
 
@@ -38,6 +39,7 @@ Content-Security-Policy-Report-Only: ...;
     report-to csp-endpoint
 
 Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
+Reporting-Endpoints: csp-endpoint="https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"
 ```
 
 When defining your policy it is important to ensure that `sentry.io` or your self-hosted Sentry domain is in your `default-src` or `connect-src` policy, or browsers will block requests that submit policy violations.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Apparently [Report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Report-To) header is deprecated and recommended to be replaced with [Reporting-endpoints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Reporting-Endpoints). Added this to the docs for maximum compatibility.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
