### PR TITLE
ref: Remove `<Note>` component in favor of using `<Alert>`

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/stacktrace.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/stacktrace.mdx
@@ -7,7 +7,7 @@ A stack trace contains a list of frames, each with various bits (most optional)
 describing the context of that frame. Frames should be sorted from oldest to
 newest.
 
-<Note><markdown>
+<Alert>
 
 Stack traces are always part of an exception or a thread. They cannot be
 declared as a top-level event property. When adding a stack trace to an event,
@@ -16,7 +16,7 @@ follow this rule of thumb:
 - If the stack trace is part of an error, exception or crash, add it to the [Exception Interface](/sdk/data-model/event-payloads/exception/).
 - Otherwise, add it as a thread in the [Threads Interface](/sdk/data-model/event-payloads/threads/).
 
-</markdown></Note>
+</Alert>
 
 ## Attributes
 

--- a/docs/cli/dif.mdx
+++ b/docs/cli/dif.mdx
@@ -13,12 +13,12 @@ information, refer to [_Debug Information Files_](/platforms/native/data-managem
 
 The `sentry-cli` requires an [Organization Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/) so that Debug Information Files can be uploaded.
 
-<Note>
+<Alert>
 
 Source maps, while also being debug information files, are handled
 differently in Sentry. For more information see [Source Maps in sentry-cli](/cli/releases/#sentry-cli-sourcemaps).
 
-</Note>
+</Alert>
 
 ## Checking Files
 
@@ -97,13 +97,13 @@ application. Alternatively, files can be uploaded during the build process. See
 [_Debug Information Files_](/platforms/native/data-management/debug-files/)
 for more information.
 
-<Note>
+<Alert>
 
 You need to specify the organization and project you are working with because
 debug information files work on projects. For more information about this refer
 to [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
 
-</Note>
+</Alert>
 
 A basic debug file upload can be started with:
 
@@ -183,13 +183,13 @@ plugin](https://github.com/getsentry/sentry-android-gradle-plugin) to do that. N
 situations where you would upload ProGuard files manually. For instance,
 when you only release some of the builds you're creating.
 
-<Note>
+<Alert>
 
 You need to specify the organization and project you are working with
 because ProGuard files work on projects. For more information about this refer to
 [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects).
 
-</Note>
+</Alert>
 
 The `upload-proguard` command is the one to use for uploading ProGuard files. It
 takes the path to one or more ProGuard mapping files and will upload them to
@@ -252,12 +252,12 @@ See the build tool plugins we currently support here:
 You can also upload ProGuard files manually with `sentry-cli` for any JVM-based language like
 Java or Kotlin.
 
-<Note>
+<Alert>
 
 Before you can upload source files, you must configure the Sentry CLI with the organization and project you are uploading bundle files for. See the CLI docs on
 [Working with Projects](/cli/configuration/#sentry-cli-working-with-projects) to learn how to do this.
 
-</Note>
+</Alert>
 
 ### Creating a Source Bundle
 

--- a/docs/contributing/pages/components.mdx
+++ b/docs/contributing/pages/components.mdx
@@ -74,8 +74,6 @@ Use this for these types of content:
 
 You can also omit the title of the alert.
 
-See also the [Note component](#note).
-
 ## Arcade embeds
 
 Render an [Arcade](https://arcade.software) embed.
@@ -207,11 +205,11 @@ function foo() {
 
 Render a heading with a configuration key in the correctly cased format for a given platform.
 
-<Note>
+<Alert>
 
 If content is specified, it will automatically hide the content when the given `platform` is not selected in context.
 
-</Note>
+</Alert>
 
 ```markdown {tabTitle:Example}
 <ConfigKey name="send-default-pii" notSupported={["javascript"]}>
@@ -227,33 +225,6 @@ Attributes:
 - `platform` (string) - defaults to the `platform` value from the page context
 - `supported` (string[])
 - `notSupported` (string[])
-
-## Note
-
-Render a note.
-
-<Note>
-
-Something important, but maybe not _that_ important.
-
-</Note>
-
-```markdown {tabTitle:Example}
-<Note>
-
-Something important, but maybe not _that_ important.
-
-</Note>
-```
-
-Use this for these types of content:
-
-- **Prerequisite(s):** Use these to list things that are required to finish. Place them prior to the procedure/process that follows so a user doesn't start and stop.
-- **Note:** to document information that's relevant to the topic, but isn't part of the larger point of the content. This might include a piece of information that should be highlighted, but isn't necessarily more important than other information. These include calling out early adopter features or providing clarification. Use sparingly.
-
-Don't use a title with this type of note.
-
-See also the [Alert component](#alert).
 
 ## PageGrid
 

--- a/docs/platforms/android/configuration/app-not-respond.mdx
+++ b/docs/platforms/android/configuration/app-not-respond.mdx
@@ -17,11 +17,11 @@ The new implementation (v2) uses the same data source as Google Play Console. Th
 
 While the original Watchdog approach (v1) reports many false positives and is based on heuristics, it still has some advantages over v2, like capturing screenshots and transactions with profiles at the time of ANR.
 
-<Note>
+<Alert>
 
 We're considering SDK support for both approaches working alongside each other on Android 11 and up. Please upvote [this GitHub discussion](https://github.com/getsentry/sentry-java/discussions/2716) and share your feedback if you have a case for v1 and v2 working together.
 
-</Note>
+</Alert>
 
 Both ANR detection implementations are controlled by the same flag:
 
@@ -37,11 +37,11 @@ Whenever the main UI thread of the application is blocked for more than five sec
 
 The integration reports ANR events with `mechanism:ANR`.
 
-<Note>
+<Alert>
 
 Sentry does not report the ANR if the application is in debug mode.
 
-</Note>
+</Alert>
 
 You can also specify how long the thread should be blocked before the ANR is reported. Provide the duration in the attribute `io.sentry.anr.timeout-interval-millis` in your `AndroidManifest.xml`:
 
@@ -58,11 +58,11 @@ and asynchronously sends ANR events to Sentry for each ANR in the history, enric
 
 The integration reports ANR events with `mechanism:AppExitInfo`.
 
-<Note>
+<Alert>
 
 If [ApplicationExitInfo#getTraceInputStream](<https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()>) returns `null`, the SDK will no longer report an ANR event, since these events won't be actionable without it.
 
-</Note>
+</Alert>
 
 ![ANR](./img/app-not-respond.png)
 

--- a/docs/platforms/android/configuration/gradle.mdx
+++ b/docs/platforms/android/configuration/gradle.mdx
@@ -35,11 +35,11 @@ plugins {
 }
 ```
 
-<Note>
+<Alert>
 
 The `io.sentry.android.gradle` >= `3.0.0` requires [Android Gradle Plugin >= 7.0.0](https://developer.android.com/studio/releases/gradle-plugin#7-0-0). For older versions of the Android Gradle Plugin, use `io.sentry.android.gradle:2.+`.
 
-</Note>
+</Alert>
 
 ### Configure
 
@@ -383,11 +383,11 @@ defaults.org=___ORG_SLUG___
 auth.token=___ORG_AUTH_TOKEN___
 ```
 
-<Note>
+<Alert>
 
 You can find your authentication token [on the Organization Auth Tokens](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/) settings page. For more information about the available configuration options, check out the [full sentry-cli documentation](/cli/configuration/#configuration-values).
 
-</Note>
+</Alert>
 
 ## Native Debug Symbols and Sources
 
@@ -405,11 +405,11 @@ defaults.org=___ORG_SLUG___
 auth.token=___ORG_AUTH_TOKEN___
 ```
 
-<Note>
+<Alert>
 
 You can find your authentication token [on the Sentry API page](https://sentry.io/api/). For more information about the available configuration options, check out the [full sentry-cli documentation](/cli/configuration/#configuration-values).
 
-</Note>
+</Alert>
 
 ## Java/Kotlin Source Context
 
@@ -435,11 +435,11 @@ The plugin uses the [bytecode manipulation](https://www.infoq.com/articles/Livin
 that starts and finishes a [span](/concepts/key-terms/tracing/trace-view/#product-walkthrough-trace-view-page) for common operations that can cause performance bottlenecks.
 This way potentially heavy operations are automatically measured without the need to manually instrument them.
 
-<Note>
+<Alert>
 
 For this data to be captured, you must enable [tracing](/platforms/android/tracing/).
 
-</Note>
+</Alert>
 
 The plugin supports the following features for auto-instrumentation:
 
@@ -486,11 +486,11 @@ enum class InstrumentationFeature {
 
 Check [Integrations](/platforms/android/integrations/) page for more detailed explanation of each instrumentation feature.
 
-<Note>
+<Alert>
 
 To learn more about the internals of auto-instrumentation, check out this [blog post](https://blog.sentry.io/2021/12/14/bytecode-transformations-the-android-gradle-plugin).
 
-</Note>
+</Alert>
 
 ## Auto-Installation
 

--- a/docs/platforms/android/configuration/manual-init.mdx
+++ b/docs/platforms/android/configuration/manual-init.mdx
@@ -20,11 +20,11 @@ dependencies {
 }
 ```
 
-<Note>
+<Alert>
 
 The [NDK integration](/platforms/android/using-ndk/) comes packaged with the SDK and requires API level 16, though other levels are supported. If you're using multiple Sentry dependencies, you can add a [bill of materials](/platforms/android/configuration/bill-of-materials) to avoid specifying the version of each dependency.
 
-</Note>
+</Alert>
 
 ## Manual Initialization
 

--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -95,11 +95,11 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 
-<Note>
+<Alert>
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 This option is turned off by default.
 
@@ -170,11 +170,11 @@ The default is `3000`.
 
 _(New in version 6.0.0)_
 
-<Note>
+<Alert>
 
 This only affects [user interaction transactions](/platforms/android/tracing/instrumentation/automatic-instrumentation/#user-interaction-instrumentation).
 
-</Note>
+</Alert>
 
 </ConfigKey>
 

--- a/docs/platforms/android/configuration/releases.mdx
+++ b/docs/platforms/android/configuration/releases.mdx
@@ -31,11 +31,11 @@ The value can be arbitrary, but we recommend either of these naming strategies:
   - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
 - **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
 
-<Note>
+<Alert>
 
 Releases are global per organization; prefix them with something project-specific for easy differentiation.
 
-</Note>
+</Alert>
 
 The behavior of a few features depends on whether a project is using semantic or time-based versioning.
 
@@ -64,11 +64,11 @@ After configuring your SDK, you can install a repository integration or manually
 
 Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
-<Note>
+<Alert>
 
 Crash reporting and app hang detection are not available for watchOS.
 
-</Note>
+</Alert>
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/android/configuration/sampling.mdx
+++ b/docs/platforms/android/configuration/sampling.mdx
@@ -14,11 +14,11 @@ To send a representative sample of your errors to Sentry, set the <PlatformIdent
 
 The error sample rate defaults to `1`, meaning all errors are sent to Sentry.
 
-<Note>
+<Alert>
 
 Changing the error sample rate requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-</Note>
+</Alert>
 
 ## Sampling Transaction Events
 

--- a/docs/platforms/android/configuration/shared-environments.mdx
+++ b/docs/platforms/android/configuration/shared-environments.mdx
@@ -4,17 +4,17 @@ description: "Learn how to use the Sentry SDK within a shared environment, e.g. 
 sidebar_order: 2000
 ---
 
-<Note>
+<Alert>
 
 Using the Sentry SDK within another SDK is [discouraged](https://docs.sentry.io/platforms/). This can lead to unexpected behaviour and potential data leakage. If you need to use Sentry within another SDK, please follow the best practices outlined below.
 
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 
 When setting up Sentry inside a library, the consuming app could use the Sentry SDK as well, thus you should **not use `Sentry.init()`**, as this will pollute the global state.
 
-</Note>
+</Alert>
 
 In order to not conflict with other Sentry instances, you should use the `Scopes` API to create a new instance of Sentry.
 The Scopes API works the same way as the global Sentry instance, but it is not global and can be used within your component. If you want to capture uncaught exceptions, you can use the `UncaughtExceptionHandlerIntegration` to capture them. As this will capture all uncaught exceptions within an app, you should use the `BeforeSendCallback` to only accept events that are relevant for your SDK.

--- a/docs/platforms/android/data-management/debug-files/file-formats/index.mdx
+++ b/docs/platforms/android/data-management/debug-files/file-formats/index.mdx
@@ -180,11 +180,11 @@ while removing all debug information from the release binary.
 
 ## ProGuard Mappings
 
-<Note>
+<Alert>
 
 The recommended method for [Android users is to use the Gradle plugin](/platforms/android/configuration/gradle/).
 
-</Note>
+</Alert>
 
 ProGuard mapping files allow Sentry to resolve obfuscated Java classpaths and
 method names into their original form. In that sense, they act as debug

--- a/docs/platforms/android/data-management/debug-files/identifiers/index.mdx
+++ b/docs/platforms/android/data-management/debug-files/identifiers/index.mdx
@@ -24,14 +24,14 @@ compute a _Debug Identifier_ for each uploaded file. This identifier is
 associated with executables and libraries as well as debug companions to ensure
 that they can be uniquely located via one common mechanism.
 
-<Note>
+<Alert>
 
 Debug information does not have to be associated with releases. The unique debug
 identifier ensures that Sentry can choose the right files for every crash
 report. However, it is still recommended to configure releases in the client to
 benefit from other features.
 
-</Note>
+</Alert>
 
 For native events, the issue details page displays a list of _Loaded Images_.
 This list contains the executable and all loaded dynamic libraries including

--- a/docs/platforms/android/data-management/debug-files/index.mdx
+++ b/docs/platforms/android/data-management/debug-files/index.mdx
@@ -24,12 +24,12 @@ the following formats:
 - [_ProGuard mappings_](./file-formats/#proguard-mappings) for
   Java and Android
 
-<Note>
+<Alert>
 
 Source maps, while also being debug information files, are handled
 differently in Sentry. For more information see [Source Maps in sentry-cli](/cli/releases/#sentry-cli-sourcemaps).
 
-</Note>
+</Alert>
 
 Sentry requires access to debug information files of your application as well as
 system libraries to provide fully symbolicated crash reports. You can either
@@ -46,11 +46,11 @@ for automatic downloads.
 From the [Project Details](/product/projects/project-details/) page, click into settings,
 then click on _Debug Files_ in the page navigation.
 
-<Note>
+<Alert>
 
 ProGuard files are listed separately, in the _ProGuard_ section of the project settings page.
 
-</Note>
+</Alert>
 
 ## Retention Policy
 

--- a/docs/platforms/android/data-management/debug-files/source-context/index.mdx
+++ b/docs/platforms/android/data-management/debug-files/source-context/index.mdx
@@ -20,11 +20,11 @@ needs to be uploaded alongside the debug information files.
 The recommended way to do this is by using `sentry-cli`.
 See [Creating Source Bundles](/cli/dif/#creating-source-bundles) for more information.
 
-<Note>
+<Alert>
 
 For Android, follow the instructions in the [Android Source Context](/platforms/android/enhance-errors/source-context) guide.
 
-</Note>
+</Alert>
 
 After they've been uploaded you can review and manage source bundles the same as
 any other debug information file. See [Managing Debug Information Files](../#managing-debug-information-files).

--- a/docs/platforms/android/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/android/data-management/sensitive-data/index.mdx
@@ -23,13 +23,13 @@ We offer the following options depending on your legal and operational needs:
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
-<Note>
+<Alert>
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 ## Personally Identifiable Information (PII)
 

--- a/docs/platforms/android/enhance-errors/kotlin-compiler-plugin.mdx
+++ b/docs/platforms/android/enhance-errors/kotlin-compiler-plugin.mdx
@@ -9,11 +9,11 @@ The [Sentry Kotlin Compiler Plugin](https://github.com/getsentry/sentry-android-
 - <PlatformLink to="/enriching-events/viewhierarchy">View Hierarchy</PlatformLink>
 - <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#user-interaction-instrumentation">User Interaction Tracing</PlatformLink>
 
-<Note>
+<Alert>
 
 The minimum supported Kotlin version is `1.8.20`.
 
-</Note>
+</Alert>
 
 ## How it works
 

--- a/docs/platforms/android/enhance-errors/proguard.mdx
+++ b/docs/platforms/android/enhance-errors/proguard.mdx
@@ -12,11 +12,11 @@ If [Source Context](/platforms/android/enhance-errors/source-context) is enabled
 
 Support for Guardsquare's ProGuard and [DexGuard](https://www.guardsquare.com/dexguard) was added in version 3.0.0 of the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/).
 
-<Note>
+<Alert>
 
 The Android SDK ships with ProGuard rules automatically defined; no further configuration is needed.
 
-</Note>
+</Alert>
 
 ## In-app Frames
 

--- a/docs/platforms/android/enriching-events/attachments/index.mdx
+++ b/docs/platforms/android/enriching-events/attachments/index.mdx
@@ -49,11 +49,11 @@ Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</Plat
 
 <PlatformContent includePath="enriching-events/attachment-upload" />
 
-<Note>
+<Alert>
 
 Sentry allows at most 20MB for a compressed request, and at most 100MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
 
-</Note>
+</Alert>
 
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.
 

--- a/docs/platforms/android/enriching-events/context/index.mdx
+++ b/docs/platforms/android/enriching-events/context/index.mdx
@@ -7,11 +7,11 @@ Custom contexts allow you to attach arbitrary data to an event. Often, this cont
 
 <Include name="common-imgs/additional_data" />
 
-<Note>
+<Alert>
 
 If you need to be able to search on custom data, [use tags](../tags) instead.
 
-</Note>
+</Alert>
 
 ## Structured Context
 

--- a/docs/platforms/android/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/android/enriching-events/identify-user/index.mdx
@@ -9,11 +9,11 @@ Users consist of a few critical pieces of information that construct a unique id
 
 ### `id`
 
-<Note>
+<Alert>
 
 If you don't provide an `id`, the SDK falls back to `installationId`, which the SDK randomly generates once during an app's installation.
 
-</Note>
+</Alert>
 
 Your internal identifier for the user.
 

--- a/docs/platforms/android/enriching-events/tags/index.mdx
+++ b/docs/platforms/android/enriching-events/tags/index.mdx
@@ -17,11 +17,11 @@ Define the tag:
 
 <PlatformContent includePath="enriching-events/set-tag" />
 
-<Note>
+<Alert>
 
 Some tags are automatically set by Sentry. We strongly recommend against overwriting these [tags](/concepts/search/searchable-properties/#search-properties). Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/concepts/search/#explicit-tag-syntax) to search for it.
 
-</Note>
+</Alert>
 
 Once you've started sending tagged data, you'll see it when logged in to sentry.io. There, you can view the filters within the sidebar on the Project page, summarized within an event, and on the Tags page for an aggregated event.
 

--- a/docs/platforms/android/enriching-events/viewhierarchy/index.mdx
+++ b/docs/platforms/android/enriching-events/viewhierarchy/index.mdx
@@ -7,11 +7,11 @@ Sentry makes it possible to render a JSON representation of the view hierarchy o
 
 This feature only applies to SDKs with a user interface, such as the ones for mobile and desktop applications. In some environments like native iOS, rendering the view hierarchy requires the UI thread and in the event of a crash, that might not be available. Another example where the view hierarchy might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 
-<Note>
+<Alert>
 
 Deobfuscation for view hierarchies is fully supported for native SDKs, and React Native, but is currently not supported for Flutter.
 
-</Note>
+</Alert>
 
 ## Enabling View Hierarchy Attachments
 
@@ -25,11 +25,11 @@ View hierarchy debugging is an opt-in feature. You can enable it as shown below:
 
 ### Customize View Hierarchy Capturing
 
-<Note>
+<Alert>
 
 Requires SDK version `6.24.0` or higher.
 
-</Note>
+</Alert>
 
 Because capturing view hierarchy can be a resource-intensive operation on Android, it's limited to one view hierarchy every 2 seconds using a debouncing mechanism. This behavior can be overruled if you supply a `BeforeCaptureCallback` for view hierarchies in the `SentryAndroidOptions`.
 
@@ -81,11 +81,11 @@ SentryAndroid.init(this) { options ->
 
 ### Jetpack Compose Support using the Sentry Kotlin Compiler Plugin
 
-<Note>
+<Alert>
 
 The Sentry Kotlin Compiler plugin is considered _experimental_. Give it a try and provide early feedback [on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin).
 
-</Note>
+</Alert>
 
 If your application uses Jetpack Compose, you can use the <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink> to see the function names of your `@Composable` elements. You must add the plugin to all modules that contain `@Composable` elements.
 

--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -14,11 +14,11 @@ keywords:
 
 On this page, we get you up and running with Sentry's Android SDK, automatically reporting errors and exceptions in your application.
 
-<Note>
+<Alert>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</Note>
+</Alert>
 
 ## Features
 

--- a/docs/platforms/android/integrations/apollo/index.mdx
+++ b/docs/platforms/android/integrations/apollo/index.mdx
@@ -8,19 +8,19 @@ categories:
   - mobile
 ---
 
-<Note>
+<Alert>
 
 Capturing transactions requires that you first <PlatformLink to="/tracing/">set up tracing</PlatformLink> if you haven't already.
 
-</Note>
+</Alert>
 
 Sentry Apollo integration provides the `SentryApolloInterceptor`, which creates a span for each outgoing HTTP request executed with an [Apollo Android](https://github.com/apollographql/apollo-android) GraphQL client.
 
-<Note>
+<Alert>
 
 This integration supports Apollo 2.x. For Apollo 3.x use our <PlatformLink to="/integrations/apollo3/">Apollo3 integration</PlatformLink>.
 
-</Note>
+</Alert>
 
 ## Install
 

--- a/docs/platforms/android/integrations/apollo3/index.mdx
+++ b/docs/platforms/android/integrations/apollo3/index.mdx
@@ -8,19 +8,19 @@ categories:
   - mobile
 ---
 
-<Note>
+<Alert>
 
 To be able to capture transactions, you'll need to first <PlatformLink to="/tracing/">set up tracing</PlatformLink>.
 
-</Note>
+</Alert>
 
 Sentry's Apollo3 integration provides both the `SentryApollo3Interceptor` and the `SentryApollo3HttpInterceptor`, which create a span for each outgoing HTTP request executed with an [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin) GraphQL client. The integration also provides extension functions on the `ApolloClient.Builder`.
 
-<Note>
+<Alert>
 
 This integration supports Apollo 3.x. It does not yet support <Link to="https://github.com/apollographql/apollo-kotlin/releases/tag/v4.0.0">Apollo4</Link>. If you're using Apollo4 and are interested in an integration for it, please track and upvote the <Link to="https://github.com/getsentry/sentry-java/issues/3662">related issue</Link>.
 
-</Note>
+</Alert>
 
 ## Install
 

--- a/docs/platforms/android/integrations/file-io/index.mdx
+++ b/docs/platforms/android/integrations/file-io/index.mdx
@@ -7,13 +7,13 @@ categories:
   - mobile
 ---
 
-<Note>
+<Alert>
 
 Supported in Sentry's Android SDK version `5.5.0` and above.
 
 Supported in Sentry Android Gradle Plugin version `3.0.0` and above.
 
-</Note>
+</Alert>
 
 The [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) provides file I/O support through bytecode manipulation. The source can be found [on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin/tree/main/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation).
 
@@ -35,11 +35,11 @@ plugins {
 }
 ```
 
-<Note>
+<Alert>
 
 Make sure, that [tracing](/platforms/android/tracing/#configure-the-sample-rate) is enabled.
 
-</Note>
+</Alert>
 
 ## Configure
 
@@ -107,11 +107,11 @@ To view the recorded transaction, log into [sentry.io](https://sentry.io) and op
 
 ![File I/O performance instrumentation](./img/file-io-instrumentation.png)
 
-<Note>
+<Alert>
 
 At the moment, we only support `java.io.FileInputStream`, `java.io.FileOutputStream`, `java.io.FileReader` and `java.io.FileWriter` classes for auto-instrumentation.
 
-</Note>
+</Alert>
 
 ## (Optional) Custom Instrumentation
 

--- a/docs/platforms/android/integrations/jetpack-compose/index.mdx
+++ b/docs/platforms/android/integrations/jetpack-compose/index.mdx
@@ -23,7 +23,7 @@ With Jetpack Compose performance metrics the Sentry Android SDK can automaticall
 
 ![Jetpack Compose Performance Metrics](./img/jetpack-compose-performance-metrics.png)
 
-<Note>
+<Alert>
 
 This feature requires an underlying transaction to attach it's spans to. Transactions can be created manually or automatically by configuring
 
@@ -31,7 +31,7 @@ This feature requires an underlying transaction to attach it's spans to. Transac
 - [Navigation Instrumentation](#jetpack-compose-navigation)
 - [User Interactions](#user-interactions)
 
-</Note>
+</Alert>
 
 Once performance metrics have been enabled, you'll see two spans inside your transactions:
 
@@ -131,18 +131,18 @@ fun LoginScreen() {
 }
 ```
 
-<Note>
+<Alert>
 
 If a `@Composable` doesn't have a `.sentryTag` or a `.testTag` modifier applied, both breadcrumbs and transactions won't be captured because they can't be uniquely identified.
 To automatically generate tags, refer to the docs about our <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink>.
 
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 
 If you want to customize the recorded breadcrumbs/transactions, you can skip to [the section below](#customize-the-recorded-breadcrumbtransaction).
 
-</Note>
+</Alert>
 
 ## Jetpack Compose Navigation
 
@@ -170,11 +170,11 @@ plugins {
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/configuration/gradle/) documentation. Details about auto-installation can be found in the [Auto Instrumentation](/platforms/android/configuration/gradle/#tracing-auto-instrumentation) section.
 
-</Note>
+</Alert>
 
 #### Disable
 

--- a/docs/platforms/android/integrations/logcat/index.mdx
+++ b/docs/platforms/android/integrations/logcat/index.mdx
@@ -7,13 +7,13 @@ categories:
   - mobile
 ---
 
-<Note>
+<Alert>
 
 Supported in Sentry's Android SDK version `6.17.0` and above.
 
 Supported in Sentry Android Gradle Plugin version `3.5.0` and above.
 
-</Note>
+</Alert>
 
 The Sentry Logcat integration adds support for automatically reporting log calls above a minimum logging level as breadcrumbs.
 Any matching `android.Log.*` calls inside your app package are captured as breadcrumbs, including `android.Log.*` calls originating from bundled third party libraries.
@@ -112,10 +112,10 @@ public class MyActivity extends AppCompatActivity {
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded message, log into [sentry.io](https://sentry.io) and open your project. Click on the error's title to open a page where you can see error details and mark errors as resolved.

--- a/docs/platforms/android/integrations/okhttp/index.mdx
+++ b/docs/platforms/android/integrations/okhttp/index.mdx
@@ -12,11 +12,11 @@ The `sentry-okhttp` library provides [OkHttp](https://github.com/square/okhttp) 
 
 On this page, we get you up and running with Sentry's OkHttp Integration, so that it will automatically add a breadcrumb and start a span out of the active span bound to the scope for each HTTP Request.
 
-<Note>
+<Alert>
 
 The minimum supported version of `okhttp` is `3.13.0` due to its [incompatibilities](https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce) with Android versions below 5.0. However, you are free to adapt our [SentryOkHttpInterceptor](https://github.com/getsentry/sentry-java/blob/main/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt) if you're using an older `okhttp` version.
 
-</Note>
+</Alert>
 
 ## Auto-Installation With the Sentry Android Gradle Plugin
 
@@ -68,11 +68,11 @@ sentry {
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more about the Sentry Android Gradle plugin in our [Gradle](/platforms/android/configuration/gradle/) documentation.
 
-</Note>
+</Alert>
 
 ## Manual Installation
 
@@ -87,11 +87,11 @@ implementation 'io.sentry:sentry-okhttp:{{@inject packages.version('sentry.java.
 
 ### Configure
 
-<Note>
+<Alert>
 
 The SentryOkHttpEventListener is available in Sentry's Android SDK version `6.20.0` and above.
 
-</Note>
+</Alert>
 
 Configuration should happen once you create your `OkHttpClient` instance.
 
@@ -176,11 +176,11 @@ String run(String url) throws IOException {
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message, in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded message, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 

--- a/docs/platforms/android/integrations/room-and-sqlite/index.mdx
+++ b/docs/platforms/android/integrations/room-and-sqlite/index.mdx
@@ -8,7 +8,7 @@ categories:
   - mobile
 ---
 
-<Note>
+<Alert>
 
 Supported in Sentry's Android SDK version `4.0.0` and above.
 
@@ -16,7 +16,7 @@ Supported in Sentry Android Gradle Plugin version `3.0.0` and above.
 
 Custom instrumentation is supported in Sentry's Android SDK, version `6.21.0` and above.
 
-</Note>
+</Alert>
 
 ## Auto-Installation With the Sentry Android Gradle Plugin
 
@@ -48,11 +48,11 @@ dependencies {
 }
 ```
 
-<Note>
+<Alert>
 
 Make sure, that [tracing](/platforms/android/tracing/#configure-the-sample-rate) is enabled.
 
-</Note>
+</Alert>
 
 ### Configure
 
@@ -83,11 +83,11 @@ sentry {
 
 ## Manual Installation
 
-<Note>
+<Alert>
 
 Supported in Sentry's Android SDK, version `6.21.0` and above.
 
-</Note>
+</Alert>
 
 ### Install
 
@@ -201,7 +201,7 @@ To view the recorded transaction, log into [sentry.io](https://sentry.io) and op
 
 ![Room and AndroidX SQLite performance instrumentation](./img/room-sqlite-instrumentation.png)
 
-<Note>
+<Alert>
 
 The Sentry Android Gradle plugin will report SQL queries for any `SupportSQLiteOpenHelper.Factory`, starting with version `3.11.0`.
 
@@ -209,12 +209,12 @@ Earlier versions will only support standard `androidx.room` usage and won't repo
 
 If you're having trouble with this SDK, we want to hear about it. Create an [issue on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin/issues) and describe your experience.
 
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 
 If you are directly using [SupportSQLiteDatabase#query](<https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase#query(java.lang.String)>) or [SupportSQLiteDatabase#execSQL](<https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase#execSQL(java.lang.String)>) methods through the Room's SQLiteOpenHelper, consider switching to their alternatives that accept `bindArgs` as a second parameter.
 
 Because Sentry captures SQL queries as Span description, there is a risk of leaking sensitive data when not using an SQL string with placeholders.
 
-</Note>
+</Alert>

--- a/docs/platforms/android/integrations/timber/index.mdx
+++ b/docs/platforms/android/integrations/timber/index.mdx
@@ -155,10 +155,10 @@ public class MyActivity extends AppCompatActivity {
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message, in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded message, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/android/metrics/index.mdx
+++ b/docs/platforms/android/metrics/index.mdx
@@ -8,11 +8,11 @@ sidebar_hidden: true
 
 <Include name="metrics-api-change.mdx" />
 
-<Note>
+<Alert>
 
 Metrics are supported with Sentry Android SDK version `7.6.0` and above.
 
-</Note>
+</Alert>
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
 

--- a/docs/platforms/android/migration/index.mdx
+++ b/docs/platforms/android/migration/index.mdx
@@ -181,11 +181,11 @@ The `sentry-android-okhttp`, `sentry-android-fragment`, and `sentry-android-timb
 
 This version is still compatible with Kotlin `1.4`.
 
-<Note>
+<Alert>
 
 This only affects integrations that are written in Kotlin, such as `timber`, `fragment`, `okhttp`, `navigation` and `compose`.
 
-</Note>
+</Alert>
 
 ## Migrating from `io.sentry:sentry-android 5.x` to `io.sentry:sentry-android 6.0.0`
 
@@ -245,11 +245,11 @@ There are more changes and refactors, but they are not user breaking changes.
 
 Starting from version `5.6.2`, the `Timber.tag` usage is no longer supported by our SDK (the tag will not be captured and reflected on Sentry). Please, vote on this [GitHub issue](https://github.com/getsentry/sentry-java/issues/1900) to let us know if we should provide support for that.
 
-<Note>
+<Alert>
 
 Support for `Timber.tag` has been brought back in version `5.7.2`.
 
-</Note>
+</Alert>
 
 ## Migrating from `io.sentry:sentry-android-gradle-plugin 2.x` to `io.sentry:sentry-android-gradle-plugin 3.0.0`
 

--- a/docs/platforms/android/profiling/index.mdx
+++ b/docs/platforms/android/profiling/index.mdx
@@ -30,12 +30,12 @@ By default, some transactions will be created automatically for common operation
 
 ## Enable Profiling
 
-<Note>
+<Alert>
 
 Android profiling is available starting in SDK version `6.16.0` and is supported on API level 22 and up.
 App start profiling is available starting in SDK version `7.3.0`.
 
-</Note>
+</Alert>
 
 In `AndroidManifest.xml`:
 
@@ -49,11 +49,11 @@ In `AndroidManifest.xml`:
 </application>
 ```
 
-<Note>
+<Alert>
 
 The `io.sentry.traces.profiling.sample-rate` setting is _relative_ to the `io.sentry.traces.sample-rate` setting.
 
-</Note>
+</Alert>
 
 ## App Start Profiling
 
@@ -62,9 +62,9 @@ This includes all methods from any `ContentProvider`, the `Application` class, a
 App start profiling can be enabled with the manifest option `io.sentry.traces.profiling.enable-app-start` as shown above, and it will respect the `io.sentry.traces.sample-rate` and the `io.sentry.traces.profiling.sample-rate`.
 If you prefer to use a <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">sampling function</PlatformLink>, the SDK sets the `isForNextAppStart` field on the `TransactionContext` to specify it will be used for the next app start profiling.
 
-<Note>
+<Alert>
 
 The SDK won't run app start profiling the very first time the app runs, as the SDK won't have read the options by the time the profile should run.
 The SDK will set the `isForNextAppStart` flag in `TransactionContext` if app start profiling is enabled.
 
-</Note>
+</Alert>

--- a/docs/platforms/android/session-replay/index.mdx
+++ b/docs/platforms/android/session-replay/index.mdx
@@ -88,11 +88,11 @@ Sampling begins as soon as a session starts. `sessionSampleRate` is evaluated fi
 The SDK is recording and aggressively masking all text, images, and webviews by default. If your app has any sensitive data, you should only turn the default masking off after explicitly masking out the sensitive data, using the APIs described below.
 However, if you're working on a mobile app that's free of PII or other types of private data, you can opt out of the default text and image masking settings. To learn more about Session Replay privacy, [read our docs](/platforms/android/session-replay/privacy/).
 
-<Note>
+<Alert>
 
 If you find that any other data isn't being masked with the default settings, please let us know by creating a [GitHub issue](https://github.com/getsentry/sentry-java/issues/new?assignees=&labels=Platform%3A+Android%2CType%3A+Bug&projects=&template=bug_report_android.yml).
 
-</Note>
+</Alert>
 
 To disable masking altogether (not to be used on applications with sensitive data):
 

--- a/docs/platforms/android/session-replay/performance-overhead.mdx
+++ b/docs/platforms/android/session-replay/performance-overhead.mdx
@@ -5,7 +5,7 @@ notSupported:
 description: "Learn about how enabling Session Replay impacts the performance of your application."
 ---
 
-If you're considering enabling Session Replay, it's important to first understand the potential performance impact to your app. While accurate metrics require realistic testing where you apply typical access patterns and correlate the results with your business metrics, to provide a baseline, we measured the overhead using the open-source [Pocket Casts](https://github.com/Automattic/pocket-casts-android) app. 
+If you're considering enabling Session Replay, it's important to first understand the potential performance impact to your app. While accurate metrics require realistic testing where you apply typical access patterns and correlate the results with your business metrics, to provide a baseline, we measured the overhead using the open-source [Pocket Casts](https://github.com/Automattic/pocket-casts-android) app.
 
 You can learn more about the various optimizations implemented in the Android Replay SDK in the [Replay Performance Overhead](/product/explore/session-replay/mobile/performance-overhead/) docs.
 
@@ -33,8 +33,8 @@ Below are the results of the benchmarking tests, presented as median values to r
 
 
 
-<Note>
+<Alert>
 
 Jetpack Compose view hierarchies may be slower to snapshot initially due to ART optimizations, compared to the traditional Android View System. But their performance improves as execution progresses.
 
-</Note>
+</Alert>

--- a/docs/platforms/android/session-replay/privacy/index.mdx
+++ b/docs/platforms/android/session-replay/privacy/index.mdx
@@ -48,11 +48,11 @@ options.sessionReplay.addMaskViewClass("com.example.MyCustomView")
 options.sessionReplay.addUnmaskViewClass("com.example.MyCustomTextView")
 ```
 
-<Note>
+<Alert>
 
 If you're using a code obfuscation tool (R8/ProGuard), adjust your proguard rules accordingly so your custom view class names don't get minified.
 
-</Note>
+</Alert>
 
 ### Class Hierarchy
 

--- a/docs/platforms/android/tracing/index.mdx
+++ b/docs/platforms/android/tracing/index.mdx
@@ -6,11 +6,11 @@ sidebar_order: 4000
 
 With [tracing](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
-<Note>
+<Alert>
 
 If you’re adopting Tracing in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
 
-</Note>
+</Alert>
 
 ## Configure
 

--- a/docs/platforms/android/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/android/tracing/instrumentation/automatic-instrumentation.mdx
@@ -4,13 +4,13 @@ sidebar_order: 10
 description: "Learn what transactions are captured after tracing is enabled."
 ---
 
-<Note>
+<Alert>
 
 Capturing transactions requires that you first <PlatformLink to="/tracing/">set up tracing</PlatformLink> if you haven't already.
 
 Supported in Sentry's Android SDK version `4.3.0` and above.
 
-</Note>
+</Alert>
 
 ### Activity Instrumentation
 
@@ -133,11 +133,11 @@ The SDK sets the Span operation to `app.start.cold` for _Cold start_ and `app.st
 
 The SDK uses the `SentryPerformanceProvider` (ContentProvider) creation time as the beginning of the app start and the first frame drawn as the end.
 
-<Note>
+<Alert>
 
 The app start is only measured if the process is of the importance [RunningAppProcessInfo.IMPORTANCE_FOREGROUND](https://developer.android.com/reference/android/app/ActivityManager.RunningAppProcessInfo#IMPORTANCE_FOREGROUND), which means the process is running the foreground UI.
 
-</Note>
+</Alert>
 
 You can opt out of Activity Instrumentation and App Start Instrumentation using options:
 
@@ -151,11 +151,11 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Slow and Frozen Frames
 
-<Note>
+<Alert>
 
 Supported on Android OS version `7.0` and above.
 
-</Note>
+</Alert>
 
 Unresponsive UI and animation hitches annoy users and degrade the user experience. Two measurements to track these types of experiences are _slow frames_ and _frozen frames_. If you want your app to run smoothly, you should try to avoid both. The SDK adds these two measurements for the [Activity](/platforms/android/tracing/instrumentation/automatic-instrumentation/#activity-instrumentation) transactions.
 
@@ -268,11 +268,11 @@ _(New in version 6.0.0)_
 
 The SDK composes the transaction name out of the host `Activity` and the `id` of the view that captured the user interaction — for example, for `LoginActivity.login_button`. The transaction operation is set to `ui.action` plus the interaction type (one of `click`, `scroll`, or `swipe`).
 
-<Note>
+<Alert>
 
 If the view doesn't have the `id` assigned, the transaction won't be captured because it can't be uniquely identified otherwise.
 
-</Note>
+</Alert>
 
 #### User Interaction Instrumentation for Jetpack Compose
 
@@ -297,20 +297,20 @@ fun LoginScreen() {
 }
 ```
 
-<Note>
+<Alert>
 
 If the `@Composable` doesn't have a `sentryTag` modifier applied, the transaction won't be captured because it can't be uniquely identified.
 To capture a transaction for the `@Composable`, you must either add a `sentryTag` modifier or enable automatic `@Composable` tagging.
 
-</Note>
+</Alert>
 
 ##### Automatic `@Composable` tagging using the Sentry Kotlin Compiler Plugin
 
-<Note>
+<Alert>
 
 The Sentry Kotlin Compiler plugin is considered _experimental_. Give it a try and provide early feedback [on GitHub](https://github.com/getsentry/sentry-android-gradle-plugin).
 
-</Note>
+</Alert>
 
 The <PlatformLink to="/enhance-errors/kotlin-compiler-plugin/">Sentry Kotlin Compiler Plugin</PlatformLink> can automatically enrich your `@Composable` functions during compilation with a tag name,
 based on the function name of your `@Composable`.
@@ -332,11 +332,11 @@ plugins {
 
 The transaction finishes automatically after it reaches the specified [idleTimeout](/platforms/android/configuration/options/#idle-timeout) and all of its child spans are finished. The `idleTimeoout` defaults to `3000` milliseconds (three seconds). You can also disable the idle timeout by setting it to `null`, but the transaction must be finished manually in this case.
 
-<Note>
+<Alert>
 
 If the UI transaction has idled, but didn't have any child spans added, it will be dropped.
 
-</Note>
+</Alert>
 
 To finish the transaction manually, you can:
 

--- a/docs/platforms/android/tracing/instrumentation/custom-instrumentation.mdx
+++ b/docs/platforms/android/tracing/instrumentation/custom-instrumentation.mdx
@@ -4,11 +4,11 @@ sidebar_order: 20
 description: "Learn how to enable trace and span data-capturing on any action in your app."
 ---
 
-<Note>
+<Alert>
 
 To capture transactions and spans customized to your organization's needs, you must first <PlatformLink to="/tracing/">set up tracing.</PlatformLink>
 
-</Note>
+</Alert>
 
 <PlatformContent includePath="performance/enable-manual-instrumentation" />
 

--- a/docs/platforms/android/tracing/instrumentation/perf-v2.mdx
+++ b/docs/platforms/android/tracing/instrumentation/perf-v2.mdx
@@ -4,12 +4,12 @@ sidebar_order: 11
 description: "Learn how to get even more insights into Android app performance"
 ---
 
-<Note>
+<Alert>
 
 This feature is marked as _experimental_.
 Supported in Sentry's Android SDK version `7.4.0` and above.
 
-</Note>
+</Alert>
 
 Performance V2 is a set of features which enrich your existing instrumentation, giving you more insights into potential performance bottlenecks. These features tightly integrate with [Mobile Vitals](/product/insights/mobile-vitals/).
 

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -155,12 +155,12 @@ If you're using [Android App Bundle](https://developer.android.com/guide/app-bun
 In addition, `sentry-native` uses [tagged pointers](https://source.android.com/devices/tech/debug/tagged-pointers)
 internally. As a result, the Android SDK won't work out of the box on devices with a newer Android OS because they have their own conflicting pointer tagging.
 
-<Note>
+<Alert>
 
 If you're using a version of `sentry-android` before 3.1, you must manually disable the [`allowNativeHeapPointerTagging`](https://developer.android.com/guide/topics/manifest/application-element#allowNativeHeapPointerTagging) configuration option because `sentry-native` uses [tagged pointers](https://source.android.com/devices/tech/debug/tagged-pointers)
 internally. As a result, this option won't work out of the box on devices with a newer Android OS because they have their own conflicting pointer tagging. This is fixed in `sentry-android` versions 3.1 and above.
 
-</Note>
+</Alert>
 
 **Example AndroidManifest.xml**:
 
@@ -311,10 +311,10 @@ sentry {
 }
 ```
 
-<Note>
+<Alert>
 
 This problem is only relevant to these specific versions: `sentry-android-core` version `6.+` and `sentry-android-gradle-plugin` version `3.1.0`.
 
-</Note>
+</Alert>
 
 Check [this issue](https://github.com/getsentry/sentry-android-gradle-plugin/issues/329) for more details.

--- a/docs/platforms/android/usage/index.mdx
+++ b/docs/platforms/android/usage/index.mdx
@@ -6,7 +6,7 @@ sidebar_order: 10
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, uncaught exceptions, and unhandled rejections as well as other types of errors depending on the platform.
 
-<Note>
+<Alert>
 
 Key terms:
 
@@ -15,7 +15,7 @@ Key terms:
 - The reporting of an event is called _capturing_.
   When an event is captured, it’s sent to Sentry.
 
-</Note>
+</Alert>
 
 The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception, it can be captured. For some SDKs, you can also omit the argument to <PlatformIdentifier name="capture-exception" /> and Sentry will attempt to capture the current exception. It is also useful for manual reporting of errors or messages to Sentry.
 

--- a/docs/platforms/dart/configuration/options.mdx
+++ b/docs/platforms/dart/configuration/options.mdx
@@ -89,11 +89,11 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 
-<Note>
+<Alert>
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 This option is turned off by default.
 

--- a/docs/platforms/dart/configuration/releases.mdx
+++ b/docs/platforms/dart/configuration/releases.mdx
@@ -29,11 +29,11 @@ The value can be arbitrary, but we recommend either of these naming strategies:
   - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
 - **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
 
-<Note>
+<Alert>
 
 Releases are global per organization; prefix them with something project-specific for easy differentiation.
 
-</Note>
+</Alert>
 
 The behavior of a few features depends on whether a project is using semantic or time-based versioning.
 
@@ -60,11 +60,10 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-<Note>
+<Alert>
 
 Looking for Flutter release health? [See the Flutter documentation](/platforms/flutter/configuration/releases/#release-health).
 
-</Note>
+</Alert>
 
 Monitoring release health is currently not supported for pure Dart applications.
-

--- a/docs/platforms/dart/configuration/sampling.mdx
+++ b/docs/platforms/dart/configuration/sampling.mdx
@@ -14,11 +14,11 @@ To send a representative sample of your errors to Sentry, set the <PlatformIdent
 
 The error sample rate defaults to `1`, meaning all errors are sent to Sentry.
 
-<Note>
+<Alert>
 
 Changing the error sample rate requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-</Note>
+</Alert>
 
 ## Sampling Transaction Events
 

--- a/docs/platforms/dart/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/dart/data-management/sensitive-data/index.mdx
@@ -23,13 +23,13 @@ We offer the following options depending on your legal and operational needs:
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
-<Note>
+<Alert>
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 If you _do not_ wish to use the default PII behavior, you can also choose to identify users in a more controlled manner, using our [user identity context](../../enriching-events/identify-user/).
 

--- a/docs/platforms/dart/enriching-events/attachments/index.mdx
+++ b/docs/platforms/dart/enriching-events/attachments/index.mdx
@@ -47,11 +47,11 @@ Attachments live on the <PlatformLink to="/enriching-events/scopes/">Scope</Plat
 
 <PlatformContent includePath="enriching-events/attachment-upload" />
 
-<Note>
+<Alert>
 
 Sentry allows at most 20MB for a compressed request, and at most 100MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
 
-</Note>
+</Alert>
 
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.
 

--- a/docs/platforms/dart/enriching-events/context/index.mdx
+++ b/docs/platforms/dart/enriching-events/context/index.mdx
@@ -7,11 +7,11 @@ Custom contexts allow you to attach arbitrary data to an event. Often, this cont
 
 <Include name="common-imgs/additional_data" />
 
-<Note>
+<Alert>
 
 If you need to be able to search on custom data, [use tags](../tags) instead.
 
-</Note>
+</Alert>
 
 ## Structured Context
 

--- a/docs/platforms/dart/enriching-events/tags/index.mdx
+++ b/docs/platforms/dart/enriching-events/tags/index.mdx
@@ -17,11 +17,11 @@ Define the tag:
 
 <PlatformContent includePath="enriching-events/set-tag" />
 
-<Note>
+<Alert>
 
 Some tags are automatically set by Sentry. We strongly recommend against overwriting these [tags](/concepts/search/searchable-properties/#search-properties). Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/concepts/search/#explicit-tag-syntax) to search for it.
 
-</Note>
+</Alert>
 
 Once you've started sending tagged data, you'll see it when logged in to sentry.io. There, you can view the filters within the sidebar on the Project page, summarized within an event, and on the Tags page for an aggregated event.
 

--- a/docs/platforms/dart/index.mdx
+++ b/docs/platforms/dart/index.mdx
@@ -11,11 +11,11 @@ categories:
 
 On this page, we get you up and running with Sentry's Dart SDK.
 
-<Note>
+<Alert>
 
 If you don't already have an account and Sentry project established, head over to [sentry.io](https://sentry.io/signup/), then return to this page.
 
-</Note>
+</Alert>
 
 ## Features
 

--- a/docs/platforms/dart/integrations/http-integration.mdx
+++ b/docs/platforms/dart/integrations/http-integration.mdx
@@ -114,11 +114,11 @@ try {
 
 ## Tracing for HTTP Requests
 
-<Note>
+<Alert>
 
 Capturing transactions requires that you first <PlatformLink to="/tracing/">set up tracing</PlatformLink> if you haven't already.
 
-</Note>
+</Alert>
 
 The `SentryHttpClient` starts a span out of the active span bound to the scope for each HTTP Request.
 

--- a/docs/platforms/dart/integrations/logging.mdx
+++ b/docs/platforms/dart/integrations/logging.mdx
@@ -61,10 +61,10 @@ void main() async {
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message, in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded message, log into [sentry.io](https://sentry.io) and open your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/dart/metrics/index.mdx
+++ b/docs/platforms/dart/metrics/index.mdx
@@ -7,11 +7,11 @@ sidebar_hidden: true
 
 <Include name="metrics-api-change.mdx" />
 
-<Note>
+<Alert>
 
 Metrics are supported with Sentry Dart SDK version `7.19.0` and above.
 
-</Note>
+</Alert>
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
 

--- a/docs/platforms/dart/tracing/index.mdx
+++ b/docs/platforms/dart/tracing/index.mdx
@@ -6,11 +6,11 @@ sidebar_order: 4000
 
 With [tracing](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
-<Note>
+<Alert>
 
 If you’re adopting Tracing in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
 
-</Note>
+</Alert>
 
 ## Configure
 

--- a/docs/platforms/dart/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/dart/tracing/instrumentation/automatic-instrumentation.mdx
@@ -4,11 +4,11 @@ description: "Learn what transactions are captured after tracing is enabled."
 sidebar_order: 10
 ---
 
-<Note>
+<Alert>
 
 Capturing transactions requires that you first <PlatformLink to="/tracing/">set up tracing</PlatformLink> if you haven't already.
 
-</Note>
+</Alert>
 
 ### http.Client Library Instrumentation
 

--- a/docs/platforms/dart/tracing/instrumentation/custom-instrumentation.mdx
+++ b/docs/platforms/dart/tracing/instrumentation/custom-instrumentation.mdx
@@ -4,11 +4,11 @@ description: "Learn how to capture performance data on any action in your app."
 sidebar_order: 20
 ---
 
-<Note>
+<Alert>
 
 To capture transactions and spans customized to your organization's needs, you must first <PlatformLink to="/tracing/">set up tracing.</PlatformLink>
 
-</Note>
+</Alert>
 
 <PlatformContent includePath="performance/enable-manual-instrumentation" />
 

--- a/docs/platforms/dart/usage/index.mdx
+++ b/docs/platforms/dart/usage/index.mdx
@@ -6,7 +6,7 @@ sidebar_order: 10
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, uncaught exceptions, and unhandled rejections as well as other types of errors depending on the platform.
 
-<Note>
+<Alert>
 
 Key terms:
 
@@ -15,7 +15,7 @@ Key terms:
 - The reporting of an event is called _capturing_.
   When an event is captured, it’s sent to Sentry.
 
-</Note>
+</Alert>
 
 The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception, it can be captured. For some SDKs, you can also omit the argument to <PlatformIdentifier name="capture-exception" /> and Sentry will attempt to capture the current exception. It is also useful for manual reporting of errors or messages to Sentry.
 

--- a/docs/platforms/index.mdx
+++ b/docs/platforms/index.mdx
@@ -8,7 +8,7 @@ Sentry provides code-level observability that makes it easy to diagnose issues a
 
 If your use case is very specific, or not covered by Sentry, you'll find documentation on how to report events on your own using our [SDK API](https://develop.sentry.dev/sdk/overview/).
 
-<Note>
+<Alert>
 
 It's considered bad practice to use Sentry SDKs in third-party plugins, packages, and libraries (such as payment SDKs or embeddable widgets) meant to be consumed by other apps. If an app uses a Sentry SDK in addition to a third-party package with its own Sentry SDK installed, the following issues can occur:
 
@@ -18,7 +18,7 @@ It's considered bad practice to use Sentry SDKs in third-party plugins, packages
 
 We also <Link to="https://sentry.zendesk.com/hc/en-us/articles/23961784367387">discourage using Sentry alongside other APM tools</Link> because it can lead to a number of side-effects that negatively impact performance and stability of the application.
 
-</Note>
+</Alert>
 
 <PlatformFilter />
 

--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -97,11 +97,11 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 
-<Note>
+<Alert>
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 This option is turned off by default.
 
@@ -192,10 +192,10 @@ Please note that the Sentry server [limits HTTP request body size](https://devel
 
 The number of characters after which the values containing text in the event payload will be truncated (defaults to `1024`).
 
-<Note>
+<Alert>
   If the value you set for this is exceptionally large, the event may exceed 1
   MiB and will be dropped by Sentry.
-</Note>
+</Alert>
 
 </ConfigKey>
 

--- a/docs/platforms/python/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/python/data-management/sensitive-data/index.mdx
@@ -23,13 +23,13 @@ We offer the following options depending on your legal and operational needs:
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
-<Note>
+<Alert>
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 ## Personally Identifiable Information (PII)
 

--- a/docs/platforms/python/enriching-events/attachments/index.mdx
+++ b/docs/platforms/python/enriching-events/attachments/index.mdx
@@ -9,11 +9,11 @@ Sentry can enrich your events for further investigation by storing additional fi
 
 <PlatformContent includePath="enriching-events/add-attachment" />
 
-<Note>
+<Alert>
 
 Sentry allows at most 20MB for a compressed request, and at most 100MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
 
-</Note>
+</Alert>
 
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.
 

--- a/docs/platforms/python/enriching-events/context/index.mdx
+++ b/docs/platforms/python/enriching-events/context/index.mdx
@@ -7,11 +7,11 @@ Custom contexts allow you to attach arbitrary data to an event. Often, this cont
 
 <Include name="common-imgs/additional_data" />
 
-<Note>
+<Alert>
 
 If you need to be able to search on custom data, [use tags](../tags) instead.
 
-</Note>
+</Alert>
 
 ## Structured Context
 

--- a/docs/platforms/python/enriching-events/scopes/index.mdx
+++ b/docs/platforms/python/enriching-events/scopes/index.mdx
@@ -25,11 +25,11 @@ We generally recommend using the top-level API to manage your scopes, since the 
 
 However, if your use case requires direct access to the scope object, you can use the <PlatformIdentifier name="new-scope" /> context manager. <PlatformIdentifier name="new-scope" /> forks the current scope, allows you to modify the new scope while the context manager is active, and restores the original scope afterwards. Using <PlatformIdentifier name="new-scope" /> allows you to send data for only one specific event, such as [modifying the context](../context/). It is roughly equivalent to the <PlatformIdentifier name="push-scope" /> context manager in earlier (1.x) versions of the SDK.
 
-<Note>
+<Alert>
 
 Avoid calling top-level APIs inside the  <PlatformIdentifier name="new-scope" /> context manager. The top-level API might interact with a different scope from what <PlatformIdentifier name="new-scope" /> yields, causing unintended results. While within the <PlatformIdentifier name="new-scope" /> context manager, please call methods directly on the scope that <PlatformIdentifier name="new-scope" /> yields!
 
-</Note>
+</Alert>
 
 Using <PlatformIdentifier name="new-scope" /> allows you to attach additional information, such as adding custom tags or informing Sentry about the currently authenticated user.
 

--- a/docs/platforms/python/enriching-events/tags/index.mdx
+++ b/docs/platforms/python/enriching-events/tags/index.mdx
@@ -25,11 +25,11 @@ from sentry_sdk import set_tags
 set_tags({"page.locale": "de-at", "page.type": "article"})
 ```
 
-<Note>
+<Alert>
 
 Some tags are automatically set by Sentry. We strongly recommend against overwriting these [tags](/concepts/search/searchable-properties/#search-properties). Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/concepts/search/#explicit-tag-syntax) to search for it.
 
-</Note>
+</Alert>
 
 Once you've started sending tagged data, you'll see it when logged in to sentry.io. There, you can view the filters within the sidebar on the Project page, summarized within an event, and on the Tags page for an aggregated event.
 

--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -61,16 +61,16 @@ Add this intentional error to your application to test that everything is workin
 division_by_zero = 1 / 0
 ```
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 
-<Note>
+<Alert>
 
 Not seeing your error in Sentry? Make sure you're running the above example from a file and not from a Python shell like IPython.
 
-</Note>
+</Alert>

--- a/docs/platforms/python/integrations/asgi/index.mdx
+++ b/docs/platforms/python/integrations/asgi/index.mdx
@@ -5,11 +5,11 @@ description: "Learn about the ASGI integration and how it adds support for ASGI 
 
 The ASGI middleware can be used to instrument any [ASGI](https://asgi.readthedocs.io/en/latest/)-compatible web framework to attach request data for your events.
 
-<Note>
+<Alert>
 
 Please check our list of [supported integrations](/platforms/python/integrations/) as there might already be a specific integration (like [FastAPI](/platforms/python/integrations/fastapi/) or [Sanic](/platforms/python/integrations/sanic/)) that is easier to use and captures more useful information than our generic ASGI middleware. If that's the case, you should use the specific integration instead of this middleware.
 
-</Note>
+</Alert>
 
 ## Install
 

--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -9,9 +9,9 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 Use the Celery integration to monitor your [Celery periodic tasks](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html) and get notified when a task is missed (or doesn't start when expected), if it fails due to a problem in the runtime (such as an error), or if it fails by exceeding its maximum runtime.
 
-<Note>
+<Alert>
   Please note that a cron monitor will only be created the first time your task runs.
-</Note>
+</Alert>
 
 Get started by setting up your Celery beat schedule:
 
@@ -30,10 +30,10 @@ app.conf.beat_schedule = {
 }
 ```
 
-<Note>
+<Alert>
   Please note that only schedules that can be parsed by crontab will be successfully
   updated or inserted.
-</Note>
+</Alert>
 
 Next, initialize Sentry. Where to do this depends on how you run beat:
 
@@ -85,11 +85,11 @@ Start your Celery beat and worker services and see your tasks being monitored at
 
 In addition to the default Celery Beat scheduler, we also support [Redbeat](https://redbeat.readthedocs.io/en/latest).
 
-<Note>
+<Alert>
 
 You don't need to create Cron Monitors for your tasks on Sentry.io, we'll do it for you.
 
-</Note>
+</Alert>
 
 ### Excluding Celery Beat Tasks from Auto Discovery
 
@@ -118,11 +118,11 @@ For more information, see the documentation for <PlatformLink to="/#options">opt
 
 We provide a lightweight decorator to make monitoring individual tasks easier. To use it, add `@sentry_sdk.monitor` to your Celery task (or any function), then supply a `monitor_slug` of a monitor created previously on Sentry.io. Once this is done, every time the task (or function) is executed, telemetry data will be captured when a task is started, when it finishes, and when it fails.
 
-<Note>
+<Alert>
 
 Make sure the Sentry `@sentry_sdk.monitor` decorator is below Celery's `@app.task` decorator.
 
-</Note>
+</Alert>
 
 ```python {diff} {filename:tasks.py}
 # tasks.py

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -7,11 +7,11 @@ description: "Learn about using Sentry with Django."
 
 Sentry's [Django](https://www.djangoproject.com/) integration adds support for the Django framework. It enables automatic reporting of errors and exceptions as well as tracing. In order to get started using the integration, you should have a [Sentry account](https://sentry.io) and a project set up.
 
-<Note>
+<Alert>
 
 If you're using Python 3.7, Django applications with `channels` 2.0 will be correctly instrumented. Older versions of Python will require the installation of [aiocontextvars](https://pypi.org/project/aiocontextvars/).
 
-</Note>
+</Alert>
 
 ## Install
 
@@ -88,11 +88,11 @@ The following parts of your Django project are monitored:
 - Redis commands
 - Access to Django caches
 
-<Note>
+<Alert>
 
 The parameter `enable_tracing` needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
 
-</Note>
+</Alert>
 
 ## Options
 

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -61,11 +61,11 @@ The following parts of your FastAPI project are monitored:
 
 ![Performance details are shown as waterfall diagram](./img/fastapi-performance-details.png)
 
-<Note>
+<Alert>
 
 The parameter `enable_tracing` needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
 
-</Note>
+</Alert>
 
 ## Options
 

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -19,11 +19,11 @@ If you have the `flask` package in your dependencies, the Flask integration will
 
 <PlatformContent includePath="getting-started-config" />
 
-<Note>
+<Alert>
 
 Our Python SDK will install the Flask integration for all of your apps. It hooks into Flask’s signals, not anything on the app object.
 
-</Note>
+</Alert>
 
 ## Verify
 

--- a/docs/platforms/python/integrations/gcp-functions/index.mdx
+++ b/docs/platforms/python/integrations/gcp-functions/index.mdx
@@ -11,13 +11,13 @@ Add the Sentry SDK to your `requirements.txt`:
  sentry-sdk>=0.17.1
 ```
 
-<Note>
+<Alert>
 
 The GCP integration currently supports only the Python `3.7` runtime environment. If you try to run it with a newer version (such as `3.9`), an error message will be displayed (with debug mode on).
 
 Limited Sentry support is available on newer Python runtimes by directly enabling [integrations for supported frameworks](/platforms/python/integrations) and/or using the generic [serverless integration](/platforms/python/integrations/serverless/).
 
-</Note>
+</Alert>
 
 ## Configure
 

--- a/docs/platforms/python/integrations/grpc/index.mdx
+++ b/docs/platforms/python/integrations/grpc/index.mdx
@@ -100,13 +100,13 @@ async with grpc.aio.insecure_channel("example.com:12345") as channel:
     ...
 ```
 
-<Note>
+<Alert>
 
 **Note:**
 
 In older versions of this integration you had to add the interceptors by hand. Since Python SDK version 1.35.0 you do not need to add any interceptors by hand but only add the GRPCIntegration as described above.
 
-</Note>
+</Alert>
 
 ## Verify
 

--- a/docs/platforms/python/integrations/wsgi/index.mdx
+++ b/docs/platforms/python/integrations/wsgi/index.mdx
@@ -5,10 +5,10 @@ description: "Learn about the WSGI integration and how it adds support for WSGI 
 
 If you use a WSGI framework not directly supported by the SDK, or wrote a raw WSGI app, you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.
 
-<Note>
+<Alert>
 
 Please check our list of [supported integrations](/platforms/python/integrations/) as there might already be a specific integration (like [Django](/platforms/python/integrations/django/) or [Flask](/platforms/python/integrations/flask/)) that is easier to use and captures more useful information than our generic WSGI middleware. If that's the case, you should use the specific integration instead of this middleware.
-</Note>
+</Alert>
 
 ## Install
 

--- a/docs/platforms/python/metrics/index.mdx
+++ b/docs/platforms/python/metrics/index.mdx
@@ -7,11 +7,11 @@ sidebar_hidden: true
 
 <Include name="metrics-api-change.mdx" />
 
-<Note>
+<Alert>
 
 Metrics for Python are supported with Sentry Python SDK version `1.40.0` and above.
 
-</Note>
+</Alert>
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
 

--- a/docs/platforms/python/profiling/index.mdx
+++ b/docs/platforms/python/profiling/index.mdx
@@ -9,11 +9,11 @@ sidebar_order: 5000
 
 ## Enable Profiling
 
-<Note>
+<Alert>
 
 Python profiling is stable as of SDK version `1.18.0`.
 
-</Note>
+</Alert>
 
 
 ```python
@@ -38,13 +38,13 @@ sentry_sdk.init(
 )
 ```
 
-<Note>
+<Alert>
 
 The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
 For Profiling to work, you have to first enable Sentry’s tracing via `traces_sample_rate` (like in the example above). Read our <PlatformLink to="/tracing/">tracing setup documentation</PlatformLink> to learn how to configure sampling. If you set your sample rate to 1.0, all transactions will be captured.
 
-</Note>
+</Alert>
 
 ### Upgrading from older SDK versions
 
@@ -60,11 +60,11 @@ The current profiling implementation stops the profiler automatically after 30 s
 
 To get started with continuous profiling, you can start and stop the profiler directly with `sentry_sdk.profiler.start_profiler` and `sentry_sdk.profiler.stop_profiler`.
 
-<Note>
+<Alert>
 
 If you previously set `profiles_sample_rate` or `profilers_sampler` to use transaction-based profiling, you must remove those lines of code from your configuration in order to use continuous profiling.
 
-</Note>
+</Alert>
 
 ```python
 import sentry_sdk

--- a/docs/platforms/python/usage/index.mdx
+++ b/docs/platforms/python/usage/index.mdx
@@ -6,7 +6,7 @@ description: "Use the SDK to manually capture errors and other events."
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, uncaught exceptions, and unhandled rejections as well as other types of errors depending on the platform.
 
-<Note>
+<Alert>
 
 Key terms:
 
@@ -15,7 +15,7 @@ Key terms:
 - The reporting of an event is called _capturing_.
   When an event is captured, it’s sent to Sentry.
 
-</Note>
+</Alert>
 
 The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception, it can be captured. For some SDKs, you can also omit the argument to <PlatformIdentifier name="capture-exception" /> and Sentry will attempt to capture the current exception. It is also useful for manual reporting of errors or messages to Sentry.
 

--- a/docs/platforms/ruby/common/configuration/options.mdx
+++ b/docs/platforms/ruby/common/configuration/options.mdx
@@ -72,9 +72,9 @@ This lets you attach diagnostic client reports about dropped events to an existi
 ```ruby
 config.send_client_reports = false
 
-<Note>
+<Alert>
 This information isn't currently visible to users, but we're planning on adding it to the user-facing UI in the near future.
-</Note>
+</Alert>
 ```
 
 </ConfigKey>

--- a/docs/platforms/ruby/common/configuration/releases.mdx
+++ b/docs/platforms/ruby/common/configuration/releases.mdx
@@ -29,11 +29,11 @@ The value can be arbitrary, but we recommend either of these naming strategies:
   - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
 - **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
 
-<Note>
+<Alert>
 
 Releases are global per organization; prefix them with something project-specific for easy differentiation.
 
-</Note>
+</Alert>
 
 The behavior of a few features depends on whether a project is using semantic or time-based versioning.
 
@@ -62,11 +62,11 @@ After configuring your SDK, you can install a repository integration or manually
 
 Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
-<Note>
+<Alert>
 
 Crash reporting and app hang detection are not available for watchOS.
 
-</Note>
+</Alert>
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/ruby/common/configuration/sampling.mdx
+++ b/docs/platforms/ruby/common/configuration/sampling.mdx
@@ -14,11 +14,11 @@ To send a representative sample of your errors to Sentry, set the <PlatformIdent
 
 The error sample rate defaults to `1`, meaning all errors are sent to Sentry.
 
-<Note>
+<Alert>
 
 Changing the error sample rate requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-</Note>
+</Alert>
 
 ## Sampling Transaction Events
 

--- a/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
@@ -23,13 +23,13 @@ We offer the following options depending on your legal and operational needs:
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
-<Note>
+<Alert>
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
 
 If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
-</Note>
+</Alert>
 
 If you _do not_ wish to use the default PII behavior, you can also choose to identify users in a more controlled manner, using our [user identity context](../../enriching-events/identify-user/).
 

--- a/docs/platforms/ruby/common/enriching-events/attachments/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/attachments/index.mdx
@@ -9,11 +9,11 @@ Sentry can enrich your events for further investigation by storing additional fi
 
 <PlatformContent includePath="enriching-events/add-attachment" />
 
-<Note>
+<Alert>
 
 Sentry allows at most 20MB for a compressed request, and at most 100MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
 
-</Note>
+</Alert>
 
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.
 

--- a/docs/platforms/ruby/common/enriching-events/context/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/context/index.mdx
@@ -7,11 +7,11 @@ Custom contexts allow you to attach arbitrary data to an event. Often, this cont
 
 <Include name="common-imgs/additional_data" />
 
-<Note>
+<Alert>
 
 If you need to be able to search on custom data, [use tags](../tags) instead.
 
-</Note>
+</Alert>
 
 ## Structured Context
 

--- a/docs/platforms/ruby/common/enriching-events/tags/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/tags/index.mdx
@@ -17,11 +17,11 @@ Define the tag:
 
 <PlatformContent includePath="enriching-events/set-tag" />
 
-<Note>
+<Alert>
 
 Some tags are automatically set by Sentry. We strongly recommend against overwriting these [tags](/concepts/search/searchable-properties/#search-properties). Instead, name your tags with your organization's nomenclature. If you overwrite an automatically set tag, you must use [explicit tag syntax](/concepts/search/#explicit-tag-syntax) to search for it.
 
-</Note>
+</Alert>
 
 Once you've started sending tagged data, you'll see it when logged in to sentry.io. There, you can view the filters within the sidebar on the Project page, summarized within an event, and on the Tags page for an aggregated event.
 

--- a/docs/platforms/ruby/common/index.mdx
+++ b/docs/platforms/ruby/common/index.mdx
@@ -31,10 +31,10 @@ This snippet includes an intentional error, so you can test that everything is w
 
 <PlatformContent includePath="getting-started-verify" />
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/ruby/common/metrics/index.mdx
+++ b/docs/platforms/ruby/common/metrics/index.mdx
@@ -7,11 +7,11 @@ sidebar_hidden: true
 
 <Include name="metrics-api-change.mdx" />
 
-<Note>
+<Alert>
 
 Metrics for Ruby are supported with Sentry Ruby SDK version `5.17.0` and above.
 
-</Note>
+</Alert>
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
 

--- a/docs/platforms/ruby/common/migration.mdx
+++ b/docs/platforms/ruby/common/migration.mdx
@@ -25,11 +25,11 @@ description: "Learn about how to migrate from the deprecated sentry-raven SDK."
 
 ## Major Changes
 
-<Note>
+<Alert>
 
 Ruby 2.3 and Rails 4 are no longer supported.
 
-</Note>
+</Alert>
 
 #### Integrations Were Extracted
 

--- a/docs/platforms/ruby/common/profiling/index.mdx
+++ b/docs/platforms/ruby/common/profiling/index.mdx
@@ -9,11 +9,11 @@ sidebar_order: 5000
 
 ## Enable Profiling using StackProf
 
-<Note>
+<Alert>
 
 StackProf profiling beta is available starting in SDK version `5.9.0`.
 
-</Note>
+</Alert>
 
 We use the [`stackprof` gem](https://github.com/tmm1/stackprof) to collect profiles for Ruby.
 
@@ -39,27 +39,27 @@ Sentry.init do |config|
 end
 ```
 
-<Note>
+<Alert>
 
 The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
 For Profiling to work, you have to first enable Sentry’s tracing via `traces_sample_rate` (like in the example above). Read our <PlatformLink to="/tracing/">tracing setup documentation</PlatformLink> to learn how to configure sampling. If you set your sample rate to 1.0, all transactions will be captured.
 
-</Note>
+</Alert>
 
 ## Enable Profiling using Vernier
 
-<Note>
+<Alert>
 
 Vernier profiling beta is available starting in SDK version `5.21.0`.
 
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 
 Vernier requires Ruby 3.2.1+
 
-</Note>
+</Alert>
 
 You can have much better profiles if you're using multi-threaded servers like Puma now by leveraging Vernier.
 

--- a/docs/platforms/ruby/common/tracing/index.mdx
+++ b/docs/platforms/ruby/common/tracing/index.mdx
@@ -6,11 +6,11 @@ sidebar_order: 4000
 
 With [tracing](/product/performance/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
-<Note>
+<Alert>
 
 If you’re adopting Tracing in a high-throughput environment, we recommend testing prior to deployment to ensure that your service’s performance characteristics maintain expectations.
 
-</Note>
+</Alert>
 
 <Include name="opentelemetry-available.mdx" />
 

--- a/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -4,11 +4,11 @@ description: "Learn how to capture performance data on any action in your app."
 sidebar_order: 20
 ---
 
-<Note>
+<Alert>
 
 To capture transactions and spans customized to your organization's needs, you must first <PlatformLink to="/tracing/">set up tracing.</PlatformLink>
 
-</Note>
+</Alert>
 
 <PlatformContent includePath="performance/enable-manual-instrumentation" />
 

--- a/docs/platforms/ruby/common/usage/index.mdx
+++ b/docs/platforms/ruby/common/usage/index.mdx
@@ -6,7 +6,7 @@ sidebar_order: 10
 
 Sentry's SDK hooks into your runtime environment and automatically reports errors, uncaught exceptions, and unhandled rejections as well as other types of errors depending on the platform.
 
-<Note>
+<Alert>
 
 Key terms:
 
@@ -15,7 +15,7 @@ Key terms:
 - The reporting of an event is called _capturing_.
   When an event is captured, it’s sent to Sentry.
 
-</Note>
+</Alert>
 
 The most common form of capturing is to capture errors. What can be captured as an error varies by platform. In general, if you have something that looks like an exception, it can be captured. For some SDKs, you can also omit the argument to <PlatformIdentifier name="capture-exception" /> and Sentry will attempt to capture the current exception. It is also useful for manual reporting of errors or messages to Sentry.
 

--- a/docs/platforms/unreal/configuration/debug-symbols/index.mdx
+++ b/docs/platforms/unreal/configuration/debug-symbols/index.mdx
@@ -5,19 +5,19 @@ description: "Learn how the Unreal Engine SDK handles debug symbols upload."
 
 Sentry requires [debug information files](/platforms/unreal/data-management/debug-files/) to symbolicate crashes. The Unreal Engine SDK provides an automated upload functionality for those symbol files that rely on the [sentry-cli](/cli/). This is done automatically, so running the `sentry-cli` manually isn't required. The symbol upload happens during the execution of `PostBuildSteps`, as specified in the `Sentry.uplugin` file. The `sentry-cli` executables for Windows, macOS, and Linux are included as part of the Unreal Engine SDK package. They can also be downloaded manually via the settings menu if the plugin was installed from the UE Marketplace.
 
-<Note>
+<Alert>
 
 For Android, debug symbols upload is handled by [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle). By default, it bumps Gradle version to 7.5 automatically, however one can fallback to using its legacy version in case compatibility issues with other third-party plugins arise.
 
-</Note>
+</Alert>
 
 The automated debug symbols upload is disabled by default and requires configuration. To configure it, navigate to **Project Settings > Plugins > Sentry**, then enter the [Auth Token](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/), Organization Slug, and Project Name. Note, that the Unreal Engine SDK automatically creates a `sentry.properties` file at the root of your project directory to store the configuration. This configuration file should **never** be made publicly available.
 
-<Note>
+<Alert>
 
 You must configure which build configurations, target types, and platforms Sentry will upload debug symbols for in the "Misc" section of the plugin settings.
 
-</Note>
+</Alert>
 
 ![The Unreal Engine debug symbols upload configuration](./img/unreal-debug-symbols.png)
 

--- a/docs/platforms/unreal/configuration/releases.mdx
+++ b/docs/platforms/unreal/configuration/releases.mdx
@@ -29,11 +29,11 @@ The value can be arbitrary, but we recommend either of these naming strategies:
   - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
 - **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
 
-<Note>
+<Alert>
 
 Releases are global per organization; prefix them with something project-specific for easy differentiation.
 
-</Note>
+</Alert>
 
 The behavior of a few features depends on whether a project is using semantic or time-based versioning.
 
@@ -70,8 +70,8 @@ A session represents the interaction between the user and the application. Sessi
 
 <PlatformContent includePath="configuration/auto-session-tracking" />
 
-<Note>
+<Alert>
 
 On Windows, release health support for Unreal Engine is currently limited to games made with UE 5.2 or later. Note, that "Enable automatic crash capturing (Windows, UE 5.2+)" in the plugin settings has to be checked to track crashed sessions properly.
 
-</Note>
+</Alert>

--- a/docs/platforms/unreal/configuration/sampling.mdx
+++ b/docs/platforms/unreal/configuration/sampling.mdx
@@ -14,11 +14,11 @@ To send a representative sample of your errors to Sentry, set the <PlatformIdent
 
 The error sample rate defaults to `1`, meaning all errors are sent to Sentry.
 
-<Note>
+<Alert>
 
 Changing the error sample rate requires re-deployment. In addition, setting an SDK sample rate limits visibility into the source of events. Setting a rate limit for your project (which only drops events when volume is high) may better suit your needs.
 
-</Note>
+</Alert>
 
 ## Sampling Transaction Events
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -58,12 +58,12 @@ CrashReportClientVersion=1.0
 DataRouterUrl="___UNREAL_URL___"
 ```
 
-<Note>
+<Alert>
 
 If a `[CrashReportClient]` section already exists, simply changing the value of `DataRouterUrl`
 is enough.
 
-</Note>
+</Alert>
 
 Alternatively, the endpoint can be added automatically to the _DefaultEngine.ini_ file
 by using the Sentry configuration window.
@@ -118,17 +118,17 @@ void ConfigureCrashReporter()
 You need to call the `ConfigureCrashReporter` some time after your game
 starts. Any [event attribute](https://develop.sentry.dev/sdk/data-model/event-payloads/) can be set.
 
-<Note>
+<Alert>
 
 You should configure Crash Reporter attributes before initializing the Sentry SDK. Otherwise, some information may get overwritten and lost.
 
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 
 The Sentry SDK provides an API which allows you to set Crash Reporter attributes as well.
 
-</Note>
+</Alert>
 
 Depending on the version of Unreal Engine you are using, you may have to
 add JSON support to the build script (`MyProject.build.cs`):
@@ -144,11 +144,11 @@ symbolicated stack traces, you need to upload _Debug Information Files_
 (sometimes also referred to as _Debug Symbols_ or just _Symbols_). We recommend
 uploading debug information during your build or release process.
 
-<Note>
+<Alert>
 
 The Sentry SDK can handle uploading [debug symbols](/platforms/unreal/configuration/debug-symbols/) automatically at build time.
 
-</Note>
+</Alert>
 
 For all libraries where you'd like to receive symbolication, **you need
 to provide debug information**. This includes dependencies and operating system

--- a/docs/platforms/unreal/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unreal/enriching-events/attachments/index.mdx
@@ -3,11 +3,11 @@ title: Attachments
 description: "Learn more about how Sentry can store additional files in the same request as event attachments."
 ---
 
-<Note>
+<Alert>
 
 This feature is supported for iOS and Android only.
 
-</Note>
+</Alert>
 
 Sentry can enrich your events for further investigation by storing additional files, such as config or log files, as attachments.
 
@@ -94,11 +94,11 @@ The same result can be achieved by calling the corresponding function in bluepri
 
 ![Upload attachmnet](./img/unreal_attachment_upload.png)
 
-<Note>
+<Alert>
 
 Sentry allows at most 20MB for a compressed request, and at most 100MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
 
-</Note>
+</Alert>
 
 Attachments persist for 30 days; if your total storage included in your quota is exceeded, attachments will not be stored. You can delete attachments or their containing events at any time. Deleting an attachment does not affect your quota - Sentry counts an attachment toward your quota as soon as it is stored.
 

--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -69,11 +69,11 @@ We recommend using the `github` version, because it uses `Crashpad`, an out-of-p
 
 To install the SDK, download the most up-to-date sources from the [Releases page](https://github.com/getsentry/sentry-unreal/releases) and add them to your project's `Plugins` directory. On the next project launch, UE will prompt you to build the Sentry and SentryEditor modules.
 
-<Note>
+<Alert>
 
 Currently, this method is available only for C++ UE projects. Blueprint projects can be converted to a C++ one by adding an empty class using the editor.
 
-</Note>
+</Alert>
 
 ### Installing from Fab
 
@@ -88,13 +88,13 @@ To get started, we recommend cloning the [Unreal SDK repository](https://github.
 * `./scripts/init.sh` on macOS/Linux
 * `./scripts/init-win.ps1` on Windows
 
-<Note>
+<Alert>
 Initialization scripts require [GitHub CLI](https://cli.github.com/) to be installed.
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 If the initialization script fails due to errors on Windows, check your PowerShell version by printing the built-in variable `$PSVersionTable`. If the version is `5.x`, upgrading to a newer version of [PowerShell](https://github.com/powershell/powershell) may resolve these errors.
-</Note>
+</Alert>
 
 This script links the checked out version of the plugin (the [plugin-dev](https://github.com/getsentry/sentry-unreal/tree/b67076ad5dc419d46b4be70a0bd6e64c2357a82d/plugin-dev) directory) to the [sample app](https://github.com/getsentry/sentry-unreal/tree/b67076ad5dc419d46b4be70a0bd6e64c2357a82d/sample) and downloads the latest builds of native SDKs from our GitHub CI.
 
@@ -122,11 +122,11 @@ The minimum configuration required is the [DSN](/product/sentry-basics/dsn-expla
 }
 ```
 
-<Note>
+<Alert>
 
 If you are logged in, you can also go to your project settings and copy its DSN directly from there.
 
-</Note>
+</Alert>
 
 Sentry can be configured using the Sentry configuration window.
 The window can be accessed by going to editor's menu: **Project Settings > Plugins > Sentry**.
@@ -156,11 +156,11 @@ The same result can be achieved by calling corresponding function in blueprint:
 
 ![Sentry capture message BP](./img/unreal_bp_message.png)
 
-<Note>
+<Alert>
 
 Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
 
-</Note>
+</Alert>
 
 To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.
 

--- a/platform-includes/capture-message/unreal.mdx
+++ b/platform-includes/capture-message/unreal.mdx
@@ -28,11 +28,11 @@ The same result can be achieved by calling corresponding functions in blueprint:
 
 ![Capture message](./img/unreal_capture_message.png)
 
-<Note>
+<Alert>
 
 Scoped message capturing is supported only on macOS, iOS and Android.
 
-</Note>
+</Alert>
 
 ## Manual Events
 
@@ -80,10 +80,10 @@ The same result can be achieved by calling corresponding functions in blueprint:
 
 ![Capture event](./img/unreal_capture_event.png)
 
-<Note>
+<Alert>
 
 Scoped events capturing is supported only on macOS, iOS and Android platforms.
 
-</Note>
+</Alert>
 
 For the full list of supported values, check out [_Event Payloads_](https://develop.sentry.dev/sdk/data-model/event-payloads/) and linked documents.

--- a/platform-includes/distributed-tracing/custom-instrumentation/dart.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/dart.mdx
@@ -16,8 +16,8 @@ try {
 }
 ```
 
-<Note>
+<Alert>
 
 The `SentryHttpClient` instrumentation handles trace continuations automatically when enabling the [performance](/platforms/dart/performance/) feature.
 
-</Note>
+</Alert>

--- a/platform-includes/distributed-tracing/custom-instrumentation/rust.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/rust.mdx
@@ -30,8 +30,8 @@ let tx_ctx = sentry::TransactionContext::continue_from_headers(
 let transaction = sentry::start_transaction(tx_ctx);
 ```
 
-<Note>
+<Alert>
 
 For usage with the `tower` crate, the `SentryHttpLayer` handles trace continuations automatically when constructed via `SentryHttpLayer::with_transaction()`.
 
-</Note>
+</Alert>

--- a/platform-includes/metrics/version-support-note/javascript.electron.mdx
+++ b/platform-includes/metrics/version-support-note/javascript.electron.mdx
@@ -1,5 +1,5 @@
-<Note>
+<Alert>
 
 Metrics for JavaScript are supported with Sentry Electron SDK version `4.17.0` and above.
 
-</Note>
+</Alert>

--- a/platform-includes/metrics/version-support-note/javascript.mdx
+++ b/platform-includes/metrics/version-support-note/javascript.mdx
@@ -1,5 +1,5 @@
-<Note>
+<Alert>
 
 Metrics for JavaScript are supported with Sentry JavaScript SDK version `7.103.0` and above.
 
-</Note>
+</Alert>

--- a/platform-includes/metrics/version-support-note/react-native.mdx
+++ b/platform-includes/metrics/version-support-note/react-native.mdx
@@ -1,5 +1,5 @@
-<Note>
+<Alert>
 
 Metrics for React Native are supported in Sentry React Native SDK version `5.19.0` and above.
 
-</Note>
+</Alert>

--- a/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
+++ b/platform-includes/migration/javascript-v8/important-changes/javascript.remix.mdx
@@ -27,13 +27,13 @@ export const handleError = Sentry.wrapRemixHandleError;
 // rest of your code and imports
 ```
 
-<Note>
+<Alert>
   Since
   [8.10.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.10.0),
   you can also setup `@sentry/remix` with a new `autoInstrumentRemix: true`
   option. See <PlatformLink to="/manual-setup">Manual Setup</PlatformLink> for
   details on how to use this option.
-</Note>
+</Alert>
 
 2. Remove any performance related integrations from your server-side init in `entry.server.tsx`.
 

--- a/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/integrations-package-removal/javascript.mdx
@@ -2,11 +2,11 @@
 
 `@sentry/integrations` has been removed and will no longer be published. We moved pluggable integrations from their own package (`@sentry/integrations`) to `@sentry/browser`. In addition they are now functions instead of classes.
 
-<Note>
+<Alert>
 
 Integrations will still be available via the CDN, but they will exposed as functions not classes as is shown below.
 
-</Note>
+</Alert>
 
 Integrations that are now exported from `@sentry/browser` for client-side init:
 

--- a/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
+++ b/platform-includes/migration/javascript-v8/v7-deprecation/javascript.mdx
@@ -58,10 +58,10 @@ Client-side Integrations:
  });
 ```
 
-<Note>
+<Alert>
 
 You only need to add the `integrations` configuration for the loader if you were previously explicitly using the `BrowserTracing` integration.
 
-</Note>
+</Alert>
 
 <Include name="migration/javascript-v8/v7-deprecation/general" />

--- a/platform-includes/performance/always-inherit-sampling-decision/php.laravel.mdx
+++ b/platform-includes/performance/always-inherit-sampling-decision/php.laravel.mdx
@@ -9,8 +9,8 @@
 },
 ```
 
-<Note>
+<Alert>
 
 Learn more in [Closures and Config Caching](/platforms/php/guides/laravel/configuration/laravel-options/#closures-and-config-caching).
 
-</Note>
+</Alert>

--- a/platform-includes/performance/always-inherit-sampling-decision/php.symfony.mdx
+++ b/platform-includes/performance/always-inherit-sampling-decision/php.symfony.mdx
@@ -33,8 +33,8 @@ class Sentry
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more in [Callables in Symfony Options](/platforms/php/guides/symfony/configuration/symfony-options/#callables).
 
-</Note>
+</Alert>

--- a/platform-includes/performance/configure-sample-rate/java.mdx
+++ b/platform-includes/performance/configure-sample-rate/java.mdx
@@ -1,8 +1,8 @@
-<Note>
+<Alert>
 
 If you are using either our [Spring](/platforms/java/guides/spring/performance/) or [Spring Boot](/platforms/java/guides/spring-boot/performance/) integrations, errors are linked with spans automatically.
 
-</Note>
+</Alert>
 
 
 ```java {diff, tabTitle:Java}

--- a/platform-includes/performance/configure-sample-rate/php.laravel.mdx
+++ b/platform-includes/performance/configure-sample-rate/php.laravel.mdx
@@ -7,8 +7,8 @@
 },
 ```
 
-<Note>
+<Alert>
 
 Learn more in [Closures and Config Caching](/platforms/php/guides/laravel/configuration/laravel-options/#closures-and-config-caching).
 
-</Note>
+</Alert>

--- a/platform-includes/performance/configure-sample-rate/php.symfony.mdx
+++ b/platform-includes/performance/configure-sample-rate/php.symfony.mdx
@@ -32,8 +32,8 @@ class Sentry
 }
 ```
 
-<Note>
+<Alert>
 
 Learn more in [Callables in Symfony Options](/platforms/php/guides/symfony/configuration/symfony-options/#callables).
 
-</Note>
+</Alert>

--- a/platform-includes/performance/opentelemetry-install/dotnet.mdx
+++ b/platform-includes/performance/opentelemetry-install/dotnet.mdx
@@ -1,8 +1,8 @@
-<Note>
+<Alert>
 
 The `Sentry.OpenTelemetry` package requires `OpenTelemetry` package `1.5.0` or higher.
 
-</Note>
+</Alert>
 
 To install, add the `Sentry` and `Sentry.OpenTelemetry` **NuGet** packages to your project:
 

--- a/platform-includes/performance/opentelemetry-install/go.mdx
+++ b/platform-includes/performance/opentelemetry-install/go.mdx
@@ -1,14 +1,14 @@
-<Note>
+<Alert>
 
 OpenTelemetry integration was added in `sentry-go` version 0.18.0, and works only for Go >= 1.18.
 
-</Note>
+</Alert>
 
-<Note>
+<Alert>
 
 The Sentry Go OpenTelemetry integration requires `go.opentelemetry.io/otel` (and its submodules), version `1.11.0` or higher.
 
-</Note>
+</Alert>
 
 Install the `otel` module in addition to the main SDK:
 

--- a/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.nextjs.mdx
@@ -18,11 +18,11 @@ pnpm add @sentry/nextjs @sentry/opentelemetry-node
 
 The minimum required version of the `@sentry/node` and the `@sentry/opentelemetry-node` package is `7.20.0` and their versions should always be aligned.
 
-<Note>
+<Alert>
 
 Note that @sentry/opentelemetry-node depends on the following peer dependencies:
 
 - @opentelemetry/api, version 1.0.0 or greater
 - @opentelemetry/sdk-trace-base, version 1.0.0 or greater, or a package that implements it, like @opentelemetry/sdk-node
 
-</Note>
+</Alert>

--- a/platform-includes/performance/opentelemetry-install/javascript.node.mdx
+++ b/platform-includes/performance/opentelemetry-install/javascript.node.mdx
@@ -12,11 +12,11 @@ pnpm add @sentry/node @sentry/opentelemetry
 
 The minimum required version of the `@sentry/node` and the `@sentry/opentelemetry` package is `7.75.0` and their versions should always be aligned.
 
-<Note>
+<Alert>
 
 Note that `@sentry/opentelemetry` depends on the following peer dependencies:
 
 - `@opentelemetry/api`, version 1.0.0 or greater
 - `@opentelemetry/sdk-trace-base`, version 1.0.0 or greater, or a package that implements it, like `@opentelemetry/sdk-node`
 
-</Note>
+</Alert>

--- a/platform-includes/performance/opentelemetry-install/python.mdx
+++ b/platform-includes/performance/opentelemetry-install/python.mdx
@@ -1,8 +1,8 @@
-<Note>
+<Alert>
 
 Sentry requires `opentelemetry-distro` version `0.350b0` or higher.
 
-</Note>
+</Alert>
 
 ```bash
 pip install --upgrade 'sentry-sdk[opentelemetry]'

--- a/platform-includes/performance/opentelemetry-install/ruby.mdx
+++ b/platform-includes/performance/opentelemetry-install/ruby.mdx
@@ -1,8 +1,8 @@
-<Note>
+<Alert>
 
 The `sentry-opentelemetry` gem requires `opentelemetry-sdk` `1.0.0` or higher.
 
-</Note>
+</Alert>
 
 ```ruby
 gem "sentry-ruby"

--- a/platform-includes/performance/opentelemetry-setup/javascript.node.mdx
+++ b/platform-includes/performance/opentelemetry-setup/javascript.node.mdx
@@ -87,11 +87,11 @@ const span = startInactiveSpan({ name: "my span" });
 span.end();
 ```
 
-<Note>
+<Alert>
 
 If you are using the [@sentry/opentelemetry-node](https://www.npmjs.com/package/@sentry/opentelemetry-node) package, you can continue to do so. Usage instructions are in the
 package's README. This package has a slightly easier setup process but
 provides a more limited connection between Sentry and OpenTelemetry than the
 instructions outlined above.
 
-</Note>
+</Alert>

--- a/platform-includes/performance/span-api-version/javascript.mdx
+++ b/platform-includes/performance/span-api-version/javascript.mdx
@@ -1,5 +1,5 @@
-<Note>
+<Alert>
 
 The below span APIs (`startSpan`, `startInactiveSpan`, and `startSpanManual`) require SDK version `7.69.0` or higher. If you are using an older version of the SDK, you can use the [explicit transaction APIs](#start-transaction) for custom instrumentation.
 
-</Note>
+</Alert>

--- a/platform-includes/replay/privacy-configuration/flutter.mdx
+++ b/platform-includes/replay/privacy-configuration/flutter.mdx
@@ -44,11 +44,11 @@ Mask given widget type `T` (or subclasses of `T`) in the screenshot. Note: maski
 
 You can find more details in the documentation for each method.
 
-<Note>
+<Alert>
 
 If you find that data isn't being masked with the default settings, please let us know by creating a [GitHub issue](https://github.com/getsentry/sentry-dart/issues/new?template=BUG_REPORT.yml).
 
-</Note>
+</Alert>
 
 To disable masking for <PlatformLink to="/enriching-events/screenshots/">`Screenshots`</PlatformLink> and <PlatformLink to="/session-replay/">`Session Replay`</PlatformLink> (not to be used on applications with sensitive data):
 

--- a/platform-includes/set-release/dotnet.mdx
+++ b/platform-includes/set-release/dotnet.mdx
@@ -14,6 +14,6 @@ The SDK will first check if there's a version set on the environment via `SENTRY
 
 If no version is found, the SDK will look at the [entry assembly's](<https://msdn.microsoft.com/en-us/library/system.reflection.assembly.getentryassembly(v=vs.110).aspx>) `AssemblyInformationalVersionAttribute`, which accepts a string value and is often used to set a GIT commit hash. If that returns null, then the SDK will look at the default `AssemblyVersionAttribute`, which accepts the numeric version number. The resulting release will be in the format `<assembly-name>@<version-number>`.
 
-<Note>
+<Alert>
 An `AssemblyInformationalVersionAttribute` is included automatically in SDK-style projects with a default value of `"1.0.0.0"`. You can set the `Version` property in your project file to override this value or [disable it entirely](https://learn.microsoft.com/en-us/dotnet/standard/assembly/set-attributes-project-file#use-package-properties-as-assembly-attributes) by setting the `GenerateAssemblyInformationalVersionAttribute` property to `false`.
-</Note>
+</Alert>

--- a/platform-includes/set-release/ruby.mdx
+++ b/platform-includes/set-release/ruby.mdx
@@ -5,8 +5,8 @@ Sentry.init do |config|
 end
 ```
 
-<Note>
+<Alert>
 
 We'll automatically attempt to detect the release in certain environments, such as Heroku and Capistrano.
 
-</Note>
+</Alert>


### PR DESCRIPTION
Removes the `<Note>` component in favor of just using `<Alert>`. They have already been exactly the same, so this is just redundant.