### PR TITLE
fix(develop): Import hook instead of queryClient

### DIFF
--- a/develop-docs/frontend/network-requests.mdx
+++ b/develop-docs/frontend/network-requests.mdx
@@ -142,7 +142,7 @@ Reusable queries like this can be placed in `/sentry/actionsCreators`.
 There are many situations where your query data becomes out of date and needs to be updated or refetched. This is usually because of some user input (e.g. creating/deleting/editing a record). If you already know what the new data should look like, you can (and should) immediately update the cache using the query client:
 
 ```tsx
-import {setQueryData, queryClient} from 'utils/queryClient'
+import {setQueryData, useQueryClient} from 'utils/queryClient'
 
 const queryClient = useQueryClient();
 


### PR DESCRIPTION
Small typo fix I noticed reading through the developer docs under frontend network requests.