### PR TITLE
Changing `o` to `options` for Xamarin docs

### DIFF
--- a/docs/platforms/dotnet/common/migration/index.mdx
+++ b/docs/platforms/dotnet/common/migration/index.mdx
@@ -262,8 +262,8 @@ To align with other SDKs, the option is now named: `DiagnosticLogger`
 
 `SentryOptions` now take a string for `Dsn`:
 
-Before: `o.Dsn = new Dsn("..");`
-After: `o.Dsn = "..";`
+Before: `options.Dsn = new Dsn("..");`  
+After: `options.Dsn = "..";`
 
 #### `LogEntry` Became `Message`
 
@@ -402,23 +402,23 @@ Changed how to initialize Sentry:
 SentrySdk.Init("___PUBLIC_DSN___");
 
 // Initialize with options
-SentrySdk.Init(o =>
+SentrySdk.Init(options =>
 {
-    o.Dsn = "___PUBLIC_DSN___";
+    options.Dsn = "___PUBLIC_DSN___";
 });
 ```
 
-For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it by calling `o.AddAspNet()`:
+For ASP.NET (classic) integration, add `Sentry.AspNet` package and initialize it by calling `options.AddAspNet()`:
 
 
 ```csharp
 using Sentry.AspNet;
 
-SentrySdk.Init(o =>
+SentrySdk.Init(options =>
 {
-    o.Dsn = "___PUBLIC_DSN___";
+    options.Dsn = "___PUBLIC_DSN___";
 
-    o.AddAspNet();
+    options.AddAspNet();
 });
 ```
 
@@ -472,9 +472,9 @@ ravenClient.BeforeSend = requester =>
 };
 
 // After
-SentrySdk.Init(o =>
+SentrySdk.Init(options =>
 {
-    o.BeforeSend = e =>
+    options.BeforeSend = e =>
     {
         // Mutate the event or return null to drop it altogether
         return e;

--- a/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
@@ -3,12 +3,12 @@ pass the option object along for modifications:
 
 
 ```csharp
-SentryXamarin.Init(o =>
+SentryXamarin.Init(options =>
 {
-    o.Dsn = "___PUBLIC_DSN___";
-	  o.AddXamarinFormsIntegration();
-    o.MaxBreadcrumbs = 50;
-    o.Debug = true;
+    options.Dsn = "___PUBLIC_DSN___";
+	  options.AddXamarinFormsIntegration();
+    options.MaxBreadcrumbs = 50;
+    options.Debug = true;
 });
     // app code here
 ```

--- a/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.xamarin.mdx
@@ -6,7 +6,7 @@ pass the option object along for modifications:
 SentryXamarin.Init(options =>
 {
     options.Dsn = "___PUBLIC_DSN___";
-	  options.AddXamarinFormsIntegration();
+    options.AddXamarinFormsIntegration();
     options.MaxBreadcrumbs = 50;
     options.Debug = true;
 });

--- a/platform-includes/enriching-events/attachment-upload/dotnet.mdx
+++ b/platform-includes/enriching-events/attachment-upload/dotnet.mdx
@@ -6,7 +6,7 @@ SentrySdk.ConfigureScope(scope =>
 });
 
 // Local Scope
-SentrySdk.CaptureMessage("my message", configureScope =>
+SentrySdk.CaptureMessage("my message", scope =>
 {
     scope.AddAttachment("log.txt");
 });

--- a/platform-includes/getting-started-config/dotnet.xamarin.mdx
+++ b/platform-includes/getting-started-config/dotnet.xamarin.mdx
@@ -3,17 +3,17 @@ on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate fo
 
 
 ```csharp
-SentryXamarin.Init(o =>
+SentryXamarin.Init(options =>
 {
-    o.AddXamarinFormsIntegration();
+    options.AddXamarinFormsIntegration();
     // Tells which project in Sentry to send events to:
-    o.Dsn = "___PUBLIC_DSN___";
+    options.Dsn = "___PUBLIC_DSN___";
     // When configuring for the first time, to see what the SDK is doing:
-    o.Debug = true;
+    options.Debug = true;
     // Set TracesSampleRate to 1.0 to capture 100%
     // of transactions for tracing.
     // We recommend adjusting this value in production
-    o.TracesSampleRate = 1.0;
+    options.TracesSampleRate = 1.0;
 });
 // App code
 

--- a/platform-includes/performance/automatic-instrumentation-integrations/dotnet.mdx
+++ b/platform-includes/performance/automatic-instrumentation-integrations/dotnet.mdx
@@ -9,14 +9,14 @@ Starting with version 3.9.0, the SDK automatically integrates with Entity Framew
 If you don't want to have this integration, you can disable it on `SentryOptions` by calling `DisableDiagnosticSourceIntegration();`
 
 ```csharp
-option.DisableDiagnosticSourceIntegration();
+options.DisableDiagnosticSourceIntegration();
 ```
 
 If your project doesn't match any of the conditions above, (for example, it targets .NET Framework 4.6.1 and uses only the `Sentry` package), you can still manually activate those instrumentations by including the package `Sentry.DiagnosticSource` and enabling it during on the SDK's initialization.
 
 ```csharp
 // Requires NuGet package: Sentry.DiagnosticSource
-option.AddDiagnosticSourceIntegration();
+options.AddDiagnosticSourceIntegration();
 ```
 
 ### Entity Framework Core Integration

--- a/platform-includes/performance/opentelemetry-setup/dotnet.mdx
+++ b/platform-includes/performance/opentelemetry-setup/dotnet.mdx
@@ -61,12 +61,12 @@ var builder = Sdk.CreateTracerProviderBuilder()
 Next, initialize Sentry and opt into the use of OpenTelemetry. Provide the SDK with the builder for OpenTelemetry's tracer provider to allow sending spans to Sentry.
 
 ```csharp
-_sentry = SentrySdk.Init(o =>
+_sentry = SentrySdk.Init(options =>
 {
-    //o.Dsn = "...Your DSN...";
-    o.TracesSampleRate = 1.0;
-    o.AddAspNet(RequestSize.Always);
-    o.UseOpenTelemetry(builder);
+    //options.Dsn = "...Your DSN...";
+    options.TracesSampleRate = 1.0;
+    options.AddAspNet(RequestSize.Always);
+    options.UseOpenTelemetry(builder);
 });
 ```
 


### PR DESCRIPTION
I noticed that we are using `o` and `options` interchangeably. I caught this while referencing docs for a blog post. I *think* I caught all of the instances, but I'm not positive. I'd like to see this in preview so that I can go through one more time to be sure.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
