### PR TITLE
ref(store-minidumps): Add link to the word 'Minidump'

### DIFF
--- a/includes/store-minidumps-as-attachments-intro.mdx
+++ b/includes/store-minidumps-as-attachments-intro.mdx
@@ -1,3 +1,3 @@
-Minidumps may contain sensitive information about the target system, such as environment variables, local pathnames, or in-memory representations of input fields, including passwords. By default, Sentry only uses minidump files to create events and immediately drops them. All sensitive information is stripped from the resulting events.
+[Minidumps](/platforms/native/guides/minidumps/#what-is-a-minidump) may contain sensitive information about the target system, such as environment variables, local pathnames, or in-memory representations of input fields, including passwords. By default, Sentry only uses minidump files to create events and immediately drops them. All sensitive information is stripped from the resulting events.
 
 All other types of attachments, such as log files or screenshots, are stored for 30 days when sent to Sentry. Note that Sentry does not apply data scrubbing to attachments.


### PR DESCRIPTION
Following up on the suggestion made [here](https://github.com/getsentry/sentry-docs/pull/12398#discussion_r1924160314)