### PR TITLE
feat(apple): add troubleshooting for Cocoapods user script sandbox setup

### DIFF
--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -15,3 +15,5 @@ end
 ```
 
 Afterwards run `pod install`.
+
+In case you are using Xcode 14 or later, you might have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See [Troubleshooting](/platforms/apple/common/troubleshooting) for more information.

--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -16,4 +16,4 @@ end
 
 Afterwards run `pod install`.
 
-In case you are using Xcode 14 or later, you might have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See [Troubleshooting](/platforms/apple/common/troubleshooting) for more information.
+In case you are using Xcode 14 or later, you might have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See <PlatformLink to="/troubleshooting#sandbox-error-using-cocoapods">Troubleshooting</PlatformLink> for more information.

--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -16,4 +16,4 @@ end
 
 Afterwards run `pod install`.
 
-In case you are using Xcode 14 or later, your project might fail to build due to `error: Sandbox: rsync.samba(42924)`. To resolve this you have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See <PlatformLink to="/troubleshooting#sandbox-error-using-cocoapods">Troubleshooting</PlatformLink> for more information.
+If you're using Xcode 14 or later, your project might fail to build due to `error: Sandbox: rsync.samba(42924)`. To resolve this you have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See <PlatformLink to="/troubleshooting#sandbox-error-using-cocoapods">Troubleshooting</PlatformLink> for more information.

--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -16,4 +16,4 @@ end
 
 Afterwards run `pod install`.
 
-In case you are using Xcode 14 or later, you might have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See <PlatformLink to="/troubleshooting#sandbox-error-using-cocoapods">Troubleshooting</PlatformLink> for more information.
+In case you are using Xcode 14 or later, your project might fail to build due to `error: Sandbox: rsync.samba(42924)`. To resolve this you have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See <PlatformLink to="/troubleshooting#sandbox-error-using-cocoapods">Troubleshooting</PlatformLink> for more information.

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -158,7 +158,7 @@ If the release health page shows fewer events in the unhandled tab, your events 
 
 We introduced a bug with a refactoring [#4101](https://github.com/getsentry/sentry-cocoa/pull/4101) released in 8.30.1, that caused unhandled/crash events to have the unhandled property and mach info missing, which is required for release health to show events in the unhandled tab. It's essential to mention that this bug doesn't impact release health statistics, such as crash-free session or user rates.
 
-## Sandbox error using Cocoapods
+## Sandbox Error Using Cocoapods
 
 After setting up Cocoapods using a `Podfile` and running `pod install` to set up the project, you might see the following error when building the target:
 

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -179,4 +179,4 @@ total size is 4950281  speedup is 328.36
 rsync error: some files could not be transferred (code 23) at /AppleInternal/Library/BuildRoots/5bb93434-bef0-11ef-bef2-d285688f7a47/Library/Caches/com.apple.xbs/Sources/rsync/rsync/main.c(996) [sender=2.6.9]
 ```
 
-While it seems to be related to Sentry, it is actually cause by the user script sandbox feature introduced in [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes), which is enabled by default. In order to fix this, you need to head to the target settings of your project and set the "Enable User Script Sandbox" option to `NO`.
+While it seems to be related to Sentry, it is actually caused by the user script sandbox feature introduced in [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes), which is enabled by default. In order to fix this, you need to head to the target settings of your project and set the "Enable User Script Sandbox" option to `NO`.

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -109,6 +109,7 @@ SentrySDK.start { options in
     options.swizzleClassNameExcludes = ["RoomPlanWrapper"]
 }
 ```
+
 ```objc {tabTitle:Objective-C}
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
      options.swizzleClassNameExcludes = [NSSet setWithObjects: @"RoomPlanWrapper", nil];
@@ -156,3 +157,26 @@ say it is due to a bug in Xcode 15.4. They recommend sticking to Xcode 15.3 unti
 If the release health page shows fewer events in the unhandled tab, your events miss the unhandled property or mach info; please update the Cocoa SDK to version 8.33.0 or above or stay on version 8.30.0.
 
 We introduced a bug with a refactoring [#4101](https://github.com/getsentry/sentry-cocoa/pull/4101) released in 8.30.1, that caused unhandled/crash events to have the unhandled property and mach info missing, which is required for release health to show events in the unhandled tab. It's essential to mention that this bug doesn't impact release health statistics, such as crash-free session or user rates.
+
+## Sandbox error using Cocoapods
+
+After setting up Cocoapods using a `Podfile` and running `pod install` to set up the project, you might see the following error when building the target:
+
+```
+error: Sandbox: rsync.samba(42924) deny(1) file-read-data <path/to/your/app>/Frameworks/Sentry.framework/Sentry.bundle (in target 'test' from project 'test')
+error: Sandbox: rsync.samba(42925) deny(1) file-read-data <path/to/your/app>/Frameworks/Sentry.framework/_CodeSignature/CodeResources (in target 'test' from project 'test')
+error: Sandbox: rsync.samba(42925) deny(1) file-write-create <path/to/your/app>/Frameworks/Sentry.framework/_CodeSignature/.CodeResources.a2sA9v (in target 'test' from project 'test')
+mkdir -p <path/to/your/app>/Frameworks
+rsync --delete -av --filter P .*.?????? --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "<path/to/derived/data>/Sentry/Sentry.framework" "<path/to/your/app>/Frameworks"
+building file list ... done
+rsync: opendir "<path/to/your/app>/Frameworks/Sentry.framework/Sentry.bundle" failed: Operation not permitted (1)
+IO error encountered -- skipping file deletion
+Sentry.framework/_CodeSignature/CodeResources
+rsync: mkstemp "<path/to/your/app>/Frameworks/Sentry.framework/_CodeSignature/.CodeResources.a2sA9v" failed: Operation not permitted (1)
+
+sent 15034 bytes  received 42 bytes  30152.00 bytes/sec
+total size is 4950281  speedup is 328.36
+rsync error: some files could not be transferred (code 23) at /AppleInternal/Library/BuildRoots/5bb93434-bef0-11ef-bef2-d285688f7a47/Library/Caches/com.apple.xbs/Sources/rsync/rsync/main.c(996) [sender=2.6.9]
+```
+
+While it seems to be related to Sentry, it is actually cause by the user script sandbox feature introduced in [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes), which is enabled by default. In order to fix this, you need to head to the target settings of your project and set the "Enable User Script Sandbox" option to `NO`.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a note to the getting started page in to disable user script sandboxing when using Cocoapods, with details on the issue in the troubleshooting guide.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
