### PR TITLE
feat(js): Stop using `provider.addSpanProcessor()`

### DIFF
--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -58,10 +58,12 @@ const provider = new NodeTracerProvider({
   // Ensure the correct subset of traces is sent to Sentry
   // This also ensures trace propagation works as expected
   sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
+  spanProcessors: [
+    // Ensure spans are correctly linked & sent to Sentry
+    new SentrySpanProcessor(),
+    // Add additional processors here
+  ],
 });
-
-// Ensure spans are correctly linked & sent to Sentry
-provider.addSpanProcessor(new SentrySpanProcessor());
 
 provider.register({
   // Ensure trace propagation works

--- a/docs/platforms/javascript/common/opentelemetry/using-opentelemetry-apis.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/using-opentelemetry-apis.mdx
@@ -78,11 +78,28 @@ You can also use any other tracer. All OpenTelemetry spans will be picked up by 
 
 ## Modifying the default OpenTelemetry TracerProvider
 
-You can access the tracer provider set up by Sentry when using Sentry's default OpenTelemetry instrumentation. This enables you to easily add additional span processors, allowing you to export tracing data to various OTEL collectors or other backends.
+You can access the tracer provider set up by Sentry when using Sentry's default OpenTelemetry instrumentation.
 
 ```javascript
 const Sentry = require("@sentry/node");
 
 const provider = Sentry.getClient()?.traceProvider;
-provider?.addSpanProcessor(new MySpanProcessor());
+```
+
+## Adding Additional Span Processors
+
+You can add additional span processors to the tracer provider set up by Sentry when using Sentry's default OpenTelemetry instrumentation.
+
+```javascript
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "___DSN___",
+
+  // The SentrySampler will use this to determine which traces to sample
+  tracesSampleRate: 1.0,
+
+  // Add additional OpenTelemetry SpanProcessors:
+  openTelemetrySpanProcessors: [new MySpanProcessor()],
+});
 ```


### PR DESCRIPTION
This fixes some things pointed out in https://github.com/getsentry/sentry-javascript/pull/15518, which are no longer compatible with OTEL v2. We already have a replacement for this in place.