### PR TITLE
docs(js): Fix incorrect instrument.mjs filename

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/install/esm-npm.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/esm-npm.mdx
@@ -139,7 +139,7 @@ export const handler = Sentry.wrapHandler(async (event, context) => {
 
 ### 4. Load the SDK
 
-To load the SDK before your function starts, you need to preload the `instrumentation.mjs` by setting the `NODE_OPTIONS` environment variable:
+To load the SDK before your function starts, you need to preload the `instrument.mjs` by setting the `NODE_OPTIONS` environment variable:
 
 ```bash
 NODE_OPTIONS="--import instrument.mjs"


### PR DESCRIPTION
When going through the docs for sentry installation on aws lambdas (js), I've noticed that in one place initialization file name is different from the rest (`instrumentation.mjs` instead of `instrument.mjs`), so I changed it to be consistent.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
