### PR TITLE
fix(.NET): Removed `enable-tracing` from options

### DIFF
--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -290,10 +290,6 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 ## Tracing Options
 
-<ConfigKey name="enable-tracing">
-
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
-
 </ConfigKey>
 
 <ConfigKey name="traces-sample-rate">

--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -290,8 +290,6 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 ## Tracing Options
 
-</ConfigKey>
-
 <ConfigKey name="traces-sample-rate">
 
 A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or <PlatformIdentifier name="traces-sampler" /> must be defined to enable tracing.

--- a/docs/platforms/powershell/configuration/options.mdx
+++ b/docs/platforms/powershell/configuration/options.mdx
@@ -164,12 +164,6 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 ## Tracing Options
 
-<ConfigKey name="enable-tracing">
-
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
-
-</ConfigKey>
-
 <ConfigKey name="traces-sample-rate">
 
 A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or <PlatformIdentifier name="traces-sampler" /> must be defined to enable tracing.

--- a/docs/platforms/unity/configuration/options.mdx
+++ b/docs/platforms/unity/configuration/options.mdx
@@ -264,12 +264,6 @@ Controls how many seconds to wait before shutting down. Sentry SDKs send events 
 
 ## Tracing Options
 
-<ConfigKey name="enable-tracing">
-
-A boolean value, if true, transactions and trace data will be generated and captured. This will set the `traces-sample-rate` to the recommended default of 1.0 if `traces-sample-rate` is not defined. Note that `traces-sample-rate` and `traces-sampler` take precedence over this option.
-
-</ConfigKey>
-
 <ConfigKey name="traces-sample-rate">
 
 A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app. Either this or <PlatformIdentifier name="traces-sampler" /> must be defined to enable tracing.


### PR DESCRIPTION
The .NET SDK removed the option `enable tracing` [here](https://github.com/getsentry/sentry-dotnet/pull/3569) that has been part of the `5.0.0` release.
