### PR TITLE
Clarify JumpCloud SSO actions

### DIFF
--- a/docs/organization/authentication/sso/index.mdx
+++ b/docs/organization/authentication/sso/index.mdx
@@ -156,7 +156,7 @@ Be sure that you have assigned yourself to the Sentry app in Jumpcloud before at
 1. Go to the "XML" within the register page.
 1. Download your Jumpcloud metadata under the "SSO" tab in your Jumpcloud Sentry SSO app by clicking "Export Metadata".
 1. Paste your XML metadata into the text field and click "Parse Metadata".
-1. On the "Map Identity Provider" page, fill in 'uniqueID', 'email', 'firstname', and 'lastname' if you have left your Jumpcloud attributes as the defaults for the Sentry app.
+1. On the "Map Identity Provider" page, fill in 'uniqueID', 'email', 'firstname', and 'lastname' if you have left your Jumpcloud attributes as the defaults for the Sentry app. Copy these attributes from the "Service Provider Attribute Name" column, not the "JumpCloud Attribute Name" one.
 
 Now, Sentry should be configured for Jumpcloud SSO.
 


### PR DESCRIPTION
Added a specification on the last step for setting up JumpCloud SSO. This should avoid confusion on which attributes to use.
