### PR TITLE
docs(react-router): Update guide for `@sentry/react-router`

### DIFF
--- a/docs/platforms/javascript/guides/react-router/config.yml
+++ b/docs/platforms/javascript/guides/react-router/config.yml
@@ -1,4 +1,4 @@
-title: React Router v7 (framework mode)
+title: React Router Framework
 description: React Router v7 is a framework for building full-stack web apps and websites. Learn how to set it up with Sentry.
 sdk: sentry.javascript.react-router
 categories:

--- a/platform-includes/getting-started-config/javascript.react-router.mdx
+++ b/platform-includes/getting-started-config/javascript.react-router.mdx
@@ -118,43 +118,6 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
 // ... rest of your server entry
 ```
 
-### Build-time Config
-
-Update `vite.config.ts` to include the `sentryReactRouter` plugin and also add your config options to the vite config (this is required for uploading source maps at the end of the build):
-
-```typescript {filename: vite.config.ts}
-import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter } from '@sentry/react-router';
-import { defineConfig } from 'vite';
-
-const sentryConfig = {
-  authToken: '...',
-  org: '...',
-  project: '...',
-  // rest of your config
-};
-
-export default defineConfig(config => {
-  return {
-    plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
-    sentryConfig,
-  };
-});
-```
-
-Include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
-
-```typescript {filename: react-router.config.ts}
-import type { Config } from '@react-router/dev/config';
-import { sentryOnBuildEnd } from '@sentry/react-router';
-
-export default {
-  ssr: true,
-  buildEnd: sentryOnBuildEnd,
-} satisfies Config;
-```
-
-
 ### Update Scripts
 
 Since React Router is running in ESM mode, you need to use the `--import` command line options to load our server-side instrumentation module before the application starts.

--- a/platform-includes/getting-started-config/javascript.react-router.mdx
+++ b/platform-includes/getting-started-config/javascript.react-router.mdx
@@ -11,7 +11,7 @@ npx react-router reveal
 Initialize the Sentry React SDK in your `entry.client.tsx` file:
 
 ```tsx {filename: entry.client.tsx} {"onboardingOptions": {"performance": "9, 12-16", "session-replay": "10, 17-21"}}
-import * as Sentry from "@sentry/react";
+import * as Sentry from "@sentry/react-router";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
@@ -47,7 +47,7 @@ startTransition(() => {
 Now, update your `app/root.tsx` file to report any unhandled errors from your error boundary:
 
 ```tsx {diff} {filename: app/root.tsx}
-import * as Sentry from "@sentry/react";
+import * as Sentry from "@sentry/react-router";
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   let message = "Oops!";
@@ -89,7 +89,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 Create an `instrument.server.mjs` file in the root of your app:
 
 ```js {filename: instrument.server.mjs} {"onboardingOptions": {"performance": "7", "profiling": "2, 6, 8"}}
-import * as Sentry from "@sentry/node";
+import * as Sentry from "@sentry/react-router";
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 
 Sentry.init({
@@ -117,6 +117,43 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
 };
 // ... rest of your server entry
 ```
+
+### Build-time Config
+
+Update your vite.config.ts file to include the `sentryReactRouter` plugin and also add your config options to the vite config (this is required for uploading sourcemaps at the end of the build):
+
+```typescript {filename: vite.config.ts}
+import { reactRouter } from '@react-router/dev/vite';
+import { sentryReactRouter } from '@sentry/react-router';
+import { defineConfig } from 'vite';
+
+const sentryConfig = {
+  authToken: '...',
+  org: '...',
+  project: '...',
+  // rest of your config
+};
+
+export default defineConfig(config => {
+  return {
+    plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
+    sentryConfig,
+  };
+});
+```
+
+Next, in your `react-router.config.ts` file, include the `sentryOnBuildEnd` hook:
+
+```typescript {filename: react-router.config.ts}
+import type { Config } from '@react-router/dev/config';
+import { sentryOnBuildEnd } from '@sentry/react-router';
+
+export default {
+  ssr: true,
+  buildEnd: sentryOnBuildEnd,
+} satisfies Config;
+```
+
 
 ### Update Scripts
 

--- a/platform-includes/getting-started-config/javascript.react-router.mdx
+++ b/platform-includes/getting-started-config/javascript.react-router.mdx
@@ -120,7 +120,7 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
 
 ### Build-time Config
 
-Update your vite.config.ts file to include the `sentryReactRouter` plugin and also add your config options to the vite config (this is required for uploading sourcemaps at the end of the build):
+Update `vite.config.ts` to include the `sentryReactRouter` plugin and also add your config options to the vite config (this is required for uploading source maps at the end of the build):
 
 ```typescript {filename: vite.config.ts}
 import { reactRouter } from '@react-router/dev/vite';

--- a/platform-includes/getting-started-config/javascript.react-router.mdx
+++ b/platform-includes/getting-started-config/javascript.react-router.mdx
@@ -142,7 +142,7 @@ export default defineConfig(config => {
 });
 ```
 
-Next, in your `react-router.config.ts` file, include the `sentryOnBuildEnd` hook:
+Include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
 
 ```typescript {filename: react-router.config.ts}
 import type { Config } from '@react-router/dev/config';

--- a/platform-includes/getting-started-install/javascript.react-router.mdx
+++ b/platform-includes/getting-started-install/javascript.react-router.mdx
@@ -1,34 +1,42 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "session-replay"]}
+  options={[
+    "error-monitoring",
+    "performance",
+    "session-replay",
+    {
+      id: 'profiling',
+      checked: false
+    }
+  ]}
 />
 
 <OnboardingOption optionId="profiling">
 
 ```bash {tabTitle:npm}
-npm install @sentry/react @sentry/node @sentry/profiling-node
+npm install @sentry/react-router @sentry/profiling-node
 ```
 
 ```bash {tabTitle:yarn}
-yarn add @sentry/react @sentry/node @sentry/profiling-node
+yarn add @sentry/react-router @sentry/profiling-node
 ```
 
 ```bash {tabTitle:pnpm}
-pnpm add @sentry/react @sentry/node @sentry/profiling-node
+pnpm add @sentry/react-router @sentry/profiling-node
 ```
 
 </OnboardingOption> 
 
 <OnboardingOption optionId="profiling" hideForThisOption>
   ```bash {tabTitle:npm}
-  npm install @sentry/react @sentry/node
+  npm install @sentry/react-router
   ```
 
   ```bash {tabTitle:yarn}
-  yarn add @sentry/react @sentry/node
+  yarn add @sentry/react-router
   ```
 
   ```bash {tabTitle:pnpm}
-  pnpm add @sentry/react @sentry/node
+  pnpm add @sentry/react-router
   ```
 </OnboardingOption>
 

--- a/platform-includes/getting-started-primer/javascript.react-router.mdx
+++ b/platform-includes/getting-started-primer/javascript.react-router.mdx
@@ -1,12 +1,12 @@
+<Alert title='SDK Limitations' level='warning'>
+
+This SDK is considered **experimental and in an alpha state**. It may experience breaking changes. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/) if you have any feedback or concerns.
+
+</Alert>
+
 <Alert title='Looking for library mode?' level='warning'>
 
 If you are using React Router in library mode, you can follow the instructions in the [React guide here](/platforms/javascript/guides/react/features/react-router/v7).
 
 </Alert>
 
-<Alert title='SDK Limitations' level='warning'>
-
-We do not yet have a dedicated SDK for React Router in framework mode.
-This guide demonstrates how to setup error monitoring and basic performance tracing using the `@sentry/react` and `@sentry/node` packages instead.
-
-</Alert>

--- a/platform-includes/getting-started-primer/javascript.react-router.mdx
+++ b/platform-includes/getting-started-primer/javascript.react-router.mdx
@@ -4,7 +4,7 @@ This SDK is considered **experimental and in an alpha state**. It may experience
 
 </Alert>
 
-<Alert title='Looking for library mode?' level='warning'>
+<Alert title='Looking for library mode?' level='info'>
 
 If you are using React Router in library mode, you can follow the instructions in the [React guide here](/platforms/javascript/guides/react/features/react-router/v7).
 

--- a/platform-includes/getting-started-sourcemaps/javascript.react-router.mdx
+++ b/platform-includes/getting-started-sourcemaps/javascript.react-router.mdx
@@ -28,7 +28,7 @@ export default defineConfig(config => {
 
 Include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
 
-```typescript {filename: react-router.config.ts}
+```typescript {filename: react-router.config.ts} {9}
 import type { Config } from '@react-router/dev/config';
 import { sentryOnBuildEnd } from '@sentry/react-router';
 

--- a/platform-includes/getting-started-sourcemaps/javascript.react-router.mdx
+++ b/platform-includes/getting-started-sourcemaps/javascript.react-router.mdx
@@ -1,9 +1,43 @@
-## Add Readable Stack Traces to Errors
+## Source Maps Upload
 
-By default, React Router will minify your JavaScript and CSS files in production. This makes it difficult to debug errors. To make debugging easier, you can generate source maps and upload them to Sentry.
+Update `vite.config.ts` to include the `sentryReactRouter` plugin and also add your `SentryReactRouterBuildOptions` config options to the vite config (this is required for uploading source maps at the end of the build):
 
-We recommend using [Sentry's Vite plugin](/platforms/javascript/sourcemaps/uploading/vite/) to upload sourcemaps.
+<OrgAuthTokenNote />
 
-Please refer to the <PlatformLink to="/sourcemaps">Source Maps Documentation</PlatformLink>, for more information.
+```typescript {filename: vite.config.ts}
+import { reactRouter } from '@react-router/dev/vite';
+import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
+import { defineConfig } from 'vite';
 
-For more advanced configuration, you can use [`sentry-cli`](https://github.com/getsentry/sentry-cli) directly to upload source maps.
+const sentryConfig: SentryReactRouterBuildOptions = {
+  org: "___ORG_SLUG___",
+  project: "___PROJECT_SLUG___",
+
+  // An auth token is required for uploading source maps.
+  authToken: "___ORG_AUTH_TOKEN___"
+  // ...
+};
+
+export default defineConfig(config => {
+  return {
+    plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
+    sentryConfig,
+  };
+});
+```
+
+Include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
+
+```typescript {filename: react-router.config.ts}
+import type { Config } from '@react-router/dev/config';
+import { sentryOnBuildEnd } from '@sentry/react-router';
+
+export default {
+  ssr: true,
+  buildEnd: ({ viteConfig, reactRouterConfig, buildManifest }) => {
+    // ...
+    // Call this at the end of the hook
+    sentryOnBuildEnd({ viteConfig, reactRouterConfig, buildManifest });
+  },
+} satisfies Config;
+```

--- a/platform-includes/getting-started-sourcemaps/javascript.react-router.mdx
+++ b/platform-includes/getting-started-sourcemaps/javascript.react-router.mdx
@@ -1,6 +1,6 @@
 ## Source Maps Upload
 
-Update `vite.config.ts` to include the `sentryReactRouter` plugin and also add your `SentryReactRouterBuildOptions` config options to the vite config (this is required for uploading source maps at the end of the build):
+Update `vite.config.ts` to include the `sentryReactRouter` plugin. Also add your `SentryReactRouterBuildOptions` config options to the Vite config (this is required for uploading source maps at the end of the build):
 
 <OrgAuthTokenNote />
 


### PR DESCRIPTION
Updates the react router guide to use the new rr package.

Closes https://github.com/getsentry/sentry-javascript/issues/15191

**Only merge this once the package got published and verified!**