### PR TITLE
fix: links

### DIFF
--- a/platform-includes/getting-started-primer/java.spring-boot.mdx
+++ b/platform-includes/getting-started-primer/java.spring-boot.mdx
@@ -1,6 +1,6 @@
 <Alert>
 
-There are two variants of Sentry available for Spring Boot. If you're using our Gradle plugin it will pick the right dependency for you. If you're manually adding the dependency and using Spring Boot 2, use `sentry-spring-boot-starter` ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter)). If you're using Spring Boot 3, use `sentry-spring-boot-starter-jakarta` instead ([GitHub](https://github.com/getsentry/sentry-java/tree/master/sentry-spring-boot-starter-jakarta)).
+There are two variants of Sentry available for Spring Boot. If you're using our Gradle plugin it will pick the right dependency for you. If you're manually adding the dependency and using Spring Boot 2, use `sentry-spring-boot-starter` ([GitHub](https://github.com/getsentry/sentry-java/tree/main/sentry-spring-boot-starter)). If you're using Spring Boot 3, use `sentry-spring-boot-starter-jakarta` instead ([GitHub](https://github.com/getsentry/sentry-java/tree/main/sentry-spring-boot-starter-jakarta)).
 
 Sentry's integration with [Spring Boot](https://spring.io/projects/spring-boot) supports Spring Boot 2.1.0 and above to report unhandled exceptions as well as release and registration of beans. If you're on an older version, use [our legacy integration](/platforms/java/legacy/spring/).
 


### PR DESCRIPTION
The linked GitHub projects contain a "main" instead of "master" branch.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
