### PR TITLE
feat(native): enable debug-option by default in debug-build.

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -31,7 +31,7 @@ Allows you to specify a path to the local event- and crash-database of the Nativ
 
 <ConfigKey name="debug">
 
-Turns debug mode on or off. If debug is enabled SDK will attempt to print out useful debugging information if something goes wrong with sending the event. The default is always `false`. It's generally not recommended to turn it on in production, though turning `debug` mode on will not cause any safety concerns.
+Turns debug mode on or off. If `debug` is enabled, the SDK will attempt to print out useful debugging information if something goes wrong. If you run a debug-build (`NDEBUG` isn't defined), it will default to `true`; otherwise, the default is always `false`. You can provide a `SENTRY_DEBUG` environment variable with either `"0"` or `"1"` for "off" and "on" respectively, which will override the defaults. It's generally not recommended to turn it on in production, though turning `debug` mode on will not cause any safety concerns. You can limit the output by setting `logger_level` to an appropriate level for your production use case.
 
 </ConfigKey>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

This updates the documentation for the debug `option`. The existing documentation was already slightly out of date and this also adds documentation for a new default when running on debug-build: https://github.com/getsentry/sentry-native/pull/1128

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
