### PR TITLE
fix(insights): Fix broken getting-started link

### DIFF
--- a/docs/product/insights/getting-started.mdx
+++ b/docs/product/insights/getting-started.mdx
@@ -1,0 +1,106 @@
+---
+title: Set Up
+sidebar_order: 1
+description: "Get started with Sentry's Performance Monitoring, which allows you to see macro-level metrics to micro-level spans, cross-reference transactions with related issues, and customize queries."
+---
+
+If you don't already have performance monitoring enabled, use the links for supported SDKs below to quickly set up access to our [Performance Monitoring](/product/performance/) features. Performance Monitoring helps you see everything from macro-level [metrics](/product/performance/metrics/) to micro-level [spans](/concepts/key-terms/tracing/trace-view/#product-walkthrough-trace-view-page), and you'll be able to cross-reference [transactions with related issues](/product/performance/transaction-summary/), customize [queries](/product/explore/discover-queries/query-builder/) based on your personal needs, and substantially more.
+
+## Supported SDKs
+
+- <PlatformLinkWithLogo platform="dotnet" url="/platforms/dotnet/tracing/" />
+
+  - [ASP.NET Core](/platforms/dotnet/guides/aspnetcore/tracing/)
+  - [OpenTelemetry](/platforms/dotnet/tracing/instrumentation/opentelemetry/)
+
+- <PlatformLinkWithLogo platform="go" url="/platforms/go/tracing/" />
+
+  - [Echo](/platforms/go/guides/echo/performance/)
+  - [FastHTTP](/platforms/go/guides/fasthttp/performance/)
+  - [Fiber](/platforms/go/guides/fiber/performance/)
+  - [Gin](/platforms/go/guides/gin/performance/)
+  - [Iris](/platforms/go/guides/iris/performance/)
+  - [Negroni](/platforms/go/guides/negroni/performance/)
+  - [net/http](/platforms/go/guides/http/performance/)
+  - [OpenTelemetry](/platforms/go/performance/instrumentation/opentelemetry/)
+
+- <PlatformLinkWithLogo
+    platform="java"
+    label="Java/Kotlin/JVM"
+    url="/platforms/java/performance/"
+  />
+
+  - [OpenTelemetry](/platforms/java/tracing/instrumentation/opentelemetry/)
+  - [Spring](/platforms/java/guides/spring/tracing/)
+  - [Spring Boot](/platforms/java/guides/spring-boot/tracing/)
+
+- <PlatformLinkWithLogo
+    platform="javascript"
+    label="JavaScript"
+    url="/platforms/javascript/tracing/"
+  />
+
+  - [Angular](/platforms/javascript/guides/angular/tracing/)
+  - [Astro](/platforms/javascript/guides/astro/tracing/)
+  - [AWS Lambda](/platforms/javascript/guides/aws-lambda/tracing/)
+  - [Azure Functions](/platforms/javascript/guides/azure-functions/tracing/)
+  - [Bun](/platforms/javascript/guides/bun/tracing/)
+  - [Connect](/platforms/javascript/guides/connect/tracing/)
+  - [Deno](/platforms/javascript/guides/deno/tracing/)
+  - [Electron](/platforms/javascript/guides/electron/tracing/)
+  - [Ember](/platforms/javascript/guides/ember/tracing/)
+  - [Express](/platforms/javascript/guides/express/tracing/)
+  - [Fastify](/platforms/javascript/guides/fastify/tracing/)
+  - [Gatsby](/platforms/javascript/guides/gatsby/tracing/)
+  - [Google Cloud Functions](/platforms/javascript/guides/gcp-functions/tracing/)
+  - [Hapi](/platforms/javascript/guides/hapi/tracing/)
+  - [Hono](/platforms/javascript/guides/hono/tracing/)
+  - [Koa](/platforms/javascript/guides/koa/tracing/)
+  - [Nest.js](/platforms/javascript/guides/nestjs/tracing/)
+  - [Next.js](/platforms/javascript/guides/nextjs/tracing/)
+  - [Node.js](/platforms/javascript/guides/node/tracing/)
+  - [OpenTelemetry](/platforms/javascript/guides/node/tracing/instrumentation/opentelemetry/)
+  - [React](/platforms/javascript/guides/react/tracing/)
+  - [Remix](/platforms/javascript/guides/remix/tracing/)
+  - [Solid](/platforms/javascript/guides/solid/tracing/)
+  - [Svelte](/platforms/javascript/guides/svelte/tracing/)
+  - [SvelteKit](/platforms/javascript/guides/sveltekit/tracing/)
+  - [Vue](/platforms/javascript/guides/vue/tracing/)
+
+- <PlatformLinkWithLogo platform="android" url="/platforms/android/tracing/" />
+
+- <PlatformLinkWithLogo
+    platform="react-native"
+    url="/platforms/react-native/tracing/"
+  />
+
+- <PlatformLinkWithLogo
+    platform="apple"
+    label="iOS"
+    url="/platforms/apple/guides/ios/tracing/"
+  />
+
+- <PlatformLinkWithLogo platform="flutter" url="/platforms/flutter/tracing/" />
+
+- <PlatformLinkWithLogo platform="native" url="/platforms/native/tracing/" />
+
+- <PlatformLinkWithLogo platform="python" url="/platforms/python/tracing/" />
+
+  - [OpenTelemetry](/platforms/python/tracing/instrumentation/opentelemetry/)
+
+- <PlatformLinkWithLogo platform="php" url="/platforms/php/tracing/" />
+
+  - [Laravel](/platforms/php/guides/laravel/tracing/)
+  - [Symfony](/platforms/php/guides/symfony/tracing/)
+
+- <PlatformLinkWithLogo platform="ruby" url="/platforms/ruby/tracing/" />
+
+  - [DelayedJob](/platforms/ruby/guides/delayed_job/tracing/)
+  - [OpenTelemetry](/platforms/ruby/tracing/instrumentation/opentelemetry/)
+  - [Rails](/platforms/ruby/guides/rails/tracing/)
+  - [Resque](/platforms/ruby/guides/resque/tracing/)
+  - [Sidekiq](/platforms/ruby/guides/sidekiq/tracing/)
+
+- <PlatformLinkWithLogo platform="rust" url="/platforms/rust/tracing/" />
+
+- <PlatformLinkWithLogo platform="unity" url="/platforms/unity/tracing/" />


### PR DESCRIPTION
In a new organization, when I navigate to performance monitoring or the mobile/frontend/backend products within insights, I encounter the following empty state:

![Screenshot 2025-02-27 at 07 35 46](https://github.com/user-attachments/assets/99b08214-ddaa-4ca1-b9cb-f00e175dd1c3)


By clicking on the 'Set Up' button I am redirected to

![image](https://github.com/user-attachments/assets/2e2149e9-6d33-4271-bcf4-02f841aabe66)


This happens because, in the PR, we moved all the performance docs to insights, but the "Getting Started" documentation was [deleted](https://github.com/getsentry/sentry-docs/pull/12720/files#diff-c96d9efe4a56b03fc4212c0a817f04ccb2997fa35b7026d4376f4e6e87df43a6). I attempted to find similar documentation, but we don't have anything available. Therefore, I am restoring it, now under insights, fixing the issue but we'll need to update the copies accordingly cc @DominikB2014 