### PR TITLE
feat(apple): Start the SDK before calling setUser

### DIFF
--- a/platform-includes/enriching-events/set-user/apple.mdx
+++ b/platform-includes/enriching-events/set-user/apple.mdx
@@ -3,6 +3,7 @@ import Sentry
 
 let user = User()
 user.email = "john.doe@example.com"
+// Start the SDK before setting the user, otherwise it will be ignored.
 SentrySDK.setUser(user)
 ```
 
@@ -11,5 +12,6 @@ SentrySDK.setUser(user)
 
 SentryUser *user = [[SentryUser alloc] init];
 user.email = @"john.doe@example.com";
+// Start the SDK before setting the user, otherwise it will be ignored.
 [SentrySDK setUser:user];
 ```


### PR DESCRIPTION


## DESCRIBE YOUR PR

Add a comment to the setUser code snipped to point out users have to start the SDK before.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

