### PR TITLE
docs(react): Add note on ignoring components

### DIFF
--- a/docs/platforms/javascript/guides/react/features/component-names.mdx
+++ b/docs/platforms/javascript/guides/react/features/component-names.mdx
@@ -50,16 +50,27 @@ Follow the instructions in the npm page for the bundler that your project uses:
 
 Please note that although there is a Sentry bundler plugin for **esbuild**, React component name capturing is currently not supported.
 
+
 Once you've followed the instructions to install the bundler plugin and added it to your bundler's config, enable component name capturing by setting the flag for it to `true`:
 
 
 ```javascript
 // Example specific to Vite, see documentation for other bundlers
 sentryVitePlugin({
-    // ... other options above
-    reactComponentAnnotation: { enabled: true }
+  // ... other options above
+    reactComponentAnnotation: {
+      enabled: true,
+      // you can ignore components from being annotated with this option
+      ignoredComponents: ["MyComponentThatShouldNotBeAnnotated"]
+    }
 }),
 ```
+
+<Alert level="warning">
+You can potentially run into errors like `Error: Passing props on "Fragment"!`
+
+To avoid these errors, you can exclude specific components from annotation by using the `ignoredComponents` option, as shown in the example above.
+</Alert>
 
 <Alert>
 


### PR DESCRIPTION
Adds a note on ignoring component annotation option.

ref https://github.com/getsentry/sentry-javascript-bundler-plugins/issues