### PR TITLE
Adding unsupported hot reload

### DIFF
--- a/platform-includes/troubleshooting/dotnet.mdx
+++ b/platform-includes/troubleshooting/dotnet.mdx
@@ -50,3 +50,11 @@ using SentrySession = Sentry.Session;
 ```
 
 Then `SentrySession` can be used instead of `Sentry.Session`.
+
+### VS Hot Reload isn't compatible with static assemblies
+
+Attempting to build a .NET MAUI iOS app will result in an error if you use Visual Studio Hot Reload when developing on Windows with a remote mac:
+
+> The xcframework sentry.bindings.cocoa\5.0.1\lib\net8.0-ios17.0\Sentry.Bindings.Cocoa.resources.zip has an incorrect or unknown format and cannot be processed.
+
+This happens because Hot Reload does not support static iOS libraries or frameworks containing static libraries, as detailed in the [Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/maui/ios/hot-restart?view=net-maui-9.0#limitations).

--- a/platform-includes/troubleshooting/dotnet.mdx
+++ b/platform-includes/troubleshooting/dotnet.mdx
@@ -51,9 +51,9 @@ using SentrySession = Sentry.Session;
 
 Then `SentrySession` can be used instead of `Sentry.Session`.
 
-### VS Hot Restart isn't compatible with static assemblies
+### Visual Studio Hot Restart Incompatibility
 
-Attempting to build a .NET MAUI iOS app will result in an error if you use Visual Studio Hot Restart when developing on Windows with a remote mac:
+Attempting to build a .NET MAUI iOS app will result in an error if you use Visual Studio Hot Restart when developing on Windows with a remote Mac:
 
 > The xcframework sentry.bindings.cocoa\5.0.1\lib\net8.0-ios17.0\Sentry.Bindings.Cocoa.resources.zip has an incorrect or unknown format and cannot be processed.
 

--- a/platform-includes/troubleshooting/dotnet.mdx
+++ b/platform-includes/troubleshooting/dotnet.mdx
@@ -51,10 +51,10 @@ using SentrySession = Sentry.Session;
 
 Then `SentrySession` can be used instead of `Sentry.Session`.
 
-### VS Hot Reload isn't compatible with static assemblies
+### VS Hot Restart isn't compatible with static assemblies
 
-Attempting to build a .NET MAUI iOS app will result in an error if you use Visual Studio Hot Reload when developing on Windows with a remote mac:
+Attempting to build a .NET MAUI iOS app will result in an error if you use Visual Studio Hot Restart when developing on Windows with a remote mac:
 
 > The xcframework sentry.bindings.cocoa\5.0.1\lib\net8.0-ios17.0\Sentry.Bindings.Cocoa.resources.zip has an incorrect or unknown format and cannot be processed.
 
-This happens because Hot Reload does not support static iOS libraries or frameworks containing static libraries, as detailed in the [Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/maui/ios/hot-restart?view=net-maui-9.0#limitations).
+This happens because Hot Restart does not support static iOS libraries or frameworks containing static libraries, as detailed in the [Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/maui/ios/hot-restart?view=net-maui-9.0#limitations).


### PR DESCRIPTION
As concluded in  https://github.com/getsentry/sentry-dotnet/issues/3889 Hot Reload isn't supported with static libraries. Adding a note to the troubleshooting page.

Closes getsentry/sentry-dotnet#3959