### PR TITLE
chore(github): Use issue types in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-content-01-sdks.yml
+++ b/.github/ISSUE_TEMPLATE/issue-content-01-sdks.yml
@@ -1,6 +1,7 @@
-name: "📝 SDK Documentation"
-labels: ["Type: Content", "SDKs"]
+name: '📝 SDK Documentation'
+labels: ['Type: Content', 'SDKs']
 description: Missing, incorrect, or unclear documentation of SDKs.
+type: Improvement
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-content-02-product.yml
+++ b/.github/ISSUE_TEMPLATE/issue-content-02-product.yml
@@ -1,6 +1,7 @@
-name: "📝 Product Documentation"
-labels: ["Type: Content", "Product"]
+name: '📝 Product Documentation'
+labels: ['Type: Content', 'Product']
 description: Missing, incorrect, or unclear documentation of product features.
+type: Improvement
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-content-03-develop.yml
+++ b/.github/ISSUE_TEMPLATE/issue-content-03-develop.yml
@@ -1,6 +1,7 @@
-name: "📝 Documentation on develop.sentry.dev"
-labels: ["Type: Content", "Develop"]
+name: '📝 Documentation on develop.sentry.dev'
+labels: ['Type: Content', 'Develop']
 description: Missing, incorrect, or unclear developer documentation.
+type: Improvement
 body:
   - type: markdown
     attributes:
@@ -35,4 +36,3 @@ body:
       value: |-
         ## Thanks 🙏
         Check our [triage docs](https://open.sentry.io/triage/) for what to expect next.
-  

--- a/.github/ISSUE_TEMPLATE/issue-platform-404.yml
+++ b/.github/ISSUE_TEMPLATE/issue-platform-404.yml
@@ -1,7 +1,7 @@
-name: "💻 Docs Platform: 🔗 404 Error"
-labels: "Type: Platform,404"
+name: '💻 Docs Platform: 🔗 404 Error'
+labels: 'Type: Platform,404'
 description: Broken links, missing pages, and other 404 errors.
-
+type: Bug
 body:
   - type: textarea
     id: url

--- a/.github/ISSUE_TEMPLATE/issue-platform-bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue-platform-bug.yml
@@ -1,5 +1,6 @@
-name: "💻 Docs Platform: 🐞 Bug"
-labels: "Type: Platform,Bug"
+name: '💻 Docs Platform: 🐞 Bug'
+labels: 'Type: Platform'
+type: Bug
 description: Problems with the technical platform of our docs.
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/issue-platform-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/issue-platform-improvement.yml
@@ -1,6 +1,7 @@
-name: "💻 Docs Platform: ✨ Improvement"
-labels: "Type: Platform,Improvement"
+name: '💻 Docs Platform: ✨ Improvement'
+labels: 'Type: Platform'
 description: Ideas on how we can improve the technical capabilities of our docs platform.
+type: Improvement
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
- Automatically apply issue types to new issues
- Remove legacy labels for `improvement` and `bug`