### PR TITLE
fix(platform): Wrap auth token code snippets

### DIFF
--- a/src/components/codeKeywords/orgAuthTokenCreator.tsx
+++ b/src/components/codeKeywords/orgAuthTokenCreator.tsx
@@ -111,7 +111,7 @@ export function OrgAuthTokenCreator() {
   }
 
   if (tokenState.status === 'success') {
-    return <Fragment>{tokenState.token}</Fragment>;
+    return <span className="whitespace-pre-wrap break-all">{tokenState.token}</span>;
   }
 
   if (tokenState.status === 'error') {


### PR DESCRIPTION
This pr will wrap all code snippets containing a generated auth token, so it is apparent to our users when they only copy partial token.

Decided against generally wrapping all code snippets because it messes up ALL of our comments.

before:
<img width="733" alt="Screenshot 2025-03-05 at 12 15 01" src="https://github.com/user-attachments/assets/0424e11a-de9f-471e-bc8f-a7d93dbcf5b3" />

after:
<img width="732" alt="Screenshot 2025-03-05 at 12 14 15" src="https://github.com/user-attachments/assets/e5caac9e-cf54-4839-a665-bbe763c34a4a" />


closes https://github.com/getsentry/sentry-docs/issues/11999