### PR TITLE
fix(codepush): Typo use `sourcemaps upload` not `react-native appcenter`

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
@@ -56,7 +56,7 @@ If you are using Hermes make sure `jq` is installed on your system. If it's not,
 
 ## Upload Source Maps
 
-Upload source maps for your CodePush release by setting up your environment variables and running the `react-native appcenter` command.
+Upload source maps for your CodePush release by setting up your environment variables and running the `sourcemaps upload` command.
 
 Before running the upload command, make sure to set up your environment variables.
 
@@ -66,7 +66,7 @@ export SENTRY_PROJECT=___PROJECT_SLUG___
 export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-To upload source maps for your CodePush release, use the `react-native appcenter` command.
+To upload source maps for your CodePush release, use the `sourcemaps upload` command.
 
 ```bash {tabTitle:Sentry CLI}
 npx sentry-cli sourcemaps upload \


### PR DESCRIPTION
Small typo fix, the command example is correct, just the text was not updated. 