### PR TITLE
feat(code-block): Do not copy diff markers

### DIFF
--- a/src/components/codeBlock/codeBlock.spec.ts
+++ b/src/components/codeBlock/codeBlock.spec.ts
@@ -1,0 +1,131 @@
+import {describe, expect, it} from 'vitest';
+
+import {cleanCodeSnippet} from './index';
+
+describe('cleanCodeSnippet', () => {
+  describe('consecutive newlines', () => {
+    it('should reduce two consecutive newlines to a single newline', () => {
+      const input = 'line1\n\nline2\n\n\n  line3';
+      const result = cleanCodeSnippet(input, {});
+      expect(result).toBe('line1\nline2\n\n  line3');
+    });
+
+    it('should handle input with single newlines', () => {
+      const input = 'line1\nline2\nline3';
+      const result = cleanCodeSnippet(input, {});
+      expect(result).toBe('line1\nline2\nline3');
+    });
+  });
+
+  describe('diff markers', () => {
+    it('should remove diff markers (+/-) from the beginning of lines by default', () => {
+      const input = '+added line\n- removed line\n  normal line';
+      const result = cleanCodeSnippet(input);
+      expect(result).toBe('added line\nremoved line\n  normal line');
+    });
+
+    it('should preserve diff markers when cleanDiffMarkers is set to false', () => {
+      const input = '+ added line\n- removed line';
+      const result = cleanCodeSnippet(input, {cleanDiffMarkers: false});
+      expect(result).toBe('+ added line\n- removed line');
+    });
+
+    it('should remove diff markers based on real-life code example', () => {
+      const input =
+        '-Sentry.init({\n' +
+        "-  dsn: '\n" +
+        '\n' +
+        "https://examplePublicKey@o0.ingest.sentry.io/0',\n" +
+        '-  tracesSampleRate: 1.0,\n' +
+        '-\n' +
+        '-  // uncomment the line below to enable Spotlight (https://spotlightjs.com)\n' +
+        '-  // spotlight: import.meta.env.DEV,\n' +
+        '-});\n' +
+        '-\n' +
+        '-export const handle = sentryHandle();\n' +
+        '+export const handle = sequence(\n' +
+        '+   initCloudflareSentryHandle({\n' +
+        "+       dsn: '\n" +
+        '\n' +
+        "https://examplePublicKey@o0.ingest.sentry.io/0',\n" +
+        '+       tracesSampleRate: 1.0,\n' +
+        '+   }),\n' +
+        '+   sentryHandle()\n' +
+        '+);';
+
+      const result = cleanCodeSnippet(input);
+      expect(result).toBe(
+        'Sentry.init({\n' +
+          " dsn: '\n" +
+          "https://examplePublicKey@o0.ingest.sentry.io/0',\n" +
+          ' tracesSampleRate: 1.0,\n' +
+          ' // uncomment the line below to enable Spotlight (https://spotlightjs.com)\n' +
+          ' // spotlight: import.meta.env.DEV,\n' +
+          '});\n' +
+          'export const handle = sentryHandle();\n' +
+          'export const handle = sequence(\n' +
+          '  initCloudflareSentryHandle({\n' +
+          "      dsn: '\n" +
+          "https://examplePublicKey@o0.ingest.sentry.io/0',\n" +
+          '      tracesSampleRate: 1.0,\n' +
+          '  }),\n' +
+          '  sentryHandle()\n' +
+          ');'
+      );
+    });
+  });
+
+  describe('bash prompt', () => {
+    it('should remove bash prompt in bash/shell language', () => {
+      const input = '$ ls -la\nsome output';
+      const result = cleanCodeSnippet(input, {language: 'bash'});
+      expect(result).toBe('ls -la\nsome output');
+    });
+
+    it('should remove bash prompt in shell language', () => {
+      const input = '$ git status\nsome output';
+      const result = cleanCodeSnippet(input, {language: 'shell'});
+      expect(result).toBe('git status\nsome output');
+    });
+
+    it('should not remove bash prompt for non-bash/shell languages', () => {
+      const input = '$ some text';
+      const result = cleanCodeSnippet(input, {language: 'python'});
+      expect(result).toBe('$ some text');
+    });
+
+    it('should handle bash prompt with multiple spaces', () => {
+      const input = '$    ls -la\nsome output';
+      const result = cleanCodeSnippet(input, {language: 'bash'});
+      expect(result).toBe('ls -la\nsome output');
+    });
+  });
+
+  describe('combination of options', () => {
+    it('should handle multiple cleaning operations together', () => {
+      const input = '+ $ ls -la\n\n- $ git status';
+      const result = cleanCodeSnippet(input, {language: 'bash'});
+      expect(result).toBe('ls -la\ngit status');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty input', () => {
+      const input = '';
+      const result = cleanCodeSnippet(input, {});
+      expect(result).toBe('');
+    });
+
+    it('should handle input with only newlines', () => {
+      const input = '\n\n\n';
+      const result = cleanCodeSnippet(input, {});
+      expect(result).toBe('\n\n');
+    });
+
+    it('should preserve leading whitespace not associated with diff markers', () => {
+      const input = '  normal line\n+ added line';
+      const result = cleanCodeSnippet(input, {});
+      expect(result).toBe('  normal line\nadded line');
+    });
+  });
+});

--- a/src/components/codeBlock/index.tsx
+++ b/src/components/codeBlock/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect, useRef, useState} from 'react';
+import {RefObject, useEffect, useRef, useState} from 'react';
 import {Clipboard} from 'react-feather';
 
 import styles from './code-blocks.module.scss';
@@ -18,6 +18,11 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
   const [showCopied, setShowCopied] = useState(false);
   const codeRef = useRef<HTMLDivElement>(null);
 
+  const {copyCodeOnClick} = useCopyCodeCleaner(codeRef, {
+    cleanDiffMarkers: true,
+    language,
+  });
+
   // Show the copy button after js has loaded
   // otherwise the copy button will not work
   const [showCopyButton, setShowCopyButton] = useState(false);
@@ -25,31 +30,21 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
     setShowCopyButton(true);
   }, []);
 
-  async function copyCode() {
-    if (codeRef.current === null) {
-      return;
-    }
+  const handleCopyOnClick = async () => {
+    const success = await copyCodeOnClick();
 
-    let code = codeRef.current.innerText.replace(/\n\n/g, '\n');
-
-    // don't copy leading prompt for bash
-    if (language === 'bash' || language === 'shell') {
-      const match = code.match(/^\$\s*/);
-      if (match) {
-        code = code.substring(match[0].length);
-      }
+    if (success) {
+      setShowCopied(true);
+      setTimeout(() => setShowCopied(false), 1200);
     }
-    await navigator.clipboard.writeText(code);
-    setShowCopied(true);
-    setTimeout(() => setShowCopied(false), 1200);
-  }
+  };
 
   return (
     <div className={styles['code-block']}>
       <div className={styles['code-actions']}>
         <code className={styles.filename}>{filename}</code>
         {showCopyButton && (
-          <button className={styles.copy} onClick={() => copyCode()}>
+          <button className={styles.copy} onClick={handleCopyOnClick}>
             <Clipboard size={16} />
           </button>
         )}
@@ -60,4 +55,103 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
       <div ref={codeRef}>{makeKeywordsClickable(children)}</div>
     </div>
   );
+}
+
+interface CleanCopyOptions {
+  cleanBashPrompt?: boolean;
+  cleanDiffMarkers?: boolean;
+  language?: string;
+}
+
+const REGEX = {
+  DIFF_MARKERS: /^[+\-](?:\s|(?=\S))/gm, // Matches diff markers (+ or -) at the beginning of lines, with or without spaces
+  BASH_PROMPT: /^\$\s*/, // Matches bash prompt ($ followed by a space)
+  CONSECUTIVE_NEWLINES: /\n\n/g, // Matches consecutive newlines
+};
+
+/**
+ * A custom hook that handles cleaning text when copying from code blocks
+ * @param codeRef - Reference to the code element
+ * @param options - Configuration options for cleaning
+ */
+export function useCopyCodeCleaner(
+  codeRef: RefObject<HTMLElement>,
+  options: CleanCopyOptions = {}
+) {
+  const {cleanDiffMarkers = true, cleanBashPrompt = true, language = ''} = options;
+
+  /**
+   *   Effect, which cleans the snippet when the user manually copies it to their clipboard
+   */
+  useEffect(() => {
+    const handleUserCopyEvent = (event: ClipboardEvent) => {
+      if (!codeRef.current || !event.clipboardData) return;
+
+      const selection = window.getSelection()?.toString() || '';
+
+      if (selection) {
+        let cleanedText = selection;
+
+        if (cleanDiffMarkers) {
+          cleanedText = cleanedText.replace(REGEX.DIFF_MARKERS, '');
+        }
+
+        if (cleanBashPrompt && (language === 'bash' || language === 'shell')) {
+          const match = cleanedText.match(REGEX.BASH_PROMPT);
+          if (match) {
+            cleanedText = cleanedText.substring(match[0].length);
+          }
+        }
+
+        event.clipboardData.setData('text/plain', cleanedText);
+        event.preventDefault();
+      }
+    };
+
+    const codeElement = codeRef.current;
+    if (codeElement) {
+      codeElement.addEventListener('copy', handleUserCopyEvent as EventListener);
+    }
+
+    return () => {
+      if (codeElement) {
+        codeElement.removeEventListener('copy', handleUserCopyEvent as EventListener);
+      }
+    };
+  }, [codeRef, cleanDiffMarkers, language, cleanBashPrompt]);
+
+  /**
+   * Function for copying code when clicking on "copy code".
+   *
+   * @returns Whether code was copied successfully
+   */
+  const copyCodeOnClick = async (): Promise<boolean> => {
+    if (codeRef.current === null) {
+      return false;
+    }
+
+    let code = codeRef.current.innerText.replace(REGEX.CONSECUTIVE_NEWLINES, '\n');
+
+    if (cleanBashPrompt && (language === 'bash' || language === 'shell')) {
+      const match = code.match(REGEX.BASH_PROMPT);
+      if (match) {
+        code = code.substring(match[0].length);
+      }
+    }
+
+    if (cleanDiffMarkers) {
+      code = code.replace(REGEX.DIFF_MARKERS, '');
+    }
+
+    try {
+      await navigator.clipboard.writeText(code);
+      return true;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to copy:', error);
+      return false;
+    }
+  };
+
+  return {copyCodeOnClick};
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,7 @@
+/// <reference types="vitest" />
+import tsconfigPaths from 'vite-tsconfig-paths';
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+});


### PR DESCRIPTION
## DESCRIBE YOUR PR

Code blocks can contain diff markers (+ or -) at the beginning of code blocks which get copied as well when copying the code. 

This modifies the function for copying code on click and adds an effect to handle copy-events initiated manually (not by clicking "copy code".

closes https://github.com/getsentry/sentry-docs/issues/12802

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


