### PR TITLE
ref(flags): link to unleash webhook docs and flatten change tracking links

### DIFF
--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -36,4 +36,6 @@ Evaluation tracking requires enabling an SDK integration. Integrations are provi
 - [LaunchDarkly](/platforms/javascript/configuration/integrations/launchdarkly/)
 - [OpenFeature](/platforms/javascript/configuration/integrations/openfeature/)
 
-<PlatformContent includePath="feature-flags/enable-change-tracking" />
+## Enable Change Tracking
+
+<PlatformContent includePath="feature-flags/change-tracking-list" />

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -36,4 +36,6 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))
 
 Go to your Sentry project and confirm that your error event has recorded the feature flag "test-flag" and its value "false".
 
-<PlatformContent includePath="feature-flags/enable-change-tracking" />
+## Enable Change Tracking
+
+<PlatformContent includePath="feature-flags/change-tracking-list" />

--- a/docs/product/explore/feature-flags/index.mdx
+++ b/docs/product/explore/feature-flags/index.mdx
@@ -28,6 +28,4 @@ Change tracking enables Sentry to listen for additions, removals, and modificati
 
 ### Set Up Change Tracking
 
-To set up change tracking, visit the webhook integration documentation for your provider:
-* [LaunchDarkly](/organization/integrations/feature-flag/launchdarkly/#change-tracking)
-* [Generic](/organization/integrations/feature-flag/generic/#change-tracking)
+<PlatformContent includePath="feature-flags/change-tracking-list" platform="_default"/>

--- a/platform-includes/feature-flags/change-tracking-list/_default.mdx
+++ b/platform-includes/feature-flags/change-tracking-list/_default.mdx
@@ -1,0 +1,4 @@
+Change tracking requires registering a Sentry webhook with a feature flag provider. For set up instructions, visit the documentation for your provider:
+* [Generic](/organization/integrations/feature-flag/generic/#change-tracking)
+* [LaunchDarkly](/organization/integrations/feature-flag/launchdarkly/#change-tracking)
+* [Unleash](/organization/integrations/feature-flag/unleash/#change-tracking)

--- a/platform-includes/feature-flags/enable-change-tracking/_default.mdx
+++ b/platform-includes/feature-flags/enable-change-tracking/_default.mdx
@@ -1,3 +1,0 @@
-## Enable Change Tracking
-
-Change tracking requires registering a Sentry webhook with your feature flag provider. Set up varies by provider and is documented in detail [here](/product/explore/feature-flags/#change-tracking).


### PR DESCRIPTION
Adds a link to the unleash webhook docs, which we were missing before.

Modifies/renames `enable-change-tracking` PlatformContent to be the list of webhook docs. These are platform-agnostic but I'm using PlatformContent to reuse this list.

In summary,
**Before**: platform FFs -> product/explore FFs -> webhook doc

**After**: 
platform FFs -> webhook doc
product/explore FFs -> webhook doc

**/product/explore/feature-flags/ Before**
![Screenshot 2025-01-15 at 1 34 14 PM](https://github.com/user-attachments/assets/be558e80-49a8-43d9-841a-f65e05046238)

**After**
![Screenshot 2025-01-14 at 2 55 13 PM](https://github.com/user-attachments/assets/1be7490e-4776-4b51-ac80-b204fa650b82)

**/platforms/[javascript or python]/feature-flags/ Before** (links to /product/explore/feature-flags/)
![Screenshot 2025-01-15 at 1 35 07 PM](https://github.com/user-attachments/assets/0e6bfdef-82ef-4bfb-9bc8-f9d3199beecc)

**After**
![Screenshot 2025-01-14 at 2 55 58 PM](https://github.com/user-attachments/assets/bee13196-a063-4ead-b834-3aab52f1f822)