### PR TITLE
feat(outcomes): Add documentation for new information on outcome "Too Large".

### DIFF
--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -69,7 +69,7 @@ Events and attachments might be discarded if they don't match the expected forma
 - **Project Missing**: The specified Sentry project is disabled or project information in the submitted request was inconclusive.
 - **Sampling**: Tracing data that is discarded during sampling.
 - **Security Report**: An invalid or unsupported security report was submitted. If this report originates from an up-to-date browser, please report a bug to Sentry. See [Security Policy Reporting](/security-legal-pii/security/security-policy-reporting/) for more information.
-- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large <what>", where <what> specifies the specific size limit that was exceeded (e.g., "Too Large Event") else "Too Large Other". For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
+- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large {what}", where {what} specifies the specific size limit that was exceeded (e.g., "Too Large Event") else "Too Large Other". For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
 - **Unreal**: An unsupported or invalid Unreal Engine crash report was submitted. If this request originates from a recent or development version of the Unreal Engine, please report a bug to Sentry. See [Unreal Engine](/platforms/unreal/) for more information.
 - **Internal**: An internal problem at Sentry prevented regular processing or storage of the submitted information.
 

--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -69,7 +69,7 @@ Events and attachments might be discarded if they don't match the expected forma
 - **Project Missing**: The specified Sentry project is disabled or project information in the submitted request was inconclusive.
 - **Sampling**: Tracing data that is discarded during sampling.
 - **Security Report**: An invalid or unsupported security report was submitted. If this report originates from an up-to-date browser, please report a bug to Sentry. See [Security Policy Reporting](/security-legal-pii/security/security-policy-reporting/) for more information.
-- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large <what>", where <what> specifies the specific size limit that was exceeded (e.g., "Too Large Attachment"). For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
+- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large <what>", where <what> specifies the specific size limit that was exceeded (e.g., "Too Large Event") else "Too Large Other". For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
 - **Unreal**: An unsupported or invalid Unreal Engine crash report was submitted. If this request originates from a recent or development version of the Unreal Engine, please report a bug to Sentry. See [Unreal Engine](/platforms/unreal/) for more information.
 - **Internal**: An internal problem at Sentry prevented regular processing or storage of the submitted information.
 

--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -69,7 +69,7 @@ Events and attachments might be discarded if they don't match the expected forma
 - **Project Missing**: The specified Sentry project is disabled or project information in the submitted request was inconclusive.
 - **Sampling**: Tracing data that is discarded during sampling.
 - **Security Report**: An invalid or unsupported security report was submitted. If this report originates from an up-to-date browser, please report a bug to Sentry. See [Security Policy Reporting](/security-legal-pii/security/security-policy-reporting/) for more information.
-- **Too Large**: The HTTP submission or its contained data exceeds size limits. The reason will be of the form "Too Large <reason>" where reason indicates which specific size limit was exceeded (for example, "Too Large Attachment"). See [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits) for the precise limits.
+- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large <what>", where <what> specifies the specific size limit that was exceeded (e.g., "Too Large Attachment"). For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
 - **Unreal**: An unsupported or invalid Unreal Engine crash report was submitted. If this request originates from a recent or development version of the Unreal Engine, please report a bug to Sentry. See [Unreal Engine](/platforms/unreal/) for more information.
 - **Internal**: An internal problem at Sentry prevented regular processing or storage of the submitted information.
 

--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -69,7 +69,7 @@ Events and attachments might be discarded if they don't match the expected forma
 - **Project Missing**: The specified Sentry project is disabled or project information in the submitted request was inconclusive.
 - **Sampling**: Tracing data that is discarded during sampling.
 - **Security Report**: An invalid or unsupported security report was submitted. If this report originates from an up-to-date browser, please report a bug to Sentry. See [Security Policy Reporting](/security-legal-pii/security/security-policy-reporting/) for more information.
-- **Too Large**: The HTTP submission or its contained data exceeds size limits. See [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits) for the precise limits.
+- **Too Large**: The HTTP submission or its contained data exceeds size limits. The reason will be of the form "Too Large <reason>" where reason indicates which specific size limit was exceeded (for example, "Too Large Attachment"). See [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits) for the precise limits.
 - **Unreal**: An unsupported or invalid Unreal Engine crash report was submitted. If this request originates from a recent or development version of the Unreal Engine, please report a bug to Sentry. See [Unreal Engine](/platforms/unreal/) for more information.
 - **Internal**: An internal problem at Sentry prevented regular processing or storage of the submitted information.
 

--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -69,7 +69,7 @@ Events and attachments might be discarded if they don't match the expected forma
 - **Project Missing**: The specified Sentry project is disabled or project information in the submitted request was inconclusive.
 - **Sampling**: Tracing data that is discarded during sampling.
 - **Security Report**: An invalid or unsupported security report was submitted. If this report originates from an up-to-date browser, please report a bug to Sentry. See [Security Policy Reporting](/security-legal-pii/security/security-policy-reporting/) for more information.
-- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large {what}", where {what} specifies the specific size limit that was exceeded (e.g., "Too Large Event") else "Too Large Other". For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
+- **Too Large**: The HTTP submission or its contained data exceeds size limits. If available, what exactly exceeded might be provided as "Too Large &lt;what&gt;", where &lt;what&gt; specifies the specific size limit that was exceeded (e.g., "Too Large Event") else "Too Large Other". For the exact size limits, refer to [this document](https://develop.sentry.dev/sdk/data-model/envelopes/#size-limits)
 - **Unreal**: An unsupported or invalid Unreal Engine crash report was submitted. If this request originates from a recent or development version of the Unreal Engine, please report a bug to Sentry. See [Unreal Engine](/platforms/unreal/) for more information.
 - **Internal**: An internal problem at Sentry prevented regular processing or storage of the submitted information.
 


### PR DESCRIPTION
Add a section on the outcome documentation explaining that the to large will now be of the form `Too Large <reason>` with reason pointing the user to exactly what was too large. In a further step this would also be further split per attachment type in the case of the "attachment" being too large.

Sentry PR: https://github.com/getsentry/sentry/pull/87078
Relay PR: https://github.com/getsentry/relay/pull/4558
