### PR TITLE
fix(apple): Usages of sendDefaultPii

### DIFF
--- a/docs/platforms/apple/common/data-management/data-collected.mdx
+++ b/docs/platforms/apple/common/data-management/data-collected.mdx
@@ -12,6 +12,11 @@ The category types and amount of data collected vary, depending on the integrati
 
 The <PlatformLink to="/configuration/http-client-errors">HTTP Client Errors</PlatformLink>, which are enabled by default, send the HTTP headers of the failed request and response to Sentry. The SDK uses a [denylist](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Swift/Tools/HTTPHeaderSanitizer.swift) to filter out any headers that contain sensitive data.
 
+## Users' IP Addresses
+
+By default, the Sentry SDK doesn't send the user's IP address. Once enabled, the Sentry backend services will infer the user ip address based on the incoming request, unless certain integrations you can enable override this behavior.
+
+To enable sending the user's IP address, set <PlatformLink to="/configuration/options/#send-default-pii">`sendDefaultPii=true`</PlatformLink>.
 
 ## Request URL
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Document the only usage of sendDefaultPii in the Cocoa SDK. See [Cocoa SDK](https://github.com/search?q=repo%3Agetsentry%2Fsentry-cocoa+sendDefaultPii+&type=code).

Fixes GH-12751

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

