### PR TITLE
docs(replay): Clarify beforeErrorSampling

### DIFF
--- a/docs/platforms/javascript/common/session-replay/configuration.mdx
+++ b/docs/platforms/javascript/common/session-replay/configuration.mdx
@@ -46,7 +46,7 @@ The following can be configured as integration options in `replayIntegration({})
 | networkRequestHeaders    | `string[]`                          | `[]`        | Additional request headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                                   |
 | networkResponseHeaders   | `string[]`                          | `[]`        | Additional response headers to capture for URLs defined in `networkDetailAllowUrls`. See [Network Details](#network-details) to learn more.                                  |
 | beforeAddRecordingEvent  | <code>(event) => event\|null</code> | `i => i`    | Filter additional recording events that include console logs and network requests/responses.                                                                                 |
-| beforeErrorSampling      | `(event) => boolean`                | `i => true` | Filter error events which should be skipped for error sampling. Return `false` if error sampling should be skipped for this error event, or `true` to sample for this error. |
+| beforeErrorSampling      | `(event) => boolean`                | `i => true` | Filter error events which should be skipped for error sampling. Return `false` if error sampling should be skipped for this error event, or `true` to sample for this error. Will only be called in `buffer` mode. |
 | slowClickIgnoreSelectors | `string[]`                          | `[]`        | Ignore slow/rage click detection on elements matching the given CSS selector(s).                                                                                             |
 
 ## Privacy Configuration

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -199,6 +199,7 @@ replayIntegration({
 
 If you return `false` from this method for a given error, we will not check the error sample rate for this error.
 If you return `true`, we will continue to check the error sample rate as normal.
+Note that this hook only runs in `buffer` mode, as `session` mode records continuously regardless of errors.
 
 ### Connect Replays with Support Software
 


### PR DESCRIPTION
Clarifies that beforeErrorSampling is only triggered in `buffer` mode.

closes https://github.com/getsentry/sentry-javascript/issues/15470