### PR TITLE
feat: Drop unnecessary default `info` level for Alert

### DIFF
--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -79,7 +79,7 @@ export default async function Page(props: {
 
   return (
     <DocPage frontMatter={frontMatter}>
-      <Alert level="info">{platformInfo}</Alert>
+      <Alert>{platformInfo}</Alert>
 
       <ul>
         {platformList.map(p => (

--- a/develop-docs/application-architecture/dynamic-sampling/architecture.mdx
+++ b/develop-docs/application-architecture/dynamic-sampling/architecture.mdx
@@ -133,7 +133,7 @@ In this case, the matching will happen from **top to bottom** and the following 
 1. Rule `1` is matched against the event payload, since it is of type `transaction`. The `samplingValue` is a `factor`, thus the accumulated factors will now be `2.0 * 1.0`, where `1.0` is the identity for the multiplication.
 2. Because rule `1` was a factor rule, the matching continues and rule `2` will be matched against the DSC, since it is of type `trace`. The `samplingValue` is a `sampleRate`, thus the matching will stop and the sample rate will be computed as `2.0 * 0.5 = 1.0`, where `2.0` is the factor accumulated from the previous rule and `0.5` is the sample rate of the current rule.
 
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 
 It is important to note that a `sampleRate` rule must match in order for a sampling decision to be made; in case this condition is not met, the event will be kept. In practice, each project will have a uniform trace rule which will always match and contain the base sample rate of the organization.
 

--- a/develop-docs/application-architecture/dynamic-sampling/fidelity-and-biases.mdx
+++ b/develop-docs/application-architecture/dynamic-sampling/fidelity-and-biases.mdx
@@ -5,7 +5,7 @@ sidebar_order: 2
 
 Dynamic Sampling allows Sentry to automatically adjust the amount of data retained based on how valuable the data is to the user. This is technically achieved by applying a **sample rate** to every event, which is determined by a **set of rules** that are evaluated for each event.
 
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 
 A sample rate is a number in the interval `[0.0, 1.0]` that will determine the likelihood of a transaction to be retained. For example, a sample rate of `0.5` means that the transaction will be retained on average 50% of the time.
 
@@ -21,15 +21,15 @@ There are two available modes to govern the target sample rates for Dynamic Samp
 - **Automatic Mode** dynamically manages the target sample rate for each project based on the target sample rate for the organization, prioritizing lower volume projects to increase visibility. Automatic Mode is active if the organization option `sentry:sampling_mode` is set to `organization`. The target sample rate for the organization is stored in the **organization** option `sentry:target_sample_rate`, and project target sample rates are calculated based on the organization target sample rate.
 - **Manual Mode** allows the user to set static target sample rates on a per-project basis that serve as the baseline sample rate before applying the dynamic biases outlined below. Target sample rates are not adjusted by the system. Manual Mode is active if the organization option `sentry:sampling_mode` is set to `project`. The target sample rates for projects are stored in the **project** option `sentry:target_sample_rate`.
 
-All functionality defaults to Automatic Mode if the option `sentry:sampling_mode` is not set, and all target sample rates default to 1 if the option `sentry:target_sample_rate` is not set. 
+All functionality defaults to Automatic Mode if the option `sentry:sampling_mode` is not set, and all target sample rates default to 1 if the option `sentry:target_sample_rate` is not set.
 
 When the user switches between modes, target sample rates are transferred unless changed explicitly. For example, if the user switches from Automatic Mode to Manual Mode, the sample rates calculated during Automatic Mode are persisted in the project option `sentry:target_sample_rate`. Conversely, if the user switches from Manual Mode to Automatic Mode, the project target sample rates are recalculated based on the overall organization target sample rate.
 
-The [sample rates are periodically recalibrated](https://github.com/getsentry/sentry/blob/9b98be6b97323a78809a829e06dcbef26a16365c/src/sentry/dynamic_sampling/rules/biases/recalibration_bias.py#L11-L44) to ensure that the overall target sample rate is met. This recalibration is done on a project level or organization level, depending on the dynamic sampling mode. Within the target sample rate, Dynamic Sampling **biases towards more meaningful data**. This is achieved by constantly updating and communicating special rules to Relay, via a project configuration, which then applies targeted sampling to every event. 
+The [sample rates are periodically recalibrated](https://github.com/getsentry/sentry/blob/9b98be6b97323a78809a829e06dcbef26a16365c/src/sentry/dynamic_sampling/rules/biases/recalibration_bias.py#L11-L44) to ensure that the overall target sample rate is met. This recalibration is done on a project level or organization level, depending on the dynamic sampling mode. Within the target sample rate, Dynamic Sampling **biases towards more meaningful data**. This is achieved by constantly updating and communicating special rules to Relay, via a project configuration, which then applies targeted sampling to every event.
 
 ![Concept of Fidelity](./images/fidelityAndPriorities.png)
 
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 For orgs under AM2, Dynamic sampling uses a [sliding window function](https://github.com/getsentry/sentry/blob/cc8cc38c8a108719d068e5622b24a8d0c744e84c/src/sentry/dynamic_sampling/tasks/sliding_window_org.py#L37-L61) over the incoming volume to calculate the target sample rate.
 </Alert>
 
@@ -39,7 +39,7 @@ It is important to note that fidelity only determines an **approximate target sa
 
 Instead, the Sentry backend **computes a set of rules** whose goal is to cooperatively achieve the target sample rate. Determining when and how to set these rules is part of the Dynamic Sampling infrastructure.
 
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 
 The effectively applied sample rate, in the end, depends on how much data matches each of the bias overrides.
 
@@ -59,7 +59,7 @@ To achieve trace sampling, SDKs pass all fields that can be sampled by [Dynamic 
 
 ![Trace Sampling](./images/traceSampling.png)
 
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 
 In order to achieve full trace sampling, the random number generator used by Relay is seeded with the trace ID inside of the DSC sent by the SDK. This ensures that traces with the same trace ID will always yield the same sampling decision.
 
@@ -115,7 +115,7 @@ The list of development environments is available [here](https://github.com/gets
 For prioritizing dev environments, we use a sample rate of `1.0` (100%), which results in all traces being sampled.
 
 ### Prioritize Low Volume Projects
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 This bias is only active in Automatic Mode (and not in Manual Mode). It applies to any incoming trace and is defined on a per-project basis.
 </Alert>
 
@@ -126,13 +126,13 @@ The algorithm used in this bias computes a new sample rate with the goal of prio
 ### Prioritize Low Volume Transactions
 This bias is used to prioritize low-volume transactions that can be drowned out by high-volume transactions. The goal is to rebalance sample rates of the individual transactions so that low-volume transactions are more likely to have representative samples. The bias is of type trace, which means that the transaction considered for rebalancing will be the root transaction of the trace.
 
-Prioritization of low volume transactions works slightly differently depending on the dynamic sampling mode: 
-- In **Automatic Mode** (`sentry:sampling_mode` == `organization`), the output of the [boost_low_volume_projects](https://github.com/getsentry/sentry/blob/dee539472e999bf590cfc4e99b9b12981963defb/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py#L183) task is used as the base sample rate for the balancing algorithm. 
+Prioritization of low volume transactions works slightly differently depending on the dynamic sampling mode:
+- In **Automatic Mode** (`sentry:sampling_mode` == `organization`), the output of the [boost_low_volume_projects](https://github.com/getsentry/sentry/blob/dee539472e999bf590cfc4e99b9b12981963defb/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py#L183) task is used as the base sample rate for the balancing algorithm.
 - In **Manual Mode** (`sentry:sampling_mode` == `project`), the project target sample rate is used as the base sample rate for the balancing algorithm.
 
-In order to rebalance transactions, the system retrieves the counts of the transactions for each project and calculates a new sample rate for each transaction. 
+In order to rebalance transactions, the system retrieves the counts of the transactions for each project and calculates a new sample rate for each transaction.
 
-<Alert title="✨ Note" level="info">
+<Alert title="✨ Note">
 
 The algorithms for boosting low volume events are run periodically (with cron jobs) with a sliding window to account for changes in the incoming volume.
 

--- a/develop-docs/application-architecture/dynamic-sampling/the-big-picture.mdx
+++ b/develop-docs/application-architecture/dynamic-sampling/the-big-picture.mdx
@@ -7,7 +7,7 @@ sidebar_order: 1
 ![Sequencing](./images/sequencing.png)
 
 
-<Alert title="💡 Note" level="info">
+<Alert title="💡 Note">
 
 Dynamic Sampling currently operates on either spans or transactions to measure data throughput. This is controlled by the feature flag `organizations:dynamic-sampling-spans` and usually set to what the organization's subscription is metered by. In development, this currently defaults to transactions.
 The logic between the two data categories is identical, so most of this documentation is kept at a generic level and important differences are pointed out explicitly.
@@ -27,7 +27,7 @@ When events arrive, in a simplified model, they go through the following steps:
 4. **Dynamic Sampling**: based on an internal set of rules, Relay determines a sample rate for every incoming event. A random number generator finally decides whether a payload should be kept or dropped.
 5. **Rate limiting**: events that are sampled by Dynamic Sampling will be stored and indexed. To protect the infrastructure, internal rate limits apply at this point. Under normal operation, this **rate limit is never reached** since dynamic sampling already reduces the volume of events stored.
 
-<Alert title="💡 Example" level="info">
+<Alert title="💡 Example">
 
 A client is sending 1000 events per second to Sentry:
 1. 100 events per second are from old browsers and get dropped through an inbound data filter.
@@ -44,7 +44,7 @@ The ingestion pipeline has two kinds of rate limits that  behave differently com
 1. **High-level request limits on load balancers**: these limits do not differentiate which data is sent by clients and drop requests as soon as the throughput from clients reaches the limit.
 2. **Specific limits per data category in Relay**: these limits apply once requests have been parsed and have gone through basic handling (see [Sequencing](#sequencing) above).
 
-<Alert title="✨️ Note" level="info">
+<Alert title="✨️ Note">
 
 There is a dedicated rate limit for stored events after inbound filters and dynamic sampling. However, it does not affect total events since the fidelity decreases with higher total event volumes and this rate limit is not expected to trigger since Dynamic Sampling already reduces the stored event throughput.
 
@@ -56,7 +56,7 @@ Dynamic sampling ensures complete traces by retaining all events associated with
 
 Despite dynamic sampling providing trace completeness, events or other items (errors, replays, ...) may still be missing from a trace when rate limiting drops one or more of them. Rate limiting drops items without regard for the trace, making each decision independently and potentially resulting in broken traces.
 
-<Alert title="💡 Example" level="info">
+<Alert title="💡 Example">
 
 For example, if there is a trace from `Project A` to `Project B` and `Project B` is subject to rate limiting or quota enforcement, events of `Project B` from the trace initiated by `Project A` are lost.
 
@@ -84,7 +84,7 @@ Each of these metrics can be filtered and grouped by a number of predefined tags
 
 For more granular queries, **stored events are needed**. _The purpose of dynamic sampling here is to ensure that there are always sufficient representative sample events._
 
-<Alert title="💡 Example" level="info">
+<Alert title="💡 Example">
 
 If Sentry applies a 1% dynamic sample rate, you can still receive accurate events per minute (SPM or TPM, depending on event type) and web vital quantiles through total event data backed by metrics. There is also a listing of each of these numbers by the transaction.
 

--- a/develop-docs/application-architecture/multi-region-deployment/control-silo.mdx
+++ b/develop-docs/application-architecture/multi-region-deployment/control-silo.mdx
@@ -15,7 +15,7 @@ Prior to our multi-region offering, all API traffic from customers would be sent
 - DSN host
 - A static list of URL names (region pin list)
 
-<Alert level="info">
+<Alert>
 💡 Requests going to sentry.io do not meet data residency requirements. Customers will need to use region domains in order to not have requests go to the US.
 </Alert>
 

--- a/develop-docs/application-architecture/overview.mdx
+++ b/develop-docs/application-architecture/overview.mdx
@@ -100,7 +100,7 @@ In order to offer customers data residency we needed to co-locate the bulk of an
 
 These constraints led our design to having multiple 'silo modes'.
 
-<Alert level="info">
+<Alert>
     ☝ The term ‘silo’ was chosen as other applicable terms (region, zone, partition, cluster) are all taken.
 </Alert>
 

--- a/develop-docs/backend/api/design.mdx
+++ b/develop-docs/backend/api/design.mdx
@@ -32,7 +32,7 @@ Here are some additional examples:
 - 👍 `/projects/\{organization_slug}/\{project_slug}/issues/`
 - 👎 `/projects/`
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Hierarchy here does not necessarily mean that one collection belongs to a parent collection. For example:
 - `projects/\{project_identifier}/teams/` refers to the **teams** that have been added to specific project
@@ -82,7 +82,7 @@ Here are some notes that can help you decide between similar methods. We use *Ge
 ## Response Object
 Each response object returned from an API should be a serialized version of the Django model associated with the resource. You can see all the existing serializers [here](https://github.com/getsentry/sentry/tree/master/src/sentry/api/serializers/models).
 
- <Alert title="Note" level="info">
+ <Alert title="Note">
 
  Some models might have different serializers based on use case. For example, `Project` can be serialized into `DetailedProjectSerializer` or `ProjectSerializer`. Decide which one to use based on your use case and API scope but **DO NOT RETURN CUSTOM OBJECTS** like \{`slug: project_slug, platform: project_platform`}. We want the API responses to be uniform and useable in multiple automations without adding extra complication to the external developers' code.
 

--- a/develop-docs/backend/api/public.mdx
+++ b/develop-docs/backend/api/public.mdx
@@ -38,7 +38,7 @@ build. With that being said, there are 3 exceptions where we don't publish APIs:
    that you think it should be published let [owners-api](https://github.com/orgs/getsentry/teams/owners-api)
    know and we can help with that.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Always keep in mind that your APIs may still be used even if they're `private`. All the APIs
 in the Sentry repo are accessible due to our open-source nature.

--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -183,7 +183,7 @@ features.add(
 feature.<feature_scope>:<feature_name>
 ```
 
-<Alert level="info">
+<Alert>
     The feature config should not be merged until the registration commit in step 1 has been fully deployed to all target environments. This is because Options Automator will fail to push options to any environments missing the option registration.
     If this happens, make sure to rerun the options deployment once all environments have been updated to ensure your feature is active.
 </Alert>

--- a/develop-docs/backend/application-domains/options.mdx
+++ b/develop-docs/backend/application-domains/options.mdx
@@ -22,7 +22,7 @@ Follow these rules when adding new options:
 
 The value of an option can be any pickleable value.
 
-<Alert level="info">
+<Alert>
   It is safe to declare and use an option in the same pull request, you don't need to
   split them up.
 </Alert>
@@ -55,7 +55,7 @@ from sentry import options
 options.set("performance.some-feature-rate", 0.01)
 ```
 
-<Alert level="info">
+<Alert>
   If you do not have access to the shell, you'll need to contact OPS to set the option
   value for you.
 </Alert>
@@ -125,7 +125,7 @@ from sentry import options
 options.delete("performance.some-feature-rate")
 ```
 
-<Alert level="info">
+<Alert>
   If you do not have access to the shell, you'll need to contact OPS to remove the option
   for you.
 </Alert>

--- a/develop-docs/development-infrastructure/environment/index.mdx
+++ b/develop-docs/development-infrastructure/environment/index.mdx
@@ -44,7 +44,7 @@ Access it at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000) (you
 A superuser account should have been created for you during bootstrap - `admin@sentry.io` with password `admin`.
 You can create other users with `sentry createuser`.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   When asked for the root address of the server, make sure that you use
   [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000), as both
   protocol _and_ port are required in order for DNS and some pages' URLs to be
@@ -75,7 +75,7 @@ yarn https-proxy
 
 After the server is running we can visit the dev server using `https` at port `:8003` instead of over `http` at `:8000`.
 
-<Alert title="HTTP Strict-Transport-Security" level="info">
+<Alert title="HTTP Strict-Transport-Security">
   You might get into a situation where [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) is enabled for your domain and you're unable to visit using `http` anymore.
 
   To clear the HSTS visit `chrome://net-internals/#hsts` in Chrome based browsers and use the "Delete domain security policies" form.

--- a/develop-docs/development-infrastructure/testing.mdx
+++ b/develop-docs/development-infrastructure/testing.mdx
@@ -341,7 +341,7 @@ SENTRY_SCREENSHOT=1 VISUAL_SNAPSHOT_ENABLE=1 \
     -k test_with_onboarding
 ```
 
-<Alert title="Tip!" level="info">
+<Alert title="Tip!">
   If you're seeing `WARNING: Failed to gather log types: Message: unknown command:
   Cannot call non W3C standard command while in W3C mode`, it means that `Webpack` hasn't compiled assets properly.
 </Alert>

--- a/develop-docs/frontend/component-library.mdx
+++ b/develop-docs/frontend/component-library.mdx
@@ -3,7 +3,7 @@ title: UI Component Library
 sidebar_order: 40
 ---
 
-<Alert level="info">
+<Alert>
   To jump straight in visit <Link to="https://sentry.io/orgredirect/organizations/:orgslug/stories/"><code>/stories/</code></Link> on your existing Sentry Org/Install.
 </Alert>
 

--- a/develop-docs/frontend/design-tenets.mdx
+++ b/develop-docs/frontend/design-tenets.mdx
@@ -3,7 +3,7 @@ title: Frontend Design Tenets
 sidebar_order: 20
 ---
 
-<Alert level="info">
+<Alert>
   <strong>ten·et (noun)</strong>
 
   _a principle or belief, especially one of the main principles of a religion or philosophy._
@@ -19,7 +19,7 @@ Why disable (grey out)?
 - Educates the user on capabilities they don't have permission for (yet)
 - Informs of the current value (read access)
 
-<Alert level="info">
+<Alert>
   Bonus: where it makes sense, consider <Link href="https://blog.sentry.io/how-we-grew-sentrys-monthly-active-users-by-rethinking-invitations/" remote>prompting the user to request access</Link>.
 </Alert>
 
@@ -36,7 +36,7 @@ Why preserve state change in the URL?
 - Preserves browser back and forward buttons
 - Makes content shareable (user can share exact view with a teammate)
 
-<Alert level="info">
+<Alert>
   Ask yourself this question: "If I was sharing this page with my coworker on Slack, is it important that they see the exact view I'm looking at?" If the answer is "yes", then the state to regenerate that view should be present in the URL.
 </Alert>
 

--- a/develop-docs/frontend/index.mdx
+++ b/develop-docs/frontend/index.mdx
@@ -108,7 +108,7 @@ For event callback props passed to the component use the `on` prefix, e.g:
 
 ## State management
 
-<Alert level="info">
+<Alert>
   For React Hooks tips check out <Link to="/frontend/using-hooks/">this page</Link>.
 </Alert>
 
@@ -120,7 +120,7 @@ Reflux implements the unidirectional data flow pattern outlined by [Flux](https:
 
 ## Testing
 
-<Alert level="info">
+<Alert>
   For React Testing Library (RTL) tips check out <Link to="/frontend/using-rtl/">this page</Link>.
 </Alert>
 

--- a/develop-docs/frontend/upgrade-policies.mdx
+++ b/develop-docs/frontend/upgrade-policies.mdx
@@ -43,7 +43,7 @@ Overall, our approach to upgrading packages is **a balanced one**, taking into a
 
 ## How to upgrade a package
 
-<Alert level="info">
+<Alert>
 
 You may not have to do this manually! See the below section on [Take advantage of tooling](#take-advantage-of-tooling) to learn more about our usage of `dependabot` for automatic frontend package upgrades.
 

--- a/develop-docs/frontend/using-styled-components.mdx
+++ b/develop-docs/frontend/using-styled-components.mdx
@@ -58,7 +58,7 @@ const SomeComponent = styled('div')`
 
 ## Dynamic Properties
 
-<Alert level="info">
+<Alert>
   Most of the time dynamic properties are not needed!
 </Alert>
 

--- a/develop-docs/ingestion/relay/relay-best-practices.mdx
+++ b/develop-docs/ingestion/relay/relay-best-practices.mdx
@@ -53,7 +53,7 @@ But they aren't always the right choice for Relay.
 Some of the listed issues are specific to the [regex](https://docs.rs/regex/latest/regex/) Rust crate Relay uses
 and others apply to regular expressions in general.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 Review the [Rust crate's documentation](https://docs.rs/regex/latest/regex/#overview) carefully before introducing a Regex.
 </Alert>
 

--- a/develop-docs/ingestion/relay/transaction-span-ratelimits.mdx
+++ b/develop-docs/ingestion/relay/transaction-span-ratelimits.mdx
@@ -17,7 +17,7 @@ A dropped transaction results in dropped spans.
 
 The following document describes how transaction and span quotas interact with each other within Relay.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 This section describes how Relay has to interpret quotas, SDKs and other consumers
 should read [SDK Development / Rate Limiting](/sdk/rate-limiting/).
 </Alert>

--- a/develop-docs/integrations/azuredevops/index.mdx
+++ b/develop-docs/integrations/azuredevops/index.mdx
@@ -66,7 +66,7 @@ Add the following to your `devlocal.py` file:
 SENTRY_FEATURES["organizations:migrate-azure-devops-integration"] = True
 ```
 
-<Alert title="Feature Flag" level="info">
+<Alert title="Feature Flag">
 
 This is a temporary measure until we fully migrate to the new Azure DevOps integration and remove references to the old one.
 

--- a/develop-docs/integrations/discord/index.mdx
+++ b/develop-docs/integrations/discord/index.mdx
@@ -47,7 +47,7 @@ Interactions Endpoint URL: {YOUR_DOMAIN}/extensions/discord/interactions/
 
 Click __Save Changes__.
 
-<Alert level="info">
+<Alert>
 When you enter the Interactions Endpoint URL, Discord will try to verify it. The verification will fail if you haven't configured the bot credentials properly, haven't restarted your server since adding them, or don't have your server properly exposed to the internet.
 </Alert>
 

--- a/develop-docs/integrations/github.mdx
+++ b/develop-docs/integrations/github.mdx
@@ -43,7 +43,7 @@ When prompted to subscribe to events, choose the following:
  - Pull Request
  - Push
 
-<Alert title="Trick" level="info">
+<Alert title="Trick">
   Enabling optional permissions will also enable the <Link to="/self-hosted/sso/#github-auth">GitHub SSO</Link> for your instance.
 </Alert>
 
@@ -62,7 +62,7 @@ github-app.client-secret: "GITHUB_CLIENT_SECRET"
 github-app.webhook-secret: "my-super-secret-example-secret"
 ```
 
-<Alert title="Invalid Application Name" level="info">
+<Alert title="Invalid Application Name">
   If you're receiving invalid application or application not found error, it's suggested to change the `github-app.name` to the correct application slug.
   This can occur if the application includes non-alphanumeric characters.
 </Alert>

--- a/develop-docs/integrations/msteams/index.mdx
+++ b/develop-docs/integrations/msteams/index.mdx
@@ -4,7 +4,7 @@ sidebar_title: Microsoft Teams
 ---
 
 
-<Alert title="Admin Privileges" level="info">
+<Alert title="Admin Privileges">
 
 You will need to be a Microsoft Teams Administrator to perform some of the required steps.
 
@@ -55,7 +55,7 @@ msteams.client-secret: 'your-bot-secret'
 
 ## Installation
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 We have encountered recent issues with this installation method. For a smoother experience, please refer to the Troubleshooting section for alternative steps.
 

--- a/develop-docs/integrations/pagerduty.mdx
+++ b/develop-docs/integrations/pagerduty.mdx
@@ -42,6 +42,6 @@ pagerduty.app-id: 'PV5SD0T'
 
 Restart your Sentry instance and follow our [documentation on configuring the PagerDuty integration](https://docs.sentry.io/product/integrations/pagerduty/) to use the integration.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
     After changing configuration files, re-run the <code>./install.sh</code> script, to rebuild and restart the containers. See the <Link to="/self-hosted/#configuration">configuration section</Link> for more information.
 </Alert>

--- a/develop-docs/integrations/slack/index.mdx
+++ b/develop-docs/integrations/slack/index.mdx
@@ -27,7 +27,7 @@ If you're a Sentry employee, you can set the `slack.client-id` and `slack.client
 
 After you update the `config.yml`, `sentry.conf.py`, or `devlocal.py` you need to restart your Sentry server to continue configuring the Slack app.
 
-<Alert title="Note (for self-hosted users)" level="info">
+<Alert title="Note (for self-hosted users)">
     After changing configuration files, re-run the <code>./install.sh</code> script, to rebuild and restart the containers. See the <Link to="/self-hosted/#configuration">configuration section</Link> for more information.
 </Alert>
 
@@ -77,7 +77,7 @@ Add the following scopes to __User Scopes__:
 * `users:read`
 * `users:read.email`
 
-<Alert level="info">
+<Alert>
 You have the option to set 'Restrict API Token Usage' on this page if you want to limit use of your app’s OAuth tokens to a list of IP addresses and ranges you provide.
 </Alert>
 
@@ -87,7 +87,7 @@ You’ll see “Verified” when you’ve entered the correct URL.
 
 ![Events](./events.png)
 
-<Alert level="info">
+<Alert>
 When you enter the 'Request URL', Slack tries to verify it. The request will fail if you didn’t configure the client keys/secret and restart Sentry to ensure those config changes were picked up. If it fails to validate, first make sure your Sentry instance is running and Slack can talk to it (Slack <Link to="https://twitter.com/slackapi/status/567110311476350976?lang=en">doesn’t have an IP range</Link>).
 </Alert>
 
@@ -118,7 +118,7 @@ Navigate to __Slash Commands__ under __Features__. Click __Create New Command__ 
 | Request URL                     | `{YOUR_DOMAIN}/extensions/slack/commands/`    |
 
 
-<Alert title="Note" level="info">
+<Alert title="Note">
     When creating the slash command, don’t use `/sentry`. Do something like `/{your_name}-sentry`. If multiple apps are installed with the same slash command, the most recently installed one takes over.
 </Alert>
 

--- a/develop-docs/sdk/data-model/envelopes.mdx
+++ b/develop-docs/sdk/data-model/envelopes.mdx
@@ -7,7 +7,7 @@ This document defines the Envelope and Item formats used by Sentry for data
 ingestion, forwarding, and offline storage. The target audience of this document
 is Sentry SDK developers and maintainers of the ingestion pipeline.
 
-<Alert title="Backward Compatibility" level="info">
+<Alert title="Backward Compatibility">
 
 Envelopes require Relay, which has been introduced in **Sentry v20.6.0**.
 Earlier versions of Sentry do not support Envelopes and respond with HTTP error
@@ -134,7 +134,7 @@ Envelopes can have a number of headers which are valid in all situations:
   [RFC 3339](https://tools.ietf.org/html/rfc3339) format. Used for clock drift
   correction of the event timestamp. The time zone must be UTC.
 
-<Alert title="Implementation Guidance for the sent_at Header" level="info">
+<Alert title="Implementation Guidance for the sent_at Header">
 
 It is recommend to *always* send the `sent_at` envelope header. Do not try to determine
 whether it should be sent or not, as that determination can be made on the receiving side.
@@ -326,7 +326,7 @@ If multiple forms of authentication are given, the endpoint validates that the
 information matches and otherwise rejects the request. If both are missing, the
 Envelope is rejected with status code `403 Forbidden`.
 
-<Alert title="Backward Compatibility" level="info">
+<Alert title="Backward Compatibility">
 
 Envelope header authentication requires **Relay v21.6.0**.
 Earlier versions of Relay do not support Envelope header authentication and respond with HTTP error

--- a/develop-docs/sdk/data-model/event-payloads/breadcrumbs.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/breadcrumbs.mdx
@@ -100,7 +100,7 @@ Contains a dictionary whose contents depend on the breadcrumb type. Additional p
 : A timestamp representing when the breadcrumb occurred. The format is either a string as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float) value representing the number of seconds that have elapsed since the [Unixepoch](https://en.wikipedia.org/wiki/Unix_time).
 Breadcrumbs are most useful when they include a timestamp, as it creates a timeline leading up to an event `expection/error`.
 
-<Alert level="info">
+<Alert>
   Breadcrumbs will not be sorted by timestamp, they keep their order in the way they were added.
 </Alert>
 

--- a/develop-docs/sdk/data-model/event-payloads/index.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/index.mdx
@@ -10,7 +10,7 @@ Events are packed into [envelopes](/sdk/data-model/envelopes/) and are sent to t
 
 Sending event payloads to the `/api/{PROJECT_ID}/store/` API endpoint is deprecated.
 
-<Alert title="Note on backwards compatibility" level="info"><markdown>
+<Alert title="Note on backwards compatibility"><markdown>
 
 We strive to document the canonical format of an event and its additional
 interfaces. However, for backwards compatibility the server also

--- a/develop-docs/sdk/data-model/event-payloads/transaction.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/transaction.mdx
@@ -6,7 +6,7 @@ Transactions are used to send tracing events to Sentry.
 
 Transactions must be wrapped in an [Envelope](/sdk/data-model/envelopes/) and therefore also be sent to the Envelope endpoint.
 
-<Alert title="Note on backwards compatibility" level="info">
+<Alert title="Note on backwards compatibility">
   Envelopes are a new format and therefore only work on Sentry >= 10. More
   information can be found on the <Link to="/sdk/data-model/envelopes/">Envelope</Link> page.
 </Alert>

--- a/develop-docs/sdk/expected-features/setup-wizards/index.mdx
+++ b/develop-docs/sdk/expected-features/setup-wizards/index.mdx
@@ -72,7 +72,7 @@ If not already specified via the `--url` param, wizards should ask if users are 
 
 When creating a new wizard, the execution flow should roughly adhere to the outlined steps. Additional steps can be added as necessary.
 
-<Alert level="info">
+<Alert>
 
 Many of the individual steps and checks are already implemented in <Link to="#building-blocks-and-helper-functions">helper functions</Link>.
 
@@ -151,7 +151,7 @@ const continueWithoutGit = await abortIfCancelled(
 );
 ```
 
-<Alert level="info">
+<Alert>
 
 A lot of <Link to="https://github.com/getsentry/sentry-wizard/blob/master/src/utils/clack-utils.ts">helpers</Link> around specific user input questions can be reused.
 For example, the entire authentication and project selection flow is <Link to="https://github.com/getsentry/sentry-wizard/blob/master/src/utils/clack-utils.ts#L518">already covered</Link>.

--- a/develop-docs/sdk/miscellaneous/hub_and_scope_refactoring.mdx
+++ b/develop-docs/sdk/miscellaneous/hub_and_scope_refactoring.mdx
@@ -3,7 +3,7 @@ title: Hub & Scope Refactoring
 sidebar_order: 3
 ---
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 This is work in progress.
 
 Development has started in JS and Python, but we are still ironing out the wrinkles.
@@ -35,7 +35,7 @@ Hubs and scopes is a complicated system, that can easily be misused (also see [h
 2. The new Scopes API is implemented in the API and can be used.
 3. The old `Hub` based API still works as expected for backwards compatibility. After a transition phase the `Hub` will be removed in a major update of the SDK.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 The decision of removing the Hub from all Sentry SDKs was confirmed in a meeting on 2024-05-03 with most of the SDK engineers and Armin present. This decision is final.
 </Alert>
 

--- a/develop-docs/sdk/miscellaneous/unified-api/index.mdx
+++ b/develop-docs/sdk/miscellaneous/unified-api/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 1
 The unified API is deprecated. It served us well over the years, but we are in the process of simplifying the API by removing the Hub and also move some of our instrumentation to OpenTelementry.
 </Alert>
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Everything written here sounds real nice. However, we live in a practical world, and expect each platform to adhere to what makese sense for the developers there. What is written below is not to be taken as strict rules. It is a guide and to be thought of as a tool to help developers build SDKs which work well which eachother.
 

--- a/develop-docs/sdk/overview.mdx
+++ b/develop-docs/sdk/overview.mdx
@@ -77,7 +77,7 @@ Sentry.init({
 })
 ```
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 SDKs should accept an empty DSN as valid configuration.
 
 If an SDK is not initialized or if it is initialized with an empty DSN, the SDK should not send any data over the network, such as captured exceptions.
@@ -168,7 +168,7 @@ The `sentry_secret` must only be included if a secret key portion was contained
 in the DSN.  Future versions of the protocol will fully deprecate the secret
 key.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 You should include the SDK version string in the User-Agent portion of the header, and it will be used if `sentry_client` is not sent in the auth header.
 </Alert>
 
@@ -320,7 +320,7 @@ The `X-Sentry-Error` header and response body will not always contain a message,
 but they can still be helpful in debugging clients. When emitted, they will
 contain a precise error message, which is useful to identify root cause.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 We do not recommend that SDKs retry event submissions automatically on error
 &nbsp; not even if `Retry-After` is declared in the response headers. If a
 request fails once, it is very likely to fail again on the next attempt.

--- a/develop-docs/sdk/telemetry/profiles/sample-format-v1.mdx
+++ b/develop-docs/sdk/telemetry/profiles/sample-format-v1.mdx
@@ -295,15 +295,15 @@ stack ID.
 You should collect samples at a frequency of 101Hz, or roughly once every 10
 milliseconds.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 The 101Hz number above is not a typo. It is intentionally slightly off from 100Hz to avoid a condition
 named "lockstep sampling" where the profiling samples occur at the same frequency as a loop in the
 application. Ideally, the samples should be much more frequent than any cycles in the application, or
 at random intervals, so that the chance it occurs in any particular operation is proportional to the
 amount of time that operation takes. But this is often not feasible, so the next best thing is to use
-a sampling rate that doesn't coincide with the likely frequency of program cycles. 
+a sampling rate that doesn't coincide with the likely frequency of program cycles.
 
-We also chose 101 for its primality, whereas 1 below 100–99–is evenly divisible by several 
+We also chose 101 for its primality, whereas 1 below 100–99–is evenly divisible by several
 smaller numbers, which could lead to similar lockstep behavior.
 
 This explanation is an excerpt from [this awesome StackOverflow answer](https://stackoverflow.com/a/45471031/1181370)

--- a/develop-docs/sdk/telemetry/scopes.mdx
+++ b/develop-docs/sdk/telemetry/scopes.mdx
@@ -2,7 +2,7 @@
 title: Scopes
 ---
 
-<Alert level="info">
+<Alert>
   This document uses key words such as "MUST", "SHOULD", and "MAY" as defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement levels.
 </Alert>
 

--- a/develop-docs/sdk/telemetry/sessions/index.mdx
+++ b/develop-docs/sdk/telemetry/sessions/index.mdx
@@ -455,7 +455,7 @@ The most basic API exposed is on the hub level and lets you start and stop sessi
 
 ## SDK Implementation Guideline
 
-<Alert title="WIP" level="info">
+<Alert title="WIP">
   Before jumping into implementing this feature in an SDK, please reach out to
   the team. https://github.com/getsentry/develop/pull/323
 </Alert>

--- a/develop-docs/sdk/telemetry/spans/filtering.mdx
+++ b/develop-docs/sdk/telemetry/spans/filtering.mdx
@@ -6,7 +6,7 @@ title: Filtering
   🚧 This document is work in progress.
 </Alert>
 
-<Alert level="info">
+<Alert>
   This document uses key words such as "MUST", "SHOULD", and "MAY" as defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement levels.
 </Alert>
 

--- a/develop-docs/sdk/telemetry/spans/sampling.mdx
+++ b/develop-docs/sdk/telemetry/spans/sampling.mdx
@@ -6,7 +6,7 @@ title: Sampling
   🚧 This document is work in progress.
 </Alert>
 
-<Alert level="info">
+<Alert>
   This document uses key words such as "MUST", "SHOULD", and "MAY" as defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement levels.
 </Alert>
 

--- a/develop-docs/sdk/telemetry/spans/scrubbing-data.mdx
+++ b/develop-docs/sdk/telemetry/spans/scrubbing-data.mdx
@@ -6,7 +6,7 @@ title: Scrubbing data
   🚧 This document is work in progress.
 </Alert>
 
-<Alert level="info">
+<Alert>
   This document uses key words such as "MUST", "SHOULD", and "MAY" as defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement levels.
 </Alert>
 

--- a/develop-docs/sdk/telemetry/traces/dynamic-sampling-context.mdx
+++ b/develop-docs/sdk/telemetry/traces/dynamic-sampling-context.mdx
@@ -134,7 +134,7 @@ The `sentry-` prefix allows SDKs to put all of the sentry key-value pairs from t
 Being able to simply copy key-value pairs from the `baggage` header onto the `trace` envelope header gives us the flexibility to provide dedicated API methods to propagate additional values using Dynamic Sampling Context.
 This, in return, allows users to define their own values in the Dynamic Sampling Context so they can sample by those in the Sentry interface.
 
-<Alert level="info">
+<Alert>
 
 #### Note on `baggage` headers from other vendors
 

--- a/develop-docs/sdk/telemetry/traces/index.mdx
+++ b/develop-docs/sdk/telemetry/traces/index.mdx
@@ -66,7 +66,7 @@ URLs matching: 'localhost:8443/api/users', 'mylocalhost:8080/api/users', '/api/e
 URLs not matching: 'someHost.com/data', 'myApi.com/v1/projects'
 ```
 
-<Alert level="info" title="Deprecation of tracingOrigins">
+<Alert title="Deprecation of tracingOrigins">
 
 This Option replaces the non-standardized `tracingOrigins` option which was previously used in some SDKs. SDKs that support `tracingOrigins` are encouraged to deprecate and and eventually remove `tracingOrigins` in favour `tracePropagationTargets`. In case both options are specified by users, SDKs should only rely on the `tracePropagationTargets` array.
 
@@ -201,7 +201,7 @@ If more than one option could apply, the following rules determine which takes p
 3. If `tracesSampler` is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 4. If `tracesSampler` is not defined and there's no parent sampling decision, `tracesSampleRate` will be used.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 <markdown>
 
 Transactions should be sampled only by `tracesSampleRate` or `tracesSampler`. The `sampleRate` configuration is used for error events and should not apply to transactions.

--- a/develop-docs/sdk/telemetry/traces/span-operations.mdx
+++ b/develop-docs/sdk/telemetry/traces/span-operations.mdx
@@ -8,7 +8,7 @@ Operations are expected to follow [OpenTelemetry's semantic conventions](https:/
 
 It's important to keep categories consistent between SDKs and integrations as they are used by Sentry in various parts of the platform. For example, both `db.init` and `db.query` will be categorized as database operations (`db`). The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/9f36200d665209c9328f5ccc21135d3de9b65318/src/sentry/projectoptions/defaults.py#L80).
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   Span operations should be lower case and use snake_case
 </Alert>
 

--- a/develop-docs/self-hosted/backup.mdx
+++ b/develop-docs/self-hosted/backup.mdx
@@ -52,7 +52,7 @@ docker compose run -v $(pwd)/sentry:/sentry-data/backup  --rm -T -e SENTRY_LOG_L
 ./scripts/backup.sh [user | organization | config | global]
 ```
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 <markdown>
 
 If you choose to backup using the `docker compose run ...` command, omitting the `-T` or `-e
@@ -185,7 +185,7 @@ data are already defined as global volumes at install time and are prefixed with
 - `sentry-clickhouse`
 - `sentry-symbolicator`
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Only backing up and restoring these volumes should bring back all persisted data. If you also need
 to back up in-flight data, we recommend backing up any project-specific volumes that <code>docker

--- a/develop-docs/self-hosted/custom-ca-roots.mdx
+++ b/develop-docs/self-hosted/custom-ca-roots.mdx
@@ -7,7 +7,7 @@ description: Add custom Certificate Authority (CA) root certificates to your sel
 
 Starting with Sentry `21.8.0`, if you need to have Sentry access services which do not have TLS certificates from publicly trusted CA roots, it's now possible to easily add them to the containers. Just add the certificates to the `certificates` folder inside the root of your Sentry install and restart the containers. Your custom CA roots will be used in addition to the publicly trusted CA roots.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   While you can run <a href="https://manpages.debian.org/buster/ca-certificates/update-ca-certificates.8.en.html"><code>update-ca-certificates</code></a> in each container, that will update the system's root bundle on disk, but does nothing for any copies in memory. Restarting the container will update the bundle and make sure it is used.
 </Alert>
 

--- a/develop-docs/self-hosted/email.mdx
+++ b/develop-docs/self-hosted/email.mdx
@@ -5,7 +5,7 @@ sidebar_order: 40
 description: Set up and configure email notifications for your self-hosted Sentry instance
 ---
 
-<Alert title="Note" level="info">
+<Alert title="Note">
     After changing configuration files, re-run the <code>./install.sh</code> script, to rebuild and restart the containers. See the <Link to="/self-hosted/#configuration">configuration section</Link> for more information.
 </Alert>
 

--- a/develop-docs/self-hosted/experimental/external-storage.mdx
+++ b/develop-docs/self-hosted/experimental/external-storage.mdx
@@ -9,7 +9,7 @@ In some cases, storing Sentry data on-disk is not really something people can do
 <Alert title="Important" level="warning">
     These are community-contributed docs. Sentry does not officially provide support for self-hosted configurations beyond the default install.
 </Alert>
-<Alert title="Note" level="info">
+<Alert title="Note">
     After changing configuration files, re-run the <code>./install.sh</code> script, to rebuild and restart the containers. See the <Link to="/self-hosted/#configuration">configuration section</Link> for more information.
 </Alert>
 

--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -121,7 +121,7 @@ By default Sentry sends anonymous usage statistics to the Sentry team. It helps 
 
 To apply new Docker daemon configuration, restart your Docker service with `systemctl restart docker.service`.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   The value `172.17.0.0/16` is the default IP pools for Docker. If you are customizing your Docker default IP pools, please modify the value accordingly.
   Further information regarding Docker default IP pools can be found on the [Troubleshooting guide](/self-hosted/troubleshooting/docker/#docker-network-conflicting-ip-address).
 </Alert>
@@ -148,7 +148,7 @@ You very likely will want to adjust the default configuration for your Sentry in
 
 You can find more about configuring Sentry at [the configuration section of our developer documentation](/config/).
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   Once you change your configuration, it's highly recommended to re-run <code>./install.sh</code> script rather than restarting all services using <code>docker compose restart</code>. This ensures no other configuration or migrations that might be missing when something is toggled on.
 </Alert>
 

--- a/develop-docs/self-hosted/releases.mdx
+++ b/develop-docs/self-hosted/releases.mdx
@@ -7,7 +7,7 @@ description: Learn how to upgrade your self-hosted Sentry installation and stay 
 
 Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io](https://sentry.io) as possible. We decided to follow a monthly release schedule using the [CalVer](https://calver.org/#scheme) versioning scheme, with a primary release on the [15th of each month](https://github.com/getsentry/self-hosted/blob/704e4c3b5b7360080f79bcfbe26583e5a95ae675/.github/workflows/release.yml#L20-L24). We don't patch old versions, but if a bug is bad enough we may cut an out-of-cycle point release, which, like our regular monthly releases, is a snapshot of the latest versions of all of our components. You can find the [latest release](https://github.com/getsentry/self-hosted/releases/latest) over at the [releases section of our self-hosted repository](https://github.com/getsentry/self-hosted/releases/).
 
-<Alert title="Why CalVer?" level="info">
+<Alert title="Why CalVer?">
   In short, this is to keep the self-hosted Sentry as close to the live version
   hosted at <Link to="https://sentry.io">sentry.io</Link>. There are more details for the
   curious over at our <Link to="https://blog.sentry.io/2020/06/22/self-hosted-sentry-switching-to-calver">blog post announcing the switch</Link>.

--- a/develop-docs/self-hosted/sso.mdx
+++ b/develop-docs/self-hosted/sso.mdx
@@ -24,7 +24,7 @@ Please refer to our [main SAML documentation](https://docs.sentry.io/accounts/ss
 
 ## SSO with OAuth
 
-<Alert title="Note" level="info">
+<Alert title="Note">
     Once you enable SSO, this will be the only way to login to your self-hosted instance. If you need free registration along with SSO, you can comment on the <Link to="https://github.com/getsentry/sentry/pull/16247">GitHub PR</Link> for this.
 </Alert>
 
@@ -37,7 +37,7 @@ auth-google.client-id: '<client id>'
 auth-google.client-secret: '<client secret>'
 ```
 
-<Alert title="Note" level="info">
+<Alert title="Note">
     After changing configuration files, re-run the <code>./install.sh</code> script, to rebuild and restart the containers. See the <Link to="/self-hosted/#configuration">configuration section</Link> for more information.
 </Alert>
 
@@ -121,7 +121,7 @@ github-login.client-secret: '<Client secret>'
 
 This will also enable the [GitHub Integration](/integrations/github/) for your instance.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
     After changing configuration files, re-run the <code>./install.sh</code> script, to rebuild and restart the containers. See the <Link to="/self-hosted/#configuration">configuration section</Link> for more information.
 </Alert>
 

--- a/develop-docs/self-hosted/support.mdx
+++ b/develop-docs/self-hosted/support.mdx
@@ -7,7 +7,7 @@ sidebar_order: 8000
 We strive to provide a great self-hosted experience for folks willing to try Sentry that way. The [self-hosted repository](https://github.com/getsentry/self-hosted) is geared towards low traffic loads (less than ~1 million submitted Sentry events per month). We believe keeping this setup simple is important to show
 how various components fit together. Folks needing larger setups can expand from here based on their specific needs and environments.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 Please see our <Link to="/self-hosted/troubleshooting/">troubleshooting section</Link> before posting on the forum or filing an issue.
 </Alert>
 

--- a/develop-docs/self-hosted/troubleshooting/kafka.mdx
+++ b/develop-docs/self-hosted/troubleshooting/kafka.mdx
@@ -41,7 +41,7 @@ The _proper_ solution is as follows ([reported](https://github.com/getsentry/sel
    docker compose run --rm kafka kafka-consumer-groups --bootstrap-server kafka:9092 --group snuba-consumers --topic events --reset-offsets --to-latest --execute
    ```
 
-<Alert title="Tip" level="info">
+<Alert title="Tip">
 You can replace <code>snuba-consumers</code> with other consumer groups or <code>events</code> with other topics when needed.
 </Alert>
 

--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -8,24 +8,20 @@ sidebar_order: 40
 
 Render an alert callout.
 
-<Alert level="info" title="Important">
-
+<Alert title="Important">
 This is an alert
-
 </Alert>
 
 ```markdown {tabTitle:Example}
-<Alert level="info" title="Important">
-
+<Alert title="Important">
 This is an alert
-
 </Alert>
 ```
 
 Attributes:
 
-- `title` (string)
-- `level` (string: `'info' | 'warning'`)
+- `title` (string) - optional
+- `level` (string: `'info' | 'warning') - optional, defaults to `'info'`
 
 Use this for these types of content:
 

--- a/docs/organization/authentication/sso/index.mdx
+++ b/docs/organization/authentication/sso/index.mdx
@@ -34,7 +34,7 @@ Sessions last for [Django's default session length](https://docs.djangoproject.c
 
 Enabling the Google integration will ask you to authenticate against a Google Apps account. Once done, membership will be restricted to only members of the given Apps domain (i.e. `sentry.io`).
 
-<Alert level="info">
+<Alert>
 
 If you need to allow users across multiple domains to access your organization or change your Google domain, please contact our support team.
 

--- a/docs/organization/integrations/issue-tracking/jira/index.mdx
+++ b/docs/organization/integrations/issue-tracking/jira/index.mdx
@@ -186,7 +186,7 @@ Here, you’ll be able to create or link Jira issues.
 
 To minimize duplication in issue tracking, you can sync comments, assignees, and status updates for Sentry issues to Jira tickets and vice versa. When you delegate an issue to an assignee or update a status on Jira, the updates will also populate in Sentry. When you resolve an issue in Sentry, the issue status will automatically update in Jira. When Jira tickets are marked Done, you can configure how the corresponding issue in Sentry should be resolved.
 
-<Alert title="Note"
+<Alert title="Note">
   Issue sync is available for organizations on the Team, Business, and
   Enterprise plans.
 </Alert>
@@ -195,7 +195,7 @@ To configure Issue sync, navigate to **Organization Settings** > **Integrations*
 
 ![Sync Jira statuses to Sentry](./img/jira-sync.png)
 
-<Alert title="Note"
+<Alert title="Note">
 
 If you hit a 4xx or 5xx error during or after setting up the Jira Server integration, see this [troubleshooting section](#receiving-a-4xx5xx-error-for-the-jira-server-integration).
 

--- a/docs/organization/integrations/issue-tracking/jira/index.mdx
+++ b/docs/organization/integrations/issue-tracking/jira/index.mdx
@@ -6,11 +6,11 @@ description: "Learn more about Sentry's Jira integration and how it can help tra
 
 ## Install
 
-<Note>
+<Alert>
 
 Sentry owner, manager, or admin permissions, and Jira admin permissions are required to install this integration. This includes the following permissions: `read`, `write`, `act_as_user`, and `access_email_addresses`.
 
-</Note>
+</Alert>
 
 1. Navigate to **Settings > Integrations > Jira**.
 
@@ -30,11 +30,11 @@ Jira should now be authorized for all projects under your Sentry organization.
 
 ### Jira Server
 
-<Note>
+<Alert>
 
 As of February 2024, Jira has discontinued support for Jira Server. Accordingly, we have stopped maintaining the docs for this integration. The instructions below may be out of date.
 
-</Note>
+</Alert>
 
 Sentry's Jira Server Integration is built using [Application Links](https://confluence.atlassian.com/adminjiraserver/link-to-other-applications-938846918.html) and should be able to integrate with Jira Data Center as well.
 
@@ -129,11 +129,11 @@ openssl x509 -pubkey -noout -in jira_publickey.cer  > jira_publickey.pem
 
 #### Connect your Jira Server application with Sentry
 
-<Note>
+<Alert>
 
 Confirm [Sentry's IP ranges](/security-legal-pii/security/ip-ranges/) are allowed.
 
-</Note>
+</Alert>
 
 1. Navigate to **Organization Settings > Integrations**.
 2. Next to Jira Server, click "Install".
@@ -151,7 +151,7 @@ Use Jira to leverage [issue management](#issue-management), [issue syncing](#iss
 
 Issue tracking allows you to create Jira issues from within Sentry, and link Sentry issues to existing Jira Issues.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   <p>
     Manual issue management is available to organizations on Team, Business, and
     Enterprise plans.
@@ -186,7 +186,7 @@ Here, you’ll be able to create or link Jira issues.
 
 To minimize duplication in issue tracking, you can sync comments, assignees, and status updates for Sentry issues to Jira tickets and vice versa. When you delegate an issue to an assignee or update a status on Jira, the updates will also populate in Sentry. When you resolve an issue in Sentry, the issue status will automatically update in Jira. When Jira tickets are marked Done, you can configure how the corresponding issue in Sentry should be resolved.
 
-<Alert title="Note" level="info">
+<Alert title="Note"
   Issue sync is available for organizations on the Team, Business, and
   Enterprise plans.
 </Alert>
@@ -195,7 +195,7 @@ To configure Issue sync, navigate to **Organization Settings** > **Integrations*
 
 ![Sync Jira statuses to Sentry](./img/jira-sync.png)
 
-<Alert title="Note" level="info">
+<Alert title="Note"
 
 If you hit a 4xx or 5xx error during or after setting up the Jira Server integration, see this [troubleshooting section](#receiving-a-4xx5xx-error-for-the-jira-server-integration).
 

--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -38,7 +38,7 @@ You’ll also see that the author of the suspect commit will be listed as a sugg
 
 Issue tracking allows you to create Azure DevOps issues from within Sentry, and link Sentry issues to existing Azure DevOps Issues.
 
-<Alert title="Note" level="info">
+<Alert title="Note">
   <p>
     Manual issue management is available to organizations on Team, Business, and
     Enterprise plans.
@@ -69,7 +69,7 @@ Once you’ve navigated to a specific issue, you’ll find the **Linked Issues**
 
 Sync comments, assignees, and status updates for issues in Sentry to Azure DevOps, to minimize duplication. When you delegate an issue to an assignee or update a status on Azure DevOps, the updates will also populate in Sentry. When you resolve an issue in Sentry, the issue status will automatically update in Azure DevOps.
 
-<Alert title="Note" level="info">
+<Alert title="Note"
   Issue sync is available for organizations on the Team, Business, and
   Enterprise plans.
 </Alert>
@@ -92,11 +92,11 @@ When Sentry sees this, we’ll automatically annotate the matching issue with re
 
 ### Stack Trace Linking
 
-<Note>
+<Alert>
 
 This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
 
-</Note>
+</Alert>
 
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default branch).
 
@@ -117,11 +117,11 @@ Stack trace linking takes you from a file in your Sentry stack trace to that sam
 
 #### Stack Trace Root and Source Code Root
 
-<Note>
+<Alert>
 
 The following information is only valid for platforms which use traditional file paths. Platforms with package names require additional steps. For **Java**, read more in the [page on source context](/platforms/java/source-context#setting-up-code-mappings).
 
-</Note>
+</Alert>
 
 First, navigate to a stack trace that you wish to map. Find an **In App** frame, which is denoted by a bubble on the right side of the frame. The filename will be shown as the first piece of text at the left hand side of the frame header. In this example, it is `src/main.py`.
 
@@ -158,8 +158,8 @@ If you reach the account selection page during the Azure Devops installation pro
 - For single sign-on, see [Azure Active Directory SSO](/organization/authentication/sso/azure-sso/).
 - If you have multiple accounts in Azure DevOps, open [this link to Azure DevOps](https://aex.dev.azure.com) in another tab, select the correct account, then reinstall.
 
-<Note>
+<Alert>
   If reinstallation solves the problem, please upvote [that solution in
   GitHub](https://github.com/getsentry/sentry/issues/14357), which is where
   we're tracking this improvement.
-</Note>
+</Alert>

--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -69,7 +69,7 @@ Once you’ve navigated to a specific issue, you’ll find the **Linked Issues**
 
 Sync comments, assignees, and status updates for issues in Sentry to Azure DevOps, to minimize duplication. When you delegate an issue to an assignee or update a status on Azure DevOps, the updates will also populate in Sentry. When you resolve an issue in Sentry, the issue status will automatically update in Azure DevOps.
 
-<Alert title="Note"
+<Alert title="Note">
   Issue sync is available for organizations on the Team, Business, and
   Enterprise plans.
 </Alert>

--- a/docs/platforms/android/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/android/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/android/enriching-events/scopes/index.mdx
+++ b/docs/platforms/android/enriching-events/scopes/index.mdx
@@ -105,7 +105,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/android/enriching-events/scopes/index__v7.x.mdx
+++ b/docs/platforms/android/enriching-events/scopes/index__v7.x.mdx
@@ -72,7 +72,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/apple/common/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/apple/common/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/apple/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/scopes/index.mdx
@@ -70,7 +70,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/apple/common/migration/index.mdx
+++ b/docs/platforms/apple/common/migration/index.mdx
@@ -101,7 +101,7 @@ SentrySDK.start { options in
 
 ## Migrating From 6.x to 7.x
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 We recommend updating to at least [7.5.3](https://github.com/getsentry/sentry-cocoa/releases/tag/7.5.3), because the HTTP instrumentation can lead to crashes. Alternatively, you can also <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#network-tracking">disable the feature</PlatformLink>.
 

--- a/docs/platforms/dart/enriching-events/scopes/index.mdx
+++ b/docs/platforms/dart/enriching-events/scopes/index.mdx
@@ -72,7 +72,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/dotnet/common/configuration/msbuild.mdx
+++ b/docs/platforms/dotnet/common/configuration/msbuild.mdx
@@ -17,7 +17,7 @@ NuGet package, and providing properties to enable it from your build.
 
 For this feature to work, you must authenticate to Sentry on the machine that is performing your release builds.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 The Sentry auth token (or legacy API key) should always be treated as secret. Be careful not to commit authentication information to source control,
 or use it in any way that it would be written to log files.
@@ -220,7 +220,7 @@ Set to `false` to disable the Sentry CLI completely, ignoring the settings of ea
 
 </ConfigKey>
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 There are two more properties, `SentryAuthToken` and `SentryApiKey`, that are available for authentication.
 However we recommend that they are used only for simple testing, and not for production. If you decide to use

--- a/docs/platforms/dotnet/common/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/dotnet/common/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/dotnet/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/dotnet/common/enriching-events/scopes/index.mdx
@@ -72,7 +72,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/dotnet/common/index.mdx
+++ b/docs/platforms/dotnet/common/index.mdx
@@ -2,7 +2,7 @@
 
 On this page, we get you up and running with Sentry's SDK.
 
-<Alert level="info" title="Using a framework?">
+<Alert title="Using a framework?">
 
 Check out the other SDKs we support in the left-hand dropdown.
 

--- a/docs/platforms/elixir/integrations/oban/index.mdx
+++ b/docs/platforms/elixir/integrations/oban/index.mdx
@@ -33,7 +33,7 @@ config :sentry,
 
 This configuration will report failed Oban jobs to Sentry. It will also report started, completed, and failed jobs, as well as their duration. It will use the worker name as the `monitor_slug` of the reported cron.
 
-<Alert level="info" title="Perform Errors">
+<Alert title="Perform Errors">
 Oban wraps *unhandled* crashes, exits, and throws in jobs inside [`Oban.CrashError`](https://hexdocs.pm/oban/2.18.0/Oban.CrashError.html) exceptions. However, if jobs return errors manually (such as by returning `{:error, reason}` tuples) then Oban will wrap those inside [`Oban.PerformError`](https://hexdocs.pm/oban/2.18.0/Oban.PerformError.html) exceptions. If you only want to report crashes to Sentry, you can either configure an event filter that doesn't report `Oban.PerformError` events, or that inspects its `:reason` field to determine whether to report them. For example:
 
 ```elixir

--- a/docs/platforms/flutter/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/flutter/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/flutter/enriching-events/scopes/index.mdx
+++ b/docs/platforms/flutter/enriching-events/scopes/index.mdx
@@ -72,7 +72,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/java/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/java/common/enriching-events/scopes/index.mdx
@@ -149,7 +149,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/java/common/enriching-events/scopes/index__v7.x.mdx
+++ b/docs/platforms/java/common/enriching-events/scopes/index__v7.x.mdx
@@ -84,7 +84,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/java/common/tracing/instrumentation/apollo3.mdx
+++ b/docs/platforms/java/common/tracing/instrumentation/apollo3.mdx
@@ -105,7 +105,7 @@ val apollo = ApolloClient.builder()
     .build()
 ```
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Apollo Kotlin is built with Kotlin coroutines. This means that `SentryApolloInterceptor` can be used with Java using only Global Hub Mode (single Hub used by all threads), with Kotlin using single Hub mode, or with <PlatformLink to="/enriching-events/scopes/#kotlin-coroutines">Sentry's coroutines support</PlatformLink>.
 

--- a/docs/platforms/java/guides/spring-boot/logging-frameworks.mdx
+++ b/docs/platforms/java/guides/spring-boot/logging-frameworks.mdx
@@ -50,7 +50,7 @@ If you decide to opt-out from the `application.properties` based Spring Boot log
 
   <appender name="SENTRY" class="io.sentry.logback.SentryAppender" />
 
-  <root level="info">
+  <root>
     <appender-ref ref="CONSOLE" />
     <appender-ref ref="SENTRY" />
   </root>

--- a/docs/platforms/javascript/common/configuration/application-not-responding.mdx
+++ b/docs/platforms/javascript/common/configuration/application-not-responding.mdx
@@ -44,7 +44,7 @@ _(Available in version 7.91.0 and above)_
 
 To enable ANR detection, add the `Anr` integration from the `@sentry/node` package.
 
-<Alert level="info">
+<Alert>
 
 ANR detection requires Node 16 or higher and can only be used in the Node.js runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.32.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/anr.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anr.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.astro
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/breadcrumbs.mdx
@@ -18,7 +18,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
@@ -18,7 +18,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserprofiling.mdx
@@ -19,7 +19,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/browsersession.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browsersession.mdx
@@ -18,7 +18,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 
@@ -27,7 +27,7 @@ This integration only works inside a browser environment.
 _Import name: `Sentry.browserSessionIntegration`_
 
 Sentry's [Release Health](/product/releases/health/) feature allows you to track user adoption and your application's crash-free rate.
-When the BrowserSession integration is enabled, it automatically creates a session each time a user loads your page or application. These sessions are used to track your release health. If an error is captured during an active session, the session will be flagged as faulty. 
+When the BrowserSession integration is enabled, it automatically creates a session each time a user loads your page or application. These sessions are used to track your release health. If an error is captured during an active session, the session will be flagged as faulty.
 Read more about <PlatformLink to="/configuration/releases/#sessions">Sessions</PlatformLink>.
 
 ```JavaScript

--- a/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
@@ -18,7 +18,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/bunserver.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/bunserver.mdx
@@ -5,7 +5,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Bun runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/childProcess.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/childProcess.mdx
@@ -21,7 +21,7 @@ supported:
   - javascript.astro
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in Node.js and requires SDK version `8.39.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/connect.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/connect.mdx
@@ -8,7 +8,7 @@ supported:
 
 For more information on setting up Sentry Connect support, see the [Connect Sentry documentation](/platforms/javascript/guides/connect/).
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/console.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/console.mdx
@@ -26,7 +26,7 @@ supported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/dataloader.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/dataloader.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.31.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/denocontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/denocontext.mdx
@@ -5,7 +5,7 @@ supported:
   - javascript.deno
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Deno runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/denocron.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/denocron.mdx
@@ -5,7 +5,7 @@ supported:
   - javascript.deno
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Deno runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/fastify.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fastify.mdx
@@ -8,7 +8,7 @@ supported:
 
 For more information on setting up Sentry Fastify support, see the [Fastify Sentry documentation](/platforms/javascript/guides/fastify/).
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
@@ -23,7 +23,7 @@ notSupported:
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
 

--- a/docs/platforms/javascript/common/configuration/integrations/fs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fs.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/genericpool.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/genericpool.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.29.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/globalhandlers.mdx
@@ -16,7 +16,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Browser and Deno runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/graphql.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/graphql.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/hapi.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/hapi.mdx
@@ -8,7 +8,7 @@ supported:
 
 For more information on setting up Sentry Hapi support, see the [Hapi Sentry documentation](/platforms/javascript/guides/hapi/).
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/httpclient.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpclient.mdx
@@ -17,7 +17,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/httpcontext.mdx
@@ -18,7 +18,7 @@ notSupported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/kafka.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/kafka.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.30.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/knex.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/knex.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.38.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/koa.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/koa.mdx
@@ -8,7 +8,7 @@ supported:
 
 For more information on setting up Sentry Koa support, see the [Koa Sentry documentation](/platforms/javascript/guides/koa/).
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -23,7 +23,7 @@ notSupported:
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
 

--- a/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.deno
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/lrumemoizer.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/lrumemoizer.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.33.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/modulemetadata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modulemetadata.mdx
@@ -18,7 +18,7 @@ notSupported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/modules.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/modules.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/mongo.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mongo.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/mongoose.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mongoose.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/mysql.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mysql.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/mysql2.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/mysql2.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/nest.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nest.mdx
@@ -8,7 +8,7 @@ supported:
 
 For more information on setting up Sentry Nest.js support, see the [Nest.js Sentry documentation](/platforms/javascript/guides/nestjs/).
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodecontext.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodefetch.mdx
@@ -24,7 +24,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/nodeprofiling.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.astro
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/normalizepath.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/normalizepath.mdx
@@ -5,7 +5,7 @@ supported:
   - javascript.deno
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Deno runtime.
 

--- a/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/onuncaughtexception.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -23,7 +23,7 @@ notSupported:
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment. It is only available from a package-based install (e.g. `npm` or `yarn`).
 

--- a/docs/platforms/javascript/common/configuration/integrations/postgres.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/postgres.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/prisma.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/prisma.mdx
@@ -22,7 +22,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. This integration only supports Prisma v5 at the current time. If you're interested in Prisma v6 support, please leave your thoughts on the [Prisma v6 tracking issue for the Sentry SDK](https://github.com/getsentry/sentry-javascript/issues/14793).
 

--- a/docs/platforms/javascript/common/configuration/integrations/processThreadsBreadcrumb.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/processThreadsBreadcrumb.mdx
@@ -27,7 +27,7 @@ This integration is deprecated and has been replaced with the <PlatformLink to="
 
 </Alert>
 
-<Alert level="info">
+<Alert>
 
 This integration only works in Node.js and requires SDK version `8.36.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/redis.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/redis.mdx
@@ -23,7 +23,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes.
 

--- a/docs/platforms/javascript/common/configuration/integrations/replay.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replay.mdx
@@ -19,7 +19,7 @@ notSupported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/replaycanvas.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/replaycanvas.mdx
@@ -19,7 +19,7 @@ notSupported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/reportingobserver.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/reportingobserver.mdx
@@ -17,7 +17,7 @@ notSupported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside a browser environment.
 

--- a/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
@@ -24,7 +24,7 @@ supported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.38.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/trpc.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/trpc.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unhandledrejection.mdx
@@ -25,7 +25,7 @@ supported:
   - javascript.cloudflare
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works inside server environments (Node.js, Bun, Deno).
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -21,7 +21,7 @@ supported:
   - javascript.bun
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.43.0` or higher.
 

--- a/docs/platforms/javascript/common/configuration/integrations/vue.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vue.mdx
@@ -5,7 +5,7 @@ supported:
   - javascript.vue
 ---
 
-<Alert level="info">
+<Alert>
 
   This integration is enabled by default (recommended) but can also be added manually.
 
@@ -38,4 +38,3 @@ const app = createApp({
 
 Sentry.addIntegration(Sentry.vueIntegration({ app }));
 `
-

--- a/docs/platforms/javascript/common/configuration/integrations/wintercgfetch.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/wintercgfetch.mdx
@@ -6,7 +6,7 @@ supported:
   - javascript.nuxt
 ---
 
-<Alert level="info">
+<Alert>
 
 This integration only works in the Edge runtime.
 

--- a/docs/platforms/javascript/common/crons/index.mdx
+++ b/docs/platforms/javascript/common/crons/index.mdx
@@ -99,7 +99,7 @@ environments.
 
 If you don't specify an environment with your check-ins the default is `production`.
 
-<Alert level="info">
+<Alert>
 
 Monitor environments are still early in development. Currently, after a check-in
 occurs for a specific environment, you must continue sending check-ins on

--- a/docs/platforms/javascript/common/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/javascript/common/data-management/debug-files/symbol-servers/index.mdx
@@ -45,7 +45,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -2,7 +2,7 @@
 
 <PlatformSection noGuides>
 
-<Alert level="info" title="Using a framework?">
+<Alert title="Using a framework?">
 
 Check out the other SDKs we support in the left-hand dropdown.
 

--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -267,7 +267,7 @@ Sentry.init({
 });
 ```
 
-<Alert level="info" title="Why is it recommended to register loader hooks yourself?">
+<Alert title="Why is it recommended to register loader hooks yourself?">
 
 It is recommended registering your own ESM loader hooks when you have a complete custom OpenTelemetry setup, first and foremost because it makes the most sense architecturally.
 You likely went through the effort to set up OpenTelemetry by itself and now you want to add Sentry to your application without messing with your OpenTelemetry setup.

--- a/docs/platforms/javascript/common/tracing/trace-propagation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/trace-propagation/index.mdx
@@ -57,7 +57,7 @@ If necessary, you can override the default trace duration by [manually starting 
 
 <PlatformContent includePath="distributed-tracing/how-to-use/" />
 
-<Alert level="info" >
+<Alert >
 
 Remember that in order to propagate trace information through your whole distributed system, you have to use Sentry in all of the involved services and applications. Take a look at the respective SDK documentation to learn how distributed tracing can be enabled for each platform.
 

--- a/docs/platforms/javascript/guides/electron/configuration/application-not-responding.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/application-not-responding.mdx
@@ -20,7 +20,7 @@ optionally attach a stack trace of the blocking code to the ANR event.
 
 _(Available in version 4.17.0 and above)_
 
-<Alert level="info">
+<Alert>
 
 ANR detection requires Electron v22 or higher.
 

--- a/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
@@ -148,7 +148,7 @@ This means that when you run a production build (`nuxt build`), source maps will
 To upload source maps, specify your Sentry auth token as well as your org and project slugs. Set them in the `sourceMapsUploadOptions` option
 inside the `sentry` options of your `nuxt.config.ts`.
 
-<Alert level="info">
+<Alert>
   The module options inside `sentry` are only affecting the **build-time** of the SDK.
 </Alert>
 

--- a/docs/platforms/javascript/guides/react/features/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router/index.mdx
@@ -7,7 +7,7 @@ _(Available in version 5.21.0 and above)_
 
 React Router support is included in the `@sentry/react` package since version `5.21.0`.
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 The React Router integration is designed to work with Sentry Tracing. Please see [Set Up Tracing with React](/platforms/javascript/guides/react/tracing/) for more details on how to set up and install the SDK.
 

--- a/docs/platforms/javascript/guides/react/features/react-router/v6.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router/v6.mdx
@@ -4,7 +4,7 @@ description: "Learn about Sentry's React Router v6 integration."
 sidebar_order: 20
 ---
 
-<Alert level="info">
+<Alert>
   - React Router v6 support is included in the `@sentry/react` package since
   version `7`.
 </Alert>
@@ -119,7 +119,7 @@ This is only needed at the top level of your app, rather than how v4/v5 required
 
 ### Usage With `useRoutes` Hook
 
-<Alert level="info">
+<Alert>
   Available in `@sentry/react` version `7.12.1` and above.
 </Alert>
 

--- a/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
@@ -4,7 +4,7 @@ description: "Learn about Sentry's React Router v7 integration."
 sidebar_order: 10
 ---
 
-<Alert level="info">
+<Alert>
   - React Router v7 (library mode) support is included in the `@sentry/react`
   package since version `8.42.0`. - React Router v7 (framework mode) is not yet
   supported.

--- a/docs/platforms/javascript/guides/react/features/tanstack-router.mdx
+++ b/docs/platforms/javascript/guides/react/features/tanstack-router.mdx
@@ -7,7 +7,7 @@ _(Available in version 8.7.0 and above)_
 
 TanStack Router support is included in the `@sentry/react` package since version `8.7.0` and is only compatible with version `1.34.5` of ` `@tanstack/router` and above.
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 The TanStack Router integration is designed to work with Sentry Tracing. Please see <PlatformLink to="/tracing/#enable-tracing">Getting Started with React Performance</PlatformLink> for more details on how to set up and install the SDK.
 

--- a/docs/platforms/javascript/legacy-sdk/integrations.mdx
+++ b/docs/platforms/javascript/legacy-sdk/integrations.mdx
@@ -39,7 +39,7 @@ On its own, Raven.js will report any uncaught exceptions triggered from your app
 
 Additionally, the Raven.js AngularJS plugin will catch any AngularJS-specific exceptions reported through AngularJS’s `$exceptionHandler` interface.
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 This documentation is for Angular 1.x. See also: [_Angular 2.x_](#angular).
 

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/scopes/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/scopes/index.mdx
@@ -70,7 +70,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/native/common/configuration/sampling.mdx
+++ b/docs/platforms/native/common/configuration/sampling.mdx
@@ -107,7 +107,7 @@ When there's the potential for more than one of these to come into play, the fol
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 
-<Alert level="info">
+<Alert>
 
 Forcing a sampling decision by passing it into <PlatformIdentifier name="start-transaction" /> is currently not supported by this platform.
 

--- a/docs/platforms/native/common/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/native/common/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/php/guides/laravel/usage/index.mdx
+++ b/docs/platforms/php/guides/laravel/usage/index.mdx
@@ -90,7 +90,7 @@ class SentryContext
 
 ### Log Channels
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 If you're using log channels to log your exceptions and are also logging exceptions to Sentry in your exception handler, exceptions might show up in Sentry twice.
 

--- a/docs/platforms/php/legacy-sdk/usage.mdx
+++ b/docs/platforms/php/legacy-sdk/usage.mdx
@@ -36,7 +36,7 @@ $error_handler->registerErrorHandler();
 $error_handler->registerShutdownFunction();
 ```
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 Calling `install()` on a Raven_Client instance will automatically register these handlers.
 

--- a/docs/platforms/powershell/enriching-events/scopes/index.mdx
+++ b/docs/platforms/powershell/enriching-events/scopes/index.mdx
@@ -72,7 +72,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -3,7 +3,7 @@ title: Anthropic
 description: "Learn about using Sentry for Anthropic."
 ---
 
-<Alert level="info" title="Beta">
+<Alert title="Beta">
 
 The support for **Anthropic** is in its beta phase.
 

--- a/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
+++ b/docs/platforms/python/integrations/aws-lambda/manual-instrumentation/index.mdx
@@ -66,7 +66,7 @@ def lambda_handler(event, context):
     # ...
 ```
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 If you're using another web framework inside of AWS Lambda, that framework may catch exceptions before we see them. Make sure to enable the framework-specific integration if it exists. See [_the Python main page_](/platforms/python/) for more information.
 

--- a/docs/platforms/python/integrations/celery/index.mdx
+++ b/docs/platforms/python/integrations/celery/index.mdx
@@ -120,7 +120,7 @@ def debug_sentry():
     1/0
 ```
 
-<Alert level="info" title="Note on distributed tracing">
+<Alert title="Note on distributed tracing">
 
 Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, with [message protocol of version 1](https://docs.celeryq.dev/en/stable/internals/protocol.html#version-1), this functionality is broken, and Celery fails to propagate custom headers to the worker. Protocol version 2, which is the default since Celery version 4.0, is not affected.
 

--- a/docs/platforms/python/integrations/cohere/index.mdx
+++ b/docs/platforms/python/integrations/cohere/index.mdx
@@ -3,7 +3,7 @@ title: Cohere
 description: "Learn about using Sentry for Cohere."
 ---
 
-<Alert level="info" title="Beta">
+<Alert title="Beta">
 
 The support for **Cohere** is in its beta phase.
 

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -165,7 +165,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
   (Note that `OPTIONS` and `HEAD` are missing by default.)
 
-  <Alert title="Added in 2.15.0" level="info">
+  <Alert title="Added in 2.15.0">
     The `http_methods_to_capture` option.
   </Alert>
 

--- a/docs/platforms/python/integrations/dramatiq/index.mdx
+++ b/docs/platforms/python/integrations/dramatiq/index.mdx
@@ -7,7 +7,7 @@ The Dramatiq integration adds support for the [Dramatiq](https://dramatiq.io/) b
 
 The Dramatiq integration only reports errors. Tracing is not yet supported. If you want to have more instrumentation, you need to do [custom instrumentation](/platforms/python/tracing/instrumentation/custom-instrumentation/).
 
-<Alert level="info">
+<Alert>
   This is the successor of the original `DramatiqIntegration` that can be found here: https://github.com/jacobsvante/sentry-dramatiq
 
   The original maintainer has [donated the integration to Sentry](https://github.com/getsentry/sentry-python/issues/3387), so we can take over maintenance.

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -154,7 +154,7 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
 
   (Note that `OPTIONS` and `HEAD` are missing by default.)
 
-  <Alert title="Added in 2.15.0" level="info">
+  <Alert title="Added in 2.15.0">
     The `http_methods_to_capture` option.
   </Alert>
 

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -101,7 +101,7 @@ You can pass the following keyword arguments to `FlaskIntegration()`:
 
   (Note that `OPTIONS` and `HEAD` are missing by default.)
 
-  <Alert title="Added in 2.15.0" level="info">
+  <Alert title="Added in 2.15.0">
     The `http_methods_to_capture` option.
   </Alert>
 

--- a/docs/platforms/python/integrations/gcp-functions/index.mdx
+++ b/docs/platforms/python/integrations/gcp-functions/index.mdx
@@ -57,7 +57,7 @@ def http_function_entrypoint(request):
     # ...
 ```
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 If you are using a web framework inside of your Cloud Function, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [_the Python main page_](/platforms/python/) for more information.
 

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -3,7 +3,7 @@ title: Huggingface Hub
 description: "Learn about using Sentry for Huggingface Hub."
 ---
 
-<Alert level="info" title="Beta">
+<Alert title="Beta">
 
 The support for **Huggingface Hub** is in its beta phase.
 

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -3,7 +3,7 @@ title: Langchain
 description: "Learn about using Sentry for Langchain."
 ---
 
-<Alert level="info" title="Beta">
+<Alert title="Beta">
 
 The support for **LangChain** is in its beta phase.
 

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -79,7 +79,7 @@ You can pass the following keyword arguments to `LoggingIntegration()`:
 
 - `event_level` (default `ERROR`): The Sentry Python SDK will report log records with a level higher than or equal to `event_level` as events as long as the logger itself is set to output records of those log levels (see note below). If a value of `None` occurs, the SDK won't send log records as events.
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 The Sentry Python SDK will honor the configured level of each logger (set with `logger.setLevel(level)` or `logging.basicConfig(level=level)`). That means that you will not see any `INFO` or `DEBUG` events from a logger with the level set to `WARNING`, regardless of how you configure the integration. If not set explicitly, the logging level defaults to `WARNING`.
 

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -3,7 +3,7 @@ title: OpenAI
 description: "Learn about using Sentry for OpenAI."
 ---
 
-<Alert level="info" title="Beta">
+<Alert title="Beta">
 
 The support for **OpenAI** is in its beta phase.
 

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -117,7 +117,7 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
   (Note that `OPTIONS` and `HEAD` are missing by default.)
 
-  <Alert title="Added in 2.15.0" level="info">
+  <Alert title="Added in 2.15.0">
     The `http_methods_to_capture` option.
   </Alert>
 

--- a/docs/platforms/python/integrations/sys_exit/index.mdx
+++ b/docs/platforms/python/integrations/sys_exit/index.mdx
@@ -66,7 +66,7 @@ sys.exit(1)
 If you use `capture_successful_exits=True`, calling `sys.exit(0)` should also report a `SystemExit` exception to Sentry.
 
 
-<Alert level="info" title="Manually-raised SystemExit">
+<Alert title="Manually-raised SystemExit">
 
 Please note that the `SysExitIntegration` only captures `SystemExit` exceptions which are raised by calling `sys.exit`. If your code raises `SystemExit` without calling `sys.exit`, the exception will not be reported to Sentry.
 

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -9,7 +9,7 @@ The Sentry SDK for Python does a very good job of auto instrumenting your applic
 
 Adding transactions will allow you to instrument and capture certain regions of your code.
 
-<Alert level="info">
+<Alert>
 
 If you're using one of Sentry's SDK integrations, transactions will be created for you automatically.
 
@@ -56,7 +56,7 @@ def eat_pizza(pizza):
                 eat_slice(pizza.slices.pop())
 ```
 
-<Alert title="Changed in 2.15.0" level="info">
+<Alert title="Changed in 2.15.0">
 
 The parameter `name` in `start_span()` used to be called `description`. In version 2.15.0 `description` was deprecated and from 2.15.0 on, only `name` should be used. `description` will be removed in `3.0.0`.
 
@@ -77,7 +77,7 @@ def eat_pizza(pizza):
             eat_slice(pizza.slices.pop())
 ```
 
-<Alert title="Static & Class Methods" level="info">
+<Alert title="Static & Class Methods">
 
 When tracing a static or class method, you **must** add the `@sentry_sdk.trace` decorator **after** the `@staticmethod` or `@classmethod` decorator (i.e., **closer** to the function definition). Otherwise, your function will break!
 
@@ -99,7 +99,7 @@ def eat_pizza(pizza):
             span.finish()
 ```
 
-<Alert title="Changed in 2.15.0" level="info">
+<Alert title="Changed in 2.15.0">
 
 The parameter `name` in `start_span()` used to be called `description`. In version 2.15.0 `description` was deprecated and from 2.15.0 on, only `name` should be used. `description` will be removed in `3.0.0`.
 
@@ -125,7 +125,7 @@ def eat_slice(slice):
             chew()
 ```
 
-<Alert title="Changed in 2.15.0" level="info">
+<Alert title="Changed in 2.15.0">
 
 The parameter `name` in `start_span()` used to be called `description`. In version 2.15.0 `description` was deprecated and from 2.15.0 on, only `name` should be used. `description` will be removed in `3.0.0`.
 
@@ -163,7 +163,7 @@ def eat_slice(slice):
     parent_span.finish()
 ```
 
-<Alert title="Changed in 2.15.0" level="info">
+<Alert title="Changed in 2.15.0">
 
 The parameter `name` in `start_span()` used to be called `description`. In version 2.15.0 `description` was deprecated and from 2.15.0 on, only `name` should be used. `description` will be removed in `3.0.0`.
 
@@ -196,7 +196,7 @@ sentry_sdk.init(
 
 Now, whenever a function specified in `functions_to_trace` will be executed, a span will be created and attached as a child to the currently running span.
 
-<Alert title="Important" level="info">
+<Alert title="Important">
 
 To enable performance monitoring for the functions specified in `functions_to_trace`, the SDK needs to load the function modules. Be aware, there may be code being executed in modules during module loading. To avoid this, use the method described above to trace your functions.
 

--- a/docs/platforms/rust/common/configuration/sampling.mdx
+++ b/docs/platforms/rust/common/configuration/sampling.mdx
@@ -47,7 +47,7 @@ The Sentry SDKs have two configuration options to control the volume of transact
 
 By default, none of these options are set, meaning no transactions will be sent to Sentry. You must set either one of the options to start sending transactions.
 
-<Alert level="info">
+<Alert>
 
 Sampling functions (<PlatformIdentifier name="traces-sampler" />) are currently not supported by this platform.
 
@@ -90,7 +90,7 @@ When there's the potential for more than one of these to come into play, the fol
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 
-<Alert level="info">
+<Alert>
 
 Forcing a sampling decision by passing it into <PlatformIdentifier name="start-transaction" /> is currently not supported by this platform.
 

--- a/docs/platforms/unity/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/unity/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/unity/enriching-events/scopes/index.mdx
+++ b/docs/platforms/unity/enriching-events/scopes/index.mdx
@@ -72,7 +72,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -84,7 +84,7 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 Takes a screenshot of the application when an error happens and includes it as an attachment.
 Learn more about enriching events with screenshots in our <PlatformLink to="/enriching-events/screenshots/">Screenshots documentation</PlatformLink>.
 
-<Alert level="info">
+<Alert>
 
 The support for screenshot attachment on crash events is limited to Windows and Linux.
 
@@ -116,7 +116,7 @@ A number between 0 and 1, controlling the percentage chance a given transaction 
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning 0 for those that are unwanted. Either this or <PlatformIdentifier name="traces-sample-rate" /> must be defined to enable tracing.
 
-<Alert level="info">
+<Alert>
 
 Currently, there is no support for sampling functions on Windows or Linux (<PlatformIdentifier name="traces-sampler" />).
 

--- a/docs/platforms/unreal/configuration/sampling.mdx
+++ b/docs/platforms/unreal/configuration/sampling.mdx
@@ -96,7 +96,7 @@ When there's the potential for more than one of these to come into play, the fol
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.
 
-<Alert level="info">
+<Alert>
 
 Currently there is no support for forcing a sampling decision by passing it into <PlatformIdentifier name="start-transaction" />.
 

--- a/docs/platforms/unreal/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/unreal/data-management/debug-files/symbol-servers/index.mdx
@@ -42,7 +42,7 @@ Beware that these cause notifications to your team members.
 
 ## Custom Repositories
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 Custom repositories are available for organizations on the _Business_ and
 _Enterprise_ plans.

--- a/docs/platforms/unreal/enriching-events/scopes/index.mdx
+++ b/docs/platforms/unreal/enriching-events/scopes/index.mdx
@@ -121,7 +121,7 @@ made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 Any exceptions that occur within the callback function for configuring a local scope will not be
 caught, and all errors that occur will be silently ignored and **not** reported.

--- a/docs/platforms/unreal/tracing/index.mdx
+++ b/docs/platforms/unreal/tracing/index.mdx
@@ -21,7 +21,7 @@ First, enable tracing and configure the sample rate for transactions. Set the sa
 
 The two options are meant to be mutually exclusive. If you set both, <PlatformIdentifier name="traces-sampler" /> will take precedence.
 
-<Alert level="info">
+<Alert>
 
 Currently there is no support for sampling functions on Windows/Linux (<PlatformIdentifier name="traces-sampler" />).
 

--- a/docs/pricing/quotas/legacy-manage-transaction-quota.mdx
+++ b/docs/pricing/quotas/legacy-manage-transaction-quota.mdx
@@ -17,7 +17,7 @@ Applying the proper SDK configuration is an iterative and on-going process, but 
 
 ## Before You Begin: Check Your Quota Usage
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 The "Usage Stats" tab is only visible if you're on a Team, Business, or Enterprise plan.
 

--- a/docs/pricing/quotas/manage-transaction-quota.mdx
+++ b/docs/pricing/quotas/manage-transaction-quota.mdx
@@ -10,7 +10,7 @@ Applying the proper SDK configuration is an iterative and on-going process, but 
 
 ## Before You Begin: Check Your Quota Usage
 
-<Alert title="Note" level="info">
+<Alert title="Note">
 
 The "Usage Stats" tab is only visible if you're on a Team, Business, or Enterprise plan.
 

--- a/docs/product/alerts/uptime-monitoring/automatic-detection.mdx
+++ b/docs/product/alerts/uptime-monitoring/automatic-detection.mdx
@@ -12,7 +12,7 @@ In order to be able to automatically detect uptime alerts, we analyze all the UR
 
 To avoid creating flaky alerts, the hostname undergoes an "onboarding period" of three days. During this period, we send HTTP requests to the hostname every hour. If the request fails three times or more, the hostname will be dropped and re-evaluated after seven days.
 
-<Alert level="info">
+<Alert>
  Sentry will execute uptime checks against the hostname root path of the most frequently-seen URLs. For example, if the most frequently-seen URL in your events is `GET https://www.example.com/docs/introduction`, the check will be `GET https://www.example.com/`.
 </Alert>
 

--- a/docs/product/crons/getting-started/http/index.mdx
+++ b/docs/product/crons/getting-started/http/index.mdx
@@ -68,7 +68,7 @@ environments.
 
 If you don't specify an environment with your check-ins the default is `production`.
 
-<Alert level="info">
+<Alert>
 
 Monitor environments are still early in development. Currently, after a check-in
 occurs for a specific environment, you must continue sending check-ins on

--- a/docs/product/crons/legacy-endpoint-migration.mdx
+++ b/docs/product/crons/legacy-endpoint-migration.mdx
@@ -7,7 +7,7 @@ ingestion-level traffic, so we have since moved Check-In APIs to use
 
 If you're using legacy endpoints for Crons, migrate to the new endpoints to avoid issues.
 
-<Alert level="info">
+<Alert>
 
 The Legacy endpoints **are deprecated** and will be removed in the future,
 however a date has not yet been set for their removal. We will communicate a

--- a/docs/product/dev-toolbar/index.mdx
+++ b/docs/product/dev-toolbar/index.mdx
@@ -4,7 +4,7 @@ sidebar_order: 120
 description: "Bring critical Sentry insights and tools directly into your web app for easier troubleshooting with the Dev Toolbar."
 ---
 
-<Alert level="info">
+<Alert>
   The Dev Toolbar is currently in **beta**. Beta features are still in progress and may have bugs. Please reach out on
   [GitHub](https://github.com/getsentry/sentry-toolbar/issues) if you have any feedback or concerns.
 </Alert>

--- a/docs/product/dev-toolbar/setup.mdx
+++ b/docs/product/dev-toolbar/setup.mdx
@@ -4,7 +4,7 @@ sidebar_order: 10
 description: "Get started with Sentry's Dev Toolbar, bringing critical Sentry insights and tools into your web app to help your team troubleshoot more effectively."
 ---
 
-<Alert level="info">
+<Alert>
   The Dev Toolbar is currently in **beta**. Beta features are still in progress and may have bugs. Please reach out on
   [GitHub](https://github.com/getsentry/sentry-toolbar/issues) if you have any feedback or concerns.
 </Alert>

--- a/docs/product/explore/feature-flags/index.mdx
+++ b/docs/product/explore/feature-flags/index.mdx
@@ -4,7 +4,7 @@ sidebar_order: 100
 description: "Learn how to set up and interact with Sentry's feature flag evaluation tracking and feature flag change tracking."
 ---
 
-<Alert level="info" title="Currently in Beta">
+<Alert title="Currently in Beta">
 
 Feature flag change tracking and feature flag evaluation tracking is currently in open beta.
 

--- a/docs/product/issues/issue-details/index.mdx
+++ b/docs/product/issues/issue-details/index.mdx
@@ -145,7 +145,7 @@ You can set up your own context items to collect useful debugging information in
 
 ## Feature Flags
 
-<Alert level="info" title="Currently in Beta">
+<Alert title="Currently in Beta">
 
 Feature flag change tracking and feature flag evaluation tracking is currently in open beta.
 

--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -80,7 +80,7 @@ This feature supports GitHub and GitLab CODEOWNERS file syntax with the followin
 - [GitLab Premium syntax](https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections)
 - [GitHub CODEOWNERS syntax exceptions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
 
-<Alert level="info">
+<Alert>
 
 Ownership rules take precedence over the information provided by your CODEOWNERS file when Sentry assigns issues.
 

--- a/docs/product/relay/getting-started.mdx
+++ b/docs/product/relay/getting-started.mdx
@@ -94,7 +94,7 @@ Configurations are fully documented in [Configuration Options](../options/).
 
 ## Creating Credentials
 
-<Alert level="info">
+<Alert>
 
 Not applicable in `proxy` or `static` mode.
 
@@ -118,7 +118,7 @@ Use the `public_key` to register your Relay with the upstream server when runnin
 
 ## Registering Relay with Sentry
 
-<Alert level="info">
+<Alert>
 
 Not applicable in `proxy` or `static` mode.
 

--- a/docs/product/relay/modes/index.mdx
+++ b/docs/product/relay/modes/index.mdx
@@ -40,7 +40,7 @@ In static mode, projects must be configured manually. In this mode, Relay will p
 
 This mode is useful when you know the projects sending events and you need to explicitly control the projects allowed to send events through this Relay.
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 In `static` mode, Relay does not register with upstream since it does not query
 information from it. After processing events for configured projects, it
@@ -67,7 +67,7 @@ identically to `static` mode. Events for unknown projects -- projects for which
 there are no statically configured settings -- are forwarded (proxied) with
 minimal processing.
 
-<Alert level="info" title="Rate Limiting">
+<Alert title="Rate Limiting">
 
 Rate limiting is still applied in `proxy` mode for all projects,
 regardless of whether they are statically configured or proxied.

--- a/docs/product/relay/operating-guidelines.mdx
+++ b/docs/product/relay/operating-guidelines.mdx
@@ -105,7 +105,7 @@ Depending on the SDK or client, requests to these endpoints are performed with c
 - `X-Forwarded-For`: to the client IP address
 - `X-Sentry-Auth`: to the value provided by the client
 
-<Alert level="info">
+<Alert>
 
 Proxies often set a default maximum body size for requests. Especially native crash reports and attachments can exceed these limits. We recommend to configure a maximum client body size of _100MB_.
 

--- a/docs/product/releases/health/index.mdx
+++ b/docs/product/releases/health/index.mdx
@@ -109,7 +109,7 @@ Depending on your "Display" selection, the sort options for the **Releases** pag
 
 ![Sort By: Crash Free Users dropdown](./img/release_crash_free_users.png)
 
-<Alert level="info">
+<Alert>
 
 Please note that the number of crashes is not expected to match the number of crashed sessions because sessions are not subject to [inbound filters](/concepts/data-management/filtering/) or [sampling](/platform-redirect/?next=/configuration/sampling/).
 

--- a/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
@@ -11,7 +11,7 @@ In addition to <PlatformLink to="/data-management/sensitive-data/">using hooks i
 - Detailed tuning on which parts of an event to scrub
 - Partial removal or hashing of sensitive data instead of deletion
 
-<Alert level="info" title="Rule Precedence">
+<Alert title="Rule Precedence">
 
 Advanced Data Scrubbing rules take precedence over other Server-Side Data Scrubbing settings. Specifically, any advanced rule will apply regardless of whether the matched field is in Safe Fields or not.
 

--- a/includes/platforms/configuration/integrations/redux.mdx
+++ b/includes/platforms/configuration/integrations/redux.mdx
@@ -9,7 +9,7 @@ const store = createStore(
 );
 ```
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 Because Sentry uses a redux **enhancer**, you should pass it as indicated above rather than passing it to `applyMiddleware`. Don't call the method when you pass it to `createStore`.
 

--- a/platform-includes/alert-using-a-framework/_default.mdx
+++ b/platform-includes/alert-using-a-framework/_default.mdx
@@ -1,4 +1,4 @@
-<Alert level="info" title="Using a framework?">
+<Alert title="Using a framework?">
 
 Check out the other SDKs we support in the left-hand dropdown.
 

--- a/platform-includes/configuration/before-send-hint/native.mdx
+++ b/platform-includes/configuration/before-send-hint/native.mdx
@@ -1,4 +1,4 @@
-<Alert level="info">
+<Alert>
 
 The Native SDK does not pass exception information into the hint, but instead allows to set a custom hint in SDK options. To detect the exception type, inspect the event instead.
 

--- a/platform-includes/configuration/config-intro/dotnet.aspnetcore.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.aspnetcore.mdx
@@ -45,7 +45,7 @@ Additionally, you can set your options on `appsettings.json` when using `UseSent
   }
 ```
 
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 You can configure the Sentry options inside of the `UseSentry` callback or through `appsettings.json`. The settings from `appsettings.json` will be applied before the callback is invoked.
 

--- a/platform-includes/enriching-events/scopes/with-isolation-scope/java.mdx
+++ b/platform-includes/enriching-events/scopes/with-isolation-scope/java.mdx
@@ -32,7 +32,7 @@ Sentry.withIsolationScope { scope ->
 Sentry.captureException(Exception("my other error"))
 ```
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 In the Java SDK `withIsolationScope` does **not** work reliably in `globalHubMode`, as the SDK always uses the global root scopes unless you call the `captureXXX` methods directly on `Scopes`.
 

--- a/platform-includes/enriching-events/scopes/with-scope/java.mdx
+++ b/platform-includes/enriching-events/scopes/with-scope/java.mdx
@@ -32,7 +32,7 @@ Sentry.withScope { scope ->
 Sentry.captureException(Exception("my error"))
 ```
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 In the Java SDK `withScope` does **not** work reliably in `globalHubMode` as the SDK always uses the global root scopes unless you call the `captureXXX` methods directly on `Scopes`.
 

--- a/platform-includes/enriching-events/scopes/with-scope/java__v7.x.mdx
+++ b/platform-includes/enriching-events/scopes/with-scope/java__v7.x.mdx
@@ -32,7 +32,7 @@ Sentry.withScope { scope ->
 Sentry.captureException(Exception("my error"))
 ```
 
-<Alert level="info" title="Important">
+<Alert title="Important">
 
 In the Java SDK `withScope` does **not** work reliably in `globalHubMode` as the `scope` gets pushed on the stack global to the hub. In `globalHubMode` use the callback parameter of the capture methods detailed below.
 

--- a/platform-includes/feature-flags/prerelease-alert/_default.mdx
+++ b/platform-includes/feature-flags/prerelease-alert/_default.mdx
@@ -1,4 +1,4 @@
-<Alert level="info" title="Currently in Beta">
+<Alert title="Currently in Beta">
 
 Feature flag change tracking and feature flag evaluation tracking is currently in open beta.
 

--- a/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
@@ -1,4 +1,4 @@
-<Alert level="info" title="Note">
+<Alert title="Note">
 
 OpenTelemetry support is only available for server-side instrumentation on Node runtimes.
 

--- a/platform-includes/performance/sampling-function-intro/unreal.mdx
+++ b/platform-includes/performance/sampling-function-intro/unreal.mdx
@@ -2,7 +2,7 @@ To use the sampling function, set the <PlatformIdentifier name="traces-sampler" 
 
 <PlatformContent includePath="performance/traces-sampler-as-sampler" />
 
-<Alert level="info">
+<Alert>
 
 Currently there's no support for sampling functions on Windows/Linux (<PlatformIdentifier name="traces-sampler" />).
 

--- a/src/components/relayMetrics/index.tsx
+++ b/src/components/relayMetrics/index.tsx
@@ -24,7 +24,7 @@ export function RelayMetrics() {
 function RelayFeatures({features}) {
   if (Array.isArray(features) && features.includes('processing')) {
     return (
-      <Alert level="info" title="Note">
+      <Alert title="Note">
         This metric is emitted only when Relay runs as internal Sentry service for event
         ingestion (<code>processing</code> feature).
       </Alert>


### PR DESCRIPTION
This is redundant, so we can just omit this.