### PR TITLE
Replace `Hub` docs with `Scopes`

### DIFF
--- a/docs/platforms/android/enriching-events/scopes/index.mdx
+++ b/docs/platforms/android/enriching-events/scopes/index.mdx
@@ -1,46 +1,79 @@
 ---
-title: Scopes and Hubs
+title: Scopes
 description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra
 information from the current scope. SDKs will typically automatically manage the scopes
 for you in the framework integrations and you don't need to think about them. However,
-you should know what a scope is and how you can use it for your advantage.
+you should know what a scope is and how you can use it to your advantage.
 
-## What's a Scope, What's a Hub
+## What's a Scope?
 
-You can think of the hub as the central point that our SDKs use to route an
-event to Sentry. When you call `init()` a hub is created and a client and a
-blank scope are created on it. That hub is then associated with the current
-thread and will internally hold a stack of scopes.
-
-The scope will hold useful information that should be sent along with the
-event. For instance [contexts](../context/) or
+Scopes hold useful information that gets sent along with the
+event. For instance, [contexts](../context/) and
 [breadcrumbs](../breadcrumbs/) are stored on
-the scope. When a scope is pushed, it inherits all data from the parent scope
-and when it pops all modifications are reverted.
+the scope. When a scope is forked, it inherits all data from its parent scope.
 
-The default SDK integrations will push and pop scopes intelligently. For
-instance web framework integrations will create and destroy scopes around your
-routes or controllers.
+## How Scopes Work
 
-## How the Scope and Hub Work
+Scopes are basically a stack of data that is attached to events. When an event is captured, the SDK will merge the data from the active scopes into the event. This allows you to attach data to events that is relevant to the context in which the event was captured.
 
-As you start using an SDK, a scope and hub are automatically created for you out
-of the box. It's unlikely that you'll interact with the hub directly unless you're
-writing an integration or you want to create or destroy scopes. Scopes, on the
-other hand are more user facing. You can call <PlatformIdentifier name="configure-scope" /> at any point in
-time to modify data stored on the scope. This is useful for doing things like
-[modifying the context](../context/).
+When you call a global function such as `Sentry.captureException`, internally Sentry discovers the active scopes and uses them when capturing the event.
 
-When you call a global function such as <PlatformIdentifier name="capture-event" /> internally Sentry
-discovers the current hub and asks it to capture an event. Internally the hub will
-then merge the event with the topmost scope's data.
+## Different Kinds of Scopes
+
+The Sentry SDK has three different kinds of scopes:
+
+- [Global scope](#global-scope)
+- [Isolation scope](#isolation-scope)
+- [Current scope](#current-scope)
+
+The Android SDK does not fork scopes on its own so you may set data on any of the scopes. The default the SDK writes to from its top level API is [current scope](#current-scope).
+
+### Global Scope
+
+The global scope is applied to _all_ events, no matter where they originate. You can use it to store data that should apply to all events, such as environmental information.
+
+### Isolation Scope
+
+The isolation scope is used to isolate events from each other. For example, each request in a web server might get its own isolation scope, so that events from one request don't interfere with events from another request.
+
+### Current Scope
+
+The current scope is the local scope that is currently active. You can modify the current scope via `Sentry.configureScope(scope -> { ... })`.
+
+## How Scope Data is Applied to Events
+
+Global scope, isolation scope and current scope are combined before an event (like an error or transaction) is sent to Sentry.
+In most cases, setting something on current scope replaces the same thing that may have been set on isolation or global scope. If it hasn't been set on current scope, the value on isolation scope takes precedence over the one from global scope. If there also isn't any value on isolation scope, the one from global scope is used if present.
+
+Note, there are exceptions to this, where values from all scopes are merged. This is the case for breadcrumbs, tags, extras, contexts, attachments and event processors.
+
+```java
+Sentry.configureScope(ScopeType.GLOBAL, scope -> {
+  scope.setExtra("shared", "global");
+  scope.setExtra("global", "data");
+});
+
+Sentry.configureScope(ScopeType.ISOLATION, scope -> {
+  scope.setExtra("shared", "isolation");
+  scope.setExtra("isolation", "data");
+});
+
+Sentry.configureScope(ScopeType.CURRENT, scope -> {
+  scope.setExtra("shared", "current");
+  scope.setExtra("current", "data");
+});
+
+Sentry.captureException(new Exception("my error"));
+// --> Will have the following extra:
+// { shared: 'current', global: 'data', isolation: 'data', current: 'data' }
+```
 
 ## Configuring the Scope
 
-The most useful operation when working with scopes is the <PlatformIdentifier name="configure-scope" /> function. It can be used to reconfigure the current scope.
+There are two main ways to interact with the scope. You can modify the current scope via `Sentry.configureScope(scope -> { ... })` and use setters on the resulting scope, or you can use global methods like `Sentry.setTag()` directly, which will set on the respective scope under the hood (which will be the isolation scope).
 
 You can, for instance, add custom tags or inform Sentry about the currently authenticated user.
 
@@ -53,7 +86,7 @@ You can also apply this configuration when unsetting a user at logout:
 <PlatformContent includePath="enriching-events/scopes/scope-synchronization" />
 
 To learn what useful information can be associated with scopes see
-[the context documentation](../context/).
+[context](../context/), [tags](../tags), [users](../identify-user) and [breadcrumbs](../breadcrumbs/).
 
 ## Local Scopes
 

--- a/docs/platforms/java/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/java/common/enriching-events/scopes/index.mdx
@@ -1,46 +1,109 @@
 ---
-title: Scopes and Hubs
+title: Scopes
 description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra
 information from the current scope. SDKs will typically automatically manage the scopes
 for you in the framework integrations and you don't need to think about them. However,
-you should know what a scope is and how you can use it for your advantage.
+you should know what a scope is and how you can use it to your advantage.
 
-## What's a Scope, What's a Hub
+## What's a Scope?
 
-You can think of the hub as the central point that our SDKs use to route an
-event to Sentry. When you call `init()` a hub is created and a client and a
-blank scope are created on it. That hub is then associated with the current
-thread and will internally hold a stack of scopes.
-
-The scope will hold useful information that should be sent along with the
-event. For instance [contexts](../context/) or
+Scopes hold useful information that gets sent along with the
+event. For instance, [contexts](../context/) and
 [breadcrumbs](../breadcrumbs/) are stored on
-the scope. When a scope is pushed, it inherits all data from the parent scope
-and when it pops all modifications are reverted.
+the scope. When a scope is forked, it inherits all data from its parent scope.
 
-The default SDK integrations will push and pop scopes intelligently. For
-instance web framework integrations will create and destroy scopes around your
-routes or controllers.
+The default SDK integrations will fork scopes intelligently. For
+instance, web framework integrations will fork scopes around your
+routes or request handlers.
 
-## How the Scope and Hub Work
+## How Scopes Work
 
-As you start using an SDK, a scope and hub are automatically created for you out
-of the box. It's unlikely that you'll interact with the hub directly unless you're
-writing an integration or you want to create or destroy scopes. Scopes, on the
-other hand are more user facing. You can call <PlatformIdentifier name="configure-scope" /> at any point in
-time to modify data stored on the scope. This is useful for doing things like
-[modifying the context](../context/).
+Scopes are basically a stack of data that is attached to events. When an event is captured, the SDK will merge the data from the active scopes into the event. This allows you to attach data to events that is relevant to the context in which the event was captured.
 
-When you call a global function such as <PlatformIdentifier name="capture-event" /> internally Sentry
-discovers the current hub and asks it to capture an event. Internally the hub will
-then merge the event with the topmost scope's data.
+A scope is generally valid inside of a callback or an execution context. This means that multiple parts of your application may have different scopes active at the same time. For instance, a web server might handle multiple requests at the same time, and each request may have different scope data to apply to its events.
+
+When you call a global function such as `Sentry.captureException`, internally Sentry discovers the active scopes and uses them when capturing the event.
+
+## Different Kinds of Scopes
+
+The Sentry SDK has three different kinds of scopes:
+
+- [Global scope](#global-scope)
+- [Isolation scope](#isolation-scope)
+- [Current scope](#current-scope)
+
+### Global Scope
+
+The global scope is applied to _all_ events, no matter where they originate. You can use it to store data that should apply to all events, such as environmental information.
+
+You can access the global scope via `Sentry.getGlobalScope()` or `Sentry.configureScope(ScopeType.GLOBAL, globalScope -> { ... })`.
+
+### Isolation Scope
+
+The isolation scope is used to isolate events from each other. For example, each request in a web server might get its own isolation scope, so that events from one request don't interfere with events from another request. In most cases, you'll want to put data that should be applied to your events on the isolation scope - which is also why all `Sentry.setXXX` methods, like `Sentry.setTag()`, will write data onto the currently active isolation scope. A classic example for data that belongs on the isolation scope is a user - each request may have a different user, so you want to make sure that the user is set on the isolation scope.
+
+You can modify the isolation scope via `Sentry.configureScope(ScopeType.ISOLATION, isolationScope -> { ... })`, but usually you'll just use the `Sentry.setXXX` methods to set data on the currently active isolation scope:
+
+```java
+Sentry.setTag("my-tag", "my value");
+// Is identical to:
+Sentry.configureScope(ScopeType.ISOLATION, scope -> {
+  scope.setTag("my-tag", "my value");
+});
+```
+
+### Current Scope
+
+The current scope is the local scope that is currently active. Unlike the rarely-forked isolation scope, the current scope may be forked more frequently and under the hood. It can be used to store data that should only be applied to specific events. In most cases, you should not access this scope directly, but use `Sentry.withScope` to create a new scope that is only active for a specific part of your code:
+
+```java
+Sentry.withScope(scope -> {
+  // scope is the current scope inside of this callback!
+  scope.setTag("my-tag", "my value");
+  // this tag will only be applied to events captured inside of this callback
+  // the following event will have the tag:
+  Sentry.captureException(new Exception("my error"));
+});
+// this event will not have the tag:
+Sentry.captureException(new Exception("my other error"));
+```
+
+You can modify the current scope via `Sentry.configureScope(ScopeType.CURRENT, scope -> { ... })`, but usually you should use `Sentry.withScope()` to interact with local scopes instead.
+
+## How Scope Data is Applied to Events
+
+Global scope, isolation scope and current scope are combined before an event (like an error or transaction) is sent to Sentry.
+In most cases, setting something on current scope replaces the same thing that may have been set on isolation or global scope. If it hasn't been set on current scope, the value on isolation scope takes precedence over the one from global scope. If there also isn't any value on isolation scope, the one from global scope is used if present.
+
+Note, there are exceptions to this, where values from all scopes are merged. This is the case for breadcrumbs, tags, extras, contexts, attachments and event processors.
+
+```java
+Sentry.configureScope(ScopeType.GLOBAL, scope -> {
+  scope.setExtra("shared", "global");
+  scope.setExtra("global", "data");
+});
+
+Sentry.configureScope(ScopeType.ISOLATION, scope -> {
+  scope.setExtra("shared", "isolation");
+  scope.setExtra("isolation", "data");
+});
+
+Sentry.configureScope(ScopeType.CURRENT, scope -> {
+  scope.setExtra("shared", "current");
+  scope.setExtra("current", "data");
+});
+
+Sentry.captureException(new Exception("my error"));
+// --> Will have the following extra:
+// { shared: 'current', global: 'data', isolation: 'data', current: 'data' }
+```
 
 ## Configuring the Scope
 
-The most useful operation when working with scopes is the <PlatformIdentifier name="configure-scope" /> function. It can be used to reconfigure the current scope.
+There are two main ways to interact with the scope. You can modify the current scope via `Sentry.configureScope(ScopeType.CURRENT, scope -> { ... })` and use setters on the resulting scope, or you can use global methods like `Sentry.setTag()` directly, which will set on the respective scope under the hood (which will be the isolation scope).
 
 You can, for instance, add custom tags or inform Sentry about the currently authenticated user.
 
@@ -51,13 +114,7 @@ You can also apply this configuration when unsetting a user at logout:
 <PlatformContent includePath="enriching-events/unset-user" />
 
 To learn what useful information can be associated with scopes see
-[the context documentation](../context/).
-
-## Local Scopes
-
-We also support pushing and configuring a scope within a single call. This is typically
-called <PlatformIdentifier name="with-scope" />, <PlatformIdentifier name="push-scope" /> or implemented as a function parameter on the capture methods, depending on the SDK. It's very helpful if
-you only want to send data for one specific event.
+[context](../context/), [tags](../tags), [users](../identify-user) and [breadcrumbs](../breadcrumbs/).
 
 ### Using <PlatformIdentifier name="with-scope" />
 
@@ -72,6 +129,14 @@ On the other hand, <PlatformIdentifier name="with-scope" /> creates a clone of t
 made will stay isolated within the <PlatformIdentifier name="with-scope" /> callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call <PlatformIdentifier name="clear" /> to briefly remove all context information.
+
+## Using `withIsolationScope`
+
+`withIsolationScope` works fundamentally the same as `withScope`, but it will fork the isolation scope instead of the current scope. Generally, the isolation scope is meant to be forked less frequently than the current scope, and in most cases the SDK will handle this automatically for you.
+
+But in cases where you e.g. want to isolate a non-request process (e.g. a background job), you can use `withIsolationScope` to create a new isolation scope that is only active for the duration of the callback:
+
+<PlatformContent includePath="enriching-events/scopes/with-isolation-scope" />
 
 ### Using Scope Callback Parameter
 
@@ -90,6 +155,7 @@ Any exceptions that occur within the callback function for configuring a local s
 caught, and all errors that occur will be silently ignored and **not** reported.
 
 </Alert>
+
 
 ## Kotlin Coroutines
 

--- a/docs/platforms/java/usage.mdx
+++ b/docs/platforms/java/usage.mdx
@@ -148,34 +148,21 @@ Find more configuration options in the [Configuration](/platforms/java/configura
 
 ## Capture an Error
 
-To report an event manually you need to initialize a `Sentry` class. It is recommended that you use the static API via the `Sentry` class, but you can also construct and manage your own `IHub` instance. An example of each style is shown below:
+To report an event manually you need to initialize a `Sentry` class. It is recommended that you use the static API via the `Sentry` class. An example is shown below:
 
 
 ```java
-import io.sentry.IHub;
-import io.sentry.Hub;
 import io.sentry.Sentry;
 import io.sentry.protocol.User;
 
 public class MyClass {
-  private static IHub hub;
-
   public static void main(String... args) {
-    // NOTE: Replace the test DSN below with YOUR OWN DSN
     Sentry.init(options -> {
       options.setDsn("___PUBLIC_DSN___");
     });
 
-    // It is possible to go around the static Sentry API, which means
-    // you are responsible for making the IHub instance available
-    // to your code.
-    SentryOptions options = new SentryOptions();
-    options.setDsn("___PUBLIC_DSN___");
-    hub = new Hub(options);
-
     MyClass myClass = new MyClass();
     myClass.logWithStaticAPI();
-    myClass.logWithInstanceAPI();
   }
 
   /**
@@ -218,60 +205,23 @@ public class MyClass {
       Sentry.captureException(e);
     }
   }
-
-  /**
-   * Examples that use the SentryClient instance directly.
-   */
-  void logWithInstanceAPI() {
-
-    // Record a breadcrumb in the current scope. By default the last 100 breadcrumbs are kept.
-    hub.addBreadcrumb("User made an action");
-
-    // Set the user in the current scope.
-    User user = new User();
-    user.setEmail("hello@sentry.io");
-    hub.setUser(user);
-
-    // This sends a simple event to Sentry.
-    hub.captureMessage("This is a test");
-
-    try {
-      unsafeMethod();
-    } catch (Exception e) {
-      // This sends an exception event to Sentry.
-      hub.captureException(e);
-    }
-  }
 }
 ```
 
 ```kotlin
-import io.sentry.IHub
-import io.sentry.Hub
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.protocol.User
 
 class MyClass {
-  companion object {
-    private lateinit var hub: IHub
-  }
-
   fun main(args: Array<String>) {
     // NOTE: Replace the test DSN below with YOUR OWN DSN
     Sentry.init { options ->
       options.dsn = "___PUBLIC_DSN___"
     }
 
-    // It is possible to go around the static Sentry API, which means
-    // you are responsible for making the IHub instance available
-    // to your code.
-    val options = SentryOptions()
-    options.dsn = "___PUBLIC_DSN___"
-    hub = Hub(options)
     val myClass = MyClass()
     myClass.logWithStaticAPI()
-    myClass.logWithInstanceAPI()
   }
 
   /**
@@ -312,30 +262,6 @@ class MyClass {
       // This sends an exception event to Sentry using the statically stored instance
       // that was created in the ``main`` method.
       Sentry.captureException(e)
-    }
-  }
-
-  /**
-   * Examples that use the SentryClient instance directly.
-   */
-  fun logWithInstanceAPI() {
-
-    // Record a breadcrumb in the current scope. By default the last 100 breadcrumbs are kept.
-    hub.addBreadcrumb("User made an action")
-
-    // Set the user in the current scope.
-    val user = User().apply {
-      email = "hello@sentry.io"
-    }
-    hub.setUser(user)
-
-    // This sends a simple event to Sentry.
-    hub.captureMessage("This is a test")
-    try {
-      unsafeMethod()
-    } catch (e: Exception) {
-      // This sends an exception event to Sentry.
-      hub.captureException(e)
     }
   }
 }
@@ -451,7 +377,6 @@ You can also implement an `EventProcessor` that is able to automatically enhance
 
 ```java
 import io.sentry.EventProcessor;
-import io.sentry.IHub;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.Hint

--- a/platform-includes/enriching-events/scopes/with-isolation-scope/java.mdx
+++ b/platform-includes/enriching-events/scopes/with-isolation-scope/java.mdx
@@ -4,8 +4,8 @@
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 
-Sentry.withScope(scope -> {
-  scope.setTag("my-tag", "my value");
+Sentry.withIsolationScope(scope -> {
+  Sentry.setTag("my-tag", "my value");
   scope.setLevel(SentryLevel.WARNING);
 
   // will be tagged with my-tag="my value"
@@ -20,8 +20,8 @@ Sentry.captureException(new Exception("my error"));
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 
-Sentry.withScope { scope ->
-  scope.setTag("my-tag", "my value")
+Sentry.withIsolationScope { scope ->
+  Sentry.setTag("my-tag", "my value")
   scope.level = SentryLevel.WARNING
 
   // will be tagged with my-tag="my value"


### PR DESCRIPTION
Since `Hub` has been deprecated in v8, we're replacing/removing docs.
This also documents the new scope types (global, isolation, current).

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
