### PR TITLE
feat(java): enable OTEL by default in onboarding options

### DIFF
--- a/platform-includes/getting-started-install/java.jul.mdx
+++ b/platform-includes/getting-started-install/java.jul.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```xml {tabTitle:Maven}

--- a/platform-includes/getting-started-install/java.log4j2.mdx
+++ b/platform-includes/getting-started-install/java.log4j2.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```xml {tabTitle:Maven Plugin}{filename:pom.xml}

--- a/platform-includes/getting-started-install/java.logback.mdx
+++ b/platform-includes/getting-started-install/java.logback.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```xml {tabTitle:Maven Plugin}{filename:pom.xml}

--- a/platform-includes/getting-started-install/java.mdx
+++ b/platform-includes/getting-started-install/java.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```groovy {filename:build.gradle}

--- a/platform-includes/getting-started-install/java.servlet.mdx
+++ b/platform-includes/getting-started-install/java.servlet.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```xml {tabTitle:Maven}

--- a/platform-includes/getting-started-install/java.spring-boot.mdx
+++ b/platform-includes/getting-started-install/java.spring-boot.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```groovy {tabTitle:Gradle Plugin}

--- a/platform-includes/getting-started-install/java.spring.mdx
+++ b/platform-includes/getting-started-install/java.spring.mdx
@@ -1,5 +1,5 @@
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "opentelemetry"]}
+  options={["error-monitoring", "performance", {id: "opentelemetry", checked: true}]}
 />
 
 ```groovy {tabTitle:Gradle Plugin}


### PR DESCRIPTION
## DESCRIBE YOUR PR
The OTEL option will now be checked by default on the getting started guides for Java backend platforms.
OTEL is fully integrated with the SDK by now and improves scopes and trace propagation.
It can be enabled independently from tracing, which we still leave unchecked by default.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+