### PR TITLE
ref(flags): remove is_enabled note from unleash and statsig python docs

### DIFF
--- a/docs/platforms/python/integrations/statsig/index.mdx
+++ b/docs/platforms/python/integrations/statsig/index.mdx
@@ -38,7 +38,7 @@ For more information on how to use Statsig, read Statsig's [Python reference](ht
 
 Test the integration by evaluating a feature flag using your Statsig SDK before capturing an exception.
 
-```python {tabTitle: Python, using is_enabled}
+```python
 import sentry_sdk
 from statsig.statsig_user import StatsigUser
 from statsig import statsig

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -38,7 +38,7 @@ For more information on how to use Unleash, read Unleash's [Python reference](ht
 
 Test the integration by evaluating a feature flag using your Unleash SDK before capturing an exception.
 
-```python {tabTitle: Python, using is_enabled}
+```python
 import sentry_sdk
 from UnleashClient import UnleashClient
 


### PR DESCRIPTION
This should be mentioned explicitly in the doc for [unleash](https://docs.sentry.io/platforms/python/integrations/unleash/), not in the tab title. For statsig, this is wrong/irrelevant (accidental copy-paste)

<img width="211" alt="Screenshot 2025-02-17 at 10 38 13 PM" src="https://github.com/user-attachments/assets/61c44b0c-2fb0-4053-bd3c-ee7a7b0b461e" />
