### PR TITLE
feat(native): honor `http_proxy` environment variables

### DIFF
--- a/docs/platforms/native/configuration/transports.mdx
+++ b/docs/platforms/native/configuration/transports.mdx
@@ -77,13 +77,16 @@ sentry_init(options);
 
 /* ... */
 ```
-Once this is set to true, any manually set proxy value will be ignored if a value exists in either the `https_proxy` or `http_proxy` environment variables.
+Once this is set to true, any manually set proxy value will be ignored if a value exists in either the `https_proxy` or `http_proxy` environment variables. These get read in this order, so `https_proxy` has precedence over `http_proxy`.
 
+### Proxy behavior
 
-We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. Depending on the platform, the transport provides a fallback in case the proxy is not reachabled. The following table shows the expected behaviour.
+We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. Depending on the platform, the default transport provides a fallback in case the proxy is not reachabled. The following table shows the expected behaviour.
 
 | Platform | http-proxy                                          | socks-proxy                                          |
 |----------|-----------------------------------------------------|------------------------------------------------------|
 | Windows  | Internal: fallback <br /> Crashpad: fallback        | N/A                                                  |
 | Linux    | Internal: fallback <br />  Crashpad: fallback       | Internal: no fallback <br />  Crashpad: no fallback  |
 | macOS    | Internal: no fallback <br />  Crashpad: no fallback | Internal: no fallback <br />  Crashpad: fallback     |
+
+On Windows, 'https' proxy servers are not supported.

--- a/docs/platforms/native/configuration/transports.mdx
+++ b/docs/platforms/native/configuration/transports.mdx
@@ -73,4 +73,13 @@ sentry_init(options);
 
 We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. On Windows, `https` proxy servers are not supported by the default transport (WinHTTP). The proxy may also contain authentication (`"http://user:password@my.proxy:8080"`) or be written in IPv6 format (`"http://[::1]:8080"`).
 
-Depending on the [DSN](https://docs.sentry.io/concepts/key-terms/dsn-explainer/) protocol (`https` for Sentry projects), the matching `http(s)_proxy` environment variable is read. To disable this, use the `sentry_options_set_proxy(options, "")` function with an empty proxy string argument.
+The SDK will always automatically configure the HTTP proxy if a corresponding environment variable is set. Depending on the [DSN](https://docs.sentry.io/concepts/key-terms/dsn-explainer/) protocol, the matching `http(s)_proxy` environment variable is read. So for a usual Sentry-hosted `DSN`, you must set the `https_proxy` variable .
+
+If you don't want the SDK to configure the HTTP proxy from the environment variables automatically, you can set the proxy option to an empty string value:
+```c
+sentry_options_t *options = sentry_options_new();
+sentry_options_set_proxy(options, "");
+sentry_init(options);
+
+/* ... */
+```

--- a/docs/platforms/native/configuration/transports.mdx
+++ b/docs/platforms/native/configuration/transports.mdx
@@ -69,24 +69,8 @@ sentry_init(options);
 /* ... */
 ```
 
-You can also enable reading the `https_proxy`/`http_proxy` environment variable by setting the following option:
-```c
-sentry_options_t *options = sentry_options_new();
-sentry_options_set_read_proxy_from_environment(options, true);
-sentry_init(options);
-
-/* ... */
-```
-Once this is set to true, any manually set proxy value will be ignored if a value exists in either the `https_proxy` or `http_proxy` environment variables. These get read in this order, so `https_proxy` has precedence over `http_proxy`.
-
 ### Proxy behavior
 
-We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. Depending on the platform, the default transport provides a fallback in case the proxy is not reachabled. The following table shows the expected behaviour.
+We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. On Windows, `https` proxy servers are not supported by the default transport (WinHTTP). The proxy may also contain authentication (`"http://user:password@my.proxy:8080"`) or be written in IPv6 format (`"http://[::1]:8080"`).
 
-| Platform | http-proxy                                          | socks-proxy                                          |
-|----------|-----------------------------------------------------|------------------------------------------------------|
-| Windows  | Internal: fallback <br /> Crashpad: fallback        | N/A                                                  |
-| Linux    | Internal: fallback <br />  Crashpad: fallback       | Internal: no fallback <br />  Crashpad: no fallback  |
-| macOS    | Internal: no fallback <br />  Crashpad: no fallback | Internal: no fallback <br />  Crashpad: fallback     |
-
-On Windows, `https` proxy servers are not supported by the default transport (WinHTTP).
+All transports read the `https_proxy` environment variable if it exists. To disable this, use the `sentry_options_set_proxy(options, "")` function with an empty proxy string.

--- a/docs/platforms/native/configuration/transports.mdx
+++ b/docs/platforms/native/configuration/transports.mdx
@@ -89,4 +89,4 @@ We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and ma
 | Linux    | Internal: fallback <br />  Crashpad: fallback       | Internal: no fallback <br />  Crashpad: no fallback  |
 | macOS    | Internal: no fallback <br />  Crashpad: no fallback | Internal: no fallback <br />  Crashpad: fallback     |
 
-On Windows, 'https' proxy servers are not supported.
+On Windows, `https` proxy servers are not supported by the default transport (WinHTTP).

--- a/docs/platforms/native/configuration/transports.mdx
+++ b/docs/platforms/native/configuration/transports.mdx
@@ -73,4 +73,4 @@ sentry_init(options);
 
 We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. On Windows, `https` proxy servers are not supported by the default transport (WinHTTP). The proxy may also contain authentication (`"http://user:password@my.proxy:8080"`) or be written in IPv6 format (`"http://[::1]:8080"`).
 
-All transports read the `https_proxy` environment variable if it exists. To disable this, use the `sentry_options_set_proxy(options, "")` function with an empty proxy string.
+Depending on the [DSN](https://docs.sentry.io/concepts/key-terms/dsn-explainer/) protocol (`https` for Sentry projects), the matching `http(s)_proxy` environment variable is read. To disable this, use the `sentry_options_set_proxy(options, "")` function with an empty proxy string argument.

--- a/docs/platforms/native/configuration/transports.mdx
+++ b/docs/platforms/native/configuration/transports.mdx
@@ -51,7 +51,7 @@ background thread or thread pool to avoid blocking execution.
 
 ## Using a Proxy
 
-The Native SDK allows the configuration of an `HTTP` (`CONNECT`) or `SOCKS5` proxy through which requests can be tunneled to our backend. It can be configured via the following option interface:
+The Native SDK allows the configuration of an `HTTP` (`CONNECT`) or `SOCKS5` proxy through which requests can be tunneled to our backend. It can be configured manually via the following option interface:
 
 ```c
 sentry_options_t *options = sentry_options_new();
@@ -68,6 +68,16 @@ sentry_init(options);
 
 /* ... */
 ```
+
+You can also enable reading the `https_proxy`/`http_proxy` environment variable by setting the following option:
+```c
+sentry_options_t *options = sentry_options_new();
+sentry_options_set_read_proxy_from_environment(options, true);
+sentry_init(options);
+
+/* ... */
+```
+Once this is set to true, any manually set proxy value will be ignored if a value exists in either the `https_proxy` or `http_proxy` environment variables.
 
 
 We support `HTTP` proxies on all platforms, and `SOCKS5` proxies on Linux and macOS. Depending on the platform, the transport provides a fallback in case the proxy is not reachabled. The following table shows the expected behaviour.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Related to https://github.com/getsentry/sentry-native/pull/1111

- [x] document not supporting `https` as a proxy interface on Windows (see [comment here](https://github.com/getsentry/sentry-native/pull/1111/files#r1919801669))
- [x] document types of proxy URLs that work
- [x] document how transports handle `https_proxy` environment variable

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
