### PR TITLE
feat(dev-docs): update `maxRequestBodySize` default to `medium`

### DIFF
--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -538,9 +538,9 @@ Ability for the SDK to attach request body to events and triggered during the ex
 User should be able to set a configuration option `maxRequestBodySize` to instruct SDK how big requests bodies should be attached.
 SDK controls what is an actual size in bytes for each option:
 
-- `none` (default)
+- `none`
 - `small` - `1000` bytes
-- `medium` - `10000` bytes
+- `medium` - `10000` bytes (default)
 - `always`
 
 ## Log context


### PR DESCRIPTION
## DESCRIBE YOUR PR
Updating the dev docs, as this option is set to `medium` by default in (almost) all of the SDKs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+