### PR TITLE
ref(flags): use platform specific links for next steps alert

### DIFF
--- a/platform-includes/feature-flags/next-steps/_default.mdx
+++ b/platform-includes/feature-flags/next-steps/_default.mdx
@@ -1,6 +1,6 @@
 <Alert level="warning" title="Next Steps">
 
-- **Track feature flag evaluations in other parts of your codebase.** If needed, you can set up evaluation tracking for more than one SDK. [Read the docs](/product/explore/feature-flags/#set-up-evaluation-tracking) to learn more. 
-- **Set up your change tracking webhook.** In order to take full advantage of the feature flag capabilities Sentry offers there is an additional setup step needed. Your feature flag provider needs to notify Sentry when a feature flag definition has changed. A Sentry webhook URL can be registered with your provider. Learn [how](/product/explore/feature-flags/#set-up-change-tracking).
+- **Track feature flag evaluations in other parts of your codebase.** If needed, you can set up evaluation tracking for more than one SDK. [Read the docs](/product/issues/issue-details/feature-flags/#set-up-evaluation-tracking) to learn more.
+- **Set up your change tracking webhook.** In order to take full advantage of the feature flag capabilities Sentry offers there is an additional setup step needed. Your feature flag provider needs to notify Sentry when a feature flag definition has changed. A Sentry webhook URL can be registered with your provider. Learn [how](/product/issues/issue-details/feature-flags/#set-up-change-tracking).
 
 </Alert>

--- a/platform-includes/feature-flags/next-steps/javascript.mdx
+++ b/platform-includes/feature-flags/next-steps/javascript.mdx
@@ -1,0 +1,6 @@
+<Alert level="warning" title="Next Steps">
+
+- **Track feature flag evaluations in other parts of your codebase.** If needed, you can set up evaluation tracking for more than one SDK. [Read the docs](/platforms/javascript/feature-flags/#enable-evaluation-tracking) to learn more.
+- **Set up your change tracking webhook.** In order to take full advantage of the feature flag capabilities Sentry offers there is an additional setup step needed. Your feature flag provider needs to notify Sentry when a feature flag definition has changed. A Sentry webhook URL can be registered with your provider. Learn [how](/platforms/javascript/feature-flags/#enable-change-tracking).
+
+</Alert>

--- a/platform-includes/feature-flags/next-steps/python.mdx
+++ b/platform-includes/feature-flags/next-steps/python.mdx
@@ -1,0 +1,6 @@
+<Alert level="warning" title="Next Steps">
+
+- **Track feature flag evaluations in other parts of your codebase.** If needed, you can set up evaluation tracking for more than one SDK. [Read the docs](/platforms/python/feature-flags/#enable-evaluation-tracking) to learn more.
+- **Set up your change tracking webhook.** In order to take full advantage of the feature flag capabilities Sentry offers there is an additional setup step needed. Your feature flag provider needs to notify Sentry when a feature flag definition has changed. A Sentry webhook URL can be registered with your provider. Learn [how](/platforms/python/feature-flags/#enable-change-tracking).
+
+</Alert>


### PR DESCRIPTION
<img width="723" alt="Screenshot 2025-02-18 at 10 38 25 AM" src="https://github.com/user-attachments/assets/fa5351f7-6d01-4e7e-930b-d7a6a61ab77f" />

Takes users directly to the FF index page for their platform. 
- [js](https://docs.sentry.io/platforms/javascript/feature-flags/#enable-evaluation-tracking)
- [python](https://docs.sentry.io/platforms/python/feature-flags/#enable-evaluation-tracking)
Right now:
https://docs.sentry.io/product/issues/issue-details/feature-flags/

Also the current links are "half broken" - take you to the right page, but not the section defined by `#`. Think this is cause the [redirect](https://github.com/getsentry/sentry-docs/blob/2de5e4661624350efad0feaafef8136a4b49ea8f/redirects.js#L963-L966)