### PR TITLE
feat(express): Add warning about express v5

### DIFF
--- a/docs/organization/integrations/issue-tracking/jira/index.mdx
+++ b/docs/organization/integrations/issue-tracking/jira/index.mdx
@@ -145,7 +145,7 @@ Jira should now be authorized for all projects under your Sentry organization.
 
 ### Self-Hosted Sentry + Jira integration
 
-To install the Jira integration with a self-hosted Sentry instance, please follow our [develop-docs](/develop-docs/integrations/jira), skip to the "Installing Local Jira App" section.
+To install the Jira integration with a self-hosted Sentry instance, please follow our [develop-docs](https://develop.sentry.dev/integrations/jira/), skip to the "Installing Local Jira App" section.
 
 ## Configure
 

--- a/docs/organization/integrations/issue-tracking/jira/index.mdx
+++ b/docs/organization/integrations/issue-tracking/jira/index.mdx
@@ -145,7 +145,7 @@ Jira should now be authorized for all projects under your Sentry organization.
 
 ### Self-Hosted Sentry + Jira integration
 
-To install the Jira integration with a self-hosted Sentry instance, please follow our [develop-docs](/develop-docs/integrations/jira/index.mdx/), skip to the "Installing Local Jira App" section.
+To install the Jira integration with a self-hosted Sentry instance, please follow our [develop-docs](/develop-docs/integrations/jira), skip to the "Installing Local Jira App" section.
 
 ## Configure
 

--- a/docs/platforms/javascript/guides/express/index.mdx
+++ b/docs/platforms/javascript/guides/express/index.mdx
@@ -11,4 +11,11 @@ categories:
 
 This guide explains how to set up Sentry in your Express application.
 
+<Alert level="warning">
+  Sentry currently has limited support for Express v5.
+  While error monitoring will work, tracing auto-instrumentation will lack instrumented routes for the time being.
+  You may also see a warning log message in your console.
+  We are working on adding full support for Express v5 in the future. For the time being, see the [Express v5 issue](https://github.com/getsentry/sentry-javascript/issues/13674) for details and workarounds.
+</Alert>
+
 <PlatformContent includePath="getting-started-node" />


### PR DESCRIPTION
As this comes up quite regularly, I figured it may make sense to explicitly call out our support for Express v5, and link to the tracking issue (https://github.com/getsentry/sentry-javascript/issues/13674) for details.