### PR TITLE
fix(flags): Remove get_variant example from unleash docs

### DIFF
--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -46,18 +46,6 @@ test_flag_enabled = unleash.is_enabled("test-flag")
 sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 
-```python {tabTitle: Python, using get_variant}
-import sentry_sdk
-from UnleashClient import UnleashClient
-
-unleash = UnleashClient(...)  # See Unleash quickstart.
-unleash.initialize_client()
-
-test_flag_variant = unleash.get_variant("test-flag")
-test_flag_enabled = test_flag_variant["enabled"]
-sentry_sdk.capture_exception(Exception("Something went wrong!"))
-```
-
 Visit the [Sentry website](https://sentry.io/issues/) and confirm that your error
 event has recorded the feature flag "test-flag", and its value is equal to `test_flag_enabled`.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
