### PR TITLE
fix(rust): fix strange formatting of Cargo.toml in Rust index page

### DIFF
--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -68,6 +68,10 @@
     svg {
       display: inline;
     }
+
+    > :global(.table) {
+      display: inline;
+    }
   }
 
   :global(.highlight-line) {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Right now the Rust index page shows up like this
<img width="750" alt="Screenshot 2025-02-07 at 12 23 43" src="https://github.com/user-attachments/assets/e0aa7acc-e92e-4427-b0a9-4f2286dd2992" />

The reason is that the `table` class is applied to `[dependencies]`, and that class has `display: table`.
This fixes that.

<img width="750" alt="Screenshot 2025-02-07 at 12 25 22" src="https://github.com/user-attachments/assets/2e33558b-3024-45c9-bbe6-2df6c011bf48" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+
