### PR TITLE
fix: don't do permanent redirects in dev mode

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,12 +22,15 @@ export function middleware(request: NextRequest) {
   return handleRedirects(request);
 }
 
+// don't send Permanent Redirects (301) in dev mode - it gets cached for "localhost" by the browser
+const redirectStatusCode = process.env.NODE_ENV === 'development' ? 302 : 301
+
 const handleRedirects = (request: NextRequest) => {
   const urlPath = request.nextUrl.pathname;
 
   const redirectTo = redirectMap.get(urlPath);
   if (redirectTo) {
-    return NextResponse.redirect(new URL(redirectTo, request.url), {status: 301});
+    return NextResponse.redirect(new URL(redirectTo, request.url), {status: redirectStatusCode});
   }
 
   // If we don't find an exact match, we try to look for a :guide placeholder
@@ -50,7 +53,7 @@ const handleRedirects = (request: NextRequest) => {
     );
 
     return NextResponse.redirect(new URL(finalRedirectToPath, request.url), {
-      status: 301,
+      status: redirectStatusCode,
     });
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,14 +23,16 @@ export function middleware(request: NextRequest) {
 }
 
 // don't send Permanent Redirects (301) in dev mode - it gets cached for "localhost" by the browser
-const redirectStatusCode = process.env.NODE_ENV === 'development' ? 302 : 301
+const redirectStatusCode = process.env.NODE_ENV === 'development' ? 302 : 301;
 
 const handleRedirects = (request: NextRequest) => {
   const urlPath = request.nextUrl.pathname;
 
   const redirectTo = redirectMap.get(urlPath);
   if (redirectTo) {
-    return NextResponse.redirect(new URL(redirectTo, request.url), {status: redirectStatusCode});
+    return NextResponse.redirect(new URL(redirectTo, request.url), {
+      status: redirectStatusCode,
+    });
   }
 
   // If we don't find an exact match, we try to look for a :guide placeholder


### PR DESCRIPTION
## DESCRIBE YOUR PR
`yarn dev:developer-docs` starts a nextJs devServer on localhost:3000/, which immediately yields a 301 - Permanent Redirect to localhost:3000/getting-started/

since Permanent Redirects get cached by the browser, all other projects that start a devserver on localhost:3000 will then redirect to /getting-started/, which likely doesn't exist.

Since port 3000 is a popular port to be used in development, this permanent redirect can interfere with other projects, which is not a great DX (ask me how I know 😂 ).

This fix changes redirects to HTTP Status Code 302 in development mode, which is a temporary redirect that doesn't get cached by browsers; in production, it's still fine to issue 301, as caching by the browser will make the redirect faster
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
