### PR TITLE
doc(unleash): Fix wrong config field key

### DIFF
--- a/platform-includes/configuration/unleash/javascript.ember.mdx
+++ b/platform-includes/configuration/unleash/javascript.ember.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.gatsby.mdx
+++ b/platform-includes/configuration/unleash/javascript.gatsby.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.mdx
+++ b/platform-includes/configuration/unleash/javascript.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.nextjs.mdx
+++ b/platform-includes/configuration/unleash/javascript.nextjs.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.nuxt.mdx
+++ b/platform-includes/configuration/unleash/javascript.nuxt.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.react.mdx
+++ b/platform-includes/configuration/unleash/javascript.react.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.remix.mdx
+++ b/platform-includes/configuration/unleash/javascript.remix.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.solid.mdx
+++ b/platform-includes/configuration/unleash/javascript.solid.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.solidstart.mdx
+++ b/platform-includes/configuration/unleash/javascript.solidstart.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.svelte.mdx
+++ b/platform-includes/configuration/unleash/javascript.svelte.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/unleash/javascript.sveltekit.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({

--- a/platform-includes/configuration/unleash/javascript.vue.mdx
+++ b/platform-includes/configuration/unleash/javascript.vue.mdx
@@ -6,7 +6,7 @@ import { UnleashClient } from 'unleash-proxy-client';
 
 Sentry.init({
   dsn: '___PUBLIC_DSN___',
-  integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+  integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
 });
 
 const unleash = new UnleashClient({


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*
While testing the unleash integration, I noticed that the field described in the doc (`unleashClientClass`) wasn't present in the integration options type, instead it was named `featureFlagClientClass`. For me it was with Nuxt.JS.

I don't know if it's the same for the other frameworks, if yes, tell me and I will update the other files too!

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
