### PR TITLE
fix: Avoid showing top-level platform in search

### DIFF
--- a/src/components/platformFilter/client.tsx
+++ b/src/components/platformFilter/client.tsx
@@ -70,6 +70,10 @@ export function PlatformFilterClient({platforms}: {platforms: Platform[]}) {
     return matches_;
   }, [filter, platformsAndGuides]);
 
+  const matchKeys = useMemo(() => {
+    return matches.map(x => x.key);
+  }, [matches]);
+
   const platformColumns: Platform[][] = splitToChunks(
     3,
     uniqByReference(matches.map(x => (x.type === 'platform' ? x : x.platform))).map(p => {
@@ -161,6 +165,7 @@ export function PlatformFilterClient({platforms}: {platforms: Platform[]}) {
                   <PlatformWithGuides
                     key={platform.key}
                     platform={platform}
+                    matchKeys={matchKeys}
                     // force expand if the filter is long enough to have few results
                     forceExpand={filter.length >= 2}
                   />
@@ -180,11 +185,19 @@ export function PlatformFilterClient({platforms}: {platforms: Platform[]}) {
 function PlatformWithGuides({
   platform,
   forceExpand,
+  matchKeys,
 }: {
   forceExpand: boolean;
+  matchKeys: string[];
   platform: Platform;
 }) {
   const [expanded, setExpanded] = useState(false);
+
+  const guides = useMemo(() => {
+    const showPlatformInContent = !forceExpand || matchKeys.includes(platform.key);
+    return showPlatformInContent ? [platform, ...platform.guides] : platform.guides;
+  }, [forceExpand, matchKeys, platform]);
+
   return (
     <Collapsible.Root
       className={styles.CollapsibleRoot}
@@ -217,7 +230,7 @@ function PlatformWithGuides({
         // scrollable if there are more than 8 (arbitrary limit) guides
         data-scrollable={platform.guides.length >= 8 || platform.integrations.length >= 8}
       >
-        {[platform, ...platform.guides].map((guide, i) => (
+        {guides.map((guide, i) => (
           <Link
             href={guide.url}
             style={{textDecoration: 'none', color: 'var(--foreground) !important'}}


### PR DESCRIPTION
If you search for something, e.g. "Next.js", we do not need to show the link to the top-level "JavaScript" entry in the platforms list.

### Old

![Screenshot 2025-03-20 at 16 56 33](https://github.com/user-attachments/assets/09eb0a19-2c9c-4f30-8f9c-b97cc0208c8c)

### New

![Screenshot 2025-03-20 at 16 56 19](https://github.com/user-attachments/assets/4ceb575d-5a6e-45a3-8a78-7f8b7178da5c)

Note that if you search for the top-level term, it is still there - but only if the top-level entry actually matches the search term:

![Screenshot 2025-03-20 at 16 56 24](https://github.com/user-attachments/assets/93a9c6b1-27b0-4022-8d82-8589e04726f5)
