### PR TITLE
docs(insights): remove ai overview page docs

### DIFF
--- a/docs/product/insights/ai/index.mdx
+++ b/docs/product/insights/ai/index.mdx
@@ -6,7 +6,7 @@ description: "Learn how to use Sentry's AI Performance tool to get insights into
 
 <Include name="feature-limited-on-team-retention.mdx" />
 
-Sentry's AI Performance page allows you to dive into LLM Monitoring and get insights into critical LLM metrics, like token usage, to monitor and fix issues with AI pipelines. In addition to having a dedicated space to monitor AI performance, you can also look at Sentry's Insights tab to monitor backend, mobile, and frontend performance.
+Sentry's AI Performance allows you to see critical metrics for your LLM pipelines, like token usage and duration. In addition to having a dedicated space to monitor AI performance, you can also look view Sentry's Frontend, Backend, and Mobile Insights to understand the performance of the applications running your pipelines.
 
 ## Learn More
 

--- a/docs/product/insights/ai/index.mdx
+++ b/docs/product/insights/ai/index.mdx
@@ -6,9 +6,7 @@ description: "Learn how to use Sentry's AI Performance tool to get insights into
 
 <Include name="feature-limited-on-team-retention.mdx" />
 
-Sentry's [**AI Performance**](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/) page gives you an overview of the health of your application. You'll be able to see things like **Transactions Per Minute**, **p50** and **p75 Duration**, and so on.
-
-You can also dive deeper into LLM Monitoring and get insights into critical LLM metrics, like token usage, to monitor and fix issues with AI pipelines. In addition to having a dedicated space to monitor AI performance, you can also look at Sentry's Insights tab to monitor backend, mobile, and frontend performance.
+Sentry's AI Performance page allows you a dive into LLM Monitoring and get insights into critical LLM metrics, like token usage, to monitor and fix issues with AI pipelines. In addition to having a dedicated space to monitor AI performance, you can also look at Sentry's Insights tab to monitor backend, mobile, and frontend performance.
 
 ## Learn More
 

--- a/docs/product/insights/ai/index.mdx
+++ b/docs/product/insights/ai/index.mdx
@@ -6,7 +6,7 @@ description: "Learn how to use Sentry's AI Performance tool to get insights into
 
 <Include name="feature-limited-on-team-retention.mdx" />
 
-Sentry's AI Performance page allows you a dive into LLM Monitoring and get insights into critical LLM metrics, like token usage, to monitor and fix issues with AI pipelines. In addition to having a dedicated space to monitor AI performance, you can also look at Sentry's Insights tab to monitor backend, mobile, and frontend performance.
+Sentry's AI Performance page allows you to dive into LLM Monitoring and get insights into critical LLM metrics, like token usage, to monitor and fix issues with AI pipelines. In addition to having a dedicated space to monitor AI performance, you can also look at Sentry's Insights tab to monitor backend, mobile, and frontend performance.
 
 ## Learn More
 

--- a/includes/performance-moving.mdx
+++ b/includes/performance-moving.mdx
@@ -1,5 +1,5 @@
 <Alert>
 
-To make it easier to see what's relevant for you, Sentry's Performance landing page is now being split into separate <a href="/product/insights/frontend/" target="_blank">Frontend</a>,  <a href="/product/insights/backend/" target="_blank">Backend</a>, and <a href="/product/insights/mobile/" target="_blank">Mobile</a>
+To make it easier to see what's relevant for you, Sentry's Performance landing page is now being split into separate <a href="/product/insights/frontend/" target="_blank">Frontend</a>, <a href="/product/insights/backend/" target="_blank">Backend</a>, and <a href="/product/insights/mobile/" target="_blank">Mobile</a> performance pages. They can all be found in the **Insights** tab.
 
 </Alert>

--- a/includes/performance-moving.mdx
+++ b/includes/performance-moving.mdx
@@ -1,6 +1,5 @@
 <Alert>
 
-To make it easier to see what's relevant for you, Sentry's Performance landing page is now being split into separate <a href="/product/insights/frontend/" target="_blank">Frontend</a>,  <a href="/product/insights/backend/" target="_blank">Backend</a>, <a href="/product/insights/mobile/" target="_blank">Mobile</a>, and
- <a href="/product/insights/ai/" target="_blank">AI</a> performance pages. They can all be found in the **Insights** tab.
+To make it easier to see what's relevant for you, Sentry's Performance landing page is now being split into separate <a href="/product/insights/frontend/" target="_blank">Frontend</a>,  <a href="/product/insights/backend/" target="_blank">Backend</a>, and <a href="/product/insights/mobile/" target="_blank">Mobile</a>
 
 </Alert>


### PR DESCRIPTION
work for https://github.com/getsentry/sentry/issues/81492

The ai overview page is going away for now, so we should remove any references to it.