### PR TITLE
fix(toolbar): Fix redirects for all /dev-toolbar/ to be /sentry-toolbar/

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -231,12 +231,8 @@ const userDocsRedirects = [
     destination: '/organization/integrations/notification-incidents/msteams/',
   },
   {
-    source: '/product/dev-toolbar/setup/',
-    destination: '/product/sentry-toolbar/setup/',
-  },
-  {
-    source: '/product/dev-toolbar/faq/',
-    destination: '/product/sentry-toolbar/faq/',
+    source: '/product/dev-toolbar/:path*',
+    destination: '/product/sentry-toolbar/:path*',
   },
   {
     source: '/product/explore/session-replay/hydration-errors/',


### PR DESCRIPTION
Using a wildcard is better than listing things out one-by-one.

I checked locally that `/product/dev-toolbar/` redirects to `/product/sentryr-toolbar/` and also `/product/dev-toolbar/setup/` continues going to `/product/sentry-toolbar/setup/`

Relates to https://github.com/getsentry/sentry-docs/issues/12876