### PR TITLE
feat(electron): Disable sessions now `autoSessionTracking` has been removed

### DIFF
--- a/docs/platforms/javascript/guides/electron/configuration/integrations/mainprocesssession.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/integrations/mainprocesssession.mdx
@@ -12,16 +12,14 @@ use the <PlatformLink
 to="/configuration/integrations/browserwindowsession">BrowserWindowSession</PlatformLink>
 integration in the renderer processes.
 
-{/* TODO(v9): When electron does a new major, update this since autoSessionTracking got removed */}
-
-Unless `autoSessionTracking` is set to `false`, this integration will be automatically added.
+To disable sending sessions, filter the `MainProcessSession` from the default integrations:
 
 ```javascript
 import * as Sentry from "@sentry/electron/main";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  autoSessionTracking: false,
+  integrations: (defaults) => defaults.filter((i) => i.name !== "MainProcessSession"),
 });
 ```
 

--- a/platform-includes/configuration/auto-session-tracking/javascript.electron.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.electron.mdx
@@ -10,12 +10,13 @@ Due to the nature of `crashed` and `abnormal` exits, these sessions are finished
 
 To receive data on user adoption, such as users crash free rate percentage, and the number of users that have adopted a specific release, set the user on the [`initialScope`](/platforms/javascript/configuration/options/#initial-scope) when initializing the SDK.
 
-{/* TODO(v9): When electron does a new major, update this since autoSessionTracking got removed */}
-
-To disable sending sessions, set the `autoSessionTracking` flag to `false`:
+To disable sending sessions, filter the `MainProcessSession` from the default integrations:
 
 ```javascript
+import * as Sentry from "@sentry/electron/main";
+
 Sentry.init({
-  autoSessionTracking: false, // default: true
+  dsn: "___PUBLIC_DSN___",
+  integrations: (defaults) => defaults.filter((i) => i.name !== "MainProcessSession"),
 });
 ```


### PR DESCRIPTION
When v6 of the Electron SDK is releases, `autoSessionTracking` has been removed so sessions can be disabled by filtering out the session integration.