### PR TITLE
fix(platform): Enable scrolling via keyboard buttons

### DIFF
--- a/src/components/platformFilter/style.module.scss
+++ b/src/components/platformFilter/style.module.scss
@@ -95,10 +95,6 @@
       background: var(--gray-a8);
     }
 
-    &::-webkit-scrollbar-button {
-      display: none;
-    }
-
     // Firefox scrollbar
     scrollbar-width: thin;
     scrollbar-color: var(--gray-a6) var(--gray-a2);

--- a/src/components/platformFilter/style.module.scss
+++ b/src/components/platformFilter/style.module.scss
@@ -95,6 +95,10 @@
       background: var(--gray-a8);
     }
 
+    &::-webkit-scrollbar-button {
+      display: none;
+    }
+
     // Firefox scrollbar
     scrollbar-width: thin;
     scrollbar-color: var(--gray-a6) var(--gray-a2);

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -9,18 +9,18 @@ import {
   SentryGlobalSearch,
   standardSDKSlug,
 } from '@sentry-internal/global-search';
-import DOMPurify from 'dompurify';
-import Link from 'next/link';
-import {usePathname, useRouter} from 'next/navigation';
+import {usePathname} from 'next/navigation';
 import algoliaInsights from 'search-insights';
 
 import {useOnClickOutside} from 'sentry-docs/clientUtils';
-import {useListKeyboardNavigate} from 'sentry-docs/hooks/useListKeyboardNavigate';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
 
 import styles from './search.module.scss';
 
 import {Logo} from '../logo';
+
+import {SearchResultItems} from './searchResultItems';
+import {relativizeUrl} from './util';
 
 // Initialize Algolia Insights
 algoliaInsights('init', {
@@ -32,8 +32,6 @@ algoliaInsights('init', {
 // so just generate a random token each time the page is loaded and
 // treat it as a random user.
 const randomUserToken = crypto.randomUUID();
-
-const MAX_HITS = 10;
 
 // this type is not exported from the global-search package
 type SentryGlobalSearchConfig = ConstructorParameters<typeof SentryGlobalSearch>[0];
@@ -59,12 +57,6 @@ const userDocsSites: SentryGlobalSearchConfig = [
 const config = isDeveloperDocs ? developerDocsSites : userDocsSites;
 const search = new SentryGlobalSearch(config);
 
-function relativizeUrl(url: string) {
-  return isDeveloperDocs
-    ? url
-    : url.replace(/^(https?:\/\/docs\.sentry\.io)(?=\/|$)/, '');
-}
-
 type Props = {
   autoFocus?: boolean;
   path?: string;
@@ -79,7 +71,7 @@ export function Search({path, autoFocus, searchPlatforms = [], showChatBot}: Pro
   const [inputFocus, setInputFocus] = useState(false);
   const [showOffsiteResults, setShowOffsiteResults] = useState(false);
   const [loading, setLoading] = useState(true);
-  const router = useRouter();
+
   const pathname = usePathname();
 
   const handleClickOutside = useCallback((ev: MouseEvent) => {
@@ -175,17 +167,6 @@ export function Search({path, autoFocus, searchPlatforms = [], showChatBot}: Pro
   );
 
   const totalHits = results.reduce((a, x) => a + x.hits.length, 0);
-
-  const flatHits = results.reduce<Hit[]>(
-    (items, item) => [...items, ...item.hits.slice(0, MAX_HITS)],
-    []
-  );
-
-  const {focused} = useListKeyboardNavigate({
-    list: flatHits,
-    onSelect: hit => router.push(relativizeUrl(hit.url)),
-    disableEventListeners: !inputFocus,
-  });
 
   const trackSearchResultClick = useCallback((hit: Hit, position: number): void => {
     try {
@@ -306,77 +287,13 @@ export function Search({path, autoFocus, searchPlatforms = [], showChatBot}: Pro
           {loading && <Logo loading />}
 
           {!loading && totalHits > 0 && (
-            <div className={styles['sgs-search-results-scroll-container']}>
-              {results
-                .filter(x => x.hits.length > 0)
-                .map((result, i) => (
-                  <Fragment key={result.site}>
-                    {showOffsiteResults && (
-                      <h4 className={styles['sgs-site-result-heading']}>
-                        From {result.name}
-                      </h4>
-                    )}
-                    <ul
-                      className={`${styles['sgs-hit-list']} ${i === 0 ? '' : styles['sgs-offsite']}`}
-                    >
-                      {result.hits.slice(0, MAX_HITS).map((hit, index) => (
-                        <li
-                          key={hit.id}
-                          className={`${styles['sgs-hit-item']} ${
-                            focused?.id === hit.id ? styles['sgs-hit-focused'] : ''
-                          }`}
-                          ref={
-                            // Scroll to element on focus
-                            hit.id === focused?.id
-                              ? el => el?.scrollIntoView({block: 'nearest'})
-                              : undefined
-                          }
-                        >
-                          <Link
-                            href={relativizeUrl(hit.url)}
-                            onClick={e => handleSearchResultClick(e, hit, index)}
-                          >
-                            {hit.title && (
-                              <h6>
-                                <span
-                                  dangerouslySetInnerHTML={{
-                                    __html: DOMPurify.sanitize(hit.title, {
-                                      ALLOWED_TAGS: ['mark'],
-                                    }),
-                                  }}
-                                />
-                              </h6>
-                            )}
-                            {hit.text && (
-                              <span
-                                dangerouslySetInnerHTML={{
-                                  __html: DOMPurify.sanitize(hit.text, {
-                                    ALLOWED_TAGS: ['mark'],
-                                  }),
-                                }}
-                              />
-                            )}
-                            {hit.context && (
-                              <div className={styles['sgs-hit-context']}>
-                                {hit.context.context1 && (
-                                  <div className={styles['sgs-hit-context-left']}>
-                                    {hit.context.context1}
-                                  </div>
-                                )}
-                                {hit.context.context2 && (
-                                  <div className={styles['sgs-hit-context-right']}>
-                                    {hit.context.context2}
-                                  </div>
-                                )}
-                              </div>
-                            )}
-                          </Link>
-                        </li>
-                      ))}
-                    </ul>
-                  </Fragment>
-                ))}
-            </div>
+            <SearchResultItems
+              results={results}
+              onSearchResultClick={({event, hit, position}) =>
+                handleSearchResultClick(event, hit, position)
+              }
+              showOffsiteResults={showOffsiteResults}
+            />
           )}
 
           {!loading && totalHits === 0 && (

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -15,7 +15,7 @@ import {usePathname, useRouter} from 'next/navigation';
 import algoliaInsights from 'search-insights';
 
 import {useOnClickOutside} from 'sentry-docs/clientUtils';
-import {useKeyboardNavigate} from 'sentry-docs/hooks/useKeyboardNavigate';
+import {useListKeyboardNavigate} from 'sentry-docs/hooks/useListKeyboardNavigate';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
 
 import styles from './search.module.scss';
@@ -181,9 +181,10 @@ export function Search({path, autoFocus, searchPlatforms = [], showChatBot}: Pro
     []
   );
 
-  const {focused} = useKeyboardNavigate({
+  const {focused} = useListKeyboardNavigate({
     list: flatHits,
     onSelect: hit => router.push(relativizeUrl(hit.url)),
+    disableEventListeners: !inputFocus,
   });
 
   const trackSearchResultClick = useCallback((hit: Hit, position: number): void => {

--- a/src/components/search/searchResultItems.tsx
+++ b/src/components/search/searchResultItems.tsx
@@ -1,0 +1,111 @@
+import {Fragment} from 'react';
+import {Hit, Result} from '@sentry-internal/global-search';
+import DOMPurify from 'dompurify';
+import Link from 'next/link';
+import {useRouter} from 'next/navigation';
+
+import {useListKeyboardNavigate} from 'sentry-docs/hooks/useListKeyboardNavigate';
+
+import styles from './search.module.scss';
+
+import {relativizeUrl} from './util';
+
+const MAX_HITS = 10;
+
+interface SearchResultClickHandler {
+  event: React.MouseEvent<HTMLAnchorElement>;
+  hit: Hit;
+  position: number;
+}
+
+export function SearchResultItems({
+  results,
+  showOffsiteResults,
+  onSearchResultClick,
+}: {
+  onSearchResultClick: (params: SearchResultClickHandler) => void;
+  results: Result[];
+  showOffsiteResults: boolean;
+}) {
+  const router = useRouter();
+  const flatHits = results.reduce<Hit[]>(
+    (items, item) => [...items, ...item.hits.slice(0, MAX_HITS)],
+    []
+  );
+  const {focused} = useListKeyboardNavigate({
+    list: flatHits,
+    onSelect: hit => router.push(relativizeUrl(hit.url)),
+  });
+
+  return (
+    <div className={styles['sgs-search-results-scroll-container']}>
+      {results
+        .filter(x => x.hits.length > 0)
+        .map((result, i) => (
+          <Fragment key={result.site}>
+            {showOffsiteResults && (
+              <h4 className={styles['sgs-site-result-heading']}>From {result.name}</h4>
+            )}
+            <ul
+              className={`${styles['sgs-hit-list']} ${i === 0 ? '' : styles['sgs-offsite']}`}
+            >
+              {result.hits.slice(0, MAX_HITS).map((hit, index) => (
+                <li
+                  key={hit.id}
+                  className={`${styles['sgs-hit-item']} ${
+                    focused?.id === hit.id ? styles['sgs-hit-focused'] : ''
+                  }`}
+                  ref={
+                    // Scroll to element on focus
+                    hit.id === focused?.id
+                      ? el => el?.scrollIntoView({block: 'nearest'})
+                      : undefined
+                  }
+                >
+                  <Link
+                    href={relativizeUrl(hit.url)}
+                    onClick={event => onSearchResultClick({event, hit, position: index})}
+                  >
+                    {hit.title && (
+                      <h6>
+                        <span
+                          dangerouslySetInnerHTML={{
+                            __html: DOMPurify.sanitize(hit.title, {
+                              ALLOWED_TAGS: ['mark'],
+                            }),
+                          }}
+                        />
+                      </h6>
+                    )}
+                    {hit.text && (
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: DOMPurify.sanitize(hit.text, {
+                            ALLOWED_TAGS: ['mark'],
+                          }),
+                        }}
+                      />
+                    )}
+                    {hit.context && (
+                      <div className={styles['sgs-hit-context']}>
+                        {hit.context.context1 && (
+                          <div className={styles['sgs-hit-context-left']}>
+                            {hit.context.context1}
+                          </div>
+                        )}
+                        {hit.context.context2 && (
+                          <div className={styles['sgs-hit-context-right']}>
+                            {hit.context.context2}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </Fragment>
+        ))}
+    </div>
+  );
+}

--- a/src/components/search/util.ts
+++ b/src/components/search/util.ts
@@ -1,0 +1,7 @@
+import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
+
+export function relativizeUrl(url: string) {
+  return isDeveloperDocs
+    ? url
+    : url.replace(/^(https?:\/\/docs\.sentry\.io)(?=\/|$)/, '');
+}

--- a/src/hooks/useListKeyboardNavigate.tsx
+++ b/src/hooks/useListKeyboardNavigate.tsx
@@ -2,10 +2,6 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 
 type Props<T> = {
   /**
-   * Whether to disable the keyboard event listeners conditionally
-   */
-  disableEventListeners: boolean;
-  /**
    * The list of values to navigate through
    */
   list: T[];
@@ -19,7 +15,7 @@ type Props<T> = {
 /**
  * Navigate a list of items using the up/down arrow and ^j/^k keys
  */
-function useListKeyboardNavigate<T>({list, onSelect, disableEventListeners}: Props<T>) {
+function useListKeyboardNavigate<T>({list, onSelect}: Props<T>) {
   const [focused, setFocus] = useState<T | null>(null);
 
   const setFocusIndex = useCallback(
@@ -90,13 +86,9 @@ function useListKeyboardNavigate<T>({list, onSelect, disableEventListeners}: Pro
   );
 
   useEffect(() => {
-    if (!disableEventListeners) {
-      document.addEventListener('keydown', handleNavigate);
-      return () => document.removeEventListener('keydown', handleNavigate);
-    }
-
-    return undefined;
-  }, [disableEventListeners, handleNavigate]);
+    document.addEventListener('keydown', handleNavigate);
+    return () => document.removeEventListener('keydown', handleNavigate);
+  }, [handleNavigate]);
 
   return {focused, setFocus};
 }

--- a/src/hooks/useListKeyboardNavigate.tsx
+++ b/src/hooks/useListKeyboardNavigate.tsx
@@ -2,9 +2,14 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 
 type Props<T> = {
   /**
+   * Whether to disable the keyboard event listeners conditionally
+   */
+  disableEventListeners: boolean;
+  /**
    * The list of values to navigate through
    */
   list: T[];
+
   /**
    * Callback triggered when the item is selected
    */
@@ -14,7 +19,7 @@ type Props<T> = {
 /**
  * Navigate a list of items using the up/down arrow and ^j/^k keys
  */
-function useKeyboardNavigate<T>({list, onSelect}: Props<T>) {
+function useListKeyboardNavigate<T>({list, onSelect, disableEventListeners}: Props<T>) {
   const [focused, setFocus] = useState<T | null>(null);
 
   const setFocusIndex = useCallback(
@@ -85,11 +90,15 @@ function useKeyboardNavigate<T>({list, onSelect}: Props<T>) {
   );
 
   useEffect(() => {
-    document.addEventListener('keydown', handleNavigate);
-    return () => document.removeEventListener('keydown', handleNavigate);
-  }, [handleNavigate]);
+    if (!disableEventListeners) {
+      document.addEventListener('keydown', handleNavigate);
+      return () => document.removeEventListener('keydown', handleNavigate);
+    }
+
+    return undefined;
+  }, [disableEventListeners, handleNavigate]);
 
   return {focused, setFocus};
 }
 
-export {useKeyboardNavigate};
+export {useListKeyboardNavigate};


### PR DESCRIPTION
Enables scrolling with keyboard arrow keys, by nesting the `useListKeyboardNavigate` within search results