### PR TITLE
fix(feedback): fix broken links to user-report envelope item

### DIFF
--- a/develop-docs/application-architecture/feedback-architecture.mdx
+++ b/develop-docs/application-architecture/feedback-architecture.mdx
@@ -21,7 +21,7 @@ the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-fe
 to the JavaScript SDK. It allows adding more information, for example tags,
 release, url, etc.
 
-`USER_REPORT_ENVELOPE`: [The older format](/sdk/data-model/envelope-items/#user-report) with name/email/comments, that requires
+`USER_REPORT_ENVELOPE`: [The older format](/sdk/data-model/envelope-items/#user-report---deprecated) with name/email/comments, that requires
 `event_id` to link a Sentry error event.
 
 `USER_REPORT_DJANGO_ENDPOINT`: [The deprecated Web API](https://docs.sentry.io/api/projects/submit-user-feedback/)
@@ -186,7 +186,7 @@ graph TD
 
 ### Envelopes
 
-User reports are also sent to Relay in envelope format, item type [user_report](/sdk/data-model/envelope-items/#user-report).
+User reports are also sent to Relay in envelope format, item type [user_report](/sdk/data-model/envelope-items/#user-report---deprecated).
 
 The SDK function that sends these is `captureUserFeedback`.
 

--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -147,7 +147,7 @@ Ability to get the ID of the last event sent. Event IDs are useful for correlati
 
 ## User Feedback
 
-For all SDKs, it is strongly recommended to send the `User Feedback` as an [envelope item](/sdk/data-model/envelope-items/#user-report). Alternatively, the SDKs can
+For all SDKs, it is strongly recommended to send the `User Feedback` as an [envelope item](/sdk/data-model/envelope-items/#user-report---deprecated). Alternatively, the SDKs can
 use the [User Feedback endpoint](https://docs.sentry.io/api/projects/submit-user-feedback/), which is not recommended.
 
 ### User Facing Platforms


### PR DESCRIPTION
Correct links to https://develop.sentry.dev/sdk/data-model/envelope-items/#user-report---deprecated