### PR TITLE
Create and use includes for quick start prerequisites and Next.js Turbopack warning

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -14,12 +14,7 @@ Check out the other SDKs we support in the left-hand dropdown.
 
 <PlatformSection supported={["javascript", "javascript.angular", "javascript.nextjs", "javascript.remix", "javascript.sveltekit", "javascript.bun", "javascript.ember", "javascript.angular", "javascript.deno","javascript.nuxt", "javascript.react", "javascript.solid", "javascript.svelte", "javascript.vue"]}>
 
-## Prerequisites
-
-You need:
-
-- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
-- Your application up and running
+<PlatformContent includePath="getting-started-prerequisites" />
 
 </PlatformSection>
 

--- a/includes/nextjs-turbopack-warning-expandable.mdx
+++ b/includes/nextjs-turbopack-warning-expandable.mdx
@@ -1,0 +1,7 @@
+<Expandable level="warning" title="Are you developing with Turbopack?">
+
+The Sentry SDK doesn't fully support `next dev --turbo` as Turbopack is still under development. This means that the Sentry SDK will not capture any data from your frontend. Other than that, your dev server should be fully operational.
+
+Check the latest information on [Sentry's support for Turbopack on GitHub](https://github.com/getsentry/sentry-javascript/issues/8105).
+
+</Expandable>

--- a/platform-includes/getting-started-prerequisites/_default.mdx
+++ b/platform-includes/getting-started-prerequisites/_default.mdx
@@ -1,0 +1,6 @@
+## Prerequisites
+
+You need:
+
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running

--- a/platform-includes/getting-started-verify/javascript.nextjs.mdx
+++ b/platform-includes/getting-started-verify/javascript.nextjs.mdx
@@ -1,12 +1,6 @@
 ## Step 2: Verify Your Setup
 
-<Expandable level="warning" title="Are you developing with Turbopack?">
-
-The Sentry SDK doesn't fully support `next dev --turbo` as Turbopack is still under development. This means that the Sentry SDK will not capture any data from your frontend. Other than that, your dev server should be fully operational.
-
-Check the latest information on [Sentry's support for Turbopack on GitHub](https://github.com/getsentry/sentry-javascript/issues/8105).
-
-</Expandable>
+<Include name="nextjs-turbopack-warning-expandable.mdx" />
 
 If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page and route created by the installation wizard:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
- Created a new file in `/includes` for Next.js Turbopack warning 
- Created a new folder `/getting-started-prerequisites` in `/platform-includes` and a file containing the "prerequisites" content for quick start guides (only javascript for now)
- replaced content with includes 

Issue: #12700 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
