### PR TITLE
fix(docs): Fix syntax highlighting for .NET migration guide

### DIFF
--- a/docs/platforms/dotnet/common/migration/index.mdx
+++ b/docs/platforms/dotnet/common/migration/index.mdx
@@ -137,7 +137,7 @@ This SDK version is compatible with a self-hosted version of Sentry `22.12.0` or
   - `SentrySdk.CaptureMessage(string message, Action<Scope> scopeCallback)`
   - `SentrySdk.CaptureException(Exception exception, Action<Scope> scopeCallback)`
 
-  ```c#
+  ```csharp
   // Before
   SentrySdk.WithScope(scope =>
   {


### PR DESCRIPTION
Should fix up https://github.com/getsentry/sentry-docs/issues/12318