### PR TITLE
ref(flags): update generic webhook instructions

### DIFF
--- a/docs/organization/integrations/feature-flag/generic/index.mdx
+++ b/docs/organization/integrations/feature-flag/generic/index.mdx
@@ -10,7 +10,7 @@ Sentry can track flag evaluations as they happen within your application.  Flag 
 
 ### Set Up Evaluation Tracking
 
-To set up evaluation tracking, visit the [explore page](/product/explore/feature-flags/) and select the language and SDK of your choice. Not using a supported SDK? That's okay. We support generic integrations with your existing system.
+To set up evaluation tracking, visit the [explore page](/product/explore/feature-flags/) and select the language and SDK of your choice. Not using a supported SDK? That's okay. We support generic solutions for your existing system.
 
 To set up generic evaluation tracking, visit one of our supported languages' pages:
 * [JavaScript](/platforms/javascript/configuration/integrations/generic/)
@@ -20,15 +20,33 @@ To set up generic evaluation tracking, visit one of our supported languages' pag
 
 Sentry can track changes to feature flag definitions and report suspicious feature flag edits.
 
-Sentry offers a change tracking feature which functions as an audit-log of feature flag changes. When a feature flag definition changes in your back-end you can emit a web hook to Sentry.
+For the generic case, you need to write a webhook that conforms to our API. You can find instructions on how to do this below.
+
+### Set Up Change Tracking
+
+Enabling Change Tracking is a four step process. To get started visit the [feature-flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags) in a new tab. Then follow the steps listed below.
+
+1. **Click the "Add New Provider" button.**
+    - One webhook secret can be registered per provider type.
+    - Select Generic in the dropdown that says "Select a provider".
+2. **Save the webhook URL**.
+    - Copy the provided Sentry webhook URL and save it for step 4.
+3. **Set the Signing Secret**.
+    - In your feature flagging system's UI, find the "Signing Secret".
+    - Copy the signing secret and paste it into the input box next to "Secret" in Sentry settings.
+    - Save the secret by clicking "Add Provider" in Sentry settings.
+4. **Write your own webhook**.
+    - Configure your system to POST to the webhook URL, whenever a feature flag definition changes.
+    - Sign your webhook payloads with the Signing Secret from step 3.
+    - See [#api-documentation](./generic/#api-documentation) for more details.
 
 ### API Documentation
 
-If you're using a generic integration it means you will likely need to write code to support this endpoint. This section documents our authentication procedures as well as the resource's fields and structure.
+This section documents our authentication procedures as well as the resource's fields and structure.
 
 #### Authentication
 
-Authentication is performed using a "signing secret". The "signing secret" must be used to sign the web hook payload in your feature flagging system. Signing the payload with your secret produces a "signature". Sentry needs this signature so it can compare the results of our signing function to yours. Both sides must use the same signing function. Sentry uses a HMAC SHA256 hex-digest of the web hook payload. In Python this function looks like:
+Authentication is performed using a "signing secret". The "signing secret" must be used to sign the webhook payload in your feature flagging system. Signing the payload with your secret produces a "signature". Sentry needs this signature so it can compare the results of our signing function to yours. Both sides must use the same signing function. Sentry uses a HMAC SHA256 hex-digest of the web hook payload. In Python this function looks like:
 
 ```python
 def hmac_sha256_hex_digest(secret: str, message: bytes):
@@ -40,19 +58,3 @@ The result of this function must be sent as a header to Sentry: `X-Sentry-Signat
 #### API Blueprint
 
 [An API blueprint is available at this permalink](https://github.com/getsentry/sentry/blob/ed324708947ca26392d6579ed76b93fc94a61ab6/src/sentry/flags/docs/api.md#create-generic-flag-log-post). We strive to keep this page updated. Be sure to check the latest master branch for new protocol versions. We will always maintain backwards compatibility so there is no harm in implementing an old version. However, new versions might introduce new features.
-
-### Set Up Change Tracking
-
-Enabling Change Tracking is a three step process. To get started visit the [feature-flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags) in a new tab. Then follow the steps listed below.
-
-1. **Click the "Add New Provider" button.**
-    - One webhook secret can be registered per provider type.
-    - Select Generic in the dropdown that says "Select a provider".
-2. **Register the webhook URL**.
-    - Copy the provided Sentry webhook URL and configure your feature flagging system to emit web hooks to this URL.
-3. **Set the Signing Secret**.
-    - In your feature flagging system's UI, find the "Signing Secret".
-    - Copy the signing secret and paste it into the input box next to "Secret" in Sentry settings.
-    - Save the secret by clicking "Add Provider" in Sentry settings.
-
-Once saved Sentry will now accept and authenticate all inbound hooks to your organization's feature flag webhook endpoint.


### PR DESCRIPTION
Tweaks this section and makes it more clear that the user has to write custom webhook code, conforming to our blueprint.

Before:
https://docs.sentry.io/organization/integrations/feature-flag/generic/#change-tracking

After:
![Screenshot 2025-01-14 at 3 31 13 PM](https://github.com/user-attachments/assets/36a38773-a9b6-45ed-81f9-974ceb601832)
