### PR TITLE
Improve `bindToScope` docs for Java

### DIFF
--- a/docs/platforms/java/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/tracing/troubleshooting/index.mdx
@@ -19,3 +19,7 @@ The 200+ character request above will become truncated to:
 `https://empowerplant.io/api/0/projects/ep/setup_form/?user_id=314159265358979323846264338327&tracking_id=EasyAsABC123OrSimpleAsDoReMi&product_name=PlantToHumanTranslator&product_id=1618033988749894848`
 
 <PlatformContent includePath="performance/control-data-truncation" />
+
+## Expected spans are missing
+
+Our auto instrumentation, for example those instrumenting database requests or HTTP calls require a transaction to be present on the `Scope` in order to attach a new child span. In case you're missing expected spans, please make sure `bindToScope` is set to `true` when starting a transaction. Also see <PlatformLink to="/tracing/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope">Create Transaction Bound to The Current Scope</PlatformLink>.

--- a/docs/platforms/java/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/tracing/troubleshooting/index.mdx
@@ -20,6 +20,6 @@ The 200+ character request above will become truncated to:
 
 <PlatformContent includePath="performance/control-data-truncation" />
 
-## Expected spans are missing
+## Expected Spans Are Missing
 
-Our auto instrumentation, for example those instrumenting database requests or HTTP calls require a transaction to be present on the `Scope` in order to attach a new child span. In case you're missing expected spans, please make sure `bindToScope` is set to `true` when starting a transaction. Also see <PlatformLink to="/tracing/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope">Create Transaction Bound to The Current Scope</PlatformLink>.
+Our auto instrumentation, for example those instrumenting database requests or HTTP calls, require a transaction to be present on the `Scope` in order to attach a new child span. In case you're missing expected spans, please make sure `bindToScope` is set to `true` when starting a transaction. Also see <PlatformLink to="/tracing/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope">Create Transaction Bound to The Current Scope</PlatformLink>.

--- a/platform-includes/performance/create-transaction-bound-to-scope/java.mdx
+++ b/platform-includes/performance/create-transaction-bound-to-scope/java.mdx
@@ -2,6 +2,8 @@
 
 Our SDK can bind a transaction to the scope making it accessible to every method running within this scope by calling `Sentry#startTransaction` method with `bindToScope` parameter to `true`.
 
+Our auto instrumentation, for example those instrumenting database requests or HTTP calls, require a transaction to be bound to the current scope in order to attach a new child span.
+
 `bindToScope` additionally ensures that your new transaction replaces any one that may be already started. This is useful if you want custom instrumentation to co-exist with auto-instrumented transactions.
 
 In cases where you want to attach Spans to an already ongoing Transaction you can use `Sentry#getSpan`. This method will return a `SentryTransaction` in case there is a running Transaction or a `Span` in case there is already a running Span, otherwise it returns `null`.

--- a/platform-includes/performance/enable-manual-instrumentation/java.mdx
+++ b/platform-includes/performance/enable-manual-instrumentation/java.mdx
@@ -36,3 +36,5 @@ try {
   transaction.finish();
 }
 ```
+
+By default the transaction is not bound to the scope. Our auto instrumentation, for example those instrumenting database requests or HTTP calls rely on a transaction to be present in order to attach new child spans to it. Please take a look at the <PlatformLink to="/tracing/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope">Create Transaction Bound to The Current Scope</PlatformLink> section further down.

--- a/platform-includes/performance/enable-manual-instrumentation/java.mdx
+++ b/platform-includes/performance/enable-manual-instrumentation/java.mdx
@@ -37,4 +37,4 @@ try {
 }
 ```
 
-By default the transaction is not bound to the scope. Our auto instrumentation, for example those instrumenting database requests or HTTP calls rely on a transaction to be present in order to attach new child spans to it. Please take a look at the <PlatformLink to="/tracing/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope">Create Transaction Bound to The Current Scope</PlatformLink> section further down.
+By default the transaction is not bound to the scope. Our auto instrumentation, for example those instrumenting database requests or HTTP calls, rely on a transaction to be present in order to attach new child spans to it. Please take a look at the <PlatformLink to="/tracing/instrumentation/custom-instrumentation/#create-transaction-bound-to-the-current-scope">Create Transaction Bound to The Current Scope</PlatformLink> section further down.


### PR DESCRIPTION
Improve `bindToScope` docs for Java as some customers were confused by missing spans due to the transaction not being bound to the scope.

Closes https://github.com/getsentry/sentry-java/issues/3760

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
