### PR TITLE
move content about error capturing to "Capturing Errors and Events" from "Manual Setup" (Next.js)

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -67,12 +67,13 @@ export default withSentryConfig(nextConfig, {
 ```
 
 ### Extend Sentry Webpack Plugin Options
+
 `withSentryConfig` uses a [custom Webpack plugin](https://www.npmjs.com/package/@sentry/webpack-plugin) to manage your sourcemaps and releases under the hood. If `withSentryConfig` does not provide the option you need to modify, you may override the `sentryWebpackPluginOptions` directly via `unstable_sentryWebpackPluginOptions`.
 
 <Alert level="warning">
-  Note that this option is unstable and its API may include breaking changes in any release.
+  Note that this option is unstable and its API may include breaking changes in
+  any release.
 </Alert>
-
 
 ## Create Initialization Config Files
 
@@ -175,7 +176,6 @@ export async function register() {
 }
 ```
 
-
 Make sure that the `import` statements point to your newly created `sentry.server.config.(js|ts)` and `sentry.edge.config.(js|ts)` files.
 
 ## Report React Component Render Errors
@@ -235,53 +235,6 @@ export default function GlobalError({ error }) {
         <NextError />
       </body>
     </html>
-  );
-}
-```
-
-Note that if you create [Next.js error.js files](https://nextjs.org/docs/app/building-your-application/routing/error-handling), these files will take precedence over the `global-error.js` file.
-This means, that if you want to report errors that are caught by `error.js` files, you need to manually capture them:
-
-```tsx {filename:error.tsx}
-"use client";
-
-import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
-
-export default function ErrorPage({
-  error,
-}: {
-  error: Error & { digest?: string };
-}) {
-  useEffect(() => {
-    // Log the error to Sentry
-    Sentry.captureException(error);
-  }, [error]);
-
-  return (
-    <div>
-      <h2>Something went wrong!</h2>
-    </div>
-  );
-}
-```
-
-```jsx {filename:error.jsx}
-"use client";
-
-import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
-
-export default function ErrorPage({ error }) {
-  useEffect(() => {
-    // Log the error to Sentry
-    Sentry.captureException(error);
-  }, [error]);
-
-  return (
-    <div>
-      <h2>Something went wrong!</h2>
-    </div>
   );
 }
 ```

--- a/platform-includes/capture-error/javascript.nextjs.mdx
+++ b/platform-includes/capture-error/javascript.nextjs.mdx
@@ -9,3 +9,53 @@ try {
   Sentry.captureException(err);
 }
 ```
+
+<Expandable type="note" title="Capturing errors in `error.js` files">
+Note that if you create [Next.js `error.js` files](https://nextjs.org/docs/app/building-your-application/routing/error-handling), these files will take precedence over any global error handling.
+This means, that if you want to report errors that are caught by `error.js` files, you need to manually capture them:
+
+```tsx {filename:error.tsx}
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+export default function ErrorPage({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    // Log the error to Sentry
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+    </div>
+  );
+}
+```
+
+```jsx {filename:error.jsx}
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+export default function ErrorPage({ error }) {
+  useEffect(() => {
+    // Log the error to Sentry
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+    </div>
+  );
+}
+```
+
+</Expandable>

--- a/platform-includes/capture-error/javascript.nextjs.mdx
+++ b/platform-includes/capture-error/javascript.nextjs.mdx
@@ -12,7 +12,7 @@ try {
 
 ### Capturing Errors in `error.js` Files
 
-Note that if you create [Next.js `error.js` files](https://nextjs.org/docs/app/building-your-application/routing/error-handling), these files will take precedence over any global error handling.
+Note that if you create [Next.js error.js files](https://nextjs.org/docs/app/building-your-application/routing/error-handling), these files will take precedence over any global error handling.
 This means, that if you want to report errors that are caught by `error.js` files, you need to manually capture them:
 
 ```tsx {filename:error.tsx}

--- a/platform-includes/capture-error/javascript.nextjs.mdx
+++ b/platform-includes/capture-error/javascript.nextjs.mdx
@@ -10,7 +10,8 @@ try {
 }
 ```
 
-<Expandable type="note" title="Capturing errors in `error.js` files">
+### Capturing Errors in `error.js` Files
+
 Note that if you create [Next.js `error.js` files](https://nextjs.org/docs/app/building-your-application/routing/error-handling), these files will take precedence over any global error handling.
 This means, that if you want to report errors that are caught by `error.js` files, you need to manually capture them:
 
@@ -57,5 +58,3 @@ export default function ErrorPage({ error }) {
   );
 }
 ```
-
-</Expandable>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
In the process of reworking the Next.js Manual Setup page, we need to move content to other places.

This PR focuses on the "Capturing Errors" related information from the setup page.

What I did:
- added a "Capturing Errors in `error.js` Files" subsection to Capturing Errors and Events page & moved content from the "Manual Setup" page to it

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
