### PR TITLE
Move python feature branch docs; add java learnings

### DIFF
--- a/develop-docs/sdk/miscellaneous/feature-branches.mdx
+++ b/develop-docs/sdk/miscellaneous/feature-branches.mdx
@@ -4,7 +4,7 @@ description: How-to for syncing long-running feature branches.
 sidebar_order: 30
 ---
 
-Sometimes we have long-running feature branches that can't be merged into `master` yet because they contain breaking changes (e.g. `sentry-sdk-2.0`, `potel-base`). They have to be kept in sync with `master` though.
+Sometimes we have long-running feature branches that can't be merged into `master` yet because they contain breaking changes (e.g. `sentry-sdk-2.0`, `potel-base` in python SDK, `8.x.x` in Java SDK). They have to be kept in sync with `master`/`main` though.
 
 You might be tempted to branch off the feature branch and do the merge there, maybe make a PR so that you can double check the changes in the UI and make sure CI is green. In that case you need to make sure you **don't actually commit the merge from another branch** — the merge commit needs to be directly on the feature branch, otherwise `git` doesn't set the parent commits for the merge commit properly and the feature branch will still have unresolved conflicts (even though you literally just resolved them).
 
@@ -20,3 +20,17 @@ If you still want the nice GH diff and have CI run on your changes:
 - push the new branch, make a PR, look at the nice diff in GitHub, see if the tests pass
 - if everything looks ok: don't merge the PR! this will not mark the merge conflicts as solved
 - instead, `git checkout` your feature branch (with the merge commit on top) and `push` it
+
+## Alternative solution B (used for Java SDK `8.x.x` branch)
+
+- Create a PR for merging `main` into `8.x.x`
+- Once that PR is merged into `8.x.x` there will still be conflicts shown in the PR for merging `8.x.x` back to `main`
+- Do another merge of `main` into `8.x.x` where you accept all changes on the `8.x.x` branch and create an empty merge commit
+- NOTE: If there are new commits on `main` this won't work correctly
+
+
+## Alternative solution B (untested)
+
+- Create a merge PR for merging `main` into e.g. `8.x.x`
+- When merging the PR do not squash but create a merge commit (might have to enable this in repo settings first)
+- If someone tests this, please update the docs here

--- a/develop-docs/sdk/miscellaneous/feature-branches.mdx
+++ b/develop-docs/sdk/miscellaneous/feature-branches.mdx
@@ -21,7 +21,7 @@ If you still want the nice GH diff and have CI run on your changes:
 - if everything looks ok: don't merge the PR! this will not mark the merge conflicts as solved
 - instead, `git checkout` your feature branch (with the merge commit on top) and `push` it
 
-## Alternative solution B (used for Java SDK `8.x.x` branch)
+## Alternative solution A (used for Java SDK `8.x.x` branch)
 
 - Create a PR for merging `main` into `8.x.x`
 - Once that PR is merged into `8.x.x` there will still be conflicts shown in the PR for merging `8.x.x` back to `main`


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
