### PR TITLE
dotnet: clarify global mode transaction state

### DIFF
--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -49,9 +49,13 @@ Example scenarios where it should be explicitly set to true:
 
 Defaults to `false`, unless in Blazor WASM, MAUI, Unity, or Xamarin where the default is `true`.
 
-In server applications, when Global Mode is **disabled**, data stored in the scope is only available in the context of the particular request in which it is created.
+When Global Mode is **disabled** data stored in the scope is set on the current [ExecutionContext](https://learn.microsoft.com/en-us/dotnet/api/system.threading.executioncontext).
+In server applications data stored in the scope is only available in the context of the particular request in which it is created.
+Broadly, the ExecutionContext passes to child tasks and threads, but not to parent tasks and threads.
 
-For UI applications (like MAUI) when Global mode is **enabled**, a single scope stack is shared by the whole application.
+When Global Mode is **enabled**, a single scope stack is shared by the whole application.
+
+Since version 5.0.0 the transaction is always set on the current ExecutionContext, regardless of the Global Mode.
 
 See the <PlatformLink to="/enriching-events/scopes/">Scopes and Hubs documentation</PlatformLink> for more information.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

Following https://github.com/getsentry/sentry-dotnet/pull/3596, the scope Transaction is always stored in an AsyncLocal, regardless of the GlobalMode configuration. Updating the docs to state this will help others avoid needing to read the SDK source in order to figure out why their transactions become unset on the scope during task switches.

I'm not completely sure about the wording. The nice thing about ExecutionContext and the GlobalMode defaults is that in the vast majority of cases they work intuitively, and ExecutionContext is an implementation detail that users can ignore. But in those special cases I think it's helpful to explain what's actually happening to help the user understand it.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
