### PR TITLE
ref(flags): remove dup paragraph from python FF index

### DIFF
--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -6,9 +6,6 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-A feature flagging integration allows you to manually track feature flag evaluations through an API. These evaluations are collected in memory, and in the event an error occurs, sent to Sentry for review and analysis.
-
-
 ## Prerequisites
 
 * You have the <PlatformLink to="/">Python SDK installed</PlatformLink>.


### PR DESCRIPTION
This paragraph is a dup of the one under ### Generic API, and also isn't correct (none of the integrations expose an API).