### PR TITLE
feat(sentry): Store previous trace information in `sessionStorage`

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,7 +4,6 @@
 
 import * as Sentry from '@sentry/nextjs';
 import * as Spotlight from '@spotlightjs/spotlight';
-import {Sen} from 'next/font/google';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 import * as Spotlight from '@spotlightjs/spotlight';
+import {Sen} from 'next/font/google';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -30,6 +31,9 @@ Sentry.init({
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ['sentry-docs'],
       behaviour: 'apply-tag-if-contains-third-party-frames',
+    }),
+    Sentry.browserTracingIntegration({
+      linkPreviousTrace: 'session-storage',
     }),
   ],
 });


### PR DESCRIPTION
Let's give this a try in our docs project to see how well it works. Happy to close if anyone has concerns regarding sessionStorage usage but we already use Replay in docs, so we already write and read from it. With this change, we can link to a previous trace even if users hard-navigate or hard-reload the page. 