### PR TITLE
fix(js): Remove `critical` as breadcrumb log level

### DIFF
--- a/docs/platforms/javascript/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/breadcrumbs/index.mdx
@@ -27,7 +27,7 @@ Manually record a breadcrumb:
 
 The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which many SDKs will set automatically for you), and `data`, which is the place to put any additional information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
 
-You can choose from the following breadcrumb log levels: `"fatal"`, `"critical"`, `"error"`, `"warning"`, `"log"`, `"info"`, and `"debug"`.
+You can choose from the following breadcrumb log levels: `"fatal"`, `"error"`, `"warning"`, `"log"`, `"info"`, and `"debug"`.
 
 ## Automatic Breadcrumbs
 


### PR DESCRIPTION
This log level does not actually exist there.

Fixes https://github.com/getsentry/sentry-javascript/issues/15293

