### PR TITLE
style: Adjust gap for icons in platform selector

### DIFF
--- a/src/components/platformSelector/style.module.scss
+++ b/src/components/platformSelector/style.module.scss
@@ -17,6 +17,7 @@
 
   .item-text {
     align-items: center;
+    gap: 0.5rem;
 
     .platform-icon {
       translate: none;
@@ -162,7 +163,7 @@
 .item-text {
   display: flex;
   align-items: start;
-  gap: 0.25rem;
+  gap: 0.375rem;
   text-align: left;
 
   .platform-icon {

--- a/src/components/platformSelector/style.module.scss
+++ b/src/components/platformSelector/style.module.scss
@@ -17,11 +17,7 @@
 
   .item-text {
     align-items: center;
-    gap: 0.5rem;
-
-    .platform-icon {
-      translate: none;
-    }
+    gap: 0.375rem;
   }
 }
 
@@ -162,13 +158,9 @@
 
 .item-text {
   display: flex;
-  align-items: start;
+  align-items: center;
   gap: 0.375rem;
   text-align: left;
-
-  .platform-icon {
-    translate: 0 4px;
-  }
 }
 
 .expand-button {


### PR DESCRIPTION
This was super jarring to my eyes for some reason.

Before:

![Screenshot 2025-03-03 at 13 25 15](https://github.com/user-attachments/assets/002fdc91-cc5e-491c-842d-4d3e1e513fce)

After:

![Screenshot 2025-03-03 at 13 24 44](https://github.com/user-attachments/assets/3dbd2770-b8d9-4f27-81c6-e679b3959e0b)

There is still a vertical alignment issue I believe but I couldn't be bothered to fix rn.
