### PR TITLE
Change redactAllText and redactAllImages to maskAllText and maskAllImages

### DIFF
--- a/docs/platforms/apple/guides/ios/session-replay/index.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/index.mdx
@@ -76,8 +76,8 @@ If you encounter any data not being redacted with the default settings, please l
 To disable redaction altogether (not to be used on applications with sensitive data):
 
 ```swift
-options.sessionReplay.redactAllText = false
-options.sessionReplay.redactAllImages = false
+options.sessionReplay.maskAllText = false
+options.sessionReplay.maskAllImages = false
 ```
 
 ## Error Linking


### PR DESCRIPTION
This is based on the change in https://github.com/getsentry/sentry-java/pull/3741

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
* redactAllText and redactAllImages are no longer valid in Xcode, and have been replaced with maskAllText and maskAllImages

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ X] None: Not urgent, can wait up to 1 week+

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.