### PR TITLE
ref(java): separate Spring and Spring Boot guides from Java guide

### DIFF
--- a/docs/platforms/java/guides/spring-boot/index.mdx
+++ b/docs/platforms/java/guides/spring-boot/index.mdx
@@ -1,0 +1,39 @@
+---
+title: "Spring Boot"
+description: "Learn how to use Sentry's Spring Boot SDK."
+sdk: sentry.java.spring-boot
+---
+
+<PlatformContent includePath="getting-started-primer" />
+
+On this page, we get you up and running with Sentry's SDK.
+
+Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+
+## Install
+
+Sentry captures data by using an SDK within your application’s runtime.
+
+<PlatformContent includePath="getting-started-install" />
+
+<PlatformContent includePath="getting-started-install/opentelemetry" />
+
+## Configure
+
+<PlatformContent includePath="getting-started-config" />
+
+<PlatformContent includePath="getting-started-config/opentelemetry" />
+
+## Verify
+
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up.
+
+<PlatformContent includePath="getting-started-verify" />
+
+<Alert>
+
+Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
+
+</Alert>
+
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.

--- a/docs/platforms/java/guides/spring/index.mdx
+++ b/docs/platforms/java/guides/spring/index.mdx
@@ -1,0 +1,39 @@
+---
+title: "Spring"
+description: "Learn how to use Sentry's Spring SDK."
+sdk: sentry.java.spring
+---
+
+<PlatformContent includePath="getting-started-primer" />
+
+On this page, we get you up and running with Sentry's SDK.
+
+Don't already have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+
+## Install
+
+Sentry captures data by using an SDK within your application’s runtime.
+
+<PlatformContent includePath="getting-started-install" />
+
+<PlatformContent includePath="getting-started-install/opentelemetry" />
+
+## Configure
+
+<PlatformContent includePath="getting-started-config" />
+
+<PlatformContent includePath="getting-started-config/opentelemetry" />
+
+## Verify
+
+This snippet includes an intentional error, so you can test that everything is working as soon as you set it up.
+
+<PlatformContent includePath="getting-started-verify" />
+
+<Alert>
+
+Learn more about manually capturing an error or message in our <PlatformLink to="/usage/">Usage documentation</PlatformLink>.
+
+</Alert>
+
+To view and resolve the recorded error, log into [sentry.io](https://sentry.io) and select your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.


### PR DESCRIPTION
## DESCRIBE YOUR PR
At the moment, due to the fact that they are merged with the Java guide, the "using a framework" alert shows up in the Spring and Spring Boot guides. This should not happen, as Spring and Spring Boot are frameworks.

<img width="1059" alt="Screenshot 2025-02-07 at 16 01 53" src="https://github.com/user-attachments/assets/832fa238-f8a7-4394-91d8-761f4f88dedb" />

This PR separates Spring and Spring Boot onboarding guides from the Java ones to avoid this.
It also adds subtitles to the pages e.g. "Learn how to use Sentry's Spring Boot SDK".
The content of the guides remains the same.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+