### PR TITLE
fix(angular): Adjust highlighted line numbers in getting started snippets

### DIFF
--- a/platform-includes/getting-started-config/javascript.angular.mdx
+++ b/platform-includes/getting-started-config/javascript.angular.mdx
@@ -1,6 +1,6 @@
 Once this is done, Sentry's Angular SDK captures all unhandled exceptions and transactions.
 
-```typescript {tabTitle: App Config} {filename: main.ts} {5-31} {"onboardingOptions": {"performance": "10-13, 19-25", "session-replay": "14-16, 28-34"}}
+```typescript {tabTitle: App Config} {filename: main.ts} {5-35} {"onboardingOptions": {"performance": "10-13, 19-25", "session-replay": "14-16, 28-34"}}
 import { bootstrapApplication } from "@angular/platform-browser";
 import { appConfig } from "./app/app.config";
 import { AppComponent } from "./app/app.component";
@@ -42,7 +42,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 );
 ```
 
-```typescript {tabTitle: NGModule Config} {filename: main.ts} {4-30} {"onboardingOptions": {"performance": "9-12, 17-24", "session-replay": "13-15, 25-29"}}
+```typescript {tabTitle: NGModule Config} {filename: main.ts} {4-34} {"onboardingOptions": {"performance": "9-12, 17-27", "session-replay": "13-15, 27-33"}}
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 import { AppModule } from "./app/app.module";
 


### PR DESCRIPTION
while working on #12983 I noticed that the highlighted line numbers were all over the place. This PR fixes them for Angular Getting Started