### PR TITLE
feat(electron): Make passing framework config more obvious

### DIFF
--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -72,7 +72,9 @@ import { init as reactInit } from "@sentry/react";
 
 init(
   {
-    /* config */
+    dsn: "___PUBLIC_DSN___",
+    integrations: [ /* integrations */ ],
+    /* Other Electron and React SDK config */
   },
   reactInit
 );


### PR DESCRIPTION
Before it was not immediately obvious where to pass the react config:
- Ref https://github.com/getsentry/sentry-electron/issues/1055#issuecomment-2607314258