### PR TITLE
docs(flutter): Fix event serverName reset in samples

### DIFF
--- a/platform-includes/configuration/before-send/dart.mdx
+++ b/platform-includes/configuration/before-send/dart.mdx
@@ -1,7 +1,7 @@
 ```dart {3}
 await Sentry.init((options) {
   options.beforeSend = (event, hint) {
-    return event.copyWith(serverName: null); // Don't send server names.
+    return event.copyWith(serverName: ""); // Don't send server names.
   };
 });
 ```

--- a/platform-includes/configuration/before-send/flutter.mdx
+++ b/platform-includes/configuration/before-send/flutter.mdx
@@ -1,7 +1,7 @@
 ```dart {3}
 await SentryFlutter.init((options) {
   options.beforeSend = (event, hint) {
-    return event.copyWith(serverName: null); // Don't send server names.
+    return event.copyWith(serverName: ""); // Don't send server names.
   };
 });
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Fix incorrect documentation on how to remove/reset event values.

Relates to https://github.com/getsentry/sentry-dart/issues/2672

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [[v9]: Not possible to remove information in beforeSend (make SentryEvent and related classes mutable)](https://github.com/getsentry/sentry-dart/issues/2672)
