### PR TITLE
chore: Add jsdocs for `PlatformSection` and `PlatformCategorySection`

### DIFF
--- a/src/components/platformCategorySection.tsx
+++ b/src/components/platformCategorySection.tsx
@@ -32,6 +32,19 @@ const isSupported = (
   return true;
 };
 
+/**
+ * Conditionally renders children based on platform categories.
+ * It filters content by checking if the current platform
+ * or guide matches the specified supported/not supported categories.
+ *
+ * @param supported - Array of platform categories that should show this content
+ * @param notSupported - Array of platform categories that should not show this content
+ * @param noGuides - If true, content will not be shown for platform guides
+ * @param children - Content to be conditionally rendered
+ *
+ * For filtering by platform categories,
+ * use PlatformCategorySection instead of PlatformSection.
+ */
 export function PlatformCategorySection({
   supported = [],
   notSupported = [],

--- a/src/components/platformSection.tsx
+++ b/src/components/platformSection.tsx
@@ -37,6 +37,19 @@ const isSupported = (
   return null;
 };
 
+/**
+ * Conditionally renders children based on the current platform or guide.
+ *
+ * @param supported - Array of platform/guide keys that should show this content
+ * @param notSupported - Array of platform/guide keys that should not show this content
+ * @param noGuides - If true, content will not be shown for platform guides
+ * @param children - Content to be conditionally rendered
+ * @param platform - (Optional) Override the current platform
+ *
+ * Note: This component checks against platform and guide keys (e.g. 'python', 'react').
+ * For filtering by platform categories (e.g. 'browser', 'node'),
+ * use PlatformCategorySection instead.
+ */
 export function PlatformSection({
   supported = [],
   notSupported = [],


### PR DESCRIPTION
Decided not to merge it due to logical conflicts (e.g. should category take precedence over name ?) and instead add docs so the user can decide which component (or a combination of both to use).

closes https://github.com/getsentry/sentry-docs/issues/12086