### PR TITLE
fix(ci): Add env vars for start command

### DIFF
--- a/.github/workflows/lint-404s.yml
+++ b/.github/workflows/lint-404s.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Start Http Server
         run: yarn start &
         if: steps.filter.outputs.docs == 'true' || steps.filter.outputs.dev-docs == 'true'
+        env:
+          SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
+          NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Lint 404s
         run: bun ./scripts/lint-404s/main.ts


### PR DESCRIPTION
Missed this in https://github.com/getsentry/sentry-docs/pull/13099