### PR TITLE
Only show Browser vs React Native source maps alert for browser sdks

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.mdx
@@ -4,7 +4,7 @@ The easiest way to configure uploading source maps is by using the Sentry Wizard
 
 <Include name="sourcemaps-wizard-instructions.mdx" />
 
-<PlatformSection notSupported={['javascript.node', 'javascript.aws-lambda', 'javascript.azure-functions', 'javascript.connect', 'javascript.express', 'javascript.fastify', 'javascript.gcp-functions', 'javascript.hapi', 'javascript.koa', 'javascript.nestjs']}>
+<PlatformSection supported={['javascript', 'javascript.react']}>
 
 <Alert>
 

--- a/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.mdx
@@ -4,11 +4,15 @@ The easiest way to configure uploading source maps is by using the Sentry Wizard
 
 <Include name="sourcemaps-wizard-instructions.mdx" />
 
+<PlatformSection notSupported={['javascript.node', 'javascript.aws-lambda', 'javascript.azure-functions', 'javascript.connect', 'javascript.express', 'javascript.fastify', 'javascript.gcp-functions', 'javascript.hapi', 'javascript.koa', 'javascript.nestjs']}>
+
 <Alert>
 
 This guide assumes you are using a Browser JavaScript SDK. For instructions on how to set up source maps for React Native, follow the [source maps guide for React Native](/platforms/react-native/sourcemaps/).
 
 </Alert>
+
+</PlatformSection>
 
 If you want to configure source maps upload manually, follow the guide for your bundler or build tool below.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

This alert seems unnecessary for Server-side JS SDKs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
