### PR TITLE
fix(cloudflare): Use correct setup snippets for Hydrogen

### DIFF
--- a/docs/platforms/javascript/guides/cloudflare/frameworks/remix.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/remix.mdx
@@ -5,6 +5,8 @@ description: "Learn how to add Cloudflare instrumentation to your Remix app."
 
 If you're running your Remix app on Cloudflare Pages, you can use the Sentry Remix SDK in combination with the Sentry Cloudflare SDK to add Sentry instrumentation.
 
+## 1. Installing Sentry Remix SDK
+
 First, install the Sentry Remix SDK in your application. We recommend using the Sentry wizard to automatically install the SDK:
 
 ```bash
@@ -12,6 +14,8 @@ npx @sentry/wizard@latest -i remix
 ```
 
 If the setup through the wizard doesn't work for you, you can also [set up the Remix SDK manually](/platforms/javascript/guides/remix/manual-setup/).
+
+## 2. Installing Sentry Cloudflare SDK
 
 After installing the Sentry Remix SDK, delete the newly generated `instrumentation.server.mjs` file. This instrumentation is not needed when using the Cloudflare SDK.
 

--- a/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
+++ b/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
@@ -5,6 +5,8 @@ description: "Learn how to use the Sentry Remix SDK to instrument your Shopify H
 
 If you're using the Shopify Hydrogen framework, you can use the Sentry Remix SDK to add Sentry instrumentation to your app.
 
+## 1. Installing Sentry Remix SDK
+
 First, install the Sentry Remix SDK in your application. We recommend using the Sentry wizard to automatically install the SDK:
 
 ```bash
@@ -13,11 +15,24 @@ npx @sentry/wizard@latest -i remix
 
 If the wizard doesn't work for you, you can also [set up the Remix SDK manually](/platforms/javascript/guides/remix/manual-setup/).
 
+## 2. Installing Sentry Cloudflare SDK
+
 After installing the Sentry Remix SDK, delete the newly generated `instrumentation.server.mjs` file and all newly generated code from `entry.server.tsx`. This instrumentation is not needed because you are going to use the Sentry Cloudflare SDK for server-side instrumentation.
 
 Now you can install the Sentry Cloudflare SDK. First, install the SDK with your package manager:
 
-<PlatformContent includePath="getting-started-install" />
+```bash {tabTitle:npm}
+npm install @sentry/cloudflare --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/cloudflare
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/cloudflare
+```
+
 
 Then update your `server.ts` file to use the `wrapRequestHandler` method:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes the Cloudflare setup page in Remix. As the page is inside the platform "Remix" it showed the Remix wizard setup in the `PlatformContent`.

issue mentioned in a comment: https://github.com/getsentry/sentry-javascript/issues/5610#issuecomment-2637594290

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
