### PR TITLE
docs(js): Extend example on `captureMessage`

### DIFF
--- a/platform-includes/capture-message/javascript.mdx
+++ b/platform-includes/capture-message/javascript.mdx
@@ -1,6 +1,7 @@
 ```javascript
 Sentry.captureMessage("Something went wrong");
 
-// optionally specify the severity level (one of "fatal", "error", "warning", "log", "info", "debug")
+// optionally specify the severity level:
+// "fatal" | "error" | "warning" | "log" | "debug" | "info" (default)
 Sentry.captureMessage("Something went wrong", "warning");
 ```

--- a/platform-includes/capture-message/javascript.mdx
+++ b/platform-includes/capture-message/javascript.mdx
@@ -2,12 +2,5 @@
 Sentry.captureMessage("Something went wrong");
 
 // optionally specify the severity level
-Sentry.captureMessage("Something went wrong", "fatal");
-
-// optionally pass additional data to the event
-Sentry.captureMessage("Something went wrong", {
-  tags: {
-    foo: "bar",
-  },
-});
+Sentry.captureMessage("Something went wrong", "warning");
 ```

--- a/platform-includes/capture-message/javascript.mdx
+++ b/platform-includes/capture-message/javascript.mdx
@@ -1,3 +1,13 @@
 ```javascript
 Sentry.captureMessage("Something went wrong");
+
+// optionally specify the severity level
+Sentry.captureMessage("Something went wrong", "fatal");
+
+// optionally pass additional data to the event
+Sentry.captureMessage("Something went wrong", {
+  tags: {
+    foo: "bar",
+  },
+});
 ```

--- a/platform-includes/capture-message/javascript.mdx
+++ b/platform-includes/capture-message/javascript.mdx
@@ -1,6 +1,6 @@
 ```javascript
 Sentry.captureMessage("Something went wrong");
 
-// optionally specify the severity level
+// optionally specify the severity level (one of "fatal", "error", "warning", "log", "info", "debug")
 Sentry.captureMessage("Something went wrong", "warning");
 ```


### PR DESCRIPTION
Extends the example on `captureMessage` to show the usage of optional params.

ref https://github.com/getsentry/sentry-docs/issues/9979