### PR TITLE
feat: Update platforms grid UI

### DIFF
--- a/src/components/platformFilter/style.module.scss
+++ b/src/components/platformFilter/style.module.scss
@@ -45,17 +45,12 @@
 
 .CollapsibleTrigger {
   cursor: pointer;
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 15px;
-  line-height: 1;
   background-color: var(--item-bg);
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding: 0.75rem 1rem;
   border-radius: 0.25rem;
   user-select: none;
 
@@ -67,7 +62,6 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem;
   }
 }
 
@@ -154,8 +148,6 @@
 }
 
 .ChevronButton {
-  width: 24px;
-  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/platformFilter/style.module.scss
+++ b/src/components/platformFilter/style.module.scss
@@ -41,6 +41,7 @@
 .CollapsibleRoot {
   border-radius: 0.25rem;
   box-shadow: var(--shadow-6);
+  align-self: flex-start;
 }
 
 .CollapsibleTrigger {


### PR DESCRIPTION
This changes the UI for the platforms grid on the home page.

it includes https://github.com/getsentry/sentry-docs/pull/13065, plus:

1. Order the platforms alphabetically from left to right - which makes more sense IMHO
2. Use a proper grid for the items - this has several implications for how stuff is rendered, some "good" some maybe a bit "weird":

a. Ordering is now horizontally:
![image](https://github.com/user-attachments/assets/f5e0b52b-0049-497c-b08e-26391414cf1b)

b. The grid is always maintained when opening a platform for guides:

https://github.com/user-attachments/assets/074d122e-ebbd-4f7a-9b12-4ab4e8132db7

c. The grid is always maintained when searching:

https://github.com/user-attachments/assets/7cacae23-0d41-435f-8db8-330f733b3467

