### PR TITLE
ref(android): rename Apollo3 to 'Apollo 3' and update callout

### DIFF
--- a/docs/platforms/android/integrations/apollo3/index.mdx
+++ b/docs/platforms/android/integrations/apollo3/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: Apollo3
+title: Apollo 3
 caseStyle: camelCase
 supportLevel: production
 sdk: sentry.java.apollo-3
-description: "Learn more about the Sentry Apollo3 integration for the Android SDK."
+description: "Learn more about the Sentry Apollo 3 integration for the Android SDK."
 categories:
   - mobile
 ---
@@ -14,17 +14,15 @@ To be able to capture transactions, you'll need to first <PlatformLink to="/trac
 
 </Alert>
 
-Sentry's Apollo3 integration provides both the `SentryApollo3Interceptor` and the `SentryApollo3HttpInterceptor`, which create a span for each outgoing HTTP request executed with an [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin) GraphQL client. The integration also provides extension functions on the `ApolloClient.Builder`.
+Sentry's Apollo 3 integration provides both the `SentryApollo3Interceptor` and the `SentryApollo3HttpInterceptor`, which create a span for each outgoing HTTP request executed with an [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin) GraphQL client. The integration also provides extension functions on the `ApolloClient.Builder`.
 
 <Alert>
 
-This integration supports Apollo 3.x. It does not yet support <Link to="https://github.com/apollographql/apollo-kotlin/releases/tag/v4.0.0">Apollo4</Link>. If you're using Apollo4 and are interested in an integration for it, please track and upvote the <Link to="https://github.com/getsentry/sentry-java/issues/3662">related issue</Link>.
+This integration supports Apollo 3.x. For Apollo 4.x use our <PlatformLink to="/integrations/apollo4/">Apollo 4 integration</PlatformLink>.
 
 </Alert>
 
 ## Install
-
-To install Apollo3:
 
 ```groovy {tabTitle:Gradle}
 implementation 'io.sentry:sentry-apollo-3:{{@inject packages.version('sentry.java.apollo-3', '6.1.4') }}'

--- a/docs/platforms/java/common/tracing/instrumentation/apollo3.mdx
+++ b/docs/platforms/java/common/tracing/instrumentation/apollo3.mdx
@@ -1,5 +1,5 @@
 ---
-title: Apollo3 Integration
+title: Apollo 3 Integration
 sidebar_order: 31
 sdk: sentry.java.apollo-3
 description: "Learn how to capture tracing information of the Apollo GraphQL client."
@@ -15,17 +15,17 @@ To be able to capture transactions, you'll need to first <PlatformLink to="/trac
 
 </Alert>
 
-Sentry's Apollo3 integration provides both the `SentryApollo3Interceptor` and the `SentryApollo3HttpInterceptor`, which create a span for each outgoing HTTP request executed with an [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin) GraphQL client. The integration also provides extension functions on the `ApolloClient.Builder`.
+Sentry's Apollo 3 integration provides both the `SentryApollo3Interceptor` and the `SentryApollo3HttpInterceptor`, which create a span for each outgoing HTTP request executed with an [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin) GraphQL client. The integration also provides extension functions on the `ApolloClient.Builder`.
 
 <Alert>
 
-This integration supports Apollo 3.x. It does not yet support <Link to="https://github.com/apollographql/apollo-kotlin/releases/tag/v4.0.0">Apollo4</Link>. If you're using Apollo4 and are interested in an integration for it, please track and upvote the <Link to="https://github.com/getsentry/sentry-java/issues/3662">related issue</Link>.
+This integration supports Apollo 3.x. For Apollo 4.x use our <PlatformLink to="/tracing/instrumentation/apollo4">Apollo 4 integration</PlatformLink>.
 
 </Alert>
 
 ## Install
 
-To install Apollo3:
+Install the Apollo 3 integration:
 
 ```xml {tabTitle:Maven}
 <dependency>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Updates "Apollo3" to be renamed to "Apollo 3" and its install paragraph for consistency.
Also updates the callout about the versions to point to the upcoming "Apollo 4" docs pages.
Comes after https://github.com/getsentry/sentry-docs/pull/12729 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+