### PR TITLE
fix(replay): Be a little clearer about whether the page is mobile or web specific at the top

### DIFF
--- a/docs/product/explore/session-replay/mobile/performance-overhead.mdx
+++ b/docs/product/explore/session-replay/mobile/performance-overhead.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Replay Performance Overhead"
 sidebar_order: 30
-description: "Learn about how enabling Session Replay impacts the performance of your application."
+description: "Learn about how enabling Session Replay impacts the performance of your mobile application."
 ---
 
 Session Replay for mobile captures snapshots of the view hierarchy as well as a screenshot within the same frame once per second. These are compressed into a video file representing parts of the user’s session, then streamed to Sentry with trace identifiers, breadcrumbs, and other debugging information to reconstruct the full session.

--- a/docs/product/explore/session-replay/web/performance-overhead.mdx
+++ b/docs/product/explore/session-replay/web/performance-overhead.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Replay Performance Overhead"
 sidebar_order: 48
-description: "Learn more about how enabling Session Replay impacts the performance of your application."
+description: "Learn about how enabling Session Replay impacts the performance of your web application."
 ---
 
 <Include name="session-replay-web-report-bug.mdx" />


### PR DESCRIPTION
Low impact change, but i was looking at these pages and just a little confused because I had 'JavaScript' selected in the top-left.

**Before**
| `/product/explore/session-replay/web/performance-overhead/` | `/product/explore/session-replay/mobile/performance-overhead/` |
| --- | --- |
| ![SCR-20250107-kixt](https://github.com/user-attachments/assets/ee391ccc-0fa0-437b-9e7c-6c7e77d14e98) | ![SCR-20250107-kiyy](https://github.com/user-attachments/assets/3de4c770-7fd5-4493-ae5f-31771f90b8a0) |
| ![SCR-20250107-kmva](https://github.com/user-attachments/assets/58a7f69d-c119-4be0-ba8d-0b153c3e423f) | ![SCR-20250107-kmwg](https://github.com/user-attachments/assets/4a35a72e-4e89-4bd7-be81-8e3d7464a3f8) |
