### PR TITLE
Added missing exception mechanism property.

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/exception.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/exception.mdx
@@ -111,6 +111,14 @@ the root exception (the last to be listed in the exception values).
 
 : An optional flag indicating that this exception is part of an exception group type specific to the platform or language.
 
+`source`
+
+: An optional string value describing the source of the exception. The SDK should populate this with the name of the property or attribute of the parent exception that this exception was acquired from. In the case of an array, it should include the zero-based array index as well.
+
+- Python Examples: `"__context__"`, `"__cause__"`, `"exceptions[0]"`, `"exceptions[1]"`
+- .NET Examples: `"InnerException"`, `"InnerExceptions[0]"`, `"InnerExceptions[1]"`
+- JavaScript Examples: `"cause"`, `"errors[0]"`, `"errors[1]"`
+
 `meta`
 
 : Optional information from the operating system or runtime on the exception


### PR DESCRIPTION
## DESCRIBE YOUR PR

The `source` property as described in the RFC was missing: 
https://github.com/getsentry/rfcs/blob/main/text/0079-exception-groups.md#source

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
