### PR TITLE
unreal minidump not on android

### DIFF
--- a/docs/platforms/unreal/data-management/store-minidumps-as-attachments/index.mdx
+++ b/docs/platforms/unreal/data-management/store-minidumps-as-attachments/index.mdx
@@ -7,6 +7,6 @@ sidebar_order: 90
 
 <Include name="store-minidumps-as-attachments-intro" />
 
-<Alert>☝ This feature is supported on Windows, Linux, and Android.</Alert>
+<Alert>☝ This feature is supported on Windows and Linux.</Alert>
 
 <Include name="store-minidumps-as-attachments-configuration" />


### PR DESCRIPTION
on Android we have our own stack walker, and we don't capture minidumps.