### PR TITLE
ref(flags): add note about feature flag search

### DIFF
--- a/docs/concepts/search/searchable-properties/issues.mdx
+++ b/docs/concepts/search/searchable-properties/issues.mdx
@@ -180,7 +180,7 @@ Returns issues with a matching first time seen. Syntax is the same as `age`.
 
 ### `flags`
 
-For [feature flag evaluations](/product/issues/issue-details/feature-flags/#evaluation-tracking) set to `true` or `false`, the name of the feature flag.
+For [feature flag evaluations](/product/issues/issue-details/feature-flags/#evaluation-tracking) set to `true` or `false`, the name of the feature flag. For example, the syntax for searching for a flag with key `my_flag` and value `true` is `flags["my_flag"]:true`.
 
 - **Type:** boolean
 

--- a/docs/product/issues/issue-details/feature-flags/index.mdx
+++ b/docs/product/issues/issue-details/feature-flags/index.mdx
@@ -16,7 +16,7 @@ Enabling a feature flag integration provides deep insights into the state of you
 
 Flag evaluations will appear in the "Feature Flag" section of Issue Details page as a table, with "suspect" flag predictions highlighted in yellow. For each event, we track the 100 most recently evaluated flags leading up to the error. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details page documentation](/product/issues/issue-details/#feature-flags).
 
-Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for events where the feature flag evaluated value is true or false. This allows you to quickly find all events containing a specific flag evaluation and its value of interest. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more information.
+Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for issues containing errors where the feature flag evaluated value is true or false. This allows you to quickly find all errors where a specific flag evaluation and its value of interest are present. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more details about the search syntax.
 
 ### Set Up Evaluation Tracking
 

--- a/docs/product/issues/issue-details/feature-flags/index.mdx
+++ b/docs/product/issues/issue-details/feature-flags/index.mdx
@@ -16,6 +16,8 @@ Enabling a feature flag integration provides deep insights into the state of you
 
 Flag evaluations will appear in the "Feature Flag" section of Issue Details page as a table, with "suspect" flag predictions highlighted in yellow. For each event, we track the 100 most recently evaluated flags leading up to the error. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [Issue Details page documentation](/product/issues/issue-details/#feature-flags).
 
+Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for events where the feature flag evaluated value is true or false. This allows you to quickly find all events containing a specific flag evaluation and its value of interest. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more information.
+
 ### Set Up Evaluation Tracking
 
 To set up evaluation tracking, visit the SDK integration documentation for your platform:

--- a/docs/product/issues/issue-details/index.mdx
+++ b/docs/product/issues/issue-details/index.mdx
@@ -177,7 +177,7 @@ Enabling one or more of our [evaluation tracking integrations](/product/explore/
 
 ![Feature Flag Table](./img/ff-table.png)
 
-Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for events where the feature flag evaluated value is true or false. This allows you to quickly find all events containing a specific flag evaluation and its value of interest. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more information.
+Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for issues containing errors where the feature flag evaluated value is true or false. This allows you to quickly find all errors where a specific flag evaluation and its value of interest are present. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more details about the search syntax.
 
 Enabling a [change tracking integration](/product/explore/feature-flags/#change-tracking) will enable annotations on the event volume chart. These lines mark feature flag changes and can help identify regressions caused by a feature flag definition change.
 

--- a/docs/product/issues/issue-details/index.mdx
+++ b/docs/product/issues/issue-details/index.mdx
@@ -177,6 +177,8 @@ Enabling one or more of our [evaluation tracking integrations](/product/explore/
 
 ![Feature Flag Table](./img/ff-table.png)
 
+Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for events where the feature flag evaluated value is true or false. This allows you to quickly find all events containing a specific flag evaluation and its value of interest. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more information.
+
 Enabling a [change tracking integration](/product/explore/feature-flags/#change-tracking) will enable annotations on the event volume chart. These lines mark feature flag changes and can help identify regressions caused by a feature flag definition change.
 
 ![Feature Flag Release Chart](./img/ff-release.png)


### PR DESCRIPTION
on https://docs.sentry.io/product/issues/issue-details/feature-flags/:

<img width="746" alt="SCR-20250317-lrcs" src="https://github.com/user-attachments/assets/d3cf2d71-e02e-41cd-a6c1-0dde0e50abd1" />

on https://docs.sentry.io/product/issues/issue-details/#feature-flags:

<img width="763" alt="SCR-20250317-lreg" src="https://github.com/user-attachments/assets/6093f1e7-ea75-44d3-addb-7b3e4d60826b" />

on searchable properties page (https://docs.sentry.io/concepts/search/searchable-properties/issues/#flags):

<img width="764" alt="SCR-20250317-mkmq" src="https://github.com/user-attachments/assets/00a04a47-8582-4e34-8398-9eaafa9d41b9" />



closes https://github.com/getsentry/sentry-docs/issues/12776