### PR TITLE
feat: Allow to have top level alias for platforms

### DIFF
--- a/docs/platforms/javascript/config.yml
+++ b/docs/platforms/javascript/config.yml
@@ -1,4 +1,5 @@
-title: JavaScript
+title: Browser JavaScript
+topLevelAlias: JavaScript
 caseStyle: camelCase
 supportLevel: production
 sdk: 'sentry.javascript.browser'

--- a/docs/platforms/javascript/config.yml
+++ b/docs/platforms/javascript/config.yml
@@ -1,5 +1,5 @@
 title: Browser JavaScript
-topLevelAlias: JavaScript
+platformTitle: JavaScript
 caseStyle: camelCase
 supportLevel: production
 sdk: 'sentry.javascript.browser'

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -9,22 +9,26 @@ type BreadcrumbsProps = {
 };
 
 export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
-  const nodes: DocNode[] = [];
+  const breadcrumbs: {title: string; to: string}[] = [];
+
   for (let node: DocNode | undefined = leafNode; node; node = node.parent) {
     if (node && !node.missing) {
-      nodes.unshift(node);
+      const to = node.path === '/' ? node.path : `/${node.path}/`;
+      const title = node.frontmatter.platformTitle ?? node.frontmatter.title;
+
+      breadcrumbs.unshift({
+        to,
+        title,
+      });
     }
   }
 
   return (
     <ul className="list-none flex p-0 flex-wrap" style={{margin: 0}}>
-      {nodes.map(n => {
-        const to = n.path === '/' ? n.path : `/${n.path}/`;
+      {breadcrumbs.map(b => {
         return (
-          <li className={styles['breadcrumb-item']} key={n.path}>
-            <SmartLink to={to}>
-              {n.frontmatter.platformTitle ?? n.frontmatter.title}
-            </SmartLink>
+          <li className={styles['breadcrumb-item']} key={b.to}>
+            <SmartLink to={b.to}>{b.title}</SmartLink>
           </li>
         );
       })}

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -22,7 +22,9 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
         const to = n.path === '/' ? n.path : `/${n.path}/`;
         return (
           <li className={styles['breadcrumb-item']} key={n.path}>
-            <SmartLink to={to}>{n.frontmatter.topLevelAlias ?? n.frontmatter.title}</SmartLink>
+            <SmartLink to={to}>
+              {n.frontmatter.topLevelAlias ?? n.frontmatter.title}
+            </SmartLink>
           </li>
         );
       })}

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -22,7 +22,7 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
         const to = n.path === '/' ? n.path : `/${n.path}/`;
         return (
           <li className={styles['breadcrumb-item']} key={n.path}>
-            <SmartLink to={to}>{n.frontmatter.title}</SmartLink>
+            <SmartLink to={to}>{n.frontmatter.topLevelAlias ?? n.frontmatter.title}</SmartLink>
           </li>
         );
       })}

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -23,7 +23,7 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
         return (
           <li className={styles['breadcrumb-item']} key={n.path}>
             <SmartLink to={to}>
-              {n.frontmatter.topLevelAlias ?? n.frontmatter.title}
+              {n.frontmatter.platformTitle ?? n.frontmatter.title}
             </SmartLink>
           </li>
         );

--- a/src/components/platformFilter/client.tsx
+++ b/src/components/platformFilter/client.tsx
@@ -62,7 +62,7 @@ export function PlatformFilterClient({platforms}: {platforms: Platform[]}) {
       return platformsAndGuides;
     }
     // any of these fields can be used to match the search value
-    const keys = ['title', 'aliases', 'name', 'sdk', 'keywords'];
+    const keys = ['title', 'aliases', 'name', 'sdk', 'keywords', 'topLevelAlias'];
     const matches_ = matchSorter(platformsAndGuides, filter, {
       keys,
       threshold: rankings.CONTAINS,
@@ -213,7 +213,7 @@ function PlatformWithGuides({
               format="lg"
               className={`${styles.PlatformIcon} !border-none !shadow-none`}
             />
-            {platform.title}
+            {platform.topLevelAlias ?? platform.title}
           </div>
           <button className={styles.ChevronButton}>
             <TriangleRightIcon

--- a/src/components/platformFilter/client.tsx
+++ b/src/components/platformFilter/client.tsx
@@ -62,7 +62,7 @@ export function PlatformFilterClient({platforms}: {platforms: Platform[]}) {
       return platformsAndGuides;
     }
     // any of these fields can be used to match the search value
-    const keys = ['title', 'aliases', 'name', 'sdk', 'keywords', 'topLevelAlias'];
+    const keys = ['title', 'aliases', 'name', 'sdk', 'keywords', 'platformTitle'];
     const matches_ = matchSorter(platformsAndGuides, filter, {
       keys,
       threshold: rankings.CONTAINS,
@@ -195,7 +195,14 @@ function PlatformWithGuides({
 
   const guides = useMemo(() => {
     const showPlatformInContent = matchKeys.includes(platform.key);
-    return showPlatformInContent ? [platform, ...platform.guides] : platform.guides;
+
+    // This is the case if `platformTitle` is configured for a platform
+    // In this case, we do not need to add the platform to the list of guides
+    const hasGuideWithPlatformKey = platform.guides.some(g => g.key === platform.key);
+
+    return showPlatformInContent && !hasGuideWithPlatformKey
+      ? [platform, ...platform.guides]
+      : platform.guides;
   }, [matchKeys, platform]);
 
   return (
@@ -213,7 +220,7 @@ function PlatformWithGuides({
               format="lg"
               className={`${styles.PlatformIcon} !border-none !shadow-none`}
             />
-            {platform.topLevelAlias ?? platform.title}
+            {platform.title}
           </div>
           <button className={styles.ChevronButton}>
             <TriangleRightIcon

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -279,17 +279,13 @@ function PlatformItem({
       isLastGuide: i === guides.length - 1,
     }));
 
-  const isPlatformWithGuidesAndTopLevelAlias =
-    platform.guides.length > 0 && !!platform.topLevelAlias;
+  // This is the case if `platformTitle` is configured for a platform
+  // In this case, the top-level select item should get the `-redirect` suffix,
+  // as we can't have two items with the same key
+  const hasGuideWithPlatformKey = platform.guides.some(g => g.key === platform.key);
 
   const guides = platform.isExpanded
-    ? markLastGuide(
-        platform.guides.length > 0
-          ? isPlatformWithGuidesAndTopLevelAlias
-            ? [platform as unknown as PlatformGuide, ...platform.guides]
-            : platform.guides
-          : platform.integrations
-      )
+    ? markLastGuide(platform.guides.length > 0 ? platform.guides : platform.integrations)
     : [];
 
   return (
@@ -299,11 +295,7 @@ function PlatformItem({
         <RadixSelect.Label className="flex">
           <Fragment>
             <RadixSelect.Item
-              value={
-                isPlatformWithGuidesAndTopLevelAlias
-                  ? `${platform.key}-redirect`
-                  : platform.key
-              }
+              value={hasGuideWithPlatformKey ? `${platform.key}-redirect` : platform.key}
               asChild
               className={styles.item}
               data-platform-with-guides
@@ -318,7 +310,7 @@ function PlatformItem({
                       format="sm"
                       className={styles['platform-icon']}
                     />
-                    {platform.topLevelAlias ?? platform.title}
+                    {platform.title}
                   </span>
                 </RadixSelect.ItemText>
               </ComboboxItem>

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -334,7 +334,7 @@ function PlatformItem({
         </RadixSelect.Label>
       </RadixSelect.Group>
       {guides.map(guide => {
-        return <GuideItem key={guide.key + '-guide'} guide={guide} />;
+        return <GuideItem key={guide.key} guide={guide} />;
       })}
     </Fragment>
   );
@@ -346,7 +346,7 @@ type GuideItemProps = {
 function GuideItem({guide}: GuideItemProps) {
   return (
     <RadixSelect.Item
-      key={guide.key + '-guide'}
+      key={guide.key}
       value={guide.key}
       asChild
       className={styles.item}

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -92,7 +92,9 @@ export function PlatformSelector({
 
   const router = useRouter();
   const onPlatformChange = (platformKey: string) => {
-    const platform_ = platformsAndGuides.find(platform => platform.key === platformKey);
+    const platform_ = platformsAndGuides.find(
+      platform => platform.key === platformKey.replace('-redirect', '')
+    );
     if (platform_) {
       localStorage.setItem('active-platform', platform_.key);
       router.push(platform_.url);
@@ -277,8 +279,17 @@ function PlatformItem({
       isLastGuide: i === guides.length - 1,
     }));
 
+  const isPlatformWithGuidesAndTopLevelAlias =
+    platform.guides.length > 0 && !!platform.topLevelAlias;
+
   const guides = platform.isExpanded
-    ? markLastGuide(platform.guides.length > 0 ? platform.guides : platform.integrations)
+    ? markLastGuide(
+        platform.guides.length > 0
+          ? isPlatformWithGuidesAndTopLevelAlias
+            ? [platform as unknown as PlatformGuide, ...platform.guides]
+            : platform.guides
+          : platform.integrations
+      )
     : [];
 
   return (
@@ -288,7 +299,11 @@ function PlatformItem({
         <RadixSelect.Label className="flex">
           <Fragment>
             <RadixSelect.Item
-              value={platform.key}
+              value={
+                isPlatformWithGuidesAndTopLevelAlias
+                  ? `${platform.key}-redirect`
+                  : platform.key
+              }
               asChild
               className={styles.item}
               data-platform-with-guides
@@ -303,7 +318,7 @@ function PlatformItem({
                       format="sm"
                       className={styles['platform-icon']}
                     />
-                    {platform.title}
+                    {platform.topLevelAlias ?? platform.title}
                   </span>
                 </RadixSelect.ItemText>
               </ComboboxItem>
@@ -327,7 +342,7 @@ function PlatformItem({
         </RadixSelect.Label>
       </RadixSelect.Group>
       {guides.map(guide => {
-        return <GuideItem key={guide.key} guide={guide} />;
+        return <GuideItem key={guide.key + '-guide'} guide={guide} />;
       })}
     </Fragment>
   );
@@ -339,7 +354,7 @@ type GuideItemProps = {
 function GuideItem({guide}: GuideItemProps) {
   return (
     <RadixSelect.Item
-      key={guide.key}
+      key={guide.key + '-guide'}
       value={guide.key}
       asChild
       className={styles.item}

--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -253,14 +253,13 @@ function nodeToPlatform(n: DocNode): Platform {
   const caseStyle = platformData?.case_style || n.frontmatter.caseStyle;
   const guides = extractGuides(n);
   const integrations = extractIntegrations(n);
-  const topLevelAlias = n.frontmatter.topLevelAlias;
 
   return {
     key: n.slug,
     name: n.slug,
     type: 'platform',
     url: '/' + n.path + '/',
-    title: n.frontmatter.title,
+    title: n.frontmatter.platformTitle ?? n.frontmatter.title,
     caseStyle,
     sdk: n.frontmatter.sdk,
     fallbackPlatform: n.frontmatter.fallbackPlatform,
@@ -268,7 +267,6 @@ function nodeToPlatform(n: DocNode): Platform {
     keywords: n.frontmatter.keywords,
     guides,
     integrations,
-    topLevelAlias,
   };
 }
 
@@ -371,9 +369,20 @@ function extractGuides(platformNode: DocNode): PlatformGuide[] {
   if (!guidesNode) {
     return [];
   }
-  return guidesNode.children
+
+  // If a `platformTitle` is defined, we add a virtual guide
+  const defaultGuide = platformNode.frontmatter.platformTitle
+    ? {
+        ...nodeToGuide(platformNode.slug, platformNode),
+        key: platformNode.slug,
+      }
+    : undefined;
+
+  const childGuides = guidesNode.children
     .filter(({path}) => !isVersioned(path))
     .map(n => nodeToGuide(platformNode.slug, n));
+
+  return defaultGuide ? [defaultGuide, ...childGuides] : childGuides;
 }
 
 const extractIntegrations = (p: DocNode): PlatformIntegration[] => {

--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -253,6 +253,7 @@ function nodeToPlatform(n: DocNode): Platform {
   const caseStyle = platformData?.case_style || n.frontmatter.caseStyle;
   const guides = extractGuides(n);
   const integrations = extractIntegrations(n);
+  const topLevelAlias = n.frontmatter.topLevelAlias;
 
   return {
     key: n.slug,
@@ -267,6 +268,7 @@ function nodeToPlatform(n: DocNode): Platform {
     keywords: n.frontmatter.keywords,
     guides,
     integrations,
+    topLevelAlias,
   };
 }
 

--- a/src/types/platform.tsx
+++ b/src/types/platform.tsx
@@ -130,11 +130,14 @@ export interface PlatformConfig {
    * Is this a first-party or third-party SDK?
    */
   supportLevel?: PlatformSupportLevel;
-
   /**
    * The human readable name of the platform.
    */
   title?: string;
+  /**
+   * Alias for the top level platform name.
+   */
+  topLevelAlias?: string;
 }
 
 /**

--- a/src/types/platform.tsx
+++ b/src/types/platform.tsx
@@ -119,6 +119,12 @@ export interface PlatformConfig {
    */
   keywords?: string[];
   /**
+   * The title of the platform as it should be displayed in the sidebar.
+   * In most cases, you do not need to define this, as the title is used.
+   * However, in some cases - e.g. JavaScript - the Platform title (JavaScript) is different from the default guide (Browser JavaScript).
+   */
+  platformTitle?: string;
+  /**
    * Used to map a platform to a specific SDK as defined by the SDK registry.
    */
   sdk?: string;
@@ -134,10 +140,6 @@ export interface PlatformConfig {
    * The human readable name of the platform.
    */
   title?: string;
-  /**
-   * Alias for the top level platform name.
-   */
-  topLevelAlias?: string;
 }
 
 /**


### PR DESCRIPTION
Today, it is a bit confusing in some cases, but especially JavaScript, that the top level platform is called "JavaScript" (which all guides inherit from), but actually it is just Browser JavaScript.

This adds a new field which, when set for a platform, will lead to a slightly different behavior:

![Screenshot 2025-03-20 at 16 30 08](https://github.com/user-attachments/assets/001f19cb-2c98-41c9-8a65-a7fb889619eb)

And

![Screenshot 2025-03-20 at 16 27 03](https://github.com/user-attachments/assets/acfa01be-fa9d-4eef-895f-f643cc762e75)

Some notes:

1. When you click on the top level "JavaScript" in the sidebar, it will basically "redirect" to "Browser JavaScript"
2. For other platforms that have not set this field, nothing changes - so with this PR, only JS changes.
3. The breadcrumbs are a bit tricky/weird, there I opted to leave it as it is for now 🤔 it's a bit inconsistent, but everything else is quite tricky as the hierarchy needs to change based on if a guide is selected etc. we may tweak this still...