### PR TITLE
chore(bitbucket): add note to issue management feature

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/bitbucket/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/bitbucket/index.mdx
@@ -148,6 +148,12 @@ For more details, see the full documentation on [commit tracking and releases](/
 
 ### Issue Management
 
+<Note>
+
+This feature is only supported on legacy Bitbucket instances. See [Bitbucket Support](https://support.atlassian.com/bitbucket-cloud/docs/use-the-issue-tracker/) for more details.
+
+</Note>
+
 Issue tracking allows you to create Bitbucket issues from within Sentry, and link Sentry issues to existing Bitbucket Issues.
 
 Once you’ve navigated to a specific issue, you’ll find the **Linked Issues** section on the right hand panel. Here, you’ll be able to create or link Bitbucket issues.

--- a/docs/organization/integrations/source-code-mgmt/bitbucket/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/bitbucket/index.mdx
@@ -148,11 +148,11 @@ For more details, see the full documentation on [commit tracking and releases](/
 
 ### Issue Management
 
-<Note>
+<Alert>
 
 This feature is only supported on legacy Bitbucket instances. See [Bitbucket Support](https://support.atlassian.com/bitbucket-cloud/docs/use-the-issue-tracker/) for more details.
 
-</Note>
+</Alert>
 
 Issue tracking allows you to create Bitbucket issues from within Sentry, and link Sentry issues to existing Bitbucket Issues.
 


### PR DESCRIPTION
added note to [this section](https://docs.sentry.io/organization/integrations/source-code-mgmt/bitbucket/#issue-management) on Bitbucket's issue management feature

<img width="748" alt="Screenshot 2025-02-03 at 10 51 42 AM" src="https://github.com/user-attachments/assets/0eff7bf3-fbd6-4fa5-8369-3b3283a2fc49" />

