### PR TITLE
feat: Drop `success` and `danger` Alert levels

### DIFF
--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -25,7 +25,7 @@ This is an alert
 Attributes:
 
 - `title` (string)
-- `level` (string: `'info' | 'warning' | 'danger' | 'success'`)
+- `level` (string: `'info' | 'warning'`)
 
 Use this for these types of content:
 

--- a/docs/platforms/javascript/common/best-practices/shared-environments.mdx
+++ b/docs/platforms/javascript/common/best-practices/shared-environments.mdx
@@ -39,7 +39,7 @@ These best practices are relevant for you if you set up Sentry in one of the fol
 - Libraries
 - Any other scenario where you might have multiple Sentry instances running in the same environment
 
-<Alert level="danger">
+<Alert level="warning">
 
 When setting up Sentry in a shared environment where multiple Sentry instances may run, you should **not use `Sentry.init()`**, as this will pollute the global state. If your browser extension uses `Sentry.init()`, and a website also uses Sentry, the extension may send events to the website's Sentry project, or vice versa.
 
@@ -121,7 +121,7 @@ Sentry.init({
 });
 ```
 
-<Alert level="danger">
+<Alert level="warning">
 
 You shouldn't use this option if you're in fact using the SDK in a browser extension or another shared environment.
 Initializing the SDK via `Sentry.init` has no advantages over manually setting up the client and scope as described on this page.

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -27,7 +27,7 @@ description: "Learn how to enable Session Replay in your app if it is not alread
 By default, our Session Replay SDK masks all DOM text content, images, and user input, giving you heightened confidence that no sensitive data will leave the browser. To learn more, see <PlatformLink to="/session-replay/privacy">Session Replay Privacy</PlatformLink>.
 
 <PlatformSection supported={["javascript.angular"]}>
-  <Alert level="danger">
+  <Alert level="warning">
     Angular's <a target="_blank" rel="noopener noreferrer" href="https://angular.dev/api/core/ChangeDetectionStrategy#Default">default "Change Detection" strategy</a> monkeypatches browser globals and can break or cause performance regressions in your application when using Session Replay. To avoid this, we recommend you use the `OnPush` strategy when using Angular.
   </Alert>
 </PlatformSection>

--- a/docs/platforms/javascript/common/sourcemaps/uploading/esbuild.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/esbuild.mdx
@@ -21,7 +21,7 @@ This guide assumes you're using a Sentry **SDK version `7.47.0` or higher**. If 
   "javascript.cordova",
 ]}>
 
-<Alert level="danger">
+<Alert level="warning">
 
 The Sentry esbuild plugin doesn't fully support esbuild configurations with `splitting: true`.
 If you rely on code splitting, use the esbuild plugin with <PlatformLink to="/sourcemaps/troubleshooting_js/legacy-uploading-methods/#uploading-using-sentry-bundler-plugins-on-version-2x">legacy source maps upload</PlatformLink>

--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -442,7 +442,7 @@ module.exports = withSentryConfig(nextConfig, {
 
 Alternatively, you can set the `SENTRY_AUTH_TOKEN` environment variable:
 
-<Alert level="danger">
+<Alert level="warning">
 
 Do not commit your auth token to version control.
 

--- a/includes/metrics-api-change.mdx
+++ b/includes/metrics-api-change.mdx
@@ -1,3 +1,3 @@
-<Alert level="danger" title="The Metrics beta has ended on October 7th">
+<Alert level="warning" title="The Metrics beta has ended on October 7th">
 Thank you for participating in our Metrics beta program. After careful consideration, we have ended the beta program and retired the current Metrics solution. We're actively developing a new solution that will make tracking and debugging any issues in your application easier. [Learn more](https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics).
 </Alert>

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -6,7 +6,7 @@ import './styles.scss';
 
 type AlertProps = {
   children?: ReactNode;
-  level?: 'info' | 'warning' | 'danger' | 'success' | '';
+  level?: 'info' | 'warning';
   title?: string;
 };
 

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -1,5 +1,4 @@
-.alert,
-.note {
+.alert {
   background: var(--accent-2);
   border-color: var(--accent-12);
   border-left: 3px solid var(--accent-12);
@@ -51,16 +50,4 @@
   background: var(--amber-2);
   border-color: var(--amber-10);
   color: var(--amber-12);
-}
-
-.alert-danger {
-  background: var(--red-2);
-  border-color: var(--red-10);
-  color: var(--red-12);
-}
-
-.alert-success {
-  background: var(--green-2);
-  border-color: var(--green-10);
-  color: var(--green-12);
 }


### PR DESCRIPTION
We do not use success at all, and danger only in few places, where we can also use `warning` instead.