### PR TITLE
chore(demo-mode): change sandbox link

### DIFF
--- a/src/components/sandboxLink.tsx
+++ b/src/components/sandboxLink.tsx
@@ -47,7 +47,7 @@ export function getSandboxURL({
   projectSlug?: string;
   scenario?: (typeof scenarios)[number];
 } = {}) {
-  const url = new URL('https://try.sentry-demo.com/demo/start/');
+  const url = new URL('https://sandbox.sentry.io/');
 
   if (scenario) {
     url.searchParams.append('scenario', scenario);


### PR DESCRIPTION
- Part of https://github.com/getsentry/projects/issues/87
- Changes the sandbox link to point to the new sandbox available at: https://sandbox.sentry.io/ 
- Will be merged after the new sandbox is publicly available