### PR TITLE
fix(replay): Fix `beforeErrorSampling` example

### DIFF
--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -190,8 +190,9 @@ If you want to skip capturing a Replay for certain errors, you can use the `befo
 
 ```javascript
 replayIntegration({
-  beforeErrorSampling: (error) => {
-    return error.message?.includes("drop me");
+  beforeErrorSampling: (event) => {
+    // Return false to skip capturing a Replay for this error
+    return !event.exception?.values?.[0]?.message?.includes("drop me");
   },
 });
 ```


### PR DESCRIPTION
@lforst noticed this, the example was incorrect, this receives an error event.