### PR TITLE
chore: Bump platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^1.6.6",
     "parse-numeric-range": "^1.3.0",
-    "platformicons": "^7.0.5",
+    "platformicons": "^8.0.0",
     "prism-sentry": "^1.0.2",
     "query-string": "^6.13.1",
     "react": "rc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10360,10 +10360,10 @@ pkg-types@^1.2.1:
     mlly "^1.7.2"
     pathe "^1.1.2"
 
-platformicons@^7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-7.0.5.tgz#bb8686f4b125a4049b7a6078994047a5e8aa0e58"
-  integrity sha512-QaNzLWD0CA6O61kDufTbdOunTwjQSB9sNbo2v+OZ/LFQJKivnrWvgY1AiPjmQ4FT5OOrQK1Y2jDnBt6ECAlPsw==
+platformicons@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.0.tgz#36fea256b6ac2f32f792a18529116efa8ffc3a67"
+  integrity sha512-mY8YP3DzL8x2PRwFV61Lrc1HM/g9ZiQqThPjde/hMgqV8jnKAwZpCYVpg/9O6j2uYgokBIeaYrZMDArX3ok+lA==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
This PR bumps the platformicons dependency to version [8.0.0](https://www.npmjs.com/package/platformicons/v/8.0.0), based on the changes introduced in the [PR](https://github.com/getsentry/platformicons/pull/198).
