### PR TITLE
chore(ci): Add env vars to 404-linter action

### DIFF
--- a/.github/workflows/lint-404s.yml
+++ b/.github/workflows/lint-404s.yml
@@ -40,9 +40,15 @@ jobs:
 
       - run: yarn build
         if: steps.filter.outputs.docs == 'true'
+        env:
+          SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
+          NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - run: yarn build:developer-docs
         if: steps.filter.outputs.dev-docs == 'true'
+        env:
+          SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
+          NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Start Http Server
         run: yarn start &


### PR DESCRIPTION
With https://github.com/getsentry/sentry-docs/pull/13083 DSN env vars are now required for prod builds, which is why the linter actions fails.

Since we do not require Sentry in this actions we can just pass a placeholder value.