### PR TITLE
feat(changelog): Add missing form-textarea class to editor

### DIFF
--- a/apps/changelog/src/client/components/editor.tsx
+++ b/apps/changelog/src/client/components/editor.tsx
@@ -169,7 +169,7 @@ function Editor({name, defaultValue, minRows = 15}: EditorProps) {
           minRows={minRows}
           required
           value={value}
-          className="w-full"
+          className="form-textarea w-full"
           onChange={e => setValue(e.target.value)}
           //   aria-invalid={actionData?.errors?.content ? true : undefined}
           //   aria-errormessage={


### PR DESCRIPTION
Was really annoying not being able to see the cursor when the text area was empty.