### PR TITLE
Mark captureconsole as error reporting integration

### DIFF
--- a/platform-includes/configuration/integrations/javascript.mdx
+++ b/platform-includes/configuration/integrations/javascript.mdx
@@ -13,7 +13,7 @@
 | [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
-| [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
+| [`captureConsoleIntegration`](./captureconsole)       |                  |     ✓      |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`debugIntegration`](./debug)                         |                  |            |             |            |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |


### PR DESCRIPTION
Caputure console integration works as error handler sending events to Sentry. 

Marking this integration as "error handler" on this page. 