### PR TITLE
Add CodePush commands for AppZung

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
@@ -4,7 +4,7 @@ sidebar_order: 100
 description: "Upload source maps for CodePush releases."
 ---
 
-Sentry's React Native SDK works out of the box with CodePush. To see readable stack traces in the product, you must upload source maps to Sentry. This guide explains how to upload source maps for CodePush releases, that are created with the AppCenter CLI.
+Sentry's React Native SDK works out of the box with CodePush. To see readable stack traces in the product, you must upload source maps to Sentry. This guide explains how to upload source maps for CodePush releases, that are created with the CodePush CLI.
 
 ## Prerequisites
 
@@ -35,6 +35,8 @@ code-push-standalone release-react \
 ```
 
 ```bash {tabTitle:Hermes (Standalone)}
+# Make sure `jq` is installed on your system. If it's not, you can install it using your system's package manager. For example `apt-get install jq` on Ubuntu, or `brew install jq` on macOS with Homebrew.
+
 rm -rf ./build
 CODEPUSH_COMMAND="code-push-standalone release-react \
   \"${APP_NAME}\" \
@@ -51,6 +53,21 @@ jq -c ". + {\"debug_id\": \"${DEBUG_ID}\"}" "${MAP_FILE}" > "${MAP_FILE}.tmp"
 mv "${MAP_FILE}.tmp" "${MAP_FILE}"
 ```
 
+```bash {tabTitle:JSC (AppZung)}
+appzung releases deploy-react-native \
+  --use-jsc
+  --output-dir ./build \
+  --sourcemap-output-dir ./build
+```
+
+```bash {tabTitle:Hermes (AppZung)}
+appzung releases deploy-react-native \
+  --use-hermes
+  --output-dir ./build \
+  --sourcemap-output-dir ./build \
+  --sentry-sourcemap-debug-id
+```
+
 ```bash {tabTitle:JSC (AppCenter)}
 appcenter codepush release-react \
   --app "${APP_NAME}" \
@@ -60,6 +77,8 @@ appcenter codepush release-react \
 ```
 
 ```bash {tabTitle:Hermes (AppCenter)}
+# Make sure `jq` is installed on your system. If it's not, you can install it using your system's package manager. For example `apt-get install jq` on Ubuntu, or `brew install jq` on macOS with Homebrew.
+
 rm -rf ./build
 CODEPUSH_COMMAND="appcenter codepush release-react \
   --app \"${APP_NAME}\" \
@@ -74,10 +93,6 @@ MAP_FILE=$(find ./build -name "*.map" -type f)
 jq -c ". + {\"debug_id\": \"${DEBUG_ID}\"}" "${MAP_FILE}" > "${MAP_FILE}.tmp"
 mv "${MAP_FILE}.tmp" "${MAP_FILE}"
 ```
-
-### Notes
-
-If you are using Hermes make sure `jq` is installed on your system. If it's not, you can install it using your system's package manager. For example `apt-get install jq` on Ubuntu, or `brew install jq` on macOS with Homebrew.
 
 ## Upload Source Maps
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Hello, an [AppZung](https://appzung.com) client using Sentry was having difficulties running the script for Hermes so we integrated this directly in our CLI with the flag `--sentry-sourcemap-debug-id`. We might integrate Sentry even more deeply in the future, but this is a good first step.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
