### PR TITLE
Fix Expo Go check in Expo Router instructions

### DIFF
--- a/docs/platforms/react-native/tracing/instrumentation/expo-router.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/expo-router.mdx
@@ -13,11 +13,11 @@ The code snippet below shows how to initialize the instrumentation.
 ```javascript {6-8, 15-16, 20-25} {filename: app/_layout.tsx}
 import React from 'react';
 import { Slot, useNavigationContainerRef } from 'expo-router';
-import Constants, { ExecutionEnvironment } from 'expo-constants';
+import { isRunningInExpoGo } from 'expo';
 import * as Sentry from '@sentry/react-native';
 
 const navigationIntegration = Sentry.reactNavigationIntegration({
-  enableTimeToInitialDisplay: Constants.executionEnvironment === ExecutionEnvironment.StoreClient, // Only in native builds, not in Expo Go.
+  enableTimeToInitialDisplay: !isRunningInExpoGo(),
 });
 
 Sentry.init({
@@ -28,7 +28,7 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   integrations: [navigationIntegration],
-  enableNativeFramesTracking: Constants.executionEnvironment === ExecutionEnvironment.StoreClient, // Only in native builds, not in Expo Go.
+  enableNativeFramesTracking: !isRunningInExpoGo(),
 });
 
 function RootLayout() {


### PR DESCRIPTION
## DESCRIBE YOUR PR

StoreClient means the app _is_ running in Expo Go, so this predicate was doing the opposite of what it intended.

Regardless, there's an easier-to-understand check if the app is running in Expo Go, and it's what is recommended by the Expo docs: https://docs.expo.dev/guides/using-sentry/#initialize-sentry

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
