### PR TITLE
ref(flags): rename self-serve in generic ffs index

### DIFF
--- a/docs/organization/integrations/feature-flag/generic/index.mdx
+++ b/docs/organization/integrations/feature-flag/generic/index.mdx
@@ -12,7 +12,7 @@ Sentry can track flag evaluations as they happen within your application.  Flag 
 
 To set up evaluation tracking, visit the [explore page](/product/explore/feature-flags/) and select the language and SDK of your choice. Not using a supported SDK? That's okay. We support generic integrations with your existing system.
 
-To set up self-serve evaluation tracking, visit one of our supported languages' pages:
+To set up generic evaluation tracking, visit one of our supported languages' pages:
 * [JavaScript](/platforms/javascript/configuration/integrations/generic/)
 * [Python](/platforms/python/integrations/feature-flags/generic/)
 


### PR DESCRIPTION
follow-up on https://github.com/getsentry/sentry-docs/pull/12270, missed a spot