### PR TITLE
ref(js): Remove `enableTracing` mentions

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/tracing/instrumentation/automatic-instrumentation.mdx
@@ -4,7 +4,7 @@ description: "Learn what transactions are captured after tracing is enabled."
 sidebar_order: 10
 ---
 
-When performance is enabled through `tracesSampleRate`, `enableTracing` or a `tracesSampler` function, the Sentry SDK will automatically capture spans for incoming requests, and HTTP requests made with:
+When performance is enabled through `tracesSampleRate` or a `tracesSampler` function, the Sentry SDK will automatically capture spans for incoming requests, and HTTP requests made with:
 
 - `http`
 - `https`

--- a/docs/platforms/javascript/guides/ember/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/guides/ember/tracing/instrumentation/automatic-instrumentation.mdx
@@ -6,4 +6,4 @@ notSupported:
   - javascript.cordova
 ---
 
-Performance data is automatically captured if you specify a `tracesSampleRate`, `tracesSampler` or `enableTracing` configuration option.
+Performance data is automatically captured if you specify a `tracesSampleRate` or `tracesSampler` configuration option.

--- a/docs/platforms/javascript/guides/gcp-functions/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/tracing/instrumentation/automatic-instrumentation.mdx
@@ -4,7 +4,7 @@ description: "Learn what transactions are captured after tracing is enabled."
 sidebar_order: 10
 ---
 
-When performance is enabled through `tracesSampleRate`, `enableTracing` or a `tracesSampler` function, the Sentry SDK will automatically capture spans for incoming, and outgoing HTTP requests.
+When performance is enabled through `tracesSampleRate` or a `tracesSampler` function, the Sentry SDK will automatically capture spans for incoming, and outgoing HTTP requests.
 
 Database instrumentation can be manually enabled by adding the corresponding integration to the `integrations` array in the `init` method. The following packages are supported:
 

--- a/includes/node-automatic-instrumentation.mdx
+++ b/includes/node-automatic-instrumentation.mdx
@@ -1,4 +1,4 @@
-When performance is enabled through `tracesSampleRate`, `enableTracing` or a `tracesSampler` function, the Sentry SDK will automatically capture spans for the following:
+When performance is enabled through `tracesSampleRate` or a `tracesSampler` function, the Sentry SDK will automatically capture spans for the following:
 
 - Incoming requests
 - Outgoing HTTP requests


### PR DESCRIPTION
Removing remaining mentions of this deprecated/removed options for JS.