### PR TITLE
Add JavaScript manual instrumentation docs for non-HTTP protocols

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -65,3 +65,7 @@ Once the callback ends, the SDK will continue the previous trace (if available).
 ## Verification
 
 If you make outgoing requests from your project to other services, check if the headers `sentry-trace` and `baggage` are present in the request. If so, distributed tracing is working.
+
+<PlatformCategorySection supported={["server"]}>
+<PlatformContent includePath="distributed-tracing/custom-instrumentation/non-http-protocols" />
+</PlatformCategorySection>

--- a/platform-includes/distributed-tracing/custom-instrumentation/non-http-protocols/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/non-http-protocols/javascript.mdx
@@ -1,0 +1,217 @@
+## Instrumenting Non-HTTP Protocols
+
+While Sentry's JavaScript SDK automatically instruments HTTP(S) requests, other protocols like gRPC (HTTP/2) ([`@grpc/grpc-js`](https://www.npmjs.com/package/@grpc/grpc-js)) require manual instrumentation. This section explains how to create custom spans for these protocols.
+
+### Creating Manual Spans
+
+For long-running operations that require explicit control over when spans are closed, you should use `startSpanManual`. This is especially important when working with request/response cycles that don't follow a simple function call pattern. For more information on creating transactions in general, see [Creating a transaction](/platforms/javascript/migration/v7-to-v8/v8-new-performance-api/#creating-a-transaction).
+
+```javascript
+// This example shows the core pattern for manual span creation
+function handleIncomingRequest(requestData, metadata) {
+  // Extract tracing data from request metadata
+  const sentryTrace = metadata['sentry-trace'];
+  const baggage = metadata['baggage'];
+  
+  // Continue the distributed trace if headers are present
+  Sentry.continueTrace({ sentryTrace, baggage }, () => {
+    // Create a manual span - note we MUST use startSpanManual here 
+    // since we needto control when the span ends, 
+    // which might be in a different callback
+    Sentry.startSpanManual(
+      {
+        name: 'process_request',
+        op: 'custom.processing',
+        forceTransaction: true, // Make this appear as a transaction in Sentry
+        attributes: {
+          // Add relevant attributes about the request
+          'request.type': requestData.type,
+          'request.id': requestData.id,
+          'user.id': metadata.userId || 'anonymous'
+        },
+      },
+      (span) => {
+        // Store the span so we can access it later when the operation completes
+        // This is crucial for asynchronous processes
+        requestContext.span = span;
+        
+        // Start processing the request
+        processRequest(requestData, (error, response) => {
+          if (error) {
+            // Update span with error information
+            span.setStatus({ code: 'error' });
+            span.setAttribute('error.message', error.message);
+            Sentry.captureException(error);
+          } else {
+            span.setAttribute('response.status', 'success');
+          }
+          
+          // IMPORTANT: Manually end the span when the operation is complete
+          span.end();
+          
+          // Complete the request
+          sendResponse(response);
+        });
+      }
+    );
+  });
+}
+
+// You can also use nested spans within your manual span
+function processRequest(requestData, callback) {
+  const parentSpan = Sentry.getCurrentScope().getSpan();
+  
+  // Use the parent span to create child spans for sub-operations
+  Sentry.withActiveSpan(parentSpan, () => {
+    // These spans will automatically be children of the manual span
+    Sentry.startSpan({ name: 'validate_data', op: 'validation' }, (span) => {
+      // Do validation...
+    });
+    
+    Sentry.startSpan({ name: 'process_data', op: 'processing' }, async (span) => {
+      // Do processing...
+      try {
+        const result = await doSomeAsyncWork();
+        callback(null, result);
+      } catch (error) {
+        callback(error);
+      }
+    });
+  });
+}
+```
+
+Key points for manual spans:
+
+1. Use `startSpanManual` when you need control over when the span ends
+2. Store the span in a context so you can access it later
+3. Always remember to call `span.end()` when the operation is complete
+4. Set appropriate attributes and status before ending the span
+
+### Example: Manual Instrumentation for gRPC
+
+For protocols that aren't automatically instrumented, you can create manual spans:
+
+```javascript
+// gRPC server interceptor with Sentry instrumentation
+function sentryInterceptor(methodDescriptor, nextCall) {
+  // Extract Sentry trace headers from the incoming metadata
+  const metadata = nextCall.metadata.getMap();
+  const sentryTrace = metadata['sentry-trace'];
+  const baggage = metadata['baggage'];
+
+  return new grpc.ServerInterceptingCall(nextCall, {
+    start: (next) => {
+      // Continue the trace using the extracted context
+      Sentry.continueTrace({ sentryTrace, baggage }, () => {
+        // Create a manual span that won't auto-close until we end it
+        Sentry.startSpanManual(
+          {
+            name: methodDescriptor.path,
+            op: 'grpc.server',
+            forceTransaction: true, // Make this a transaction in the Sentry UI
+            attributes: {
+              'grpc.method': methodDescriptor.path,
+              'grpc.service': methodDescriptor.service.serviceName,
+              'grpc.status_code': grpc.status.OK,
+            },
+          },
+          (span) => {
+            // Store the span for later use
+            nextCall.sentrySpan = span;
+            next();
+          }
+        );
+      });
+    },
+    sendStatus: (status, next) => {
+      const span = nextCall.sentrySpan;
+      if (span) {
+        // Update status based on the gRPC result
+        if (status.code !== grpc.status.OK) {
+          span.setStatus({ code: 'error' });
+          span.setAttribute('grpc.status_code', status.code);
+          span.setAttribute('grpc.status_description', status.details);
+        }
+        // End the span when the call completes
+        span.end();
+      }
+      next(status);
+    }
+  });
+}
+
+// Add the interceptor to your gRPC server
+const server = new grpc.Server({
+  interceptors: [sentryInterceptor]
+});
+
+// In your service implementation, use the active span
+const serviceImplementation = {
+  myMethod: async (call, callback) => {
+    try {
+      const span = call.call?.nextCall?.sentrySpan;
+      
+      // Use withActiveSpan to make the span active during service execution
+      await Sentry.withActiveSpan(span, async () => {
+        // Create child spans for operations within the service
+        await Sentry.startSpan({ name: 'database.query', op: 'db' }, async (childSpan) => {
+          // Database operations here
+          const result = await database.query('SELECT * FROM table');
+          childSpan.setAttribute('db.rows_affected', result.rowCount);
+        });
+        
+        callback(null, { result: 'success' });
+      });
+    } catch (error) {
+      // Capture the error with the current span as context
+      Sentry.captureException(error);
+      callback(error);
+    }
+  }
+};
+```
+
+### Client-Side Propagation
+
+To ensure distributed tracing works across services, propagate the trace context in client calls:
+
+```javascript
+function createGrpcClient() {
+  // Create client with interceptor
+  return new MyServiceClient(address, grpc.credentials.createInsecure(), {
+    interceptors: [(options, nextCall) => {
+      // Create metadata for the call
+      const metadata = new grpc.Metadata();
+      
+      // Get current trace information
+      const traceData = Sentry.getTraceData();
+      
+      // Add trace headers to metadata
+      if (traceData) {
+        metadata.set('sentry-trace', traceData['sentry-trace']);
+        metadata.set('baggage', traceData['baggage']);
+      }
+      
+      // Add metadata to the call
+      return new grpc.InterceptingCall(nextCall(options), {
+        start: (metadata_, listener, next) => {
+          next(metadata, listener);
+        }
+      });
+    }]
+  });
+}
+```
+
+This approach allows you to:
+
+1. Create transactions for incoming requests
+2. Propagate trace context between services
+3. Create child spans for operations within your service
+4. Capture errors with the proper context
+5. End spans appropriately when operations complete
+
+### Complete Example
+
+For a complete working example of Sentry instrumentation with gRPC in JavaScript, see [grpc-sentry example repository](https://github.com/jdaison/grpc-sentry).


### PR DESCRIPTION
## DESCRIBE YOUR PR
 adds comprehensive documentation for manually instrumenting non-HTTP protocols in JavaScript applications, with a specific focus on gRPC. The documentation includes:

- Detailed guidance on creating and managing manual spans for long-running operations
- Examples of server-side instrumentation for gRPC with Sentry
- Client-side trace propagation for distributed tracing across services
- Code examples demonstrating proper span creation, management, and closure
- Key points and best practices for manual instrumentation

These additions will help developers implement proper distributed tracing in applications that use protocols beyond standard HTTP/HTTPS, which aren't automatically instrumented by the Sentry JavaScript SDK.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
