### PR TITLE
Clean up shopify hydrogen remix guide

### DIFF
--- a/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
+++ b/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
@@ -5,41 +5,23 @@ description: "Learn how to use the Sentry Remix SDK to instrument your Shopify H
 
 If you're using the Shopify Hydrogen framework, you can use the Sentry Remix SDK to add Sentry instrumentation to your app.
 
-## 1. Installing Sentry Remix SDK
+## 1. Installing Sentry Remix and Clouflare SDKs
 
-First, install the Sentry Remix SDK with your package manager:
+First, install the Sentry Remix and Cloudflare SDKs with your package manager:
 
 ```bash {tabTitle:npm}
-npm install @sentry/remix --save
+npm install @sentry/remix @sentry/cloudflare --save
 ```
 
 ```bash {tabTitle:yarn}
-yarn add @sentry/remix
+yarn add @sentry/remix @sentry/cloudflare
 ```
 
 ```bash {tabTitle:pnpm}
-pnpm add @sentry/remix
+pnpm add @sentry/remix @sentry/cloudflare
 ```
 
-## 2. Installing Sentry Cloudflare SDK
-
-After installing the Sentry Remix SDK, delete the newly generated `instrumentation.server.mjs` file and all newly generated code from `entry.server.tsx`. This instrumentation is not needed because you are going to use the Sentry Cloudflare SDK for server-side instrumentation.
-
-Now you can install the Sentry Cloudflare SDK. First, install the SDK with your package manager:
-
-```bash {tabTitle:npm}
-npm install @sentry/cloudflare --save
-```
-
-```bash {tabTitle:yarn}
-yarn add @sentry/cloudflare
-```
-
-```bash {tabTitle:pnpm}
-pnpm add @sentry/cloudflare
-```
-
-## 3. Instrumenting Your Server
+## 2. Instrumenting Your Server
 
 Then update your `server.ts` file to use the `wrapRequestHandler` method:
 
@@ -80,12 +62,12 @@ export default {
 };
 ```
 
-## 4. Instrumenting Your Client
+## 3. Instrumenting Your Client
 
 Wrap your Remix root component using `withSentry`:
 
 ```tsx {filename:root.tsx}
-import { withSentry } from "@sentry/remix/cloudflare";
+import { withSentry } from "@sentry/remix";
 
 function App({ children }) {
   return <>{children}</>;
@@ -95,11 +77,10 @@ function App({ children }) {
 export default withSentry(App, useEffect, useLocation, useMatches);
 ```
 
-
 Finally, update your `entry.client.tsx` file to initialize Sentry SDK on the client:
 
 ```tsx {filename:entry.client.tsx}
-import * as Sentry from "@sentry/remix/cloudflare";
+import * as Sentry from "@sentry/remix";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
+++ b/docs/platforms/javascript/guides/remix/frameworks/hydrogen.mdx
@@ -67,7 +67,7 @@ export default {
 Wrap your Remix root component using `withSentry`:
 
 ```tsx {filename:root.tsx}
-import { withSentry } from "@sentry/remix";
+import { withSentry } from "@sentry/remix/cloudflare";
 
 function App({ children }) {
   return <>{children}</>;


### PR DESCRIPTION
This cleans up the instructions for shopify hydrogen remix.

I'm also going to add a guide for plain remix apps with cloudflare.