### PR TITLE
ref(feedback): update JS SDK API example

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -22,7 +22,7 @@ The embeddable JavaScript widget allows users to submit feedback from anywhere i
 
 ### Installation
 
-<PlatformContent includePath="user-feedback/install" />
+<PlatformContent includePath="user-feedback/install" /> fdf
 
 ### Set Up
 
@@ -51,11 +51,11 @@ The User Feedback widget integrates easily with <PlatformLink to="/session-repla
 
 The user feedback API allows you to collect user feedback while utilizing your own UI. You can use the same programming language you have in your app to send user feedback. In this case, the SDK creates the HTTP request so you don't have to deal with posting data via HTTP.
 
-Sentry pairs the feedback with the original event, giving you additional insight into issues. Sentry needs the `eventId` to be able to associate the user feedback to the corresponding event. For example, to get the `eventId`, you can use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> or the return value of the method capturing an event.
+You can optionally pass in an `associatedEventId` to associate user feedback with an error event, giving you additional insight into issues. To get an event ID, you have 2 options:
+1. Use the return value of a method capturing an event.
+2. Use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> and `Sentry.lastEventId()`.
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />
-
-Alternatively, you can use the [User Feedback API endpoint](/api/projects/submit-user-feedback/) directly.
 
 ## Crash-Report Modal
 

--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -22,7 +22,7 @@ The embeddable JavaScript widget allows users to submit feedback from anywhere i
 
 ### Installation
 
-<PlatformContent includePath="user-feedback/install" /> fdf
+<PlatformContent includePath="user-feedback/install" />
 
 ### Set Up
 

--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -53,7 +53,8 @@ The user feedback API allows you to collect user feedback while utilizing your o
 
 You can optionally pass in an `associatedEventId` to associate user feedback with an error event, giving you additional insight into issues. To get an event ID, you have 2 options:
 1. Use the return value of a method capturing an event.
-2. Use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink> and `Sentry.lastEventId()`.
+2. Use <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>{' '}and `Sentry.lastEventId()`.
+
 
 <PlatformContent includePath="user-feedback/sdk-api-example/" />
 

--- a/platform-includes/user-feedback/sdk-api-example/javascript.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.mdx
@@ -10,7 +10,7 @@ const userFeedback = {
 Sentry.captureFeedback(userFeedback);
 ```
 
-```javascript {tabTitle: JavaScript w/eventId}
+```javascript {tabTitle: JavaScript with eventId}
 import * as Sentry from "@sentry/browser";
 
 const eventId = Sentry.captureException(new Error("Something went wrong!"));

--- a/platform-includes/user-feedback/sdk-api-example/javascript.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/javascript.mdx
@@ -1,9 +1,22 @@
-```javascript
+```javascript {tabTitle: JavaScript}
 import * as Sentry from "@sentry/browser";
 
-const eventId = Sentry.captureMessage("User Feedback");
+// All feedback fields are optional, except `message`.
+const userFeedback = {
+  name: "John Doe",
+  email: "john@doe.com",
+  message: "I really like your App, thanks!",
+};
+Sentry.captureFeedback(userFeedback);
+```
+
+```javascript {tabTitle: JavaScript w/eventId}
+import * as Sentry from "@sentry/browser";
+
+const eventId = Sentry.captureException(new Error("Something went wrong!"));
 // OR: const eventId = Sentry.lastEventId();
 
+// All feedback fields are optional, except `message`.
 const userFeedback = {
   name: "John Doe",
   email: "john@doe.com",


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-docs/issues/10822
Closes https://github.com/getsentry/sentry-docs/issues/11635

- Rewords https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-api so it's clear `associatedEventId` is optional. 
- Splits the "stand-alone" and "w/eventId" usecases into 2 separate tabs in the code snippet.
- Removes link to deprecated HTTP endpoint

**Standalone**
<img width="813" alt="Screenshot 2025-01-21 at 1 15 06 PM" src="https://github.com/user-attachments/assets/d64e8bf9-8462-489f-92b1-5e960f2b759a" />

**w/eventId**
<img width="814" alt="Screenshot 2025-01-21 at 1 14 31 PM" src="https://github.com/user-attachments/assets/5389436f-f13f-4a6f-8715-2b29bfcfb10c" />

**Before**
![Screenshot 2025-01-21 at 1 15 38 PM](https://github.com/user-attachments/assets/67592d33-f6fb-4755-8db7-91c603c851e7)
