### PR TITLE
docs(self-hosted): remove deprecated github sso auth config

### DIFF
--- a/develop-docs/self-hosted/sso.mdx
+++ b/develop-docs/self-hosted/sso.mdx
@@ -86,17 +86,6 @@ When prompted for permissions, choose the following:
 
 You will then need to set the following configuration values:
 
-In [`sentry/sentry.conf.py`](https://github.com/getsentry/self-hosted/blob/master/sentry/sentry.conf.example.py)
-
-```python
-GITHUB_APP_ID="<App ID>"
-GITHUB_API_SECRET="<Client secret>"
-GITHUB_REQUIRE_VERIFIED_EMAIL = True  # Optional but recommended
-
-# Only if you are using GitHub Enterprise
-#GITHUB_BASE_DOMAIN = "git.example.com"
-#GITHUB_API_DOMAIN = "api.git.example.com"
-```
 In [`sentry/config.yaml`](https://github.com/getsentry/self-hosted/blob/master/sentry/config.example.yml)
 
 ```yaml
@@ -117,6 +106,7 @@ github-app.private-key: |
 # Only needed if you have multiple organizations enabled
 github-login.client-id: '<Client ID>'
 github-login.client-secret: '<Client secret>'
+github-login.require-verified-email: true # Optional but recommended
 ```
 
 This will also enable the [GitHub Integration](/integrations/github/) for your instance.


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Closes https://github.com/getsentry/self-hosted/issues/3481
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
