### PR TITLE
fix: Mark metric envelope items as deprecated

### DIFF
--- a/develop-docs/sdk/data-model/envelope-items.mdx
+++ b/develop-docs/sdk/data-model/envelope-items.mdx
@@ -146,7 +146,7 @@ details.
 
 *None*
 
-### Statsd
+### Statsd (deprecated)
 
 Item type `"statsd"` contains metrics emissions in a superset of the statsd format.
 
@@ -162,7 +162,7 @@ details.
 
 *None*
 
-### Metric Meta
+### Metric Meta (deprecated)
 
 Item type `"metric_meta"` contains per-metric meta data which is persisted alongside
 metrics in the system.


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Mark both statsd and metric meta envelope items as deprecated.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
