### PR TITLE
chore(debug-files): Mention PE files in the top-level debug files list

### DIFF
--- a/platform-includes/debug-information-files/_default.mdx
+++ b/platform-includes/debug-information-files/_default.mdx
@@ -5,7 +5,7 @@ the following formats:
   tvOS, watchOS, macOS, and visionOS
 - [_ELF symbols_](./file-formats/#executable-and-linkable-format-elf) for Linux and
   Android (NDK)
-- [_PDB files_](./file-formats/#pe-and-pdb) for Windows and .NET
+- [_PE and PDB files_](./file-formats/#pe-and-pdb) for Windows and .NET
 - [_Breakpad symbols_](./file-formats/#breakpad-symbols) for all
   platforms
 - [_WASM files_](./file-formats/#wasm) for WebAssembly


### PR DESCRIPTION
A user did not know we support uploading PE files which costed them some hours of debugging