### PR TITLE
ref(flags): mention is_enabled method for Unleash eval tracking

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/unleash.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unleash.mdx
@@ -29,7 +29,7 @@ This integration only works inside a browser environment. It is only available f
 
 </Alert>
 
-The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.** This integration is available in Sentry SDK **versions 8.51.0 or higher.**
+The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations from Unleash's isEnabled method.** This integration is available in Sentry SDK **versions 8.51.0 or higher.**
 
 _Import names: `Sentry.unleashIntegration`_
 

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to use Sentry with Unleash."
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory and sent to Sentry for review and analysis if an error occurs. **At the moment, we only support boolean flag evaluations.**
+The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory and sent to Sentry for review and analysis if an error occurs. **At the moment, we only support boolean flag evaluations from Unleash's is_enabled method.**
 
 ## Install
 


### PR DESCRIPTION
Our Unleash implementation patches the `is_enabled`/`isEnabled` method only. Let's mention this method to avoid potential confusion.

`is_enabled` is the main way users evaluate boolean flags, but you could technically use the result of `get_variant` too. We chose not to support the latter which is explained in depth on https://github.com/getsentry/sentry-python/pull/3914

