### PR TITLE
fix(nextjs-redirects): Fix unexpected nextjs redirects

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1331,10 +1331,6 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/platforms/javascript/sourcemaps/troubleshooting_js/',
   },
   {
-    from: '/platforms/javascript/guides/nextjs/sourcemaps/troubleshooting_js/legacy-uploading-methods/',
-    to: '/platforms/javascript/sourcemaps/troubleshooting_js/',
-  },
-  {
     from: '/platforms/javascript/sourcemaps/troubleshooting_js/verify-artifact-distribution-value-matches-value-configured-in-your-sdk/',
     to: '/platforms/javascript/sourcemaps/troubleshooting_js/',
   },


### PR DESCRIPTION
When navigating through the `/sourcemaps/troubleshooting_js/legacy-uploading-methods/` pages, when I click on the nextjs platform, I am redirected to the javascript, which is not expected. see:


https://github.com/user-attachments/assets/574529d6-2bc5-4f31-8fe2-2865444eaa82

