### PR TITLE
RN: fixes SAGP Expo plugin default option values

### DIFF
--- a/docs/platforms/react-native/manual-setup/expo/gradle.mdx
+++ b/docs/platforms/react-native/manual-setup/expo/gradle.mdx
@@ -74,7 +74,7 @@ Experimental flag to turn on support for GuardSquare's tools integration (Dexgua
 
 ### uploadNativeSymbols
 
-Disables or enables the automatic configuration of Native Symbols for Sentry. This executes sentry-cli automatically so you don't need to do it manually. Default is disabled.
+Disables or enables the automatic configuration of Native Symbols for Sentry. This executes sentry-cli automatically so you don't need to do it manually. Default is enabled.
 
 ### autoUploadNativeSymbols
 
@@ -82,8 +82,8 @@ Defines whether the plugin should attempt to auto-upload the native debug symbol
 
 ### includeNativeSources
 
-Does or doesn't include the source code of native code for Sentry. This executes sentry-cli with the --include-sources param. automatically so you don't need to do it manually. This option has an effect only when `uploadNativeSymbols` is enabled. Default is disabled.
+Does or doesn't include the source code of native code for Sentry. This executes sentry-cli with the --include-sources param. automatically so you don't need to do it manually. This option has an effect only when `uploadNativeSymbols` is enabled. Default is enabled.
 
 ### includeSourceContext
 
-Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry. This enables source context, allowing you to see your source code as part of your stack traces in Sentry.
+Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry. This enables source context, allowing you to see your source code as part of your stack traces in Sentry. Default is disabled.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

This PR fixes the default values of the Expo Sentry Android Gradle Plugin configuration options [to align with the plugin code](https://github.com/getsentry/sentry-react-native/blob/main/packages/core/plugin/src/withSentryAndroidGradlePlugin.ts#L23).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
