### PR TITLE
feat(python): Add a note about the Event and Hint types

### DIFF
--- a/docs/platforms/python/configuration/filtering/index.mdx
+++ b/docs/platforms/python/configuration/filtering/index.mdx
@@ -18,7 +18,7 @@ Configure your SDK to filter error events by using the <PlatformIdentifier name=
 
 The `before_send` callback allows you to modify the event payload before the SDK sends the event to Sentry. You can also stop the event from being sent by returning `None`.
 
-The callback receives two arguments: the event payload and a [hint](#event-hints). The corresponding `Event` and the `Hint` types can be imported from `sentry_sdk.types` for better introspection into what fields are available. The callback can return either the event payload to send to Sentry or `None` if the event should be dropped.
+The callback receives two arguments: the event payload and a [hint](#event-hints). The corresponding `Event` and `Hint` types can be imported from `sentry_sdk.types` for better introspection into what fields are available. The callback can return either the event payload to send to Sentry or `None` if the event should be dropped.
 
 Any modifications to the event payload done in the callback, including adding data to the event and modifying or deleting existing event fields, will be reflected in Sentry.
 

--- a/docs/platforms/python/configuration/filtering/index.mdx
+++ b/docs/platforms/python/configuration/filtering/index.mdx
@@ -18,7 +18,7 @@ Configure your SDK to filter error events by using the <PlatformIdentifier name=
 
 The `before_send` callback allows you to modify the event payload before the SDK sends the event to Sentry. You can also stop the event from being sent by returning `None`.
 
-The callback receives two arguments: the event payload and a [hint](#event-hints). The callback can return either the event payload to send to Sentry or `None` if the event should be dropped.
+The callback receives two arguments: the event payload and a [hint](#event-hints). The corresponding `Event` and the `Hint` types can be imported from `sentry_sdk.types` for better introspection into what fields are available. The callback can return either the event payload to send to Sentry or `None` if the event should be dropped.
 
 Any modifications to the event payload done in the callback, including adding data to the event and modifying or deleting existing event fields, will be reflected in Sentry.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

We can do a better job being more clear about the `Event` and `Hint` types that are handy for callbacks like `before_send`, see https://github.com/getsentry/sentry-python/issues/4122.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
