### PR TITLE
fix: Use prisma instrumentation of current prisma versoin

### DIFF
--- a/apps/changelog/package.json
+++ b/apps/changelog/package.json
@@ -21,6 +21,7 @@
     "@auth/prisma-adapter": "^2.7.4",
     "@google-cloud/storage": "^7.7.0",
     "@prisma/client": "^5.8.1",
+    "@prisma/instrumentation": "^5.8.1",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-toolbar": "^1.1.0",
     "@radix-ui/themes": "^3.1.3",

--- a/apps/changelog/sentry.server.config.ts
+++ b/apps/changelog/sentry.server.config.ts
@@ -1,9 +1,14 @@
 import * as Sentry from '@sentry/nextjs';
+import {PrismaInstrumentation} from '@prisma/instrumentation';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1,
   environment: process.env.NODE_ENV,
-  integrations: [Sentry.prismaIntegration()],
+  integrations: [
+    Sentry.prismaIntegration({
+      prismaInstrumentation: new PrismaInstrumentation(),
+    }),
+  ],
   spotlight: process.env.NODE_ENV === 'development',
 });


### PR DESCRIPTION
Fixes crashing changelog because of prisma instrumentation version mismatch.