### PR TITLE
ref(android): rename Apollo 2 to mention version and update callout

### DIFF
--- a/docs/platforms/android/integrations/apollo2/index.mdx
+++ b/docs/platforms/android/integrations/apollo2/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Apollo Integration
-sidebar_order: 30
+title: Apollo 2
+caseStyle: camelCase
+supportLevel: production
 sdk: sentry.java.apollo
-description: "Learn how to capture tracing information of the Apollo GraphQL client."
-notSupported:
-  - java.logback
-  - java.log4j2
-  - java.jul
+description: "Learn more about the Sentry Apollo 2 integration for the Android SDK."
+categories:
+  - mobile
 ---
 
 <Alert>
@@ -19,26 +18,14 @@ Sentry Apollo integration provides the `SentryApolloInterceptor`, which creates 
 
 <Alert>
 
-This integration supports Apollo 2.x. For Apollo 3.x use our <PlatformLink to="/tracing/instrumentation/apollo3">Apollo3 integration</PlatformLink>.
+This integration supports Apollo 2.x. For Apollo 3.x use our <PlatformLink to="/integrations/apollo3/">Apollo 3 integration</PlatformLink>. For Apollo 4.x use our <PlatformLink to="/integrations/apollo4/">Apollo 4 integration</PlatformLink>.
 
 </Alert>
 
 ## Install
 
-```xml {tabTitle:Maven}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-apollo</artifactId>
-    <version>{{@inject packages.version('sentry.java.apollo', '5.2.0') }}</version>
-</dependency>
-```
-
 ```groovy {tabTitle:Gradle}
 implementation 'io.sentry:sentry-apollo:{{@inject packages.version('sentry.java.apollo', '5.2.0') }}'
-```
-
-```scala {tabTitle: SBT}
-libraryDependencies += "io.sentry" % "sentry-apollo" % "{{@inject packages.version('sentry.java.apollo', '5.2.0') }}"
 ```
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-apollo).
@@ -65,45 +52,6 @@ val apollo = ApolloClient.builder()
     .serverUrl("https://your-api-host/")
     .addApplicationInterceptor(SentryApolloInterceptor())
     .build()
-```
-
-Apollo Android is built with Kotlin coroutines. This means that `SentryApolloInterceptor` can be used with Java using only Global Hub Mode (single Hub used by all threads), with Kotlin using single Hub mode, or with <PlatformLink to="/enriching-events/scopes/#kotlin-coroutines">Sentry's coroutines support</PlatformLink>.
-
-## Using With Java
-
-Configure Global Hub Mode:
-
-```java
-import io.sentry.Sentry;
-
-Sentry.init(options -> {
-  ..
-}, true)
-```
-
-<Alert>
-
-In Global Hub Mode, all threads use the same Hub.
-
-</Alert>
-
-## Using With Kotlin Coroutines
-
-To make sure that a coroutine has access to the correct Sentry context, an instance of `SentryContext` must be provided when launching a coroutine.
-
-```kotlin
-import io.sentry.kotlin.SentryContext
-import com.apollographql.apollo.exception.ApolloException
-import kotlinx.coroutines.launch
-
-launch(SentryContext()) {
-  val response = try {
-    apollo.query(..).toDeferred().await()
-  } catch (e: ApolloException) {
-    // handle protocol errors
-    return@launch
-  }
-}
 ```
 
 ## Modify or Drop Spans

--- a/docs/platforms/java/common/tracing/instrumentation/apollo2.mdx
+++ b/docs/platforms/java/common/tracing/instrumentation/apollo2.mdx
@@ -1,11 +1,12 @@
 ---
-title: Apollo
-caseStyle: camelCase
-supportLevel: production
+title: Apollo 2 Integration
+sidebar_order: 30
 sdk: sentry.java.apollo
-description: "Learn more about the Sentry Apollo integration for the Android SDK."
-categories:
-  - mobile
+description: "Learn how to capture tracing information of the Apollo GraphQL client."
+notSupported:
+  - java.logback
+  - java.log4j2
+  - java.jul
 ---
 
 <Alert>
@@ -18,14 +19,26 @@ Sentry Apollo integration provides the `SentryApolloInterceptor`, which creates 
 
 <Alert>
 
-This integration supports Apollo 2.x. For Apollo 3.x use our <PlatformLink to="/integrations/apollo3/">Apollo3 integration</PlatformLink>.
+This integration supports Apollo 2.x. For Apollo 3.x use our <PlatformLink to="/tracing/instrumentation/apollo3">Apollo 3 integration</PlatformLink>. For Apollo 4.x use our <PlatformLink to="/tracing/instrumentation/apollo4">Apollo 4 integration</PlatformLink>.
 
 </Alert>
 
 ## Install
 
+```xml {tabTitle:Maven}
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-apollo</artifactId>
+    <version>{{@inject packages.version('sentry.java.apollo', '5.2.0') }}</version>
+</dependency>
+```
+
 ```groovy {tabTitle:Gradle}
 implementation 'io.sentry:sentry-apollo:{{@inject packages.version('sentry.java.apollo', '5.2.0') }}'
+```
+
+```scala {tabTitle: SBT}
+libraryDependencies += "io.sentry" % "sentry-apollo" % "{{@inject packages.version('sentry.java.apollo', '5.2.0') }}"
 ```
 
 For other dependency managers, see the [central Maven repository](https://search.maven.org/artifact/io.sentry/sentry-apollo).
@@ -52,6 +65,45 @@ val apollo = ApolloClient.builder()
     .serverUrl("https://your-api-host/")
     .addApplicationInterceptor(SentryApolloInterceptor())
     .build()
+```
+
+Apollo Android is built with Kotlin coroutines. This means that `SentryApolloInterceptor` can be used with Java using only Global Hub Mode (single Hub used by all threads), with Kotlin using single Hub mode, or with <PlatformLink to="/enriching-events/scopes/#kotlin-coroutines">Sentry's coroutines support</PlatformLink>.
+
+## Using With Java
+
+Configure Global Hub Mode:
+
+```java
+import io.sentry.Sentry;
+
+Sentry.init(options -> {
+  ..
+}, true)
+```
+
+<Alert>
+
+In Global Hub Mode, all threads use the same Hub.
+
+</Alert>
+
+## Using With Kotlin Coroutines
+
+To make sure that a coroutine has access to the correct Sentry context, an instance of `SentryContext` must be provided when launching a coroutine.
+
+```kotlin
+import io.sentry.kotlin.SentryContext
+import com.apollographql.apollo.exception.ApolloException
+import kotlinx.coroutines.launch
+
+launch(SentryContext()) {
+  val response = try {
+    apollo.query(..).toDeferred().await()
+  } catch (e: ApolloException) {
+    // handle protocol errors
+    return@launch
+  }
+}
 ```
 
 ## Modify or Drop Spans


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Updates "Apollo" to be renamed to "Apollo 2" to avoid confusion as we already have "Apollo 3" and soon we will have "Apollo 4".
Also updates the callout about the versions to point to the upcoming "Apollo 4" docs pages.
Comes after https://github.com/getsentry/sentry-docs/pull/12729 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+