### PR TITLE
fix(docs): update Dart and Flutter platform links in getting-started.mdx

### DIFF
--- a/docs/product/insights/getting-started.mdx
+++ b/docs/product/insights/getting-started.mdx
@@ -80,7 +80,12 @@ If you don't already have performance monitoring enabled, use the links for supp
     url="/platforms/apple/guides/ios/tracing/"
   />
 
-- <PlatformLinkWithLogo platform="flutter" url="/platforms/dart/guides/flutter/tracing/" />
+- <PlatformLinkWithLogo
+    platform="dart"
+    url="/platforms/dart/tracing/"
+  />
+
+  - [Flutter](/platforms/dart/guides/flutter/tracing/)
 
 - <PlatformLinkWithLogo platform="native" url="/platforms/native/tracing/" />
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Update Dart and Flutter platform links in product insights getting-started section.

https://docs.sentry.io/product/insights/getting-started/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.