### PR TITLE
fix: More precise home page platform search

### DIFF
--- a/src/components/platformFilter/client.tsx
+++ b/src/components/platformFilter/client.tsx
@@ -3,7 +3,7 @@ import {useMemo, useState} from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import {TriangleRightIcon} from '@radix-ui/react-icons';
 import classNames from 'classnames';
-import {matchSorter} from 'match-sorter';
+import {matchSorter, rankings} from 'match-sorter';
 import Link from 'next/link';
 
 import {type Platform} from 'sentry-docs/types';
@@ -63,7 +63,10 @@ export function PlatformFilterClient({platforms}: {platforms: Platform[]}) {
     }
     // any of these fields can be used to match the search value
     const keys = ['title', 'aliases', 'name', 'sdk', 'keywords'];
-    const matches_ = matchSorter(platformsAndGuides, filter, {keys});
+    const matches_ = matchSorter(platformsAndGuides, filter, {
+      keys,
+      threshold: rankings.CONTAINS,
+    });
     return matches_;
   }, [filter, platformsAndGuides]);
 


### PR DESCRIPTION
makes the platform filter less fuzzy resulting in more relevant matches

## Before
![image](https://github.com/user-attachments/assets/daf42e9d-a84c-4775-abc7-080176dd61c1)
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/80a9a7d1-8982-4fd2-a9af-831dc1cdaceb" />


## After
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/d6f33867-949d-45d3-934c-1c555596233c" />
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/98a3b0b6-7f16-4940-a896-471ad3c9c4f2" />
