### PR TITLE
codeowners pointers for replay

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,12 +45,12 @@
 
 # ###### Replays #######
 
-# /src/docs/product/session-replay/                                 @getsentry/replay
-# /src/includes/session-replay-web-report-bug.mdx                   @getsentry/replay
-# /src/platform-includes/session-replay/                            @getsentry/replay @getsentry/replay-sdk-web
-# /src/platforms/javascript/common/session-replay/                  @getsentry/replay @getsentry/replay-sdk-web
-# /src/wizard/javascript/replay-onboarding/                         @getsentry/replay @getsentry/replay-sdk-web
+# /src/docs/product/session-replay/web                              @jas-kas @getsentry/replay-sdk-web @getsentry/replay-frontend @getsentry/replay-backend
+# /src/docs/product/session-replay/mobile                           @jas-kas @getsentry/replay-sdk-mobile @getsentry/replay-frontend @getsentry/replay-backend
+# /src/includes/session-replay-web-report-bug.mdx                   @getsentry/replay-sdk-web
+# /src/platform-includes/session-replay/                            @getsentry/replay-sdk-web @getsentry/replay-sdk-mobile
+# /src/platforms/javascript/common/session-replay/                  @getsentry/replay-sdk-web
 
-# /src/docs/product/dev-toolbar/                                    @getsentry/replay
+# /src/docs/product/dev-toolbar/                                    @ryan953 @jas-kas
 
 # ###### End Replays #######


### PR DESCRIPTION
we're removing the global replay group as it's spammy.

Ideally devtoolbar gets a new group. But I'd say Ryan + Jasmin could be a good start (specially since this is **deadcode** that serves as a guide).

relates to:
* https://github.com/getsentry/security-as-code/pull/1174