### PR TITLE
fix(proguard): Add type field for debug images doc

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/debugmeta.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/debugmeta.mdx
@@ -359,6 +359,12 @@ Proguard images refer to `mapping.txt` files generated when Proguard obfuscates
 function names. The Java SDK integrations assign this file a unique identifier,
 which has to be included in the list of images.
 
+Attributes:
+
+`type`
+
+: **Required**. Type of the debug image. Must be `"proguard"`.
+
 `uuid`
 
 : **Required**. The unique identifier assigned by the Java SDK.
@@ -367,6 +373,7 @@ Example:
 
 ```json
 {
+  "type": "proguard",
   "uuid": "395835f4-03e0-4436-80d3-136f0749a893"
 }
 ```


### PR DESCRIPTION
While looking at the docs I saw that the `type` field for proguard is missing, this PR adds that field to fix the docs.


