### PR TITLE
fix(auth-creator): Add warnings to not commit token

### DIFF
--- a/src/components/codeKeywords/orgAuthTokenCreator.tsx
+++ b/src/components/codeKeywords/orgAuthTokenCreator.tsx
@@ -168,7 +168,7 @@ export function OrgAuthTokenCreator() {
       <KeywordDropdown
         ref={setReferenceEl}
         role="button"
-        title="Click to generate token"
+        title="Click to generate token (DO NOT commit)"
         tabIndex={0}
         onClick={() => {
           handlePress();
@@ -192,7 +192,7 @@ export function OrgAuthTokenCreator() {
               onAnimationStart={() => setIsAnimating(true)}
               onAnimationComplete={() => setIsAnimating(false)}
             >
-              Click to generate token
+              Click to generate token (DO NOT commit)
             </Keyword>
           </AnimatePresence>
         </span>

--- a/src/components/orgAuthTokenNote.tsx
+++ b/src/components/orgAuthTokenNote.tsx
@@ -37,7 +37,8 @@ export function OrgAuthTokenNote() {
             manually create an Auth Token
           </ExternalLink>{' '}
           or create a token directly from this page. A created token will only be visible
-          once right after creation - make sure to copy it!
+          once right after creation - make sure to copy-paste it immediately and DO NOT commit it!
+          We recommend adding it as an environment variable.
         </Alert>
       </SignedInCheck>
     </Fragment>

--- a/src/components/orgAuthTokenNote.tsx
+++ b/src/components/orgAuthTokenNote.tsx
@@ -37,8 +37,8 @@ export function OrgAuthTokenNote() {
             manually create an Auth Token
           </ExternalLink>{' '}
           or create a token directly from this page. A created token will only be visible
-          once right after creation - make sure to copy-paste it immediately and DO NOT commit it!
-          We recommend adding it as an environment variable.
+          once right after creation - make sure to copy-paste it immediately and DO NOT
+          commit it! We recommend adding it as an environment variable.
         </Alert>
       </SignedInCheck>
     </Fragment>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Users sometimes commit their auth tokens because the docs don't communicate that this is something that should be kept secret.

While we have warnings about not committing the token in our [wizard here](https://github.com/getsentry/sentry-wizard/blob/f89b4f80731da8857a5a1bd4ab32d93b9a6ba898/src/sourcemaps/sourcemaps-wizard.ts#L304), there is no warning when just following the docs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

