### PR TITLE
fix: Update default kapa query

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -311,7 +311,7 @@ export function Search({
                   // close search results
                   setInputFocus(false);
                   // open kapa modal
-                  window.Kapa.open({query: `Explain ${query}`, submit: true});
+                  window.Kapa.open({query, submit: true});
                 }
               }}
             >


### PR DESCRIPTION
This pr removes the `Explain ...` prefix when opening kapa ai from search