### PR TITLE
docs(issue-views): Update Issue Views docs to reflect page filter persistence

### DIFF
--- a/docs/product/issues/issue-views/index.mdx
+++ b/docs/product/issues/issue-views/index.mdx
@@ -22,6 +22,7 @@ Here, you'll be able to select a view from one of the recommended options or cre
 1. **Name your view**: Give your view a name that describes the types of issues it will show.
 2. **Set your view's search query**: Choose the search query that will be applied by default when you select this view. Don't forget to hit enter to apply the query!
 3. **Set your view's sort**: Select how you want the issues to be sorted in this view (for example, by date, events, and so on).
+4. **Set your view's project, environment, and time range filters**: Using the filters next to the search bar, select the projects, environments, and time range you want this view to filter by.
 4. **Save your view**: Click on the ellipsis menu within the tab and select **Save Changes**.
 
 <Alert>
@@ -31,15 +32,15 @@ If you had a default custom saved search, it'll be converted to an issue view an
 ## Customizing Your Views
 
 
-### Updating View Queries and Sorting
+### Updating View Parameters
 
-Views are defined by their search query and sort order, but you can safely change the query or sort within your view without changing the persistent query or sort. If you want to input a different query from the one your view was saved with, you'll see an **unsaved changes indicator** (shown below). To update your view with this new query or sort, click the ellipsis menu and select **Save Changes**. To discard them, click **Discard Changes** within the ellipsis menu, or close your Sentry tab without saving.
+Views are defined by their serach query, sort, and project/environment/time range filters. Changing any of these parameters won't automatically persist those changes to your view. If you do want to update your view with new changes, click on the ellipsis menu after applying those changes and select **Save Changes**. You can also hit cmd+s (or ctrl+s on Windows) to save your changes. To discard them, click **Discard Changes** within the ellipsis menu, or close your Sentry tab without saving.
 
 ![Unsaved Changes Indicator](./img/issue_views_unsaved_changes_indicator.png)
 
 ### Reordering Views and Setting a Default View
 
-Your can reorder your view tabs by dragging them to where you want them to be. The first tab will always be your default view and will be what you see when you first open the **Issues** page.
+Your can reorder your view tabs by dragging and dropping them to whichever position you want them to be in. The first tab will always be your default view and will be what you see when you first open the **Issues** page.
 
 
 ### Renaming Views


### PR DESCRIPTION
Updates the Issue Views docs to reflect the fact that page filters now save to views.

This feature is slated to release on Thursday, Feb 13th

(This feature has not been released just yet, and I will not merge these docs changes until it is) 