### PR TITLE
Add UE Crash Reporter and Sentry Unreal SDK comparison

### DIFF
--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -49,9 +49,9 @@ Sentry SDK can integrate with the UE Crash Reporter, but it also offers addition
 Legend:
 `*`: On Windows, the underlying crash capturing mechanisms used in the Sentry SDK and the UE Crash Reporter are mutually exclusive.
 `**`: On Windows, crash capturing is supported out of the box starting from UE 5.2.
-`***`: Currently this features is supported only on Windows/Linux.
+`***`: Currently this feature is supported only on Windows/Linux.
 
-### Using Sentry SDK and UE Crash Reporter together on Windows
+### Using Sentry SDK and UE Crash Reporter together
 
 Adding event context (e.g., tags, custom breadcrumbs, or user information) can always be done through the unified Sentry SDK interface.  While only one crash-capturing mechanism can be active at a time, both solutions can be used together for context enrichment, helping to improve the debugging process.
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -42,14 +42,14 @@ Sentry SDK can integrate with the UE Crash Reporter, but it also offers addition
 | Additonal event context      | Supported                  | Supported              |
 | Automatic breadcrumbs        | Supported                  | Not supported          |
 | Screenshot attachment        | Supported ***              | Not supported          |
-| Crash events filtering       | Supported ***              | Not supported          |
+| Crash events filtering       | Supported                  | Not supported          |
 | Release health monitoring    | Supported                  | Not supported          |
 | Performance insights         | Supported                  | Not supported          |
 
 Legend:
 `*`: On Windows, the underlying crash capturing mechanisms used in the Sentry SDK and the UE Crash Reporter are mutually exclusive.
 `**`: On Windows, crash capturing is supported out of the box starting from UE 5.2.
-`***`: Currently this feature is supported only on Windows/Linux.
+`***`: Currently this [feature](https://github.com/getsentry/sentry-unreal/issues/567) is supported only on Windows/Linux.
 
 ### Using Sentry SDK and UE Crash Reporter together
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -182,3 +182,32 @@ Check out this community-generated [thread in Sentry's forum](https://forum.sent
 <Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />
+
+## Sentry SDK and UE Crash Reporter feature comparison
+
+Sentry SDK can integrate with the UE Crash Reporter, but it also offers additional features beyond those provided by the built-in tool. The table below outlines the key feature differences:
+
+| Feature                      | Sentry SDK                 | Crash Reporter         |
+|------------------------------|----------------------------|------------------------|
+| Supported engine versions    | All UE 5 and UE 4.27       | Built-in engine tool   |
+| Supported platforms          | Desktop, mobile, consoles  | Desktop                |
+| Crash capturing *            | Supported **               | Supported              |
+| Additonal event context      | Supported                  | Supported              |
+| Automatic breadcrumbs        | Supported                  | Not supported          |
+| Screenshot attachment        | Supported ***              | Not supported          |
+| Crash events filtering       | Supported ***              | Not supported          |
+| Release health monitoring    | Supported                  | Not supported          |
+| Performance insights         | Supported                  | Not supported          |
+
+Legend:
+`*`: On Windows, the underlying crash capturing mechanisms used in the Sentry SDK and the UE Crash Reporter are mutually exclusive.
+`**`: On Windows, crash capturing is supported out of the box starting from UE 5.2.
+`***`: Currently this features is supported only on Windows/Linux.
+
+### Using Sentry SDK and UE Crash Reporter together on Windows
+
+For crash captuirng users must choose between the two options: the built-in crash hadnler or the `sentry-native` library that's integrated into the Sentry SDK. The two mechanisms are mutually exclusive and can't be used simultaneously.
+
+Adding event context (e.g., tags, custom breadcrumbs, or user information) can always be done through the unified Sentry SDK interface.  While only one crash-capturing mechanism can be active at a time, both solutions can be used together for context enrichment, helping to improve the debugging process.
+
+Features like crash events filtering, screenshot attachment and release health monitoring require the Sentry SDK to be enabled for crash capturing to work properly.

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -30,7 +30,34 @@ to the user:
 
 The UE Crash Reporter works if the Sentry SDK is installed. Sentry SDK can help with configuring the UE Crash Reporter, uploading debug symbols, and enriching crash reports with custom data. **Starting from UE 5.2** users have to choose between the two available crash capturing mechanisms - the UE Crash Reporter or the `sentry-native` library that's integrated into the Sentry plugin. By default, the `sentry-native` library is used instead of the UE Crash Reporter. (See "Enable automatic crash capturing (Windows, UE 5.2+)" in the plugin settings.) The two solutions are mutually exclusive and can't be used simultaneously.
 
-### Include the UE Crash Reporter
+## Sentry SDK and UE Crash Reporter feature comparison
+
+Sentry SDK can integrate with the UE Crash Reporter, but it also offers additional features beyond those provided by the built-in tool. The table below outlines the key feature differences:
+
+| Feature                      | Sentry SDK                 | Crash Reporter         |
+|------------------------------|----------------------------|------------------------|
+| Supported engine versions    | All UE 5 and UE 4.27       | Built-in engine tool   |
+| Supported platforms          | Desktop, mobile, consoles  | Desktop                |
+| Crash capturing *            | Supported **               | Supported              |
+| Additonal event context      | Supported                  | Supported              |
+| Automatic breadcrumbs        | Supported                  | Not supported          |
+| Screenshot attachment        | Supported ***              | Not supported          |
+| Crash events filtering       | Supported ***              | Not supported          |
+| Release health monitoring    | Supported                  | Not supported          |
+| Performance insights         | Supported                  | Not supported          |
+
+Legend:
+`*`: On Windows, the underlying crash capturing mechanisms used in the Sentry SDK and the UE Crash Reporter are mutually exclusive.
+`**`: On Windows, crash capturing is supported out of the box starting from UE 5.2.
+`***`: Currently this features is supported only on Windows/Linux.
+
+### Using Sentry SDK and UE Crash Reporter together on Windows
+
+Adding event context (e.g., tags, custom breadcrumbs, or user information) can always be done through the unified Sentry SDK interface.  While only one crash-capturing mechanism can be active at a time, both solutions can be used together for context enrichment, helping to improve the debugging process.
+
+Features like crash events filtering, screenshot attachment and release health monitoring require the Sentry SDK to be enabled for crash capturing to work properly.
+
+## Include the UE Crash Reporter
 
 You can add the _Crash Reporter Client_ to your game in your _Project Settings_.
 
@@ -182,32 +209,3 @@ Check out this community-generated [thread in Sentry's forum](https://forum.sent
 <Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />
-
-## Sentry SDK and UE Crash Reporter feature comparison
-
-Sentry SDK can integrate with the UE Crash Reporter, but it also offers additional features beyond those provided by the built-in tool. The table below outlines the key feature differences:
-
-| Feature                      | Sentry SDK                 | Crash Reporter         |
-|------------------------------|----------------------------|------------------------|
-| Supported engine versions    | All UE 5 and UE 4.27       | Built-in engine tool   |
-| Supported platforms          | Desktop, mobile, consoles  | Desktop                |
-| Crash capturing *            | Supported **               | Supported              |
-| Additonal event context      | Supported                  | Supported              |
-| Automatic breadcrumbs        | Supported                  | Not supported          |
-| Screenshot attachment        | Supported ***              | Not supported          |
-| Crash events filtering       | Supported ***              | Not supported          |
-| Release health monitoring    | Supported                  | Not supported          |
-| Performance insights         | Supported                  | Not supported          |
-
-Legend:
-`*`: On Windows, the underlying crash capturing mechanisms used in the Sentry SDK and the UE Crash Reporter are mutually exclusive.
-`**`: On Windows, crash capturing is supported out of the box starting from UE 5.2.
-`***`: Currently this features is supported only on Windows/Linux.
-
-### Using Sentry SDK and UE Crash Reporter together on Windows
-
-For crash captuirng users must choose between the two options: the built-in crash hadnler or the `sentry-native` library that's integrated into the Sentry SDK. The two mechanisms are mutually exclusive and can't be used simultaneously.
-
-Adding event context (e.g., tags, custom breadcrumbs, or user information) can always be done through the unified Sentry SDK interface.  While only one crash-capturing mechanism can be active at a time, both solutions can be used together for context enrichment, helping to improve the debugging process.
-
-Features like crash events filtering, screenshot attachment and release health monitoring require the Sentry SDK to be enabled for crash capturing to work properly.


### PR DESCRIPTION
This PR adds a side-by-side comparison of the two crash-capturing tools available for Unreal Engine: the default Crash Reporter and Sentry's UE plugin.

Related to https://github.com/getsentry/sentry-unreal/issues/704

Supersedes #12763