### PR TITLE
chore(apple): add SentrySDK.startProfiler to configure

### DIFF
--- a/docs/platforms/apple/common/index.mdx
+++ b/docs/platforms/apple/common/index.mdx
@@ -119,6 +119,13 @@ func application(_ application: UIApplication,
 
     return true
 }
+
+// Start continuous profiling when the app becomes active again.
+//
+// This is optional, and you can start and stop the profiler as needed.
+func applicationDidBecomeActive(_ application: UIApplication) {
+    SentrySDK.startProfiler()
+}
 ```
 
 ```objc {tabTitle:Objective-C} {"onboardingOptions": {"performance": "12-15", "profiling": "17-27"}}

--- a/docs/platforms/apple/common/index.mdx
+++ b/docs/platforms/apple/common/index.mdx
@@ -87,7 +87,7 @@ To capture all errors, initialize the SDK as soon as possible, such as in your `
 
 <PlatformSection notSupported={["apple.tvos", "apple.watchos", "apple.visionos"]}>
 
-```swift {tabTitle:Swift} {"onboardingOptions": {"performance": "13-16", "profiling": "18-28"}}
+```swift {tabTitle:Swift} {"onboardingOptions": {"performance": "13-16", "profiling": "18-28,32-38"}}
 import Sentry
 
 func application(_ application: UIApplication,


### PR DESCRIPTION
## DESCRIBE YOUR PR

The current configuration docs display an example usage of the `SentrySDK.startProfiler()` and `SentrySDK.stopProfiler()` and mentions that the call of stop is optional, as the profiler will automatically stop when going to the background.

Now if a user calls `SentrySDK.startProfiler()` in the `didFinishLaunching` hook, which is only called once per app start, the profiler would stop when the app goes to the first going to the background and not start again.

I would like to propose/discuss if the `SentrySDK.startProfiler()` should be used in [`applicationDidBecomeActive(_:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidbecomeactive(_:)) too.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

cc @jas-kas 