### PR TITLE
fix(rust): fix logo for actix-web

### DIFF
--- a/src/components/platformIcon.tsx
+++ b/src/components/platformIcon.tsx
@@ -997,7 +997,7 @@ export const PLATFORM_TO_ICON = {
   'ruby-sidekiq': 'sidekiq',
   'ruby-sinatra': 'sinatra',
   rust: 'rust',
-  'rust-actix': 'actix',
+  'rust-actix-web': 'actix',
   scala: 'scala',
   stride3d: 'stride3d',
   sql: 'sql',


### PR DESCRIPTION
## DESCRIBE YOUR PR
Fixes the logo to the correct one for `actix-web`, which was previously showing up with the Rust logo instead because `rust-actix` didn't match the platform name.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+
