### PR TITLE
ref(flags): add missing links to unleash JS integration page

### DIFF
--- a/docs/organization/integrations/feature-flag/unleash/index.mdx
+++ b/docs/organization/integrations/feature-flag/unleash/index.mdx
@@ -11,6 +11,7 @@ Sentry can track flag evaluations as they happen within your application.  Flag 
 ### Set Up Evaluation Tracking
 
 To set up evaluation tracking, visit one of our supported languages pages:
+* [JavaScript](/platforms/javascript/configuration/integrations/unleash/)
 * [Python](/platforms/python/integrations/feature-flags/unleash/)
 
 ## Change Tracking
@@ -25,7 +26,7 @@ Enabling Change Tracking is a three-step process. To get started visit the [feat
     - One webhook secret can be registered per provider type.
     - Select Unleash in the dropdown that says "Select a provider".
 2. **Register the webhook URL**.
-    - Go to your Unleash homepage and navigate to the `/integrations/` page, which can be found by clicking Integrations on the left-hand sidebar navigation, under the Configure heading. 
+    - Go to your Unleash homepage and navigate to the `/integrations/` page, which can be found by clicking Integrations on the left-hand sidebar navigation, under the Configure heading.
     - Select the Webhook option. You should be on the `/integrations/create/webhook/` page.
     - Copy the provided Sentry webhook URL in settings and paste it into Unleash within their webhook integration UI.
     - Make sure the integration is toggled to Enabled.

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -35,6 +35,7 @@ Evaluation tracking requires enabling an SDK integration. Integrations are provi
 - [Generic](/platforms/javascript/configuration/integrations/featureflags/)
 - [LaunchDarkly](/platforms/javascript/configuration/integrations/launchdarkly/)
 - [OpenFeature](/platforms/javascript/configuration/integrations/openfeature/)
+- [Unleash](/platforms/javascript/configuration/integrations/unleash/)
 
 ## Enable Change Tracking
 


### PR DESCRIPTION
Forgot to link this in
- https://docs.sentry.io/platforms/javascript/feature-flags/
- https://docs.sentry.io/organization/integrations/feature-flag/unleash/