### PR TITLE
fix(csp): Remove javascript redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1287,10 +1287,6 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/security-legal-pii/security/security-policy-reporting/',
   },
   {
-    from: '/platforms/javascript/security-policy-reporting/',
-    to: '/security-legal-pii/security/security-policy-reporting/',
-  },
-  {
     from: '/platforms/javascript/troubleshooting/session-replay/',
     to: '/platforms/javascript/session-replay/troubleshooting/',
   },


### PR DESCRIPTION
This was resulting in being unable to view these docs for javascript.

Confirmed [/platforms/javascript/security-policy-reporting/](https://sentry-docs-git-mrduncan-fix-javascript-security-redirect.sentry.dev/platforms/javascript/security-policy-reporting/) is now working correctly.