### PR TITLE
ref(flags): mention 100 flag limit in product docs

### DIFF
--- a/docs/product/issues/issue-details/feature-flags/index.mdx
+++ b/docs/product/issues/issue-details/feature-flags/index.mdx
@@ -14,7 +14,7 @@ Enabling a feature flag integration provides deep insights into the state of you
 
 ## Evaluation Tracking
 
-Flag evaluations will appear in the "Feature Flag" section of Issue Details page as a table, with "suspect" flag predictions highlighted in yellow. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details page documentation](/product/issues/issue-details/#feature-flags).
+Flag evaluations will appear in the "Feature Flag" section of Issue Details page as a table, with "suspect" flag predictions highlighted in yellow. For each event, we track the 100 most recently evaluated flags leading up to the error. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details page documentation](/product/issues/issue-details/#feature-flags).
 
 ### Set Up Evaluation Tracking
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-docs/issues/13013

