### PR TITLE
feat: Update `<Alert>` style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,9 +63,6 @@
   --flame7: #edcf9e;
   --flame8: #ffefae;
 
-  /* Desaturated oranges */
-  --desatFlame8: #fefbe9;
-
   /* A range of desaturated purples */
   --desatPurple0: #0f0a1f;
   --desatPurple1: #231c3d;

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,9 @@
   --flame7: #edcf9e;
   --flame8: #ffefae;
 
+  /* Desaturated oranges */
+  --desatFlame8: #fefbe9;
+
   /* A range of desaturated purples */
   --desatPurple0: #0f0a1f;
   --desatPurple1: #231c3d;

--- a/develop-docs/frontend/design-tenets.mdx
+++ b/develop-docs/frontend/design-tenets.mdx
@@ -49,7 +49,7 @@ Why minimize content refreshes?
 - Less rendering / data fetching for the browser
 - Assists user navigation by preserving sense of state ("where am I?")
 
-<Alert level="error">
+<Alert level="warning">
   Note: while there are a few good examples of this in action in the app, we are actually pretty inconsistent applying this design principle.
 </Alert>
 

--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -16,6 +16,10 @@ This is an info alert. Use these for information that's critical to know; it's i
 This is a warning alert. Use these for items that MUST be well understood before proceeding. These highlight information that could cause users to make catastrophic errors that break their applications in ways that are very difficult to fix or create liabilities for them, such as information needed to avoid leaking PII. These should be used very rarely.
 </Alert>
 
+<Alert level="success" title="Tip">
+This is a success alert. Use these when.... TODO?
+</Alert>
+
 <Alert>
 This is an alert without title.
 </Alert>
@@ -44,6 +48,12 @@ This is a warning alert.
 </Alert>
 ```
 
+```markdown {tabTitle:Success}
+<Alert level="success" title="Tip">
+This is a success alert.
+</Alert>
+```
+
 ```markdown {tabTitle:No Title}
 <Alert>
 This is an alert without title.
@@ -53,7 +63,7 @@ This is an alert without title.
 Attributes:
 
 - `title` (string) - optional
-- `level` (string: `'info' | 'warning') - optional, defaults to `'info'`
+- `level` (string: `'info' | 'warning' | 'success') - optional, defaults to `'info'`
 
 Use this for these types of content:
 

--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -20,6 +20,10 @@ This is a warning alert. Use these for items that MUST be well understood before
 This is an alert without title.
 </Alert>
 
+<Alert>
+This is a multi-line alert without title.  Use these for information that's critical to know; it's important for users to read, but won't cause a catastrophic problem if they don't read it. These include versions that introduce breaking changes or feature limitations. Use infrequently.
+</Alert>
+
 <Alert title="List">
 <ul>
 <li>Item 1</li>

--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -8,13 +8,41 @@ sidebar_order: 40
 
 Render an alert callout.
 
-<Alert title="Important">
-This is an alert
+<Alert title="Watch out!">
+This is an info alert. Use these for information that's critical to know; it's important for users to read, but won't cause a catastrophic problem if they don't read it. These include versions that introduce breaking changes or feature limitations. Use infrequently.
 </Alert>
 
-```markdown {tabTitle:Example}
-<Alert title="Important">
-This is an alert
+<Alert level="warning" title="Important">
+This is a warning alert. Use these for items that MUST be well understood before proceeding. These highlight information that could cause users to make catastrophic errors that break their applications in ways that are very difficult to fix or create liabilities for them, such as information needed to avoid leaking PII. These should be used very rarely.
+</Alert>
+
+<Alert>
+This is an alert without title.
+</Alert>
+
+<Alert title="List">
+<ul>
+<li>Item 1</li>
+<li>Item 2</li>
+</ul>
+</Alert>
+
+
+```markdown {tabTitle:Info}
+<Alert title="Watch out!">
+This is an info alert.
+</Alert>
+```
+
+```markdown {tabTitle:Warning}
+<Alert level="warning" title="Important">
+This is a warning alert.
+</Alert>
+```
+
+```markdown {tabTitle:No Title}
+<Alert>
+This is an alert without title.
 </Alert>
 ```
 
@@ -30,7 +58,7 @@ Use this for these types of content:
 - **Warning:** Use these for items that MUST be well understood before proceeding. These highlight information that could cause users to make catastrophic errors that break their applications in ways that are very difficult to fix or create liabilities for them, such as information needed to avoid leaking PII. These should be used very rarely.
   - Use with the title "Important"; do not use the title "Warning"
 
-An Alert component with no level setting will render as a Note component.
+You can also omit the title of the alert.
 
 See also the [Note component](#note).
 

--- a/docs/platforms/android/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/android/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/apple/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/dart/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/dart/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/dotnet/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/dotnet/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/dotnet/guides/nlog/configuration/advanced-configuration-example.mdx
+++ b/docs/platforms/dotnet/guides/nlog/configuration/advanced-configuration-example.mdx
@@ -4,7 +4,7 @@ sidebar_order: 20
 description: "Review an advanced example of configuration for NLog."
 ---
 
-<Alert level="" title="NLog Layouts">
+<Alert title="NLog Layouts">
 
 For more information on how to dynamically set event data via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).
 

--- a/docs/platforms/dotnet/guides/nlog/index.mdx
+++ b/docs/platforms/dotnet/guides/nlog/index.mdx
@@ -41,7 +41,7 @@ Messages logged from assemblies with the name starting with `Sentry` will not ge
 
 ## Configure
 
-<Alert level="" title="NLog Layouts">
+<Alert title="NLog Layouts">
 
 For more information on how to dynamically set event data via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).
 

--- a/docs/platforms/elixir/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/elixir/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/flutter/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/flutter/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/go/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/go/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/java/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/java/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/javascript/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -35,7 +35,7 @@ By default, this will insert the widget into the bottom right corner of your web
 
 On SDK version 8.0.0 and above, users can send screenshots with their feedback. If you're self-hosting, you also need release 24.4.2 and above. You can configure this using the `enableScreenshot` option, by default it is set to `true`. Screenshots aren't supported on mobile devices, so the screenshot button will be hidden automatically in this case.
 
-<Alert level="">
+<Alert>
   Screenshots use your [attachments
   quota](/pricing/quotas/manage-attachments-quota). All plans come with 1GB of
   attachments, which is approxiamately 2500 screenshots.

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/native/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/native/common/enriching-events/breadcrumbs/index.mdx
@@ -12,7 +12,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/native/guides/minidumps/index.mdx
+++ b/docs/platforms/native/guides/minidumps/index.mdx
@@ -34,7 +34,7 @@ and can later be uploaded to Sentry. A minidump typically includes:
   assertion message is also included in the dump.
 - Meta data about the CPU architecture and the user’s operating system.
 
-<Alert level="" title="A Word on Data Privacy">
+<Alert title="A Word on Data Privacy">
 
 Minidumps are memory dumps of the process at the moment it crashes. As such,
 they might contain sensitive information on the target system, such as

--- a/docs/platforms/php/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/php/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/powershell/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/powershell/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/python/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/python/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/python/legacy-sdk/integrations.mdx
+++ b/docs/platforms/python/legacy-sdk/integrations.mdx
@@ -875,7 +875,7 @@ logger.error('There was an error, with a stack trace!', extra={
 })
 ```
 
-<Alert level="" title="Note on Python version">
+<Alert title="Note on Python version">
 
 Depending on the version of Python you’re using, `extra` might not be an acceptable keyword argument for a logger’s `.exception()` method (`.debug()`, `.info()`, `.warning()`, `.error()` and `.critical()` should work fine regardless of Python version). This should be fixed as of Python 2.7.4 and 3.2. Official issue here: [bugs.python.org/issue15541](https://bugs.python.org/issue15541).
 
@@ -1200,7 +1200,7 @@ class AsyncExceptionHandler(SentryMixin, tornado.web.RequestHandler):
         self.finish()
 ```
 
-<Alert level="" title="Tip">
+<Alert title="Tip">
 
 The value returned by the yield is a `HTTPResponse` object.
 

--- a/docs/platforms/react-native/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/react-native/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/ruby/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/rust/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/rust/common/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/docs/platforms/unity/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/unity/enriching-events/breadcrumbs/index.mdx
@@ -7,7 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 
 This page provides an overview of manual breadcrumb recording and customization. Learn more about the information that displays on the **Issue Details** page and how you can filter breadcrumbs to quickly resolve issues in [Using Breadcrumbs](/product/error-monitoring/breadcrumbs).
 
-<Alert level="" title="Learn about SDK usage">
+<Alert title="Learn about SDK usage">
 
 Developers who want to modify the breadcrumbs interface can learn more in our [developer documentation about the Breadcrumbs Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/).
 

--- a/platform-includes/configuration/config-intro/dotnet.nlog.mdx
+++ b/platform-includes/configuration/config-intro/dotnet.nlog.mdx
@@ -1,4 +1,4 @@
-<Alert level="" title="NLog Layouts">
+<Alert title="NLog Layouts">
 
 For more information on how to dynamically set event data via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).
 

--- a/platform-includes/debug-symbols-apple/_default.mdx
+++ b/platform-includes/debug-symbols-apple/_default.mdx
@@ -29,7 +29,7 @@ You can also upload your code for source context. This feature allows Sentry to 
 
 <OnboardingOptionButtons
   options={[{ id:"source-context", checked: false }]}
-/> 
+/>
 
 ```bash {"onboardingOptions": {"source-context": "2"}}
 sentry-cli debug-files upload --auth-token ___ORG_AUTH_TOKEN___ \
@@ -74,7 +74,7 @@ sentry_upload_dif(
 )
 ```
 
-<Alert level="" title="On Prem">
+<Alert title="On Prem">
 
 By default fastlane will connect to sentry.io. For on-prem you need to provide the _url_ parameter to instruct the tool to connect to your server:
 
@@ -96,7 +96,7 @@ Sentry can display snippets of your code next to the event stack traces. This fe
 
 For this to work, your project settings for `DEBUG_INFORMATION_FORMAT` must be set to `DWARF with dSYM File`, which is the default for release builds but not for debug builds. If you don't want Sentry to upload your source code, remove the `--include-sources` argument from the copied script.
 
-<Alert level="" title="Warnings vs. Errors">
+<Alert title="Warnings vs. Errors">
 
 Depending on your needs, you may want to emit warnings to the Xcode build log to let the build pass, or emit errors to fail it. For example, in a CI deployment where debug symbols may be harder to recover, and you might not realize symbols couldn't be symbolicated until after release, it might be better to fail the build.
 
@@ -115,7 +115,7 @@ if which sentry-cli >/dev/null; then
 export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
 export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
-ERROR=$(sentry-cli debug-files upload \ 
+ERROR=$(sentry-cli debug-files upload \
 --include-sources \
 "$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)
 if [ ! $? -eq 0 ]; then
@@ -136,7 +136,7 @@ export SENTRY_ORG=___ORG_SLUG___
 export SENTRY_PROJECT=___PROJECT_SLUG___
 export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ERROR=$(sentry-cli debug-files upload \
---include-sources \ 
+--include-sources \
 "$DWARF_DSYM_FOLDER_PATH" --force-foreground 2>&1 >/dev/null)
 if [ ! $? -eq 0 ]; then
 echo "error: sentry-cli - $ERROR"
@@ -162,7 +162,7 @@ ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TAR
 
 ![enable-user-script-sandboxing](./img/enable_user_script_sandboxing.png)
 
-<Alert level="" title="Self Hosted">
+<Alert title="Self Hosted">
 
 By default sentry-cli will connect to sentry.io. For on-prem you need to export the _SENTRY_URL_ environment variable to instruct the tool to connect to your server:
 

--- a/platform-includes/enriching-events/set-tag/dotnet.nlog.mdx
+++ b/platform-includes/enriching-events/set-tag/dotnet.nlog.mdx
@@ -1,4 +1,4 @@
-<Alert level="" title="NLog Layouts">
+<Alert title="NLog Layouts">
 
 For more information on how to dynamically set event tags via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).
 

--- a/platform-includes/enriching-events/set-user/dotnet.nlog.mdx
+++ b/platform-includes/enriching-events/set-user/dotnet.nlog.mdx
@@ -1,4 +1,4 @@
-<Alert level="" title="NLog Configuration">
+<Alert title="NLog Configuration">
 
 - If setting it via `NLog.config`, the camelCase key `ipAddress` should be used instead of `ip_address`.
 - For more information on how to dynamically set event data via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).

--- a/platform-includes/set-environment/dotnet.nlog.mdx
+++ b/platform-includes/set-environment/dotnet.nlog.mdx
@@ -1,4 +1,4 @@
-<Alert level="" title="NLog Layouts">
+<Alert title="NLog Layouts">
 
 For more information on how to dynamically set event data via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).
 

--- a/platform-includes/set-release/dotnet.nlog.mdx
+++ b/platform-includes/set-release/dotnet.nlog.mdx
@@ -1,4 +1,4 @@
-<Alert level="" title="NLog Layouts">
+<Alert title="NLog Layouts">
 
 For more information on how to dynamically set event data via `NLog.config`, see NLog's [layout renderer documentation](https://nlog-project.org/config/?tab=layout-renderers).
 

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+import {ExclamationTriangleIcon, InfoCircledIcon} from '@radix-ui/react-icons';
 
 // explicitly not usig CSS modules here
 // because there's some prerendered content that depends on these exact class names
@@ -11,10 +12,15 @@ type AlertProps = {
 };
 
 export function Alert({title, children, level = 'info'}: AlertProps) {
+  const Icon = level === 'warning' ? ExclamationTriangleIcon : InfoCircledIcon;
+
   return (
     <div className={`alert ${'alert-' + level}`} role="alert">
-      {title && <h5 className="alert-header">{title}</h5>}
-      <div className="alert-body content-flush-bottom">{children}</div>
+      <Icon className='alert-icon' />
+      <div className="alert-content">
+        {title && <h5 className="alert-header">{title}</h5>}
+        <div className="alert-body content-flush-bottom">{children}</div>
+      </div>
     </div>
   );
 }

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -1,5 +1,9 @@
 import {ReactNode} from 'react';
-import {ExclamationTriangleIcon, InfoCircledIcon} from '@radix-ui/react-icons';
+import {
+  CheckCircledIcon,
+  ExclamationTriangleIcon,
+  InfoCircledIcon,
+} from '@radix-ui/react-icons';
 
 // explicitly not usig CSS modules here
 // because there's some prerendered content that depends on these exact class names
@@ -7,12 +11,18 @@ import './styles.scss';
 
 type AlertProps = {
   children?: ReactNode;
-  level?: 'info' | 'warning';
+  level?: 'info' | 'warning' | 'success';
   title?: string;
 };
 
+const ICON_MAP = {
+  info: InfoCircledIcon,
+  warning: ExclamationTriangleIcon,
+  success: CheckCircledIcon,
+} as const;
+
 export function Alert({title, children, level = 'info'}: AlertProps) {
-  const Icon = level === 'warning' ? ExclamationTriangleIcon : InfoCircledIcon;
+  const Icon = ICON_MAP[level];
 
   return (
     <div className={`alert ${'alert-' + level}`} role="alert">

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -16,7 +16,7 @@ export function Alert({title, children, level = 'info'}: AlertProps) {
 
   return (
     <div className={`alert ${'alert-' + level}`} role="alert">
-      <Icon className='alert-icon' />
+      <Icon className="alert-icon" />
       <div className="alert-content">
         {title && <h5 className="alert-header">{title}</h5>}
         <div className="alert-body content-flush-bottom">{children}</div>
@@ -30,9 +30,5 @@ type NoteProps = {
 };
 
 export function Note({children}: NoteProps) {
-  return (
-    <div role="note" className="alert">
-      <div className="alert-body">{children}</div>
-    </div>
-  );
+  return <Alert>{children}</Alert>;
 }

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -24,6 +24,10 @@ const ICON_MAP = {
 export function Alert({title, children, level = 'info'}: AlertProps) {
   const Icon = ICON_MAP[level];
 
+  if (!Icon) {
+    throw new Error(`Invalid alert level: "${level}" passed to Alert component`);
+  }
+
   return (
     <div className={`alert ${'alert-' + level}`} role="alert">
       <Icon className="alert-icon" />

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -18,7 +18,8 @@
     font-weight: 500;
   }
 
-  ul, ol {
+  ul,
+  ol {
     padding-inline-start: 2rem;
     margin-top: 0;
   }
@@ -32,9 +33,6 @@
 .alert-icon {
   flex: 1em 0 0;
   height: 1.75em;
-}
-
-.alert-content {
 }
 
 .alert-header {

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -41,7 +41,7 @@
 }
 
 .alert-info {
-  --alert-highlight-color: var(--accent-12);
+  --alert-highlight-color: var(--accent-11);
   background: var(--accent-2);
 }
 

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -1,5 +1,4 @@
 .alert {
-  background: var(--accent-2);
   margin-bottom: 1rem;
   padding: 0.5rem 1rem;
   border-radius: 6px;
@@ -8,6 +7,7 @@
   flex-direction: row;
   gap: 0.7em;
   line-height: 1.75em;
+  border: 1px solid var(--alert-highlight-color);
 
   p {
     margin-bottom: 0.5rem;
@@ -28,32 +28,31 @@
     padding-inline-start: 0;
     margin: 0;
   }
+
+  .alert-header {
+    font-weight: 500;
+    color: inherit;
+  }
 }
 
 .alert-icon {
   flex: 1em 0 0;
   height: 1.75em;
-}
-
-.alert-header {
-  font-weight: 500;
+  color: var(--alert-highlight-color);
 }
 
 .alert-info {
+  --alert-highlight-color: var(--desatPurple5);
   background: var(--desatPurple15);
-  background: color-mix(in srgb, var(--desatPurple15), transparent 10%);
 }
 
 .alert-success {
+  --alert-highlight-color: var(--successGreen);
   background: var(--successGreen);
   background: color-mix(in srgb, var(--successGreen), transparent 85%);
 }
 
 .alert-warning {
+  --alert-highlight-color: var(--flame0);
   background: var(--desatFlame8);
-  background: color-mix(in srgb, var(--desatFlame8), transparent 10%);
-
-  > .alert-icon {
-    color: var(--flame5);
-  }
 }

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -2,7 +2,6 @@
   margin-bottom: 1rem;
   padding: 0.5rem 1rem;
   border-radius: 6px;
-  color: var(--gray-500);
   display: flex;
   flex-direction: row;
   gap: 0.7em;
@@ -42,8 +41,8 @@
 }
 
 .alert-info {
-  --alert-highlight-color: var(--desatPurple5);
-  background: var(--desatPurple15);
+  --alert-highlight-color: var(--accent-12);
+  background: var(--accent-2);
 }
 
 .alert-success {
@@ -53,6 +52,6 @@
 }
 
 .alert-warning {
-  --alert-highlight-color: var(--flame0);
-  background: var(--desatFlame8);
+  --alert-highlight-color: var(--amber-10);
+  background: var(--amber-2);
 }

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -1,53 +1,54 @@
 .alert {
   background: var(--accent-2);
-  border-color: var(--accent-12);
-  border-left: 3px solid var(--accent-12);
   margin-bottom: 1rem;
   padding: 0.5rem 1rem;
-
-  > .alert-header {
-    font-weight: 500;
-    position: relative;
-    font-size: 1em;
-    margin-bottom: 0.5rem;
-    margin-top: 0.25rem;
-  }
+  border-radius: 6px;
+  color: var(--gray-500);
+  display: flex;
+  flex-direction: row;
+  gap: 0.7em;
+  line-height: 1.75em;
 
   p {
     margin-bottom: 0.5rem;
+    margin-top: 0;
   }
 
   strong {
     font-weight: 500;
   }
 
-  ul {
+  ul, ol {
     padding-inline-start: 2rem;
-  }
-
-  p:last-of-type,
-  ul:last-of-type {
-    margin-bottom: 0;
-  }
-
-  p:first-of-type,
-  ul:first-of-type {
     margin-top: 0;
   }
 
-  .alert-body {
-    font-size: 0.9rem;
+  li {
+    padding-inline-start: 0;
+    margin: 0;
   }
 }
 
+.alert-icon {
+  flex: 1em 0 0;
+  height: 1.75em;
+}
+
+.alert-content {
+}
+
+.alert-header {
+  font-weight: 500;
+}
+
 .alert-info {
-  background: var(--blue-2);
-  border-color: var(--blue-11);
-  color: var(--blue-12);
+  background: var(--desatPurple15);
 }
 
 .alert-warning {
-  background: var(--amber-2);
-  border-color: var(--amber-10);
-  color: var(--amber-12);
+  background: var(--desatFlame8);
+
+  > .alert-icon {
+    color: var(--flame5);
+  }
 }

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -44,6 +44,11 @@
   background: color-mix(in srgb, var(--desatPurple15), transparent 10%);
 }
 
+.alert-success {
+  background: var(--successGreen);
+  background: color-mix(in srgb, var(--successGreen), transparent 85%);
+}
+
 .alert-warning {
   background: var(--desatFlame8);
   background: color-mix(in srgb, var(--desatFlame8), transparent 10%);

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -41,10 +41,12 @@
 
 .alert-info {
   background: var(--desatPurple15);
+  background: color-mix(in srgb, var(--desatPurple15), transparent 10%);
 }
 
 .alert-warning {
   background: var(--desatFlame8);
+  background: color-mix(in srgb, var(--desatFlame8), transparent 10%);
 
   > .alert-icon {
     color: var(--flame5);


### PR DESCRIPTION
This updates the style of the `<Alert>` component according to new designes from @Jesse-Box .

This also re-introduces the `succeess` level

Before:

![Screenshot 2025-01-22 at 11 09 36](https://github.com/user-attachments/assets/735174d0-1a65-421d-9823-53e9eedb3a3c)

Afterwards:

![image](https://github.com/user-attachments/assets/87d4eb22-4fb2-4b94-9ad6-fb4ccc91f390)

The `<Note>` component is now just an alias for `<Alert>` without a title, it will be removed in a follow up.