### PR TITLE
fix(flags): Fix node platform name in notSupported list

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
@@ -17,7 +17,7 @@ notSupported:
   - javascript.hapi
   - javascript.koa
   - javascript.nestjs
-  - javascript.nodejs
+  - javascript.node
   - javascript.wasm
 ---
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -17,7 +17,7 @@ notSupported:
   - javascript.hapi
   - javascript.koa
   - javascript.nestjs
-  - javascript.nodejs
+  - javascript.node
   - javascript.wasm
 ---
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -17,7 +17,7 @@ notSupported:
   - javascript.hapi
   - javascript.koa
   - javascript.nestjs
-  - javascript.nodejs
+  - javascript.node
   - javascript.wasm
 ---
 

--- a/docs/platforms/javascript/common/configuration/integrations/unleash.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unleash.mdx
@@ -17,7 +17,7 @@ notSupported:
   - javascript.hapi
   - javascript.koa
   - javascript.nestjs
-  - javascript.nodejs
+  - javascript.node
   - javascript.wasm
 ---
 


### PR DESCRIPTION
Docs uses this list to hide integrations from specific platforms. Turns out "nodejs" should be "node". You can check https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/launchdarkly/ to see FFs are showing for node, which is definitely confusing users since we have the browser-only alert.