### PR TITLE
Add redirect for Apollo Java link still reachable from Google that 404s

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -851,6 +851,10 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/platforms/android/integrations/file-io/',
   },
   {
+    from: '/platforms/java/tracing/instrumentation/apollo/',
+    to: '/platforms/java/tracing/instrumentation/apollo4/',
+  },
+  {
     from: '/platforms/android/performance/instrumentation/apollo/',
     to: '/platforms/android/integrations/apollo4/',
   },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -855,6 +855,14 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/platforms/java/tracing/instrumentation/apollo4/',
   },
   {
+    from: '/platforms/java/guides/spring/tracing/instrumentation/apollo/',
+    to: '/platforms/java/guides/spring/tracing/instrumentation/apollo4/',
+  },
+  {
+    from: '/platforms/java/guides/spring-boot/tracing/instrumentation/apollo/',
+    to: '/platforms/java/guides/spring-boot/tracing/instrumentation/apollo4/',
+  },
+  {
     from: '/platforms/android/performance/instrumentation/apollo/',
     to: '/platforms/android/integrations/apollo4/',
   },


### PR DESCRIPTION
## DESCRIBE YOUR PR
404 lints work fine but the link can still be reachable from Google
Closes https://github.com/getsentry/sentry-docs/issues/12969

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+