### PR TITLE
feat: Update `Expandable` style

### DIFF
--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -94,8 +94,32 @@ Render an expandable section.
 
 <Expandable title="This is a title">This is some content</Expandable>
 
+<Expandable permalink title="With Permalink">This is some content</Expandable>
+
+<Expandable title="Warning" level="warning">This is some warning content</Expandable>
+
+<Expandable title="Success" level="success">This is some success content</Expandable>
+
 ```markdown {tabTitle:Example}
 <Expandable title="This is a title">
+  This is some content
+</Expandable>
+```
+
+```markdown {tabTitle:Permalink}
+<Expandable permalink title="With Permalink">
+  This is some content
+</Expandable>
+```
+
+```markdown {tabTitle:Warning}
+<Expandable level="warning" title="This is a title">
+  This is some content
+</Expandable>
+```
+
+```markdown {tabTitle:Success}
+<Expandable level="success" title="This is a title">
   This is some content
 </Expandable>
 ```

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -137,14 +137,11 @@ You can work around our CDN bundles being blocked by [using our NPM packages](#u
 
 <PlatformSection supported={["javascript.nextjs"]}>
 
-<Note>
-  The Sentry Next.js SDK has a separate option to make setting up tunnels very
-  straight-forward, allowing you to skip the setup below. See
-  <PlatformLink to="/manual-setup/#configure-tunneling-to-avoid-ad-blockers">
-    Configure Tunneling to avoid Ad-Blockers
-  </PlatformLink>
-  to learn how to set up tunneling on Next.js.
-</Note>
+The Sentry Next.js SDK has a separate option to make setting up tunnels very
+straight-forward, allowing you to skip the setup below. See <PlatformLink to="/manual-setup/#configure-tunneling-to-avoid-ad-blockers">
+Configure Tunneling to avoid Ad-Blockers</PlatformLink> to learn how to set up tunneling on Next.js.
+
+If you do not want to configure `tunnelRoute`, you can follow the guide below.
 
 </PlatformSection>
 
@@ -543,7 +540,7 @@ shamefully-hoist=true
 <PlatformSection supported={['javascript.nextjs']}>
   <Expandable permalink title="Out of Memory (OOM) errors during build">
     The problem here is related to memory consumption during the build process, especially when generating source maps. Here are some potential solutions and workarounds:
-    
+
     - Update your `@sentry/nextjs` package to the latest version.
     - Increase Node.js memory limit: You can try increasing the memory limit for Node.js during the build process. Add this to your build command: `NODE_OPTIONS="--max-old-space-size=8192" next build`. This flag will increase the memory available to the node process to 8 GB. We have found that Next.js consumes around 4 GB in most cases. Decrease the size depending on your memory availability.
     - Disable source maps entirely: As a last resort, you can disable source map generation completely:

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -5,7 +5,7 @@ import {
   InfoCircledIcon,
 } from '@radix-ui/react-icons';
 
-import {Callout} from '../callout';
+import {Callout} from './callout';
 
 type AlertProps = {
   children?: ReactNode;

--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -5,9 +5,7 @@ import {
   InfoCircledIcon,
 } from '@radix-ui/react-icons';
 
-// explicitly not usig CSS modules here
-// because there's some prerendered content that depends on these exact class names
-import './styles.scss';
+import {Callout} from '../callout';
 
 type AlertProps = {
   children?: ReactNode;
@@ -29,13 +27,9 @@ export function Alert({title, children, level = 'info'}: AlertProps) {
   }
 
   return (
-    <div className={`alert ${'alert-' + level}`} role="alert">
-      <Icon className="alert-icon" />
-      <div className="alert-content">
-        {title && <h5 className="alert-header">{title}</h5>}
-        <div className="alert-body content-flush-bottom">{children}</div>
-      </div>
-    </div>
+    <Callout role="alert" level={level} Icon={Icon} title={title}>
+      {children}
+    </Callout>
   );
 }
 

--- a/src/components/callout/index.tsx
+++ b/src/components/callout/index.tsx
@@ -1,0 +1,25 @@
+import {ForwardRefExoticComponent, ReactNode} from 'react';
+
+// explicitly not usig CSS modules here
+// because there's some prerendered content that depends on these exact class names
+import './styles.scss';
+
+type CalloutProps = {
+  Icon: ForwardRefExoticComponent<any>;
+  children?: ReactNode;
+  level?: 'info' | 'warning' | 'success';
+  role?: string;
+  title?: string;
+};
+
+export function Callout({title, children, level = 'info', Icon, role}: CalloutProps) {
+  return (
+    <div className={`callout ${'callout-' + level}`} role={role}>
+      <Icon className="callout-icon" />
+      <div className="callout-content">
+        {title && <h5 className="callout-header">{title}</h5>}
+        <div className="callout-body content-flush-bottom">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/callout/index.tsx
+++ b/src/components/callout/index.tsx
@@ -1,4 +1,4 @@
-import {ForwardRefExoticComponent, ReactNode} from 'react';
+import {ForwardRefExoticComponent, MouseEventHandler, ReactNode} from 'react';
 
 // explicitly not usig CSS modules here
 // because there's some prerendered content that depends on these exact class names
@@ -7,17 +7,70 @@ import './styles.scss';
 type CalloutProps = {
   Icon: ForwardRefExoticComponent<any>;
   children?: ReactNode;
+  /** If defined, the title of the callout will receive this ID and render a link to this ID. */
+  id?: string;
   level?: 'info' | 'warning' | 'success';
   role?: string;
   title?: string;
+  titleOnClick?: MouseEventHandler;
 };
 
-export function Callout({title, children, level = 'info', Icon, role}: CalloutProps) {
+function Header({
+  title,
+  id,
+  onClick,
+}: {
+  title: string;
+  id?: string;
+  onClick?: MouseEventHandler;
+}) {
+  if (!id) {
+    return (
+      <h5
+        className="callout-header"
+        onClick={onClick}
+        role={onClick ? 'button' : undefined}
+      >
+        {title}
+      </h5>
+    );
+  }
+
+  // We want to avoid actually triggering the link
+  const wrappedOnClick = onClick
+    ? (event: React.MouseEvent) => {
+        event.preventDefault();
+        onClick(event);
+      }
+    : undefined;
+
+  return (
+    <h5 className="callout-header" id={id}>
+      <a href={'#' + id} onClick={wrappedOnClick}>
+        {title}
+      </a>
+    </h5>
+  );
+}
+
+export function Callout({
+  title,
+  children,
+  level = 'info',
+  Icon,
+  role,
+  id,
+  titleOnClick,
+}: CalloutProps) {
   return (
     <div className={`callout ${'callout-' + level}`} role={role}>
-      <Icon className="callout-icon" />
+      <Icon
+        className="callout-icon"
+        onClick={titleOnClick}
+        role={titleOnClick ? 'button' : undefined}
+      />
       <div className="callout-content">
-        {title && <h5 className="callout-header">{title}</h5>}
+        {title && <Header title={title} id={id} onClick={titleOnClick} />}
         <div className="callout-body content-flush-bottom">{children}</div>
       </div>
     </div>

--- a/src/components/callout/index.tsx
+++ b/src/components/callout/index.tsx
@@ -1,4 +1,9 @@
-import {ForwardRefExoticComponent, MouseEventHandler, ReactNode} from 'react';
+import {
+  ForwardRefExoticComponent,
+  MouseEventHandler,
+  ReactNode,
+  useCallback,
+} from 'react';
 
 // explicitly not usig CSS modules here
 // because there's some prerendered content that depends on these exact class names
@@ -24,6 +29,19 @@ function Header({
   id?: string;
   onClick?: MouseEventHandler;
 }) {
+  // We want to avoid actually triggering the link
+  const preventDefaultOnClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (!onClick) {
+        return;
+      }
+
+      event.preventDefault();
+      onClick(event);
+    },
+    [onClick]
+  );
+
   if (!id) {
     return (
       <h5
@@ -36,17 +54,9 @@ function Header({
     );
   }
 
-  // We want to avoid actually triggering the link
-  const wrappedOnClick = onClick
-    ? (event: React.MouseEvent) => {
-        event.preventDefault();
-        onClick(event);
-      }
-    : undefined;
-
   return (
     <h5 className="callout-header" id={id}>
-      <a href={'#' + id} onClick={wrappedOnClick}>
+      <a href={'#' + id} onClick={preventDefaultOnClick}>
         {title}
       </a>
     </h5>

--- a/src/components/callout/styles.scss
+++ b/src/components/callout/styles.scss
@@ -31,6 +31,14 @@
   .callout-header {
     font-weight: 500;
     color: inherit;
+
+    & a {
+      color: inherit;
+    }
+
+    &[role="button"] {
+      cursor: pointer;
+    }
   }
 }
 
@@ -38,6 +46,14 @@
   flex: 1em 0 0;
   height: 1.75em;
   color: var(--callout-highlight-color);
+
+  &[role="button"] {
+    cursor: pointer;
+  }
+}
+
+.callout-content {
+  min-width: 0;
 }
 
 .callout-info {

--- a/src/components/callout/styles.scss
+++ b/src/components/callout/styles.scss
@@ -1,4 +1,4 @@
-.alert {
+.callout {
   margin-bottom: 1rem;
   padding: 0.5rem 1rem;
   border-radius: 6px;
@@ -6,7 +6,7 @@
   flex-direction: row;
   gap: 0.7em;
   line-height: 1.75em;
-  border: 1px solid var(--alert-highlight-color);
+  border: 1px solid var(--callout-highlight-color);
 
   p {
     margin-bottom: 0.5rem;
@@ -28,30 +28,30 @@
     margin: 0;
   }
 
-  .alert-header {
+  .callout-header {
     font-weight: 500;
     color: inherit;
   }
 }
 
-.alert-icon {
+.callout-icon {
   flex: 1em 0 0;
   height: 1.75em;
-  color: var(--alert-highlight-color);
+  color: var(--callout-highlight-color);
 }
 
-.alert-info {
-  --alert-highlight-color: var(--accent-11);
+.callout-info {
+  --callout-highlight-color: var(--accent-11);
   background: var(--accent-2);
 }
 
-.alert-success {
-  --alert-highlight-color: var(--successGreen);
+.callout-success {
+  --callout-highlight-color: var(--successGreen);
   background: var(--successGreen);
   background: color-mix(in srgb, var(--successGreen), transparent 85%);
 }
 
-.alert-warning {
-  --alert-highlight-color: var(--amber-10);
+.callout-warning {
+  --callout-highlight-color: var(--amber-10);
   background: var(--amber-2);
 }

--- a/src/components/callout/styles.scss
+++ b/src/components/callout/styles.scss
@@ -4,12 +4,12 @@
   border-radius: 6px;
   display: flex;
   flex-direction: row;
-  gap: 0.7em;
-  line-height: 1.75em;
+  gap: 0.7rem;
+  line-height: 1.75rem;
   border: 1px solid var(--callout-highlight-color);
 
   p {
-    margin-bottom: 0.5rem;
+    margin-bottom: 1rem;
     margin-top: 0;
   }
 
@@ -21,6 +21,7 @@
   ol {
     padding-inline-start: 2rem;
     margin-top: 0;
+    margin-bottom: 1rem;
   }
 
   li {
@@ -44,7 +45,7 @@
 
 .callout-icon {
   flex: 1em 0 0;
-  height: 1.75em;
+  height: 1.75rem;
   color: var(--callout-highlight-color);
 
   &[role="button"] {

--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -26,7 +26,11 @@ export function Expandable({title, level, children, permalink}: Props) {
 
   // Ensure we scroll to the element if the URL hash matches
   useEffect(() => {
-    if (id && window.location.hash === `#${id}`) {
+    if (!id) {
+      return () => {};
+    }
+
+    if (window.location.hash === `#${id}`) {
       document.querySelector(`#${id}`)?.scrollIntoView();
       setIsExpanded(true);
     }

--- a/src/components/expandable.tsx
+++ b/src/components/expandable.tsx
@@ -22,13 +22,13 @@ function slugify(str: string) {
 export function Expandable({title, level, children, permalink}: Props) {
   const id = permalink ? slugify(title) : undefined;
 
-  const defaultIsExpanded = id && window.location.hash === `#${id}`;
-  const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   // Ensure we scroll to the element if the URL hash matches
   useEffect(() => {
     if (id && window.location.hash === `#${id}`) {
       document.querySelector(`#${id}`)?.scrollIntoView();
+      setIsExpanded(true);
     }
 
     // When the hash changes (e.g. when the back/forward browser buttons are used),


### PR DESCRIPTION
For this, I extracted the `Alert` component stuff into a more generic `Callout` component, which the `Alert` extends.

The `Expandable` can now use the same basis, ensuring we have the same style etc, and just pass some more stuff into it.

For this, the `Callout` component also allows to pass `id` and `titleOnClick` attributes which we need for the Expandable.

## Before

![Screenshot 2025-01-24 at 11 19 02](https://github.com/user-attachments/assets/88710331-09d8-4678-aa8e-c7bfcd4fc0f9)
![Screenshot 2025-01-24 at 11 19 07](https://github.com/user-attachments/assets/47447961-355c-4848-a12d-e288cacfaa50)

## After

![Screenshot 2025-01-24 at 11 19 41](https://github.com/user-attachments/assets/30e79342-fac9-4ced-9d54-ccc694b9a01b)

## Permalinks

I made sure that permalinks continue to work. I tweaked the behavior a bit, now it does not scroll into view when you open a permalink expandable, this should be a bit more subtle now. You can try the behavior on any Troubleshoot page in the JS repo, for example.