### PR TITLE
fix(remix): Move `instrumentBuild` inside `fetch` callback.

### DIFF
--- a/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
+++ b/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
@@ -49,10 +49,6 @@ import { instrumentBuild } from "@sentry/remix/cloudflare";
 // Virtual entry point for the app
 import * as remixBuild from 'virtual:remix/server-build';
 
-// Instrument your server build with Sentry
-// and use the instrumented build inside the fetch handler
-const instrumentedBuild = instrumentBuild(remixBuild)
-
 /**
  * Export a fetch handler in module format.
  */
@@ -73,6 +69,10 @@ export default {
         context: executionContext,
       },
       async () => {
+        // Instrument your server build with Sentry
+        // and use the instrumented build inside the fetch handler
+        const instrumentedBuild = instrumentBuild(remixBuild)
+
         // request handling logic
       }
     );


### PR DESCRIPTION
Updates the example to make sure `instrumentBuild` runs after SDK initialization.