### PR TITLE
ref(stats): Remove 'other' from Filters

### DIFF
--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -30,7 +30,7 @@ Events and attachments that were successfully processed and stored.
 
 ### Filtered
 
-Filtered events and attachments intentionally excluded based on defined settings. The following reasons are currently defined:
+Filtered events and attachments intentionally excluded based on defined settings. Common reasons include:
 
 - **Browser Extensions**: Filtered by browser extension.
 - **Chunk Load Errors**: Filtered when code chunks can’t be found on the server.
@@ -43,7 +43,6 @@ Filtered events and attachments intentionally excluded based on defined settings
 - **Release Version**: Filtered by release name (version).
 - **React Hydration Errors**: Filtered due to a mismatch between the server-rendered and initial client User Interface.
 - **Web Crawlers**: Identified as a known web crawler.
-- **Other**: Filtered due to other generic filtering rules not specified above.
 
 For more details, please consult the [Inbound Filters](/concepts/data-management/filtering/) documentation.
 


### PR DESCRIPTION
Since all the 'filtered' reasons are going to be displayed on the stats page (see [PR](https://github.com/getsentry/sentry/pull/83916)), it makes sense to remove 'others' from the documentation. However, I’d still like to keep the most common reasons listed in the docs, especially since the inbound filters documentation doesn’t include all of them. 