### PR TITLE
ref(replays): add redirect for new replay count api doc

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -730,6 +730,11 @@ const userDocsRedirects = [
     destination: '/api/releases/create-a-new-deploy-for-an-organization/',
   },
   {
+    source: '/api/replays/retrieve-a-count-of-replays/',
+    destination:
+      '/api/replays/retrieve-a-count-of-replays-for-a-given-issue-or-transaction/',
+  },
+  {
     source: '/api/projects/post-project-user-reports/',
     destination: '/api/projects/submit-user-feedback/',
   },


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry/pull/85677

New page live: https://docs.sentry.io/api/replays/retrieve-a-count-of-replays-for-a-given-issue-or-transaction/