### PR TITLE
fix(go): fix wrong redirect and typo in Go fiber docs

### DIFF
--- a/docs/platforms/go/guides/fiber/index.mdx
+++ b/docs/platforms/go/guides/fiber/index.mdx
@@ -3,11 +3,9 @@ title: Fiber
 description: "Learn how to add Sentry instrumentation to programs using the Fiber package."
 ---
 
-package.
-
 The Sentry Go SDK repository has a [complete
 example](https://github.com/getsentry/sentry-go/tree/master/_examples/fiber)
-of how to set up Sentry for a Fiber app. 
+of how to set up Sentry for a Fiber app.
 
 For additional reference, see the [`sentryfiber` API
 documentation](https://godoc.org/github.com/getsentry/sentry-go/fiber).
@@ -19,8 +17,6 @@ go get github.com/getsentry/sentry-go/fiber
 ```
 
 <Break />
-
-<SignInNote />
 
 ```go
 import (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3243,10 +3243,6 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/organization/authentication/two-factor-authentication/',
   },
   {
-    from: '/platforms/go/guides/fiber/',
-    to: '/platforms/go/',
-  },
-  {
     from: '/platforms/go/guides/fiber/user-feedback/configuration/',
     to: '/platforms/go/user-feedback/',
   },


### PR DESCRIPTION
## DESCRIBE YOUR PR
https://docs.sentry.io/platforms/go/fiber currently redirects to https://docs.sentry.io/platforms/go even though there is a dedicated page for Fiber. This fixes that.
Also fixes a typo in the Fiber page

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+