### PR TITLE
docs(profiling): Add profile_session_sample_rate docs for python

### DIFF
--- a/docs/platforms/python/profiling/index.mdx
+++ b/docs/platforms/python/profiling/index.mdx
@@ -69,6 +69,8 @@ To get started with continuous profiling, you can start and stop the profiler di
 
 Sampling for continuous profiling is determined only once when the SDK is configured. That sampling decision is used to decide if the profiles will be collected or not for the entirety of the process.
 
+Set `profile_session_sample_rate=1.0` to collect continuous profiles for 100% of profile sessions.
+
 <Alert>
 
 If you previously set `profiles_sample_rate` or `profilers_sampler` to use transaction-based profiling, you must remove those lines of code from your configuration in order to use continuous profiling.
@@ -82,6 +84,8 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     send_default_pii=True,
     traces_sample_rate=1.0,
+
+    # To collect profiles for all profile sessions, set `profile_session_sample_rate` to 1.0.
     profile_session_sample_rate=1.0,
 )
 

--- a/docs/platforms/python/profiling/index.mdx
+++ b/docs/platforms/python/profiling/index.mdx
@@ -59,11 +59,15 @@ Profiling was experimental in SDK versions `1.17.0` and older. Learn how to upgr
 
 <Include name="feature-stage-beta.mdx" />
 
-_(New in version 2.13.0)_
+_(New in version 2.21.0)_
 
 The current profiling implementation stops the profiler automatically after 30 seconds (unless you manually stop it earlier). Naturally, this limitation makes it difficult to get full coverage of your app's execution. We now offer an experimental continuous mode, where profiling data is periodically uploaded while running, with no limit on how long the profiler may run.
 
 To get started with continuous profiling, you can start and stop the profiler directly with `sentry_sdk.profiler.start_profiler` and `sentry_sdk.profiler.stop_profiler`.
+
+### Sampling
+
+Sampling for continuous profiling is determined only once when the SDK is configured. That sampling decision is used to decide if the profiles will be collected or not for the entirety of the process.
 
 <Alert>
 
@@ -78,6 +82,7 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     send_default_pii=True,
     traces_sample_rate=1.0,
+    profile_session_sample_rate=1.0,
 )
 
 sentry_sdk.profiler.start_profiler()


### PR DESCRIPTION
## DESCRIBE YOUR PR

The newly introduced `profile_session_sample_rate` defaults to `0.0` and needs to be set to use continuous profiling.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): 2025-02-12 (to catch up to the new SDK release)
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
