### PR TITLE
ref(flags): restructure generic api and integration docs

### DIFF
--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -30,13 +30,15 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 
 ## Enable Evaluation Tracking
 
-Evaluation tracking requires enabling an SDK integration. Integrations are provider specific. Documentation for supported providers is listed below.
+If you use a third-party SDK to evaluate feature flags, you can enable a Sentry SDK integration to track those evaluations. Integrations are provider specific. Documentation for supported SDKs is listed below.
 
-- [Generic](/platforms/javascript/configuration/integrations/featureflags/)
 - [LaunchDarkly](/platforms/javascript/configuration/integrations/launchdarkly/)
 - [OpenFeature](/platforms/javascript/configuration/integrations/openfeature/)
 - [Statsig](/platforms/javascript/configuration/integrations/statsig/)
 - [Unleash](/platforms/javascript/configuration/integrations/unleash/)
+
+### Generic Integration
+The generic `featureFlagsIntegration` allows you to manually track feature flag evaluations. Read the [documentation](/platforms/javascript/configuration/integrations/featureflags/) to learn more.
 
 ## Enable Change Tracking
 

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -38,6 +38,7 @@ If you use a third-party SDK to evaluate feature flags, you can enable a Sentry 
 - [Unleash](/platforms/javascript/configuration/integrations/unleash/)
 
 ### Generic Integration
+
 The generic `featureFlagsIntegration` allows you to manually track feature flag evaluations. Read the [documentation](/platforms/javascript/configuration/integrations/featureflags/) to learn more.
 
 ## Enable Change Tracking

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -31,6 +31,7 @@ import sentry_sdk
 from sentry_sdk.feature_flags import add_feature_flag
 
 add_feature_flag('test-flag', False)  # Records an evaluation and its result.
+
 sentry_sdk.capture_exception(Exception("Something went wrong!"))`
 ```
 

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -12,9 +12,8 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 
 ## Enable Evaluation Tracking
 
-Evaluation tracking typically requires enabling an SDK integration. Integrations are provider specific. Documentation for supported providers is listed below.
+If you use a third-party SDK to evaluate feature flags, you can enable a Sentry SDK integration to track those evaluations. Integrations are provider specific. Documentation for supported SDKs is listed below.
 
-- [Generic (API)](/platforms/python/feature-flags/#generic-api)
 - [LaunchDarkly](/platforms/python/integrations/launchdarkly/)
 - [OpenFeature](/platforms/python/integrations/openfeature/)
 - [Statsig](/platforms/python/integrations/statsig/)
@@ -28,11 +27,21 @@ users to integrate with proprietary (or otherwise unsupported) feature flagging
 solutions.  **At the moment, we only support boolean flag evaluations.**
 
 ```python
+import sentry_sdk
 from sentry_sdk.feature_flags import add_feature_flag
 
-add_feature_flag('test-flag', False)  # Records an evaluation and its result.
+sentry_sdk.init(
+  dsn="${dsn}",
+  # Add data like request headers and IP for users, if applicable;
+  # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+  send_default_pii=True,
+  integrations=[
+    # your other integrations here
+  ]
+)
 
-sentry_sdk.capture_exception(Exception("Something went wrong!"))
+add_feature_flag('test-flag', False)  # Records an evaluation and its result.
+sentry_sdk.capture_exception(Exception("Something went wrong!"))`
 ```
 
 Go to your Sentry project and confirm that your error event has recorded the feature flag "test-flag" and its value "false".

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -32,7 +32,7 @@ from sentry_sdk.feature_flags import add_feature_flag
 
 add_feature_flag('test-flag', False)  # Records an evaluation and its result.
 
-sentry_sdk.capture_exception(Exception("Something went wrong!"))`
+sentry_sdk.capture_exception(Exception("Something went wrong!"))
 ```
 
 Go to your Sentry project and confirm that your error event has recorded the feature flag "test-flag" and its value "false".

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -30,16 +30,6 @@ solutions.  **At the moment, we only support boolean flag evaluations.**
 import sentry_sdk
 from sentry_sdk.feature_flags import add_feature_flag
 
-sentry_sdk.init(
-  dsn="${dsn}",
-  # Add data like request headers and IP for users, if applicable;
-  # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-  send_default_pii=True,
-  integrations=[
-    # your other integrations here
-  ]
-)
-
 add_feature_flag('test-flag', False)  # Records an evaluation and its result.
 sentry_sdk.capture_exception(Exception("Something went wrong!"))`
 ```

--- a/platform-includes/feature-flags/change-tracking-list/_default.mdx
+++ b/platform-includes/feature-flags/change-tracking-list/_default.mdx
@@ -1,5 +1,5 @@
 Change tracking requires registering a Sentry webhook with a feature flag provider. For set up instructions, visit the documentation for your provider:
-* [Generic](/organization/integrations/feature-flag/generic/#change-tracking)
 * [LaunchDarkly](/organization/integrations/feature-flag/launchdarkly/#change-tracking)
 * [Statsig](/organization/integrations/feature-flag/statsig/#change-tracking)
 * [Unleash](/organization/integrations/feature-flag/unleash/#change-tracking)
+* [Generic](/organization/integrations/feature-flag/generic/#change-tracking)


### PR DESCRIPTION
Restructures both generic eval tracking descriptions at:

https://docs.sentry.io/platforms/python/feature-flags/
| Before    | After |
| -------- | ------- |
| <img width="570" alt="Screenshot 2025-02-18 at 4 13 42 PM" src="https://github.com/user-attachments/assets/5359c61f-ff47-4708-8da2-40f804040eaa" />  | <img width="383" alt="Screenshot 2025-02-18 at 4 15 32 PM" src="https://github.com/user-attachments/assets/1f6171ba-3708-449c-86ed-aac26b5e2326" />   |

https://docs.sentry.io/platforms/javascript/feature-flags/
| Before    | After |
| -------- | ------- |
| <img width="558" alt="Screenshot 2025-02-18 at 4 16 23 PM" src="https://github.com/user-attachments/assets/e694397d-6659-4d8a-bbfa-ab8f1570948e" />  | <img width="380" alt="Screenshot 2025-02-18 at 4 16 38 PM" src="https://github.com/user-attachments/assets/a931b220-9e46-422d-8358-cb6f924680e8" />   |

