### PR TITLE
ref(flags): update change tracking settings links

### DIFF
--- a/docs/organization/integrations/feature-flag/generic/index.mdx
+++ b/docs/organization/integrations/feature-flag/generic/index.mdx
@@ -24,7 +24,7 @@ For the generic case, you need to write a webhook that conforms to our API. You 
 
 ### Set Up Change Tracking
 
-Enabling Change Tracking is a four step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags) in a new tab. Then follow the steps listed below.
+Enabling Change Tracking is a four step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags/change-tracking/) in a new tab. Then follow the steps listed below.
 
 1. **Click the "Add New Provider" button.**
     - One webhook secret can be registered per provider type.

--- a/docs/organization/integrations/feature-flag/launchdarkly/index.mdx
+++ b/docs/organization/integrations/feature-flag/launchdarkly/index.mdx
@@ -20,7 +20,7 @@ Sentry can track changes to feature flag definitions and report suspicious featu
 
 ### Set Up Change Tracking
 
-Enabling Change Tracking is a three step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags) in a new tab. Then follow the steps listed below.
+Enabling Change Tracking is a three step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags/change-tracking/) in a new tab. Then follow the steps listed below.
 
 1. **Click the "Add New Provider" button.**
     - One webhook secret can be registered per provider type.

--- a/docs/organization/integrations/feature-flag/statsig/index.mdx
+++ b/docs/organization/integrations/feature-flag/statsig/index.mdx
@@ -20,7 +20,7 @@ Sentry can track changes to feature flag definitions and report suspicious featu
 
 ### Set Up Change Tracking
 
-Enabling Change Tracking is a three-step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags) in a new tab. Then follow the steps listed below.
+Enabling Change Tracking is a three-step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags/change-tracking/) in a new tab. Then follow the steps listed below.
 
 1. **Click the "Add New Provider" button.**
     - One webhook secret can be registered per provider type.

--- a/docs/organization/integrations/feature-flag/unleash/index.mdx
+++ b/docs/organization/integrations/feature-flag/unleash/index.mdx
@@ -20,7 +20,7 @@ Sentry can track changes to feature flag definitions and report suspicious featu
 
 ### Set Up Change Tracking
 
-Enabling Change Tracking is a three-step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags) in a new tab. Then follow the steps listed below.
+Enabling Change Tracking is a three-step process. To get started, visit the [feature flags settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/feature-flags/change-tracking/) in a new tab. Then follow the steps listed below.
 
 1. **Click the "Add New Provider" button.**
     - One webhook secret can be registered per provider type.


### PR DESCRIPTION
The old settings w/"Add New Provider" is now nested under `/change-tracking`