### PR TITLE
fix: Drop unsupported `level="note"` for Alert

### DIFF
--- a/develop-docs/frontend/upgrade-policies.mdx
+++ b/develop-docs/frontend/upgrade-policies.mdx
@@ -61,7 +61,7 @@ yarn outdated --color | sort
 yarn upgrade --latest [package-name] [...]
 ```
 
-<Alert level="note">
+<Alert>
 
 Don’t forget to upgrade the `@types/[package-name]` package as well if necessary.
 

--- a/docs/cli/crons.mdx
+++ b/docs/cli/crons.mdx
@@ -4,7 +4,7 @@ sidebar_order: 200
 description: "Follow this guide to set up and manage monitors using the Sentry CLI."
 ---
 
-<Alert level="note" title="Deprecation Notice">
+<Alert title="Deprecation Notice">
 
 Starting with v2.16.1 of the Sentry CLI, the ability to monitor check-ins using an auth token for authorization has been deprecated. Read on to learn how to update your CLI and use your project's DSN instead.
 

--- a/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
+++ b/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
@@ -68,7 +68,7 @@ Once these changes have been made, newly assigned users will be sent an invitati
 
 You can use "Push Groups" to sync and assign groups in Okta; they'll be mirrored in Sentry teams.
 
-<Alert level="note">
+<Alert>
 
 If you use Okta to assign organization membership, you’ll be unable to make membership changes through Sentry and will need to continue using Okta. To remove these users, deprovision them in Okta.
 
@@ -116,13 +116,13 @@ Here's how to assign an organization-level role to an Okta group:
 - For security reasons, the "Owner" role cannot be provisioned through SCIM. However, you <i>can</i> deprovision users who have the "Owner" role in Sentry, but aren't provisioned through SCIM.
   - For self-hosted users with custom roles, this extends to any role with the `org:admin` permission
 
-<Alert level="note">
+<Alert>
 
 If a user is a member of multiple Okta groups, only the attributes set by the first group will be used.
 
 </Alert>
 
-<Alert level="note">
+<Alert>
 
 If you use Okta to assign organization-level roles, you’ll be unable to make membership changes through Sentry and will need to continue using Okta. To change a user's organization-level role, you will need to deprovision and then reprovision them with the new role.
 

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -16,7 +16,7 @@ With [tracing](/product/performance/), Sentry tracks your software performance, 
   </Note>
 
   <PlatformSection notSupported={["javascript.deno", "javascript.bun", "javascript.cloudflare"]}>
-    <Alert level="note">
+    <Alert>
       Sentry can integrate with <strong>OpenTelemetry</strong>. You can find more
       information about it
       <PlatformLink to="/opentelemetry/">here</PlatformLink>.

--- a/docs/platforms/native/common/enriching-events/attachments/index.mdx
+++ b/docs/platforms/native/common/enriching-events/attachments/index.mdx
@@ -41,7 +41,7 @@ By default, access is granted to all members when storage is enabled. If a membe
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />
 

--- a/docs/platforms/unity/data-management/store-minidumps-as-attachments/index.mdx
+++ b/docs/platforms/unity/data-management/store-minidumps-as-attachments/index.mdx
@@ -6,6 +6,6 @@ sidebar_order: 90
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />

--- a/docs/platforms/unity/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unity/enriching-events/attachments/index.mdx
@@ -75,7 +75,7 @@ By default, access is granted to all members when storage is enabled. If a membe
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />
 

--- a/docs/platforms/unity/native-support/index.mdx
+++ b/docs/platforms/unity/native-support/index.mdx
@@ -79,6 +79,6 @@ sentry-cli --auth-token ___ORG_AUTH_TOKEN___ debug-files upload --org ___ORG_SLU
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -179,6 +179,6 @@ Check out this community-generated [thread in Sentry's forum](https://forum.sent
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />

--- a/docs/platforms/unreal/data-management/store-minidumps-as-attachments/index.mdx
+++ b/docs/platforms/unreal/data-management/store-minidumps-as-attachments/index.mdx
@@ -7,6 +7,6 @@ sidebar_order: 90
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />

--- a/docs/platforms/unreal/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unreal/enriching-events/attachments/index.mdx
@@ -116,7 +116,7 @@ By default, access is granted to all members when storage is enabled. If a membe
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />
 

--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -168,6 +168,6 @@ To view and resolve the recorded error, log into [sentry.io](https://sentry.io) 
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert level="note">☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />

--- a/docs/product/crons/getting-started/index.mdx
+++ b/docs/product/crons/getting-started/index.mdx
@@ -23,7 +23,7 @@ To set up Sentry Crons, use the links below for supported SDKs or the Sentry CLI
 - [Ruby](/platforms/ruby/crons/)
 - [Elixir](/platforms/elixir/crons/)
 
-<Alert level="note" title="Don't see your platform?">
+<Alert title="Don't see your platform?">
 
 We're working on enabling additional platforms for Crons. In the meantime, you can use the Sentry CLI or HTTP to set up monitoring for your jobs.
 

--- a/docs/product/insights/ai/llm-monitoring/getting-started/index.mdx
+++ b/docs/product/insights/ai/llm-monitoring/getting-started/index.mdx
@@ -25,7 +25,7 @@ To start sending LLM data to Sentry, make sure you've created a Sentry project f
 - [Huggingface Hub](/platforms/python/integrations/huggingface_hub/)
 - [Cohere](/platforms/python/integrations/cohere/)
 
-<Alert level="note" title="Don't see your platform?">
+<Alert title="Don't see your platform?">
 
 We'll be adding AI integrations continuously. You can also instrument AI manually with the Sentry Python SDK.
 

--- a/docs/product/releases/setup/release-automation/netlify/index.mdx
+++ b/docs/product/releases/setup/release-automation/netlify/index.mdx
@@ -15,7 +15,7 @@ Full docs are available in the [plugin's README](https://github.com/getsentry/se
 
 For more details about Sentry release management concepts, see our docs on [releases](/product/releases/).
 
-<Alert level="note">
+<Alert>
 
 Note: This build plugin is separate from `@netlify/sentry`, which is a monitoring plugin built by Netlify. Docs for that plugin can be found [here](https://docs.netlify.com/netlify-labs/experimental-features/sentry-integration/). For more information, see [`@sentry/netlify-build-plugin` vs. `@netlify/sentry`](https://github.com/getsentry/sentry-netlify-build-plugin#sentrynetlify-build-plugin-vs-netlifysentry).
 

--- a/docs/security-legal-pii/security/security-policy-reporting.mdx
+++ b/docs/security-legal-pii/security/security-policy-reporting.mdx
@@ -23,7 +23,7 @@ Content-Security-Policy: ...;
 Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://___ORG_INGEST_DOMAIN___/api/___PROJECT_ID___/security/?sentry_key=___PUBLIC_KEY___"}],"include_subdomains":true}
 ```
 
-<Alert level="note" title="Compatibility Recommendation">
+<Alert title="Compatibility Recommendation">
 
 Though the `report-to` directive is intended to replace the deprecated `report-uri` directive, `report-to` isn't supported in most browsers yet. So for compatibility with current browsers while also adding forward compatibility when browsers get `report-to` support, you can specify both `report-uri` and `report-to` in your Content-Security-Policy (CSP).
 

--- a/includes/opentelemetry-available.mdx
+++ b/includes/opentelemetry-available.mdx
@@ -1,4 +1,4 @@
-<Alert level="note">
+<Alert>
   Sentry can integrate with <strong>OpenTelemetry</strong>. You can find more
   information about it
   <PlatformLink to="/tracing/instrumentation/opentelemetry/">here</PlatformLink>.


### PR DESCRIPTION
This level does not exist, so this does nothing.