### PR TITLE
bias symbol server format to unified

### DIFF
--- a/docs/platforms/native/common/data-management/debug-files/symbol-servers/index.mdx
+++ b/docs/platforms/native/common/data-management/debug-files/symbol-servers/index.mdx
@@ -118,6 +118,36 @@ schemas applied for specific files:
 
 The path schemas in the table above are defined as follows:
 
+### Unified
+
+Path: `nn/nnnnnnnnnnnnnnnn.../type`
+
+The unified path layout is specific to Sentry and enables a consistent structure
+for all debug files independent of platform. It can store breakpad files, PDBs,
+PEs, and everything else. 
+
+The [symsorter tool] can automatically sort debug
+symbols into this format and also automatically create source bundles.
+
+The path is based on a `build_id` formatted to a hexadecimal using
+lower case. The first two bytes of that ID are taken as a root folder.
+
+The `build_id` construction differs among file formats:
+
+- PE: `<Signature><Age>` (age in hex, not padded)
+- PDB: `<Signature><Age>` (age in hex, not padded)
+- Portable PDB: `<Signature><Age>` (age in hex, not padded)
+- ELF: the gnu-build-id code note byte sequence.
+- Mach-O: `LC_UUID` bytes
+- WASM: `build_id` section as bytes
+
+Examples:
+
+- `b5/381a457906d279073822a5ceb24c4bfef94ddb/executable` (executable or library)
+- `b5/381a457906d279073822a5ceb24c4bfef94ddb/debuginfo` (debug file)
+- `b5/381a457906d279073822a5ceb24c4bfef94ddb/breakpad` (breakpad file)
+- `b5/381a457906d279073822a5ceb24c4bfef94ddb/sourcebundle` (source bundle)
+
 ### Breakpad
 
 Path: `<DebugName>/<BREAKPADid>/<SymName>`
@@ -185,34 +215,6 @@ Examples:
 
 - `b5/381a457906d279073822a5ceb24c4bfef94ddb` (executable or library)
 - `b5/381a457906d279073822a5ceb24c4bfef94ddb.debug` (stripped debug file)
-
-**Unified**
-
-Path: `nn/nnnnnnnnnnnnnnnn.../type`
-
-The unified path layout is specific to Sentry and enables a consistent structure
-for all debug files independent of platform. It can store breakpad files, PDBs,
-PEs, and everything else. The [symsorter tool] can automatically sort debug
-symbols into this format and also automatically create source bundles.
-
-The path is based on a `build_id` formatted to a hexadecimal using
-lower case. The first two bytes of that ID are taken as a root folder.
-
-The `build_id` construction differs among file formats:
-
-- PE: `<Signature><Age>` (age in hex, not padded)
-- PDB: `<Signature><Age>` (age in hex, not padded)
-- Portable PDB: `<Signature><Age>` (age in hex, not padded)
-- ELF: the gnu-build-id code note byte sequence.
-- Mach-O: `LC_UUID` bytes
-- WASM: `build_id` section as bytes
-
-Examples:
-
-- `b5/381a457906d279073822a5ceb24c4bfef94ddb/executable` (executable or library)
-- `b5/381a457906d279073822a5ceb24c4bfef94ddb/debuginfo` (debug file)
-- `b5/381a457906d279073822a5ceb24c4bfef94ddb/breakpad` (breakpad file)
-- `b5/381a457906d279073822a5ceb24c4bfef94ddb/sourcebundle` (source bundle)
 
 ### SSQP
 


### PR DESCRIPTION
unified today is not a heading (it's just bold) so doesn't show on the list on the right

![image](https://github.com/user-attachments/assets/881069b3-0fc1-4b0d-9387-77b47ea25df1)

It's the format we use on our internal symbols, so moving it to the top.