### PR TITLE
feat(dart & flutter): add data collected page and `sendDefaultPii` to getting started

### DIFF
--- a/docs/platforms/dart/configuration/options.mdx
+++ b/docs/platforms/dart/configuration/options.mdx
@@ -149,6 +149,17 @@ _(New in version 7.0.0)_
 
 </ConfigKey>
 
+<ConfigKey name="max-request-body-size">
+
+This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
+
+- `never`: Request bodies are never sent.
+- `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
+- `medium`: Medium and small requests will be captured (typically 10KB).
+- `always`: The SDK will always capture the request body as long as Sentry can make sense of it.
+
+</ConfigKey>
+
 ## Integration Configuration
 
 For many platform SDKs integrations can be configured alongside it. On some platforms that happen as part of the `init()` call, in some others, different patterns apply.

--- a/docs/platforms/dart/data-management/data-collected.mdx
+++ b/docs/platforms/dart/data-management/data-collected.mdx
@@ -12,7 +12,7 @@ Many of the categories listed here require you to enable the <PlatformLink to="/
 
 ## HTTP Headers
 
-By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/util/HttpUtils.java#L21-L34) in place, which filters out any headers that contain sensitive data.
+By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-dart/blob/ea1d45d64f52551e2e033c50b0ff8512e3d8a4e3/dart/lib/src/utils/http_sanitizer.dart#L9C1-L21C1) in place, which filters out any headers that contain sensitive data.
 
 To start sending HTTP headers, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
 

--- a/docs/platforms/dart/data-management/data-collected.mdx
+++ b/docs/platforms/dart/data-management/data-collected.mdx
@@ -1,0 +1,64 @@
+---
+title: Data Collected
+description: "See what data is collected by the Sentry SDK."
+sidebar_order: 1
+---
+
+Sentry takes data privacy very seriously and has default settings in place that prioritize data safety, especially when it comes to personally identifiable information (PII) data. When you add the Sentry SDK to your application, you allow it to collect data and send it to Sentry during the runtime of your application.
+
+The category types and amount of data collected vary, depending on the integrations you've enabled in the Sentry SDK. This page lists data categories that the Sentry Dart SDK collects.
+
+Many of the categories listed here require you to enable the <PlatformLink to="/configuration/options/#send-default-pii">sendDefaultPii option</PlatformLink>.
+
+## HTTP Headers
+
+By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/util/HttpUtils.java#L21-L34) in place, which filters out any headers that contain sensitive data.
+
+To start sending HTTP headers, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Information About Logged-in User
+
+By default, the Sentry SDK doesn't send any information about the logged-in user, such as email address, user ID, or username. Even if enabled, the type of logged-in user information you'll be able to send depends on the integrations you enable in Sentry's SDK. Most integrations won't send any user information. Some will only set the user ID, but there are a few that will set the user ID, username, and email address.
+
+To start sending logged-in user information, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Users' IP Addresses
+
+By default, the Sentry SDK doesn't send the user's IP address. Once enabled, the Sentry backend services will infer the user ip address based on the incoming request, unless certain integrations you can enable override this behavior.
+
+To enable sending the user's IP address, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Request URL
+
+The full request URL of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
+
+## Request Query String
+
+The full request query string of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
+
+## Request Body
+
+The request body of incoming HTTP requests can be sent to Sentry. Whether it's sent or not, depends on the type and size of request body as described below:
+
+- **The type of the request body:**
+  - JSON and form bodies are sent
+- **The size of the request body:** There's a <PlatformLink to="/configuration/options/#max-request-body-size">maxRequestBodySize</PlatformLink> option that's set to `NONE` by default. This means by default no request body is sent to Sentry.
+
+## File I/O
+
+By default the Sentry SDK does not send the name or path of files when [instrumenting File I/O](/platforms/dart/integrations/file/).
+
+If you want to send file names and paths, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Runtime Information
+
+By default, the SDK collects basic runtime information like the Dart version and platform.
+
+When <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>, additional runtime details are collected:
+- Executable path e.g `dart`
+- Resolved executable locations e.g `/system/bin/app_process64`
+- Script path e.g `file:///main.dart`
+
+## SQL Queries
+
+While SQL queries are sent to Sentry, neither the full SQL query (`UPDATE app_user SET password='supersecret' WHERE id=1;`), nor the values of its parameters will ever be sent. A parameterized version of the query (`UPDATE app_user SET password=? WHERE id=?;`) is sent instead.

--- a/docs/platforms/dart/data-management/data-collected.mdx
+++ b/docs/platforms/dart/data-management/data-collected.mdx
@@ -46,7 +46,7 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
 
 ## File I/O
 
-By default the Sentry SDK does not send the name or path of files when [instrumenting File I/O](/platforms/dart/integrations/file/).
+By default the Sentry SDK does not send the name or path of files when <PlatformLink to="/integrations/file">instrumenting File I/O</PlatformLink>.
 
 If you want to send file names and paths, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
 

--- a/docs/platforms/dart/index.mdx
+++ b/docs/platforms/dart/index.mdx
@@ -53,6 +53,9 @@ Future<void> main() async {
     // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
     // We recommend adjusting this value in production.
     options.tracesSampleRate = 1.0;
+    // Adds request headers and IP for users,
+    // visit: https://docs.sentry.io/platforms/dart/data-management/data-collected/ for more info
+    options.sendDefaultPii = true;
   });
 
   // you can also configure SENTRY_DSN, SENTRY_RELEASE, SENTRY_DIST, and

--- a/docs/platforms/flutter/configuration/options.mdx
+++ b/docs/platforms/flutter/configuration/options.mdx
@@ -190,6 +190,17 @@ _(New in version 7.0.0)_
 
 </ConfigKey>
 
+<ConfigKey name="max-request-body-size">
+
+This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
+
+- `never`: Request bodies are never sent.
+- `small`: Only small request bodies will be captured. The cutoff for small depends on the SDK (typically 4KB).
+- `medium`: Medium and small requests will be captured (typically 10KB).
+- `always`: The SDK will always capture the request body as long as Sentry can make sense of it.
+
+</ConfigKey>
+
 ## Integration Configuration
 
 For many platform SDKs integrations can be configured alongside it. On some platforms that happen as part of the `init()` call, in some others, different patterns apply.

--- a/docs/platforms/flutter/data-management/data-collected.mdx
+++ b/docs/platforms/flutter/data-management/data-collected.mdx
@@ -79,7 +79,7 @@ While SQL queries are sent to Sentry, neither the full SQL query (`UPDATE app_us
 
 By default, the SDK collects basic UI interaction data while protecting sensitive information by excluding text content. This means button clicks and UI interactions are tracked, but without any text or labels that could contain personal or sensitive data.
 
-When <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii=true`</PlatformLink>, the SDK will additionally collect text content from UI elements including:
+When <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>, the SDK will additionally collect text content from UI elements including:
 - Text content from buttons (for example, "Submit" or "Cancel" button labels)
 - Semantic labels that help describe UI elements for accessibility
 - Tooltip messages that appear when hovering over UI elements

--- a/docs/platforms/flutter/data-management/data-collected.mdx
+++ b/docs/platforms/flutter/data-management/data-collected.mdx
@@ -12,7 +12,7 @@ Many of the categories listed here require you to enable the <PlatformLink to="/
 
 ## HTTP Headers
 
-By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/util/HttpUtils.java#L21-L34) in place, which filters out any headers that contain sensitive data.
+By default, the Sentry SDK doesn't send any HTTP headers.
 
 To start sending HTTP headers, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
 
@@ -48,7 +48,7 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
 
 Our build tool plugins `sentry_dart_plugin` can upload your source code to Sentry, which can then used to show the lines of code where an error happened in the Issue Details page.
 
-To opt into sending this source context to Sentry, you have to enable the feature as described in <PlatformLink to="/source-context/">the Source Context documentation</PlatformLink>.
+To opt into sending this source context to Sentry, you have to enable the feature as described in <PlatformLink to="/upload-debug/#source-context">the Source Context documentation</PlatformLink>.
 
 ## File I/O
 

--- a/docs/platforms/flutter/data-management/data-collected.mdx
+++ b/docs/platforms/flutter/data-management/data-collected.mdx
@@ -1,0 +1,92 @@
+---
+title: Data Collected
+description: "See what data is collected by the Sentry SDK."
+sidebar_order: 1
+---
+
+Sentry takes data privacy very seriously and has default settings in place that prioritize data safety, especially when it comes to personally identifiable information (PII) data. When you add the Sentry SDK to your application, you allow it to collect data and send it to Sentry during the runtime of your application.
+
+The category types and amount of data collected vary, depending on the integrations you've enabled in the Sentry SDK. This page lists data categories that the Sentry Flutter SDK collects.
+
+Many of the categories listed here require you to enable the <PlatformLink to="/configuration/options/#send-default-pii">sendDefaultPii option</PlatformLink>.
+
+## HTTP Headers
+
+By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/util/HttpUtils.java#L21-L34) in place, which filters out any headers that contain sensitive data.
+
+To start sending HTTP headers, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Information About Logged-in User
+
+By default, the Sentry SDK doesn't send any information about the logged-in user, such as email address, user ID, or username. Even if enabled, the type of logged-in user information you'll be able to send depends on the integrations you enable in Sentry's SDK. Most integrations won't send any user information. Some will only set the user ID, but there are a few that will set the user ID, username, and email address.
+
+To start sending logged-in user information, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Users' IP Addresses
+
+By default, the Sentry SDK doesn't send the user's IP address. Once enabled, the Sentry backend services will infer the user ip address based on the incoming request, unless certain integrations you can enable override this behavior.
+
+To enable sending the user's IP address, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Request URL
+
+The full request URL of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
+
+## Request Query String
+
+The full request query string of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
+
+## Request Body
+
+The request body of incoming HTTP requests can be sent to Sentry. Whether it's sent or not, depends on the type and size of request body as described below:
+
+- **The type of the request body:**
+  - JSON and form bodies are sent
+- **The size of the request body:** There's a <PlatformLink to="/configuration/options/#max-request-body-size">maxRequestBodySize</PlatformLink> option that's set to `NONE` by default. This means by default no request body is sent to Sentry.
+
+## Source Context
+
+Our build tool plugins `sentry_dart_plugin` can upload your source code to Sentry, which can then used to show the lines of code where an error happened in the Issue Details page.
+
+To opt into sending this source context to Sentry, you have to enable the feature as described in <PlatformLink to="/source-context/">the Source Context documentation</PlatformLink>.
+
+## File I/O
+
+By default the Sentry SDK does not send the name or path of files when [instrumenting File I/O](/platforms/dart/integrations/file/).
+
+If you want to send file names and paths, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Device Information
+
+By default the Sentry SDK does not send the name of the device.
+
+If you want to send the device name, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
+
+## Runtime Information
+
+By default, the SDK collects basic runtime information like the Dart version and platform.
+
+When <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>, additional runtime details are collected:
+- Executable path e.g `flutter`
+- Resolved executable locations e.g `/system/bin/app_process64`
+- Script path e.g `file:///main.dart`
+
+## SQL Queries
+
+While SQL queries are sent to Sentry, neither the full SQL query (`UPDATE app_user SET password='supersecret' WHERE id=1;`), nor the values of its parameters will ever be sent. A parameterized version of the query (`UPDATE app_user SET password=? WHERE id=?;`) is sent instead.
+
+## User Interaction Data
+
+By default, the SDK collects basic UI interaction data while protecting sensitive information by excluding text content. This means button clicks and UI interactions are tracked, but without any text or labels that could contain personal or sensitive data.
+
+When <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii=true`</PlatformLink>, the SDK will additionally collect text content from UI elements including:
+- Text content from buttons (for example, "Submit" or "Cancel" button labels)
+- Semantic labels that help describe UI elements for accessibility
+- Tooltip messages that appear when hovering over UI elements
+- Text labels from icons and other UI components
+
+This additional text content can be useful for debugging and understanding user interactions, but should be enabled with caution if your UI contains sensitive information.
+
+## Session Replay
+
+By default, our Session Replay SDK masks all text content, images, webviews, and user input. This helps ensure that no sensitive data is exposed. You can find <PlatformLink to="/session-replay/#redact-session-replay-via-masking/">more details in the Session Replay documentation</PlatformLink>.

--- a/docs/platforms/flutter/data-management/data-collected.mdx
+++ b/docs/platforms/flutter/data-management/data-collected.mdx
@@ -46,7 +46,7 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
 
 ## Source Context
 
-Our tool [sentry_dart_plugin](https://pub.dev/packages/sentry_dart_plugin) can upload your source code to Sentry, which can then used to show the lines of code where an error happened in the Issue Details page.
+Our tool [sentry_dart_plugin](https://pub.dev/packages/sentry_dart_plugin) can upload your source code to Sentry, which can be used to show the lines of code where an error happened in the Issue Details page.
 
 To opt into sending this source context to Sentry, you have to enable the feature as described in <PlatformLink to="/upload-debug/#source-context">the Source Context documentation</PlatformLink>.
 

--- a/docs/platforms/flutter/data-management/data-collected.mdx
+++ b/docs/platforms/flutter/data-management/data-collected.mdx
@@ -46,7 +46,7 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
 
 ## Source Context
 
-Our build tool plugins `sentry_dart_plugin` can upload your source code to Sentry, which can then used to show the lines of code where an error happened in the Issue Details page.
+Our tool [sentry_dart_plugin](https://pub.dev/packages/sentry_dart_plugin) can upload your source code to Sentry, which can then used to show the lines of code where an error happened in the Issue Details page.
 
 To opt into sending this source context to Sentry, you have to enable the feature as described in <PlatformLink to="/upload-debug/#source-context">the Source Context documentation</PlatformLink>.
 

--- a/docs/platforms/flutter/data-management/data-collected.mdx
+++ b/docs/platforms/flutter/data-management/data-collected.mdx
@@ -12,7 +12,7 @@ Many of the categories listed here require you to enable the <PlatformLink to="/
 
 ## HTTP Headers
 
-By default, the Sentry SDK doesn't send any HTTP headers.
+By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-dart/blob/ea1d45d64f52551e2e033c50b0ff8512e3d8a4e3/dart/lib/src/utils/http_sanitizer.dart#L9C1-L21C1) in place, which filters out any headers that contain sensitive data.
 
 To start sending HTTP headers, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii = true`</PlatformLink>.
 

--- a/docs/platforms/flutter/index.mdx
+++ b/docs/platforms/flutter/index.mdx
@@ -61,6 +61,9 @@ Future<void> main() async {
       // Setting to 1.0 will profile 100% of sampled transactions:
       // Note: Profiling alpha is available for iOS and macOS since SDK version 7.12.0
       options.profilesSampleRate = 1.0;
+      // Adds request headers and IP for users,
+      // visit: https://docs.sentry.io/platforms/flutter/data-management/data-collected/ for more info
+      options.sendDefaultPii = true;
     },
     appRunner: () => runApp(
       SentryWidget(


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Add details about data collection and the `sendDefaultPii` flag to the getting started

closes https://github.com/getsentry/sentry-dart/issues/2692
closes https://github.com/getsentry/sentry-dart/issues/2691

