### PR TITLE
docs: update continuous profiling docs

### DIFF
--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -35,6 +35,12 @@ You have to have the <PlatformSdkPackageName fallback="@sentry/node"/> (minimum 
 
 ## Enabling Profiling
 
+Profiling supports two manin modes - manual and trace lifecycle. The two modes are mutually exclusive, and cannot be used at the same time. In manual mode, the profiling data collection can be managed via calls to Sentry.profiler.startProfileSession and Sentry.profiler.stopProfileSession. In this mode, you are entirely in the in control of when the profiler runs.
+
+Trace lifecycle mode differs in the sense that the profiler manages it's own start and stop calls, which are based on the logic of active spans. In this mode, the profiler continues to run while there is at least one active span, and stops when there are no active spans.
+
+### Enabling Automatic Trace Profiling
+
 To enable profiling, add `@sentry/profiling-node` to your imports and set up `nodeProfilingIntegration` in your Sentry config.
 
 ```javascript {diff}
@@ -47,23 +53,64 @@ Sentry.init({
 +   nodeProfilingIntegration(),
   ],
   tracesSampleRate: 1.0,
-+  // Set sampling rate for profiling - this is relative to tracesSampleRate
-+  profilesSampleRate: 1.0,
++ profileLifecycle: 'trace',
 });
 
 // Profiling happens automatically after setting it up with `Sentry.init()`.
-// All spans captured in your application will have profiling data attached to them.
-// You can also manually capture spans with `startSpan`, as shown below:
+// All spans (unless those discarded by sampling) will have profiling data attached to them.
 Sentry.startSpan(
   {
     op: "rootSpan",
     name: "My root span",
   },
   () => {
-    // Any code in this callback will be profiled.
+    // The code executed here will be profiled
   }
 );
 ```
+
+### Enabling Manual Trace Profiling
+
+To enable profiling, add `@sentry/profiling-node` to your imports and set up `nodeProfilingIntegration` in your Sentry config.
+
+```javascript {diff}
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add our Profiling integration
++   nodeProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
++ profileLifecycle: 'manual', // default can be omitted
+});
+
+// All spans (unless those discarded by sampling) will have profiling data attached to them.
+Sentry.profiler.startProfileSession();
+// Code executed between these two calls will be profiled
+Sentry.profiler.stopProfileSession();
+```
+
+### Managing profile sampling rates
+
+Sentry SDK supports an additional `profileSessionSampleRate` that will enable or disable profiling for the entire session. This can be used if you want to control session sampling rates at the service level. The sampling decision is evaluated only once at SDK init, and it controls whether all calls to the profiler will be enabled or disabled.
+
+This is useful for cases where you deploy your service N times, but would only like for a subset of those services to be profiled.
+
+```javascript {diff}
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    // Add our Profiling integration
+    nodeProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
++ profileSessionSampleRate: 0.0 // All profiling is disabled
+});
+
 
 ## How Does It Work?
 
@@ -81,3 +128,4 @@ Starting from version `0.1.0`, the `@sentry/profiling-node` package precompiles 
 - Windows x64: Node v16, v18, v20, v22
 
 The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue in the [Sentry JavaScript SDK](https://github.com/getsentry/sentry-javascript) repository.
+```

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -35,7 +35,9 @@ You have to have the <PlatformSdkPackageName fallback="@sentry/node"/> (minimum 
 
 ## Enabling Profiling
 
-Profiling supports two main modes - manual and trace lifecycle. The two modes are mutually exclusive, and cannot be used at the same time. In manual mode, the profiling data collection can be managed via calls to Sentry.profiler.startProfileSession and Sentry.profiler.stopProfileSession. In this mode, you are entirely in the in control of when the profiler runs.
+Profiling supports two modes - `manual` and `trace`. The two modes are mutually exclusive, and cannot be used at the same time.
+
+In `manual` mode, the profiling data collection can be managed via calls to `Sentry.profiler.startProfileSession` and `Sentry.profiler.stopProfileSession`. You are entirely in the in control of when the profiler runs.
 
 In `trace` mode, the profiler manages its own start and stop calls, which are based on spans: the profiler continues to run while there is at least one active span, and stops when there are no active spans.
 

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -37,7 +37,7 @@ You have to have the <PlatformSdkPackageName fallback="@sentry/node"/> (minimum 
 
 Profiling supports two main modes - manual and trace lifecycle. The two modes are mutually exclusive, and cannot be used at the same time. In manual mode, the profiling data collection can be managed via calls to Sentry.profiler.startProfileSession and Sentry.profiler.stopProfileSession. In this mode, you are entirely in the in control of when the profiler runs.
 
-Trace lifecycle mode differs in the sense that the profiler manages it's own start and stop calls, which are based on the logic of active spans. In this mode, the profiler continues to run while there is at least one active span, and stops when there are no active spans.
+In `trace` mode, the profiler manages its own start and stop calls, which are based on spans: the profiler continues to run while there is at least one active span, and stops when there are no active spans.
 
 ### Enabling Automatic Trace Profiling
 

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -41,7 +41,7 @@ In `manual` mode, the profiling data collection can be managed via calls to `Sen
 
 In `trace` mode, the profiler manages its own start and stop calls, which are based on spans: the profiler continues to run while there is at least one active span, and stops when there are no active spans.
 
-### Enabling Automatic Trace Profiling
+### Enabling Trace Lifecycle Profiling
 
 To enable profiling, add `@sentry/profiling-node` to your imports and set up `nodeProfilingIntegration` in your Sentry config.
 

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -35,7 +35,7 @@ You have to have the <PlatformSdkPackageName fallback="@sentry/node"/> (minimum 
 
 ## Enabling Profiling
 
-Profiling supports two manin modes - manual and trace lifecycle. The two modes are mutually exclusive, and cannot be used at the same time. In manual mode, the profiling data collection can be managed via calls to Sentry.profiler.startProfileSession and Sentry.profiler.stopProfileSession. In this mode, you are entirely in the in control of when the profiler runs.
+Profiling supports two main modes - manual and trace lifecycle. The two modes are mutually exclusive, and cannot be used at the same time. In manual mode, the profiling data collection can be managed via calls to Sentry.profiler.startProfileSession and Sentry.profiler.stopProfileSession. In this mode, you are entirely in the in control of when the profiler runs.
 
 Trace lifecycle mode differs in the sense that the profiler manages it's own start and stop calls, which are based on the logic of active spans. In this mode, the profiler continues to run while there is at least one active span, and stops when there are no active spans.
 

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -53,6 +53,7 @@ Sentry.init({
 +   nodeProfilingIntegration(),
   ],
   tracesSampleRate: 1.0,
++ profileSessionSampleRate: 1.0,
 + profileLifecycle: 'trace',
 });
 
@@ -83,7 +84,8 @@ Sentry.init({
 +   nodeProfilingIntegration(),
   ],
   tracesSampleRate: 1.0,
-+ profileLifecycle: 'manual', // default can be omitted
++ profileSessionSampleRate: 1.0,
++ profileLifecycle: 'manual',
 });
 
 // All spans (unless those discarded by sampling) will have profiling data attached to them.
@@ -94,9 +96,9 @@ Sentry.profiler.stopProfileSession();
 
 ### Managing profile sampling rates
 
-Sentry SDK supports an additional `profileSessionSampleRate` that will enable or disable profiling for the entire session. This can be used if you want to control session sampling rates at the service level. The sampling decision is evaluated only once at SDK init, and it controls whether all calls to the profiler will be enabled or disabled.
+Sentry SDK supports an additional `profileSessionSampleRate` that will enable or disable profiling for the entire session. This can be used if you want to control session sampling rates at the service level as the sampling decision is evaluated only once at SDK init.
 
-This is useful for cases where you deploy your service N times, but would only like for a subset of those services to be profiled.
+This is useful for cases where you deploy your service many times, but would only like a subset of those services to be profiled.
 
 ```javascript {diff}
 const { nodeProfilingIntegration } = require("@sentry/profiling-node");
@@ -108,7 +110,7 @@ Sentry.init({
     nodeProfilingIntegration(),
   ],
   tracesSampleRate: 1.0,
-+ profileSessionSampleRate: 0.0 // All profiling is disabled
++ profileSessionSampleRate: 0.0
 });
 
 

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -37,7 +37,7 @@ You have to have the <PlatformSdkPackageName fallback="@sentry/node"/> (minimum 
 
 Profiling supports two modes - `manual` and `trace`. The two modes are mutually exclusive, and cannot be used at the same time.
 
-In `manual` mode, the profiling data collection can be managed via calls to `Sentry.profiler.startProfileSession` and `Sentry.profiler.stopProfileSession`. You are entirely in the in control of when the profiler runs.
+In `manual` mode, the profiling data collection can be managed via calls to `Sentry.profiler.startProfiler` and `Sentry.profiler.stopProfiler`. You are entirely in the in control of when the profiler runs.
 
 In `trace` mode, the profiler manages its own start and stop calls, which are based on spans: the profiler continues to run while there is at least one active span, and stops when there are no active spans.
 
@@ -91,9 +91,9 @@ Sentry.init({
 });
 
 // All spans (unless those discarded by sampling) will have profiling data attached to them.
-Sentry.profiler.startProfileSession();
+Sentry.profiler.startProfiler();
 // Code executed between these two calls will be profiled
-Sentry.profiler.stopProfileSession();
+Sentry.profiler.stopProfiler();
 ```
 
 ### Managing profile sampling rates
@@ -132,3 +132,4 @@ Starting from version `0.1.0`, the `@sentry/profiling-node` package precompiles 
 - Windows x64: Node v16, v18, v20, v22
 
 The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue in the [Sentry JavaScript SDK](https://github.com/getsentry/sentry-javascript) repository.
+```

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -132,4 +132,3 @@ Starting from version `0.1.0`, the `@sentry/profiling-node` package precompiles 
 - Windows x64: Node v16, v18, v20, v22
 
 The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue in the [Sentry JavaScript SDK](https://github.com/getsentry/sentry-javascript) repository.
-```

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -70,7 +70,7 @@ Sentry.startSpan(
 );
 ```
 
-### Enabling Manual Trace Profiling
+### Enabling Manual Lifecycle Profiling
 
 To enable profiling, add `@sentry/profiling-node` to your imports and set up `nodeProfilingIntegration` in your Sentry config.
 


### PR DESCRIPTION
Update continuous profiling docs for nodejs. Requires https://github.com/getsentry/sentry-javascript/pull/15635 to be released