### PR TITLE
chore(deps): Bump sentry to 9.8.0

### DIFF
--- a/apps/changelog/package.json
+++ b/apps/changelog/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-toolbar": "^1.1.0",
     "@radix-ui/themes": "^3.1.3",
-    "@sentry/nextjs": "9.7.0-alpha.0",
+    "@sentry/nextjs": "9.8.0",
     "@spotlightjs/spotlight": "^2.1.1",
     "next": "15.1.2",
     "next-auth": "^4.24.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@radix-ui/themes": "^3.1.3",
     "@sentry-internal/global-search": "^1.3.0",
-    "@sentry/nextjs": "9.7.0-alpha.0",
+    "@sentry/nextjs": "9.8.0",
     "@types/mdx": "^2.0.9",
     "algoliasearch": "^4.23.3",
     "dompurify": "3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,19 +3022,19 @@
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz"
   integrity sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==
 
-"@sentry-internal/browser-utils@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.7.0-alpha.0.tgz#0033cbd5e695f28f3a1c738facdd1cbc4deb86bd"
-  integrity sha512-+xAMDyiedqArr76i4xUXfWrfC8jgLgL5k5mSYzAkOq9iK2pndml7LpsPVxsaeQe7Nxf1w9MtIIalFxwufK200Q==
+"@sentry-internal/browser-utils@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.8.0.tgz#b524384a5ceae84f7982b58fc97ae69893c011bf"
+  integrity sha512-7aQDeU9ogMLKnEBFM/vvgMMgZDkfMhoZCtX8kq65gn33L4X2B8sI5oyUj2QJtXaRSsiUjbdCaquDLqZBCaLQHA==
   dependencies:
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry/core" "9.8.0"
 
-"@sentry-internal/feedback@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.7.0-alpha.0.tgz#437f72c7eaaa177c577a151959caa5c3749cf61f"
-  integrity sha512-KN7v9ZakkYH33ryqENfnRKR8OW1HBGPO9t8GbStpoVSQRVGOB5B7S2iVPLPGrajoyAkbzXptQbzycLS9a1cQ5w==
+"@sentry-internal/feedback@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.8.0.tgz#ffdf7e9577a58bff5ff48ccdf597246e3a61d0a2"
+  integrity sha512-xWiCJkD8ROuy2pnojuRLcLI6sezK399gasA5ZL4MCXdkryqZYs55Ef2Ofj4z0RdUc8gMUb81+LTqwbmbfTqNlQ==
   dependencies:
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry/core" "9.8.0"
 
 "@sentry-internal/global-search@^1.3.0":
   version "1.3.0"
@@ -3050,37 +3050,37 @@
     htmlparser2 "^4.1.0"
     title-case "^3.0.2"
 
-"@sentry-internal/replay-canvas@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.7.0-alpha.0.tgz#9c2b06c291c44a625bc207a9d639dccafad06644"
-  integrity sha512-Uot+rqHv23nn77tg5Lm78S+qlMmsu1Ntt256e/enxuoHlrI3VWKx26zAffUo0sjt+Labkz9GJ4uCmZ7z08keyw==
+"@sentry-internal/replay-canvas@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.8.0.tgz#8c2c07c055e0db3dcf0caefd9ee45cde5bea35e7"
+  integrity sha512-/6ELOnyCOItvqv2Os29JhE8ydDds3xibMQ+FomsSkClQdC4bbc/L74nm/fdXVpJkMswtjksiTwZo1nYTS3JsIw==
   dependencies:
-    "@sentry-internal/replay" "9.7.0-alpha.0"
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry-internal/replay" "9.8.0"
+    "@sentry/core" "9.8.0"
 
-"@sentry-internal/replay@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.7.0-alpha.0.tgz#9d194556bbd00be61ec4712d2c56aa272a93b2b8"
-  integrity sha512-9/E4NGB90hX7AhHf3sNToN5lNmwBeLF6BoIAfWZKr6YgxpVXekrRCbrOX+y8zbbeuy3dNPnU4L7SSEthpZbI2A==
+"@sentry-internal/replay@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.8.0.tgz#c5ef93efabd249d6cfa07c6fdbc34c71095b53e8"
+  integrity sha512-YJhhNnrsufYVIX9s5lNSFFQrBJjUtn5AxvrcnN0fvLymNg3Y73GOUpFmhTxyELjQneKiOViClxjoWSVAN7sqQA==
   dependencies:
-    "@sentry-internal/browser-utils" "9.7.0-alpha.0"
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry-internal/browser-utils" "9.8.0"
+    "@sentry/core" "9.8.0"
 
 "@sentry/babel-plugin-component-annotate@3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-3.2.2.tgz#0c5f26e417b8f524924fa4531b82ad5603216e90"
   integrity sha512-D+SKQ266ra/wo87s9+UI/rKQi3qhGPCR8eSCDe0VJudhjHsqyNU+JJ5lnIGCgmZaWFTXgdBP/gdr1Iz1zqGs4Q==
 
-"@sentry/browser@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.7.0-alpha.0.tgz#e8bb459a4efc249107191c32aedca3c71b9730e9"
-  integrity sha512-9DQtpxcbhlllRZqvIgazSyMWgCBAT/wV5/jx37BI7I54yXvpGA8G5MshjFI9KCjxwHA2Irm+QcHytkaTatoJtw==
+"@sentry/browser@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.8.0.tgz#fa26d8a8dd604a22b3e63499b45b5faffd95af22"
+  integrity sha512-iFM4PGLc6qCb0GaHnA5Uy09k25RXVSepAgS574cm1CH7II1wrRjTozKnPKROW89WDMuxoTOL7Tk7qPGCyWmA4g==
   dependencies:
-    "@sentry-internal/browser-utils" "9.7.0-alpha.0"
-    "@sentry-internal/feedback" "9.7.0-alpha.0"
-    "@sentry-internal/replay" "9.7.0-alpha.0"
-    "@sentry-internal/replay-canvas" "9.7.0-alpha.0"
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry-internal/browser-utils" "9.8.0"
+    "@sentry-internal/feedback" "9.8.0"
+    "@sentry-internal/replay" "9.8.0"
+    "@sentry-internal/replay-canvas" "9.8.0"
+    "@sentry/core" "9.8.0"
 
 "@sentry/bundler-plugin-core@3.2.2":
   version "3.2.2"
@@ -3150,35 +3150,35 @@
     "@sentry/cli-win32-i686" "2.42.2"
     "@sentry/cli-win32-x64" "2.42.2"
 
-"@sentry/core@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.7.0-alpha.0.tgz#de61946913d3fec8a98cdc50a4d75be39522fc00"
-  integrity sha512-lyHN4OK3+C5zLvxn6dGsyhDkvUAP0EPWkRUQ9JFsSh4M8i00b00dLHI+4o9e4tAcelm1bjexNN2do9gBZ7OHIA==
+"@sentry/core@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.8.0.tgz#31f04746cff67ba004eb478f2dd144eadfa2d9cf"
+  integrity sha512-EnN2yLWCbWjooWBPzwlXdZoJG/Bqn3ymbuXX++DUJuBGjSmtixQeTf/hKeVzj4zbib3BbbYsNBasRVjq8Rk5ng==
 
-"@sentry/nextjs@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-9.7.0-alpha.0.tgz#09d56e43cd03095e9afecfbaacf959a3957a7bbf"
-  integrity sha512-1RcgjXZAtOxb4tppehsmMM17Pb+ORX/+1odzFpnFzYLLFpoO8v/Lty+O8y1IrG6MIniP11vFcNmPqVdQRz4iZg==
+"@sentry/nextjs@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-9.8.0.tgz#e9d2a14943ea6d2c548080aeaad1e8c1374080f9"
+  integrity sha512-wBH9Z2FsnoezZIwEfK5iW5S2Ht9MGqA0K0cmv4sd2XHHk+jjORzZBUpYsn+SLNRpnfS8Hbk5R+NofFxCgjoZ8A==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/semantic-conventions" "^1.30.0"
     "@rollup/plugin-commonjs" "28.0.1"
-    "@sentry-internal/browser-utils" "9.7.0-alpha.0"
-    "@sentry/core" "9.7.0-alpha.0"
-    "@sentry/node" "9.7.0-alpha.0"
-    "@sentry/opentelemetry" "9.7.0-alpha.0"
-    "@sentry/react" "9.7.0-alpha.0"
-    "@sentry/vercel-edge" "9.7.0-alpha.0"
+    "@sentry-internal/browser-utils" "9.8.0"
+    "@sentry/core" "9.8.0"
+    "@sentry/node" "9.8.0"
+    "@sentry/opentelemetry" "9.8.0"
+    "@sentry/react" "9.8.0"
+    "@sentry/vercel-edge" "9.8.0"
     "@sentry/webpack-plugin" "3.2.2"
     chalk "3.0.0"
     resolve "1.22.8"
     rollup "4.35.0"
     stacktrace-parser "^0.1.10"
 
-"@sentry/node@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.7.0-alpha.0.tgz#1300c9266461ca24df3130e1591667e023d5ffb7"
-  integrity sha512-kUZOJY4nMkCUxGxMt9D8UVJzNBG+ozvYX5ZRJSvXVdzdNqFgGefiOSGBYnlamwifF28tVqmh7umZ/bQRkE02GA==
+"@sentry/node@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.8.0.tgz#0398e491a49008fefef86af587272d6810be29f6"
+  integrity sha512-whkz/TBkEhwqdm/onukqMLEVjFW0j9OqEx5GkaqqRPpiX8Q3nZV80C1KV6J7phV0asMduHftBXQLKMmJs5ZODw==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.30.1"
@@ -3211,33 +3211,33 @@
     "@opentelemetry/sdk-trace-base" "^1.30.1"
     "@opentelemetry/semantic-conventions" "^1.30.0"
     "@prisma/instrumentation" "6.5.0"
-    "@sentry/core" "9.7.0-alpha.0"
-    "@sentry/opentelemetry" "9.7.0-alpha.0"
+    "@sentry/core" "9.8.0"
+    "@sentry/opentelemetry" "9.8.0"
     import-in-the-middle "^1.13.0"
 
-"@sentry/opentelemetry@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.7.0-alpha.0.tgz#763ff18289e2257a4b7cd56d9c9fdef1e6348056"
-  integrity sha512-KjmNlQVAXBNlYv0mzWjj0dUC+59uQnGN3gzF3hOY8NPtErDE7cE6PssPwtM6VaPo9xY3Zb2c3RJuy6c74/XCmQ==
+"@sentry/opentelemetry@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.8.0.tgz#a02e91c2e6bf668c47babe4ab0a2fa2f6d86d644"
+  integrity sha512-7EWfLC5HOBYH23FxZJNK8BuQ3MCWTf/1cfH3UH773653Z/z4V49N4Xo4Zcx+y7BNVt9g6Hy23Jn0AsFAk2oisQ==
   dependencies:
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry/core" "9.8.0"
 
-"@sentry/react@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-9.7.0-alpha.0.tgz#65e96e5e5b5e7639c8dc8a3d7938772baad185ad"
-  integrity sha512-5duJOHcbod9x4u0wkpKLYF5HZaNZvo5k4fJrq6puTCZ3QqJXW1elpcDdtUSPfghAqDH7ko4WBfplS+W+EIgqWA==
+"@sentry/react@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-9.8.0.tgz#bf79f0af054b4aea2d0ff78682b721e60636b40c"
+  integrity sha512-P/Lhiso8504Jza4NH3BQlP3WbnSaUsCNk21acYY3sb1lHKnpPjvWZT61D1nFIh+hisdQO6oLjTTr2O1opT43jQ==
   dependencies:
-    "@sentry/browser" "9.7.0-alpha.0"
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry/browser" "9.8.0"
+    "@sentry/core" "9.8.0"
     hoist-non-react-statics "^3.3.2"
 
-"@sentry/vercel-edge@9.7.0-alpha.0":
-  version "9.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/vercel-edge/-/vercel-edge-9.7.0-alpha.0.tgz#8c04015013fb4de46d2ce8dcb4bde29a9baa6eb8"
-  integrity sha512-NpzzDYa+Q5leYiKl4G8/cKzl77mdb7sXVeJo1QxNerS90nvCSm0/1ZhWXm2gC/afFBKY1CuHkjcyClGY3ok9mQ==
+"@sentry/vercel-edge@9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/vercel-edge/-/vercel-edge-9.8.0.tgz#f7b477443759a6739a8ebce0b8a9d604378b1658"
+  integrity sha512-+jpz2yV1kRfhzcdzoqDTuX2sKVLAF07UncGH4lxdygLah/zhST1jucD2KSHzfYem5GYvDc9WtuCrDOgg9qn6TQ==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
-    "@sentry/core" "9.7.0-alpha.0"
+    "@sentry/core" "9.8.0"
 
 "@sentry/webpack-plugin@3.2.2":
   version "3.2.2"


### PR DESCRIPTION
We somehow did not receive any events using 9.7.0-alpha.0