### PR TITLE
fix(solidstart): Remove outdated `sentrySolidStartVite` option

### DIFF
--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -191,7 +191,7 @@ SENTRY_PROJECT="___PROJECT_SLUG___"
 SENTRY_AUTH_TOKEN="___ORG_AUTH_TOKEN___"
 ```
 
-We recommend you add the auth token to your CI/CD environment as an environment variable.
+We recommend adding the auth token to your CI/CD environment as an environment variable.
 
 ## Verify
 

--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -157,17 +157,33 @@ For example, update your scripts in `package.json`.
 
 ## Add Readable Stack Traces to Errors
 
-To upload source maps, use the `sentrySolidStartVite` plugin from `@sentry/solidstart` and configure an auth token.
-Auth tokens can be passed to the plugin explicitly with the `authToken` option. You can use the
-`SENTRY_AUTH_TOKEN` environment variable or have an `.env.sentry-build-plugin` file in the working directory when
-building your project.
-
-We recommend you add the auth token to your CI/CD environment as an environment variable.
-
-Learn more about configuring the plugin in our
-[Sentry Vite Plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin).
+To upload source maps, configure an auth token. Auth tokens can be passed to `withSentry` explicitly with the `authToken`
+option. You can also use the `SENTRY_AUTH_TOKEN` environment variable or have an `.env.sentry-build-plugin` file in the
+working directory when building your project.
 
 <OrgAuthTokenNote />
+
+Update your `app.config.ts`:
+
+```TypeScript {filename:app.config.ts}
+import { withSentry } from '@sentry/solidstart';
+import { defineConfig } from '@solidjs/start/config';
+
+export default defineConfig(
+  withSentry(
+    {
+      /* Your SolidStart config */
+    },
+    {
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
+      authToken: "___ORG_AUTH_TOKEN___",
+    }
+  ),
+);
+```
+
+or create a `.env.sentry-build-plugin` file:
 
 ```bash {filename:.env.sentry-build-plugin}
 SENTRY_ORG="___ORG_SLUG___"
@@ -175,28 +191,7 @@ SENTRY_PROJECT="___PROJECT_SLUG___"
 SENTRY_AUTH_TOKEN="___ORG_AUTH_TOKEN___"
 ```
 
-Add the plugin to your `app.config.ts`.
-
-```TypeScript {filename:app.config.ts}
-// app.config.ts
-import { defineConfig } from '@solidjs/start/config';
-import { sentrySolidStartVite } from '@sentry/solidstart';
-
-export default defineConfig({
-  // ...
-
-  vite: {
-    plugins: [
-      sentrySolidStartVite({
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_PROJECT,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-      }),
-    ],
-  },
-  // ...
-});
-```
+We recommend you add the auth token to your CI/CD environment as an environment variable.
 
 ## Verify
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The docs for Solid Start still had a mention to `sentrySolidStartVite` which we removed with v9.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
