### PR TITLE
Clarify that tree shaking replay worker is optional

### DIFF
--- a/docs/platforms/javascript/common/session-replay/configuration.mdx
+++ b/docs/platforms/javascript/common/session-replay/configuration.mdx
@@ -135,7 +135,7 @@ replayIntegration({
 });
 ```
 
-4. You can now <PlatformLink to="/configuration/tree-shaking/">Tree Shake</PlatformLink> the default included worker script. If you are using our bundler plugins (version 2.10.0 or later), you can do:
+4. (optional) To reduce bundle size, you can now <PlatformLink to="/configuration/tree-shaking/">Tree Shake</PlatformLink> the default included worker script. If you are using one of the [Sentry Bundler Plugins](https://github.com/getsentry/sentry-javascript-bundler-plugins) (version 2.10.0 or later), you can do:
 
 ```javascript
 sentryPlugin({
@@ -161,7 +161,7 @@ replayIntegration({
 
 ## Custom breadcrumbs
 
-Our SDKs allow you to send custom breadcrumbs, which will appear in the Replay Details UI alongside existing breadcrumbs. To learn how to send custom breadcrumbs, [read the docs here](/platforms/javascript/enriching-events/breadcrumbs/#customize-breadcrumbs). Note that any custom breadcrumbs you send will be reflected in both the Issue Details breadcrumbs UI and the Replay Details breadcrumbs tab.       
+Our SDKs allow you to send custom breadcrumbs, which will appear in the Replay Details UI alongside existing breadcrumbs. To learn how to send custom breadcrumbs, [read the docs here](/platforms/javascript/enriching-events/breadcrumbs/#customize-breadcrumbs). Note that any custom breadcrumbs you send will be reflected in both the Issue Details breadcrumbs UI and the Replay Details breadcrumbs tab.
 
 All custom breadcrumbs in the Replay Details will appear grey, and can be identified by the terminal logo.
 

--- a/docs/platforms/javascript/common/session-replay/configuration.mdx
+++ b/docs/platforms/javascript/common/session-replay/configuration.mdx
@@ -135,7 +135,7 @@ replayIntegration({
 });
 ```
 
-4. (optional) To reduce bundle size, you can now <PlatformLink to="/configuration/tree-shaking/">Tree Shake</PlatformLink> the default included worker script. If you are using one of the [Sentry Bundler Plugins](https://github.com/getsentry/sentry-javascript-bundler-plugins) (version 2.10.0 or later), you can do:
+4. (optional) To reduce bundle size, you can now <PlatformLink to="/configuration/tree-shaking/">Tree Shake</PlatformLink> the default included worker script. If you are using one of the [Sentry Bundler Plugins](https://github.com/getsentry/sentry-javascript-bundler-plugins) (version 2.10.0 or later):
 
 ```javascript
 sentryPlugin({


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

We had a comment that it was unclear whether the tree shaking step when adding a custom worker script for replay was optional.

https://github.com/getsentry/sentry-javascript/discussions/14794#discussioncomment-11744828

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+