### PR TITLE
ref: Remove TS enums in favor of type constant strings

### DIFF
--- a/src/components/platformCategorySection.tsx
+++ b/src/components/platformCategorySection.tsx
@@ -1,19 +1,19 @@
 import {getCurrentPlatformOrGuide} from 'sentry-docs/docTree';
 import {serverContext} from 'sentry-docs/serverContext';
-import {Platform, PlatformGuide} from 'sentry-docs/types';
+import {Platform, PlatformCategory, PlatformGuide} from 'sentry-docs/types';
 
 type Props = {
   children?: React.ReactNode;
   noGuides?: boolean;
-  notSupported?: string[];
+  notSupported?: PlatformCategory[];
   platform?: string;
-  supported?: string[];
+  supported?: PlatformCategory[];
 };
 
 const isSupported = (
   platformOrGuide: Platform | PlatformGuide,
-  supported: string[],
-  notSupported: string[]
+  supported: PlatformCategory[],
+  notSupported: PlatformCategory[]
 ): boolean => {
   if (platformOrGuide.categories === null) {
     return false;

--- a/src/types/platform.tsx
+++ b/src/types/platform.tsx
@@ -138,30 +138,18 @@ export interface PlatformConfig {
 }
 
 /**
- * @see PlatformConfig.caseStyle
+ * The case style of a platform defines the casing used for sentry SDK
+ * functions / keywords. For example `before-send` would become `BeforeSend`
+ * if the caseStyle is configured as PascalCase.
  */
-export enum PlatformCaseStyle {
-  CANONICAL = 'canonical',
-  CAMEL_CASE = 'camelCase',
-  PASCAL_CASE = 'PascalCase',
-  SNAKE_CASE = 'snake_case',
-}
+export type PlatformCaseStyle = 'canonical' | 'camelCase' | 'PascalCase' | 'snake_case';
 
 /**
- * @see PlatformConfig.supportLevel
+ * Is this a first-party or third-party SDK?
  */
-export enum PlatformSupportLevel {
-  PRODUCTION = 'production',
-  COMMUNITY = 'community',
-}
+export type PlatformSupportLevel = 'production' | 'community';
 
 /**
- * @see PlatformConfig.categories
+ * Possible types of categories.
  */
-export enum PlatformCategory {
-  BROWSER = 'browser',
-  DESKTOP = 'desktop',
-  MOBILE = 'mobile',
-  SERVER = 'server',
-  SERVERLESS = 'serverless',
-}
+export type PlatformCategory = 'browser' | 'desktop' | 'mobile' | 'server' | 'serverless';


### PR DESCRIPTION
Let's see if this breaks somehow, but I can't see anything in the code that would actually use the enums directly 🤔 