### PR TITLE
enha: update .NET profiling docs after AddProfilingIntegration() was added

### DIFF
--- a/docs/platforms/dotnet/common/profiling/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/index.mdx
@@ -49,7 +49,7 @@ SentrySdk.Init(options =>
     // Attach the profiling integration.
     options.AddProfilingIntegration();
 
-    // On Windows, Linux and macOS, the profiler is initialized asynchronously by default.
+    // On Windows, Linux, and macOS, the profiler is initialized asynchronously by default.
     // Alternatively, you can switch to synchronous initialization by adding a timeout argument.
     // The SDK waits up to the specified timeout for the .NET runtime profiler to start up before continuing.
     // e.g. options.AddProfilingIntegration(TimeSpan.FromMilliseconds(500));

--- a/docs/platforms/dotnet/common/profiling/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/index.mdx
@@ -31,7 +31,7 @@ dotnet add package Sentry.Profiling
 
 Profiling depends on Sentry’s tracing product being enabled beforehand. To enable tracing in the SDK, set the `TracesSampleRate` option to the desired value.
 
-```csharp {tabTitle:Windows/Linux/macOS}
+```csharp
 SentrySdk.Init(options =>
 {
     // ... usual setup options omitted for clarity (see Getting Started) ...

--- a/docs/platforms/dotnet/common/profiling/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/index.mdx
@@ -46,32 +46,16 @@ SentrySdk.Init(options =>
     // We recommend adjusting this value in production.
     options.ProfilesSampleRate = 1.0;
 
-    // Requires NuGet package: Sentry.Profiling
-    // Note: By default, the profiler is initialized asynchronously. This can be tuned by passing a desired initialization timeout to the constructor.
-    options.AddIntegration(new ProfilingIntegration(
-        // During startup, wait up to 500ms to profile the app startup code. This could make launching the app a bit slower so comment it out if your prefer profiling to start asynchronously
-        TimeSpan.FromMilliseconds(500)
-    ));
+    // Attach the profiling integration.
+    options.AddProfilingIntegration();
+
+    // On Windows, Linux and macOS, the profiler is initialized asynchronously by default.
+    // Alternatively, you can switch to synchronous initialization by adding a timeout argument.
+    // The SDK waits up to the specified timeout for the .NET runtime profiler to start up before continuing.
+    // e.g. options.AddProfilingIntegration(TimeSpan.FromMilliseconds(500));
+    // Note: the timeout has no effect on iOS and MacCatalyst, which use native profiling and always start synchronously.
 });
 ```
-
-```csharp {tabTitle:iOS/MacCatalyst}
-SentrySdk.Init(options =>
-{
-    // ... usual setup options omitted for clarity (see Getting Started) ...
-
-    // Sample rate for your transactions, e.g. value 0.1 means we want to report 10% of transactions.
-    // Setting 1.0 means all transactions are profiled.
-    // We recommend adjusting this value in production.
-    options.TracesSampleRate = 1.0;
-
-    // Sample rate for profiling, applied on top of othe TracesSampleRate,
-    // e.g. 0.2 means we want to profile 20 % of the captured transactions.
-    // We recommend adjusting this value in production.
-    options.ProfilesSampleRate = 1.0;
-});
-```
-
 ###
 
 Check out the <PlatformLink to="/tracing/">tracing setup documentation</PlatformLink> for more detailed information on how to configure sampling.

--- a/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
@@ -14,8 +14,8 @@ If you don't see any profiling data in [sentry.io](https://sentry.io), you can t
 - Enable <PlatformLink to="/configuration/options/#debug">debug mode</PlatformLink> in the SDK and check the logs.
 - If the transactions happen too soon after `Sentry.Init()`, they may not be captured yet.
   This is because the `ProfilingIntegration()` from `Sentry.Profiling` NuGet package initializes asynchronously by default.
-  If you'd like to initialize it synchronously, set the desired timeout constructor argument, e.g. `new ProfilingIntegration(TimeSpan.FromMilliseconds(500))` to wait up to 500 ms for the profiler to start up.
-  Note: this doesn't apply to iOS and Mac Catalyst which use native profiling and are initialized synchronously.
+  If you'd like to initialize it synchronously, set the desired timeout argument, e.g. `options.AddProfilingIntegration(TimeSpan.FromMilliseconds(500))` to wait up to 500 ms for the profiler to start up.
+  Note: this doesn't apply to iOS and Mac Catalyst which use native profiling, are initialized synchronously, and the timeout argument is ignored.
 - Maybe you're trying to capture profiles on a platform that is currently **not** supported, notably:
   - .NET Framework; we only support .NET 6.0, .NET 7.0 and .NET 8.0
   - Native AOT - this is only supported for iOS and Mac Catalyst (alongside the standard Mono AOT)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

closes #12323

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
