### PR TITLE
Fix Apollo links

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/android.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/android.mdx
@@ -34,7 +34,7 @@ If you pass these headers to Sentry's `continueTrace()` function it will store t
 
 For distributed tracing to work, the two headers `sentry-trace` and `baggage`, must now also be added to outgoing requests.
 
-If you are sending outgoing HTTP requests with <PlatformLink to="/integrations/okhttp/">OkHttp</PlatformLink>, <PlatformLink to="/integrations/apollo/">Apollo</PlatformLink> or <PlatformLink to="/integrations/apollo3/">Apollo 3</PlatformLink> and have our integration for it enabled, this tracing information is automatically added to outgoing requests. You do not have to enable Performance for distributed tracing to work.
+If you are sending outgoing HTTP requests with <PlatformLink to="/integrations/okhttp/">OkHttp</PlatformLink>, <PlatformLink to="/integrations/apollo2/">Apollo 2</PlatformLink>, <PlatformLink to="/integrations/apollo3/">Apollo 3</PlatformLink> or <PlatformLink to="/integrations/apollo4/">Apollo 4</PlatformLink>  and have our integration for it enabled, this tracing information is automatically added to outgoing requests. You do not have to enable Performance for distributed tracing to work.
 
 If you're using none of the above, you can generate this tracing information with the Sentry SDK's `getTraceparent()` and `getBaggage()` functions. Here's an example:
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -852,15 +852,15 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
   },
   {
     from: '/platforms/android/performance/instrumentation/apollo/',
-    to: '/platforms/android/integrations/apollo2/',
+    to: '/platforms/android/integrations/apollo4/',
   },
   {
     from: '/platforms/android/configuration/integrations/apollo/',
-    to: '/platforms/android/integrations/apollo2/',
+    to: '/platforms/android/integrations/apollo4/',
   },
   {
     from: '/platforms/android/integrations/apollo/',
-    to: '/platforms/android/integrations/apollo2/',
+    to: '/platforms/android/integrations/apollo4/',
   },
   {
     from: '/platforms/android/configuration/integrations/fragment/',


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Now `/apollo` will redirect to the newest `/apollo4`.
Mentioned and linked to `apollo2` explicitly where needed.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+