### PR TITLE
ref(flags): update python supported vers and install snippets

### DIFF
--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -9,10 +9,10 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 
 ## Install
 
-Install `sentry-sdk` (>=2.19.2) from PyPI.
+Install `sentry-sdk` from PyPI with the `launchdarkly` extra.
 
 ```bash
-pip install --upgrade 'sentry-sdk'
+pip install --upgrade 'sentry-sdk[launchdarkly]'
 ```
 
 ## Configure
@@ -46,5 +46,11 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 
 Visit the Sentry website and confirm that your error event has recorded the feature flag "hello" and its value "false".
+
+## Supported Versions
+
+- launchdarkly-server-sdk >= 9.8.0
+- sentry-sdk >= 2.19.2
+- python >= 3.8
 
 <PlatformContent includePath="feature-flags/next-steps" />

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -9,10 +9,10 @@ The [OpenFeature](https://openfeature.dev/) integration tracks feature flag eval
 
 ## Install
 
-Install `sentry-sdk` (>=2.19.2) from PyPI.
+Install `sentry-sdk` from PyPI with the `openfeature` extra.
 
 ```bash
-pip install --upgrade 'sentry-sdk'
+pip install --upgrade 'sentry-sdk[openfeature]'
 ```
 
 ## Configure
@@ -46,5 +46,11 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 
 Visit the Sentry website and confirm that your error event has recorded the feature flag "hello" and its value "false".
+
+## Supported Versions
+
+- openfeature-sdk >= 0.7.1
+- sentry-sdk >= 2.19.2
+- python >= 3.8
 
 <PlatformContent includePath="feature-flags/next-steps" />

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -9,10 +9,10 @@ The [Unleash](https://www.getunleash.io/) integration tracks feature flag evalua
 
 ## Install
 
-Install `sentry-sdk` (>=2.20.0) and `UnleashClient` (>=6.0.1) from PyPI.
+Install `sentry-sdk` from PyPI with the `unleash` extra.
 
 ```bash
-pip install --upgrade sentry-sdk UnleashClient
+pip install --upgrade 'sentry-sdk[unleash]'
 ```
 
 ## Configure
@@ -48,5 +48,11 @@ sentry_sdk.capture_exception(Exception("Something went wrong!"))
 
 Visit the [Sentry website](https://sentry.io/issues/) and confirm that your error
 event has recorded the feature flag "test-flag", and its value is equal to `test_flag_enabled`.
+
+## Supported Versions
+
+- UnleashClient >= 6.0.1
+- sentry-sdk >= 2.20.0
+- python >= 3.8
 
 <PlatformContent includePath="feature-flags/next-steps" />


### PR DESCRIPTION
Update python integration docs to follow the pattern of [clickhouse-driver](https://docs.sentry.io/platforms/python/integrations/clickhouse-driver/). Versions are based on `tox.ini` and extras_require dict in `setup.py` of python repo. Using the extra (e.g. `[launchdarkly]`) will automatically install the required dependencies.

LD after:
![Screenshot 2025-01-14 at 3 57 46 PM](https://github.com/user-attachments/assets/723e21a4-af98-4384-8b60-25ca493046a5)

Before:
![Screenshot 2025-01-14 at 3 58 17 PM](https://github.com/user-attachments/assets/ae9b9ea8-2d07-412c-b285-ec8e98c6acb0)