### PR TITLE
Adjust for sentry-ruby changes

### DIFF
--- a/platform-includes/performance/traces-sampler-as-sampler/ruby.mdx
+++ b/platform-includes/performance/traces-sampler-as-sampler/ruby.mdx
@@ -34,7 +34,7 @@ Sentry.init do |config|
       else
         0.1
       end
-    when /sidekiq/
+    when /queue/
       0.01 # you may want to set a lower rate for background jobs if the number is large
     else
       0.0 # ignore all other transactions


### PR DESCRIPTION
## DESCRIBE YOUR PR
Updates example for sample rate, to match PR for https://github.com/getsentry/sentry-ruby/pull/2403 - That means that we now follow "correct" Sentry op.name `queue.process`, instead of custom `sidekiq`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
