### PR TITLE
Add missing Laravel Crons parameters

### DIFF
--- a/platform-includes/crons/setup/php.laravel.mdx
+++ b/platform-includes/crons/setup/php.laravel.mdx
@@ -27,12 +27,16 @@ protected function schedule(Schedule $schedule)
     $schedule->command('emails:send')
         ->everyHour()
         ->sentryMonitor(
-            // Specify the slug of the job monitor in case of duplicate commands or if the monitor was created in the UI
+            // Specify the slug of the job monitor in case of duplicate commands or if the monitor was created in the UI.
             monitorSlug: null,
-            // Check-in margin in minutes
+            // Number of minutes before a check-in is considered missed.
             checkInMargin: 5,
-            // Max runtime in minutes
+            // Number of minutes before an in-progress check-in is marked timed out.
             maxRuntime: 15,
+            // Create a new issue when this many consecutive missed or error check-ins are processed.
+            failureIssueThreshold: 1,
+            // Resolve the issue when this many consecutive healthy check-ins are processed.
+            recoveryThreshold: 1,
             // In case you want to configure the job monitor exclusively in the UI, you can turn off sending the monitor config with the check-in.
             // Passing a monitor-slug is required in this case.
             updateMonitorConfig: false,


### PR DESCRIPTION
Recovery Tolerance and Failure Tolerance were missing.
Aligned the docs comments with our UI.