### PR TITLE
fix(flutter): add missing auto-enabled checks

### DIFF
--- a/docs/platforms/dart/guides/flutter/integrations/index.mdx
+++ b/docs/platforms/dart/guides/flutter/integrations/index.mdx
@@ -8,7 +8,6 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 
 Integrations can automatically add error instrumentation, performance instrumentation, and/or extra context information to your application. Flutter builds on the Dart SDK, so all Dart integrations are available in Flutter as well.
 
-## Available Integrations
 
 <Include name="dart-integrations/index.mdx" />
 

--- a/includes/dart-integrations/index.mdx
+++ b/includes/dart-integrations/index.mdx
@@ -1,6 +1,5 @@
-### Integrations
 
-|                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
+| **Integration**                                       | **Auto <br /> Enabled** | **Errors** | **Tracing** | **Additional <br /> Context** |
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
 | [`App Start`](/platforms/dart/guides/flutter/integrations/app-start-instrumentation) |         ✓         |            |      ✓      |                        |
 | [`Asset Bundle`](/platforms/dart/guides/flutter/integrations/asset-bundle-instrumentation) |            |            |      ✓      |                        |
@@ -12,6 +11,12 @@
 | [`Isar`](/platforms/dart/guides/flutter/integrations/isar-instrumentation) |                  |            |      ✓      |                        |
 | [`Logging`](/platforms/dart/guides/flutter/integrations/logging) |                  |     ✓      |             |           ✓            |
 | [`Routing`](/platforms/dart/guides/flutter/integrations/routing-instrumentation) |                  |            |      ✓      |           ✓            |
-| [`Slow and Frozen Frames`](/platforms/dart/guides/flutter/integrations/slow-and-frozen-frames-instrumentation) | ✓ (not if `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`) |  |      ✓     |                        |
+| [`Slow and Frozen Frames`](/platforms/dart/guides/flutter/integrations/slow-and-frozen-frames-instrumentation) | ✓ * |  |      ✓     |                        |
 | [`Sqflite`](/platforms/dart/guides/flutter/integrations/sqflite-instrumentation) |                  |            |      ✓      |                        |
 | [`User Interaction`](/platforms/dart/guides/flutter/integrations/user-interaction-instrumentation) |    |        |      ✓      |           ✓            |
+
+<Alert>
+
+*Slow and Frozen Frames* should work automatically, however if `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`) then this instrumentation will not work automatically.
+
+</Alert>

--- a/includes/dart-integrations/index.mdx
+++ b/includes/dart-integrations/index.mdx
@@ -2,7 +2,7 @@
 
 |                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
-| [`App Start`](/platforms/dart/guides/flutter/integrations/app-start-instrumentation) |                  |            |      ✓      |                        |
+| [`App Start`](/platforms/dart/guides/flutter/integrations/app-start-instrumentation) |         ✓         |            |      ✓      |                        |
 | [`Asset Bundle`](/platforms/dart/guides/flutter/integrations/asset-bundle-instrumentation) |            |            |      ✓      |                        |
 | [`Dio`](/platforms/dart/guides/flutter/integrations/dio) |                  |     ✓      |      ✓      |           ✓            |
 | [`Drift`](/platforms/dart/guides/flutter/integrations/drift-instrumentation) |                  |            |      ✓      |                        |
@@ -12,6 +12,6 @@
 | [`Isar`](/platforms/dart/guides/flutter/integrations/isar-instrumentation) |                  |            |      ✓      |                        |
 | [`Logging`](/platforms/dart/guides/flutter/integrations/logging) |                  |     ✓      |             |           ✓            |
 | [`Routing`](/platforms/dart/guides/flutter/integrations/routing-instrumentation) |                  |            |      ✓      |           ✓            |
-| [`Slow and Frozen Frames`](/platforms/dart/guides/flutter/integrations/slow-and-frozen-frames-instrumentation) |  |  |      ✓     |                        |
+| [`Slow and Frozen Frames`](/platforms/dart/guides/flutter/integrations/slow-and-frozen-frames-instrumentation) | ✓ (not if `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`) |  |      ✓     |                        |
 | [`Sqflite`](/platforms/dart/guides/flutter/integrations/sqflite-instrumentation) |                  |            |      ✓      |                        |
-| [`User Interaction`](/platforms/dart/guides/flutter/integrations/user-interaction-instrumentation) |    |        |      ✓      |           ✓            | 
+| [`User Interaction`](/platforms/dart/guides/flutter/integrations/user-interaction-instrumentation) |    |        |      ✓      |           ✓            |

--- a/includes/dart-integrations/index.mdx
+++ b/includes/dart-integrations/index.mdx
@@ -17,6 +17,6 @@
 
 <Alert>
 
-*Slow and Frozen Frames* should work automatically, however if `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`) then this instrumentation will not work automatically.
+*Slow and Frozen Frames* should work automatically, however if `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`, then this instrumentation will not work automatically.
 
 </Alert>

--- a/includes/dart-integrations/slow-and-frozen-frames-instrumentation.mdx
+++ b/includes/dart-integrations/slow-and-frozen-frames-instrumentation.mdx
@@ -43,7 +43,7 @@ In most cases, no additional configuration is required.
 
 <Alert>
 
-If `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`) then this instrumentation will not work automatically.
+If `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`, then this instrumentation will not work automatically.
 
 </Alert>
 

--- a/includes/dart-integrations/slow-and-frozen-frames-instrumentation.mdx
+++ b/includes/dart-integrations/slow-and-frozen-frames-instrumentation.mdx
@@ -41,6 +41,12 @@ This instrumentation is automatically enabled through two integrations:
 
 In most cases, no additional configuration is required.
 
+<Alert>
+
+If `WidgetsFlutterBinding` is initialized before `SentryFlutter.init`) then this instrumentation will not work automatically.
+
+</Alert>
+
 ### Early Widgets Binding Initialization
 
 If you need to initialize the widgets binding earlier than `SentryFlutter.init()`, you must call `SentryWidgetsFlutterBinding.ensureInitialized()` manually. Note that using a different custom binding will prevent this instrumentation from working properly.


### PR DESCRIPTION
Add * to Slow and Frozen Frames integrations, since there is a scenario where auto-instrumentation will not work.