### PR TITLE
fix(gatsby): make it clear where to put Sentry SDK config

### DIFF
--- a/docs/platforms/javascript/guides/gatsby/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/index.mdx
@@ -51,7 +51,7 @@ module.exports = {
 
 ## Configure
 
-Then, configure your `Sentry.init`:
+Then, configure your `Sentry.init`. For this, create a new file called `sentry.config.js` in the root of your project and add the following code:
 
 
 ```javascript {filename:sentry.config.(js|ts)} {"onboardingOptions": {"performance": "6, 9-15", "session-replay": "7, 16-22"}}


### PR DESCRIPTION
Contributes to https://github.com/getsentry/projects/issues/799