### PR TITLE
Document `forceInit` for Java SDK

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -192,6 +192,14 @@ _(New in version 6.0.0)_
 
 </ConfigKey>
 
+<ConfigKey name="force-init">
+
+Set this boolean to `true` to force a call to `SentryAndroid.init` to go through, even if the SDK has already been initialized with high priority.
+
+_(New in version 8.0.0)_
+
+</ConfigKey>
+
 ## Integration Configuration
 
 For many platform SDKs integrations can be configured alongside it. On some platforms that happen as part of the `init()` call, in some others, different patterns apply.

--- a/docs/platforms/java/common/configuration/options.mdx
+++ b/docs/platforms/java/common/configuration/options.mdx
@@ -162,6 +162,14 @@ _(New in version 6.0.0)_
 
 </ConfigKey>
 
+<ConfigKey name="force-init">
+
+Set this boolean to `true` to force a call to `Sentry.init` to go through, even if the SDK has already been initialized by a high priority integration.
+
+_(New in version 8.0.0)_
+
+</ConfigKey>
+
 ## Integration Configuration
 
 For many platform SDKs integrations can be configured alongside it. On some platforms that happen as part of the `init()` call, in some others, different patterns apply.


### PR DESCRIPTION
Document `forceInit` for Java SDK

Closes https://github.com/getsentry/sentry-java/issues/3762

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
