### PR TITLE
feat(Unity): `BeforeCapture` hooks for `ViewHierarchy` and `Screenshots`

### DIFF
--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -208,26 +208,26 @@ Once enabled, this feature automatically captures HTTP client errors, like bad r
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
 
-<ConfigKey name="before-send">
+<ConfigKey name="set-before-send">
 
 This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
-By the time <PlatformIdentifier name="before-send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
+By the time <PlatformIdentifier name="set-before-send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
 </ConfigKey>
 
-<ConfigKey name="before-breadcrumb">
+<ConfigKey name="set-before-breadcrumb">
 
 This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
 
 </ConfigKey>
 
-<ConfigKey name="before-send-transaction">
+<ConfigKey name="set-before-send-transaction">
 
 This function is called with an SDK-specific transaction object, and can return a modified transaction object, or `null` to skip reporting the transaction. This can be used, for instance, for manual PII-stripping before sending.
 
-By the time <PlatformIdentifier name="before-send-transaction" /> is executed, all scope data has already been applied to the event and further modification of the scope won't have any effect.
+By the time <PlatformIdentifier name="set-before-send-transaction" /> is executed, all scope data has already been applied to the event and further modification of the scope won't have any effect.
 
 </ConfigKey>
 

--- a/docs/platforms/unity/configuration/options/index.mdx
+++ b/docs/platforms/unity/configuration/options/index.mdx
@@ -208,18 +208,38 @@ These options can be used to hook the SDK in various ways to customize the repor
 The callbacks you set as hooks will be called on the thread where the event happened. So you can only use
 thread-safe APIs and only use Unity-specific APIs after you've checked that you're on the UI thread.
 
-<ConfigKey name="before-send">
+<ConfigKey name="set-before-send">
 
 This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
-By the time <PlatformIdentifier name="before-send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
+By the time <PlatformIdentifier name="set-before-send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
 </ConfigKey>
 
-<ConfigKey name="before-breadcrumb">
+<ConfigKey name="set-before-breadcrumb">
 
 This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
+
+</ConfigKey>
+
+<ConfigKey name="set-before-send-transaction">
+
+This function is called with an SDK-specific transaction object, and can return a modified transaction object, or `null` to skip reporting the transaction. This can be used, for instance, for manual PII-stripping before sending.
+
+By the time <PlatformIdentifier name="set-before-send-transaction" /> is executed, all scope data has already been applied to the event and further modification of the scope won't have any effect.
+
+</ConfigKey>
+
+<ConfigKey name="set-before-capture-screenshot">
+
+A callback function that controls screenshot capture behavior. Return `false` to prevent a screenshot from being captured for a specific event. This allows for fine-grained control over when screenshots are included with error reports.
+
+</ConfigKey>
+
+<ConfigKey name="set-before-capture-viewhierarchy">
+
+A callback function that controls view hierarchy capture behavior. Return `false` to prevent the view hierarchy from being captured for a specific event. This allows for fine-grained control over when view hierarchies are included with error reports.
 
 </ConfigKey>
 


### PR DESCRIPTION
Added documentation to the new `BeforeCapture` callbacks for `ViewHierarchy` and `Screenshots` added in https://github.com/getsentry/sentry-unity/pull/2023

Also updated the naming of the hooks in the .NET SDK as they changed to `SetBeforeX` in https://github.com/getsentry/sentry-dotnet/pull/2351