### PR TITLE
docs(js): Add Meta-framework settings for filter integration

### DIFF
--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -103,58 +103,7 @@ This allows you to filter out errors with "unmarked" stack frames, which would i
 To set up this integration and to mark your JavaScript files with an application key, first pass an `applicationKey` option to your Sentry bundler plugin.
 This can be an arbitrary string that identifies your application code:
 
-```ts {tabTitle:Vite} {8}
-// vite.config.ts
-import { defineConfig } from "vite";
-import { sentryVitePlugin } from "@sentry/vite-plugin";
-
-export default defineConfig({
-  plugins: [
-    sentryVitePlugin({
-      applicationKey: "your-custom-application-key",
-    }),
-  ],
-});
-```
-
-```js {tabTitle:Webpack} {7}
-// webpack.config.js
-const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
-
-module.exports = {
-  plugins: [
-    sentryWebpackPlugin({
-      applicationKey: "your-custom-application-key",
-    }),
-  ],
-};
-```
-
-```js {tabTitle:esbuild} {7}
-// esbuild.config.js
-const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
-
-require("esbuild").build({
-  plugins: [
-    sentryEsbuildPlugin({
-      applicationKey: "your-custom-application-key",
-    }),
-  ],
-});
-```
-
-```js {tabTitle:Rollup} {7}
-// rollup.config.mjs
-import { sentryRollupPlugin } from "@sentry/rollup-plugin";
-
-export default {
-  plugins: [
-    sentryRollupPlugin({
-      applicationKey: "your-custom-application-key",
-    }),
-  ],
-};
-```
+<PlatformContent includePath="configuration/filter-application-key" />
 
 Next, add the `thirdPartyErrorFilterIntegration` to your Sentry initialization:
 

--- a/platform-includes/configuration/filter-application-key/javascript.mdx
+++ b/platform-includes/configuration/filter-application-key/javascript.mdx
@@ -1,0 +1,52 @@
+```ts {tabTitle:Vite} {8}
+// vite.config.ts
+import { defineConfig } from "vite";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    sentryVitePlugin({
+      applicationKey: "your-custom-application-key",
+    }),
+  ],
+});
+```
+
+```js {tabTitle:Webpack} {7}
+// webpack.config.js
+const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
+
+module.exports = {
+  plugins: [
+    sentryWebpackPlugin({
+      applicationKey: "your-custom-application-key",
+    }),
+  ],
+};
+```
+
+```js {tabTitle:esbuild} {7}
+// esbuild.config.js
+const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
+
+require("esbuild").build({
+  plugins: [
+    sentryEsbuildPlugin({
+      applicationKey: "your-custom-application-key",
+    }),
+  ],
+});
+```
+
+```js {tabTitle:Rollup} {7}
+// rollup.config.mjs
+import { sentryRollupPlugin } from "@sentry/rollup-plugin";
+
+export default {
+  plugins: [
+    sentryRollupPlugin({
+      applicationKey: "your-custom-application-key",
+    }),
+  ],
+};
+```

--- a/platform-includes/configuration/filter-application-key/javascript.nextjs.mdx
+++ b/platform-includes/configuration/filter-application-key/javascript.nextjs.mdx
@@ -1,0 +1,15 @@
+```javascript {tabTitle:CJS} {filename:next.config.js} {3}
+module.exports = withSentryConfig(nextConfig, {
+  unstable_sentryWebpackPluginOptions: {
+    applicationKey: "your-custom-application-key",
+  },
+});
+```
+
+```javascript {tabTitle:ESM} {filename:next.config.mjs} {3}
+export default withSentryConfig(nextConfig, {
+  unstable_sentryWebpackPluginOptions: {
+    applicationKey: "your-custom-application-key",
+  },
+});
+```

--- a/platform-includes/configuration/filter-application-key/javascript.nuxt.mdx
+++ b/platform-includes/configuration/filter-application-key/javascript.nuxt.mdx
@@ -1,0 +1,10 @@
+```javascript {tabTitle:Nuxt Config} {filename:nuxt.config.ts} {4}
+export default defineNuxtConfig({
+  sentry: {
+    unstable_sentryBundlerPluginOptions: {
+      applicationKey: "your-custom-application-key",
+    },
+  },
+});
+
+```

--- a/platform-includes/configuration/filter-application-key/javascript.react-router.mdx
+++ b/platform-includes/configuration/filter-application-key/javascript.react-router.mdx
@@ -1,0 +1,14 @@
+```js {tabTitle:Vite} {filename:vite.config.ts} {3}
+const sentryConfig = {
+  unstable_sentryVitePluginOptions: {
+    applicationKey: "your-custom-application-key",
+  },
+};
+
+export default defineConfig((config) => {
+  return {
+    plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
+    sentryConfig,
+  };
+});
+```

--- a/platform-includes/configuration/filter-application-key/javascript.solidstart.mdx
+++ b/platform-includes/configuration/filter-application-key/javascript.solidstart.mdx
@@ -1,0 +1,16 @@
+```js {tabTitle:Vite} {filename:app.config.ts} {9}
+export default defineConfig(
+  withSentry(
+    {
+      /* Your SolidStart config */
+    },
+    {
+      sourceMapsUploadOptions: {
+        unstable_sentryVitePluginOptions: {
+          applicationKey: "your-custom-application-key",
+        },
+      },
+    },
+  ),
+);
+```

--- a/platform-includes/configuration/filter-application-key/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/filter-application-key/javascript.sveltekit.mdx
@@ -1,0 +1,13 @@
+```js {tabTitle:Vite} {filename:vite.config.js} {6}
+export default defineConfig({
+	plugins: [
+    sentrySvelteKit({
+      sourceMapsUploadOptions: {
+        unstable_sentryVitePluginOptions: {
+          applicationKey: "your-custom-application-key",
+        },
+      },
+    })
+  ]
+});
+```


### PR DESCRIPTION
## DESCRIBE YOUR PR

The code snippets for adding options to the bundler plugins in Meta-framework SDKs are misleading as they show usage of each bundler plugins. However, the Meta-frameworks already include those plugins under the hood and the options should be passed differently. 

related to this issue: https://github.com/getsentry/sentry-javascript/issues/13286

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

