### PR TITLE
ref(java): add Maven plugin to Java guides

### DIFF
--- a/docs/platforms/java/common/integrations/graphql.mdx
+++ b/docs/platforms/java/common/integrations/graphql.mdx
@@ -34,6 +34,16 @@ plugins {
 implementation 'io.sentry:sentry-graphql:{{@inject packages.version('sentry.java.graphql', '6.28.0') }}'
 ```
 
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
+```
+
 ```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>

--- a/docs/platforms/java/common/integrations/graphql22.mdx
+++ b/docs/platforms/java/common/integrations/graphql22.mdx
@@ -34,6 +34,16 @@ plugins {
 implementation 'io.sentry:sentry-graphql-22:{{@inject packages.version('sentry.java.graphql-22', '8.0.0') }}'
 ```
 
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
+```
+
 ```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>

--- a/docs/platforms/java/common/integrations/quartz.mdx
+++ b/docs/platforms/java/common/integrations/quartz.mdx
@@ -23,6 +23,16 @@ plugins {
 implementation 'io.sentry:sentry-quartz:{{@inject packages.version('sentry.java.quartz', '6.30.0') }}'
 ```
 
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
+```
+
 ```xml {tabTitle:Maven}
 <dependency>
     <groupId>io.sentry</groupId>

--- a/platform-includes/getting-started-install/java.log4j2.mdx
+++ b/platform-includes/getting-started-install/java.log4j2.mdx
@@ -2,12 +2,14 @@
   options={["error-monitoring", "performance", "opentelemetry"]}
 />
 
-```xml {tabTitle:Maven}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-log4j2</artifactId>
-    <version>{{@inject packages.version('sentry.java.log4j2', '4.2.0') }}</version>
-</dependency>
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
 ```
 
 ```groovy {tabTitle:Gradle Plugin}

--- a/platform-includes/getting-started-install/java.logback.mdx
+++ b/platform-includes/getting-started-install/java.logback.mdx
@@ -2,12 +2,14 @@
   options={["error-monitoring", "performance", "opentelemetry"]}
 />
 
-```xml {tabTitle:Maven}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-logback</artifactId>
-    <version>{{@inject packages.version('sentry.java.logback', '4.2.0') }}</version>
-</dependency>
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
 ```
 
 ```groovy {tabTitle:Gradle Plugin}

--- a/platform-includes/getting-started-install/java.mdx
+++ b/platform-includes/getting-started-install/java.mdx
@@ -8,12 +8,14 @@ plugins {
 }
 ```
 
-```xml {tabTitle:Maven}{filename:pom.xml}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry</artifactId>
-    <version>{{@inject packages.version('sentry.java', '4.2.0') }}</version>
-</dependency>
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
 ```
 
 ```scala {tabTitle:SBT}

--- a/platform-includes/getting-started-install/java.spring-boot.mdx
+++ b/platform-includes/getting-started-install/java.spring-boot.mdx
@@ -8,20 +8,14 @@ plugins {
 }
 ```
 
-```xml {tabTitle:Maven (Spring Boot 2)}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-spring-boot-starter</artifactId>
-    <version>{{@inject packages.version('sentry.java.spring-boot', '4.2.0') }}</version>
-</dependency>
-```
-
-```xml {tabTitle:Maven (Spring Boot 3)}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
-    <version>{{@inject packages.version('sentry.java.spring-boot.jakarta', '6.7.0') }}</version>
-</dependency>
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
 ```
 
 ```groovy {tabTitle:Gradle (Spring Boot 2)}

--- a/platform-includes/getting-started-install/java.spring.mdx
+++ b/platform-includes/getting-started-install/java.spring.mdx
@@ -8,20 +8,14 @@ plugins {
 }
 ```
 
-```xml {tabTitle:Maven (Spring 5)}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-spring</artifactId>
-    <version>{{@inject packages.version('sentry.java.spring', '4.2.0') }}</version>
-</dependency>
-```
-
-```xml {tabTitle:Maven (Spring 6)}
-<dependency>
-    <groupId>io.sentry</groupId>
-    <artifactId>sentry-spring-jakarta</artifactId>
-    <version>{{@inject packages.version('sentry.java.spring.jakarta', '6.7.0') }}</version>
-</dependency>
+```xml {tabTitle:Maven Plugin}{filename:pom.xml}
+<plugin>
+  <groupId>io.sentry</groupId>
+  <artifactId>sentry-maven-plugin</artifactId>
+  <version>{{@inject packages.version('sentry.java.maven-plugin', '0.0.2') }}</version>
+  <!-- Required to allow auto-install of Sentry SDK and Integrations -->
+  <extensions>true</extensions>
+</plugin>
 ```
 
 ```groovy {tabTitle:Gradle (Spring 5)}


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adds Maven plugin instructions on some of the Java docs (those where the Gradle plugin is also mentioned)
Closes https://github.com/getsentry/sentry-java/issues/4112

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+