### PR TITLE
[v9] Encourage using `inheritOrSampleWith` for `tracesSampler` in js

### DIFF
--- a/docs/platforms/javascript/common/configuration/sampling.mdx
+++ b/docs/platforms/javascript/common/configuration/sampling.mdx
@@ -42,8 +42,8 @@ The Sentry SDKs have two configuration options to control the volume of transact
 
 2. Sampling function (<PlatformIdentifier name="traces-sampler" />) which:
    - Samples different transactions at different rates
-   - <PlatformLink to="/configuration/filtering/">Filters</PlatformLink> out some
-     transactions entirely
+   - <PlatformLink to="/configuration/filtering/">Filters</PlatformLink> out
+     some transactions entirely
    - Modifies default [precedence](#precedence) and [inheritance](#inheritance) behavior
 
 By default, none of these options are set, meaning no transactions will be sent to Sentry. You must set either one of the options to start sending transactions.
@@ -98,7 +98,6 @@ There are multiple ways for a transaction to end up with a sampling decision.
 
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 
-1. If a sampling decision is passed to <PlatformIdentifier name="start-transaction" />, that decision will be used, overriding everything else.
 1. If <PlatformIdentifier name="traces-sampler" /> is defined, its decision will be used. It can choose to keep or ignore any parent sampling decision, use the sampling context data to make its own decision, or choose a sample rate for the transaction. We advise against overriding the parent sampling decision because it will break distributed traces)
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined, but there's a parent sampling decision, the parent sampling decision will be used.
 1. If <PlatformIdentifier name="traces-sampler" /> is not defined and there's no parent sampling decision, <PlatformIdentifier name="traces-sample-rate" /> will be used.

--- a/platform-includes/performance/sampling-function-intro/javascript.mdx
+++ b/platform-includes/performance/sampling-function-intro/javascript.mdx
@@ -3,3 +3,4 @@ To use the sampling function, set the <PlatformIdentifier name="traces-sampler" 
 <PlatformContent includePath="performance/traces-sampler-as-sampler" />
 
 For convenience, the function can also return a boolean. Returning `true` is equivalent to returning `1`, and will guarantee the transaction will be sent to Sentry. Returning `false` is equivalent to returning `0` and will guarantee the transaction will **not** be sent to Sentry.
+Note that sampling decisions will be inherited for downstream services if you have set up distributed tracing.

--- a/platform-includes/performance/traces-sampler-as-sampler/javascript.mdx
+++ b/platform-includes/performance/traces-sampler-as-sampler/javascript.mdx
@@ -5,8 +5,10 @@ interface SamplingContext {
   name: string;
   // Initial attributes of the span
   attributes: SpanAttributes | undefined;
-  // If the parent span was sampled - undefined if there is no parent span
+  // If the parent span was sampled - undefined if there is no incoming trace
   parentSampled: boolean | undefined;
+  // Sample rate that is coming from the incoming trace - undefined if there is no incoming trace
+  parentSampleRate: number | undefined;
 }
 
 Sentry.init({
@@ -15,7 +17,6 @@ Sentry.init({
   tracesSampler: ({ name, attributes, parentSampled }) => {
     // Do not sample health checks ever
     if (name.includes("healthcheck")) {
-      // Drop this completely by setting its sample rate to 0%
       return 0;
     }
 
@@ -29,9 +30,11 @@ Sentry.init({
       return 0.01;
     }
 
-    // Continue trace decision, if there is any parentSampled information
-    if (typeof parentSampled === "boolean") {
-      return parentSampled;
+    // Inherit the samle rate of the incoming trace if there is one. Sampling is deterministic
+    // for one entire trace, i.e. if the parent was sampled, we will be sampled too at the same
+    // rate.
+    if (typeof parentSampleRate === "number") {
+      return parentSampleRate;
     }
 
     // Else, use default sample rate
@@ -39,3 +42,12 @@ Sentry.init({
   },
 });
 ```
+
+<Alert title="parentSampleRate">
+
+The `parentSampleRate` sampling context was introduced in version 9 of the SDK.
+To inherit sampling decisions in earlier versions of the SDK, us the `parentSampled` sampling context.
+
+Going forward, using `parentSampleRate` is strongly encouraged over using `parentSampled`, because it allows for deterministic sampling and metric extrapolation for downstream traces.
+
+</Alert>

--- a/platform-includes/performance/traces-sampler-as-sampler/javascript.mdx
+++ b/platform-includes/performance/traces-sampler-as-sampler/javascript.mdx
@@ -14,7 +14,7 @@ interface SamplingContext {
 Sentry.init({
   // ...
 
-  tracesSampler: ({ name, attributes, parentSampled }) => {
+  tracesSampler: ({ name, attributes, inheritOrSampleWith }) => {
     // Do not sample health checks ever
     if (name.includes("healthcheck")) {
       return 0;
@@ -30,24 +30,17 @@ Sentry.init({
       return 0.01;
     }
 
-    // Inherit the samle rate of the incoming trace if there is one. Sampling is deterministic
-    // for one entire trace, i.e. if the parent was sampled, we will be sampled too at the same
-    // rate.
-    if (typeof parentSampleRate === "number") {
-      return parentSampleRate;
-    }
-
-    // Else, use default sample rate
-    return 0.5;
+    // Otherwise, inherit the sample sampling decision of the incoming trace, or use a fallback sampling rate.
+    return inheritOrSampleWith(0.5);
   },
 });
 ```
 
 <Alert title="parentSampleRate">
 
-The `parentSampleRate` sampling context was introduced in version 9 of the SDK.
-To inherit sampling decisions in earlier versions of the SDK, us the `parentSampled` sampling context.
+The `inheritOrSampleWith` sampling context utility was introduced in version 9 of the SDK.
+To inherit sampling decisions in earlier versions of the SDK, use the `parentSampled` sampling context.
 
-Going forward, using `parentSampleRate` is strongly encouraged over using `parentSampled`, because it allows for deterministic sampling and metric extrapolation for downstream traces.
+Going forward, using `inheritOrSampleWith()` is strongly encouraged over using `parentSampled`, because it allows for deterministic sampling and metric extrapolation for downstream traces.
 
 </Alert>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Swaps over to documenting `inheritOrSampleWith` over parentSampled as migration guide for v9. Wasn't done with a versioned docs page because it was too annoying.

Resolves https://github.com/getsentry/sentry-javascript/issues/15124

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+
