### PR TITLE
chore(github-enterprise): add note about resolvable installation URL

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -159,7 +159,7 @@ If you're using GitHub Enterprise Cloud, follow the [instructions for GitHub](/o
 
    ![Add Installation](./img/github-e-add-installation.png)
 
-4. Fill out the following form with information from your GitHub apps configuration page.
+4. Fill out the following form with information from your GitHub apps configuration page. The installation URL must be resolvable from the Internet.
 
    ![GitHub Enterprise configuration form](./img/github-e-form.png)
 

--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -159,7 +159,7 @@ If you're using GitHub Enterprise Cloud, follow the [instructions for GitHub](/o
 
    ![Add Installation](./img/github-e-add-installation.png)
 
-4. Fill out the following form with information from your GitHub apps configuration page. The installation URL must be resolvable from the Internet.
+4. Fill out the following form with information from your GitHub apps configuration page. The installation URL must be resolvable over the Internet.
 
    ![GitHub Enterprise configuration form](./img/github-e-form.png)
 


### PR DESCRIPTION
GH Enterprise installation requires an installation URL that is resolvable over the Internet, otherwise we cannot grab a token to make requests on behalf of the installation from Sentry.