### PR TITLE
chore: user-feedback-replay-clip feature is always enabled

### DIFF
--- a/develop-docs/application-architecture/feedback-architecture.mdx
+++ b/develop-docs/application-architecture/feedback-architecture.mdx
@@ -264,7 +264,7 @@ This feature is available if you enable the following feature flags.
 
 - `organizations:user-feedback-ingest`
 - `organizations:user-feedback-ui`
-- `organizations:user-feedback-replay-clip` (v24.7.1+)
+- `organizations:user-feedback-replay-clip` (from v24.7.1 to v??.?.?)
 
 Auto-registered flags for issue platform, for versions \<= v24.10.0 only:
 

--- a/develop-docs/application-architecture/feedback-architecture.mdx
+++ b/develop-docs/application-architecture/feedback-architecture.mdx
@@ -264,7 +264,7 @@ This feature is available if you enable the following feature flags.
 
 - `organizations:user-feedback-ingest`
 - `organizations:user-feedback-ui`
-- `organizations:user-feedback-replay-clip` (from v24.7.1 to v??.?.?)
+- `organizations:user-feedback-replay-clip` (from v24.7.1 through to v25.3.0)
 
 Auto-registered flags for issue platform, for versions \<= v24.10.0 only:
 


### PR DESCRIPTION
`user-feedback-replay-clip` was added in self-hosted v24.7.1 and removed in v25.4.0. Therefore if you're on v25.3.0 keep that clip config in your install. Once you get past 25.3.0 then it's ok to remove.

**Timeline**

- March 17 
  - [v25.3.0](https://github.com/getsentry/sentry/releases/tag/25.3.0) released
- March 24
  - Depends on https://github.com/getsentry/sentry/pull/87770
  - Depends on https://github.com/getsentry/sentry/pull/87771
  - Depends on https://github.com/getsentry/sentry-options-automator/pull/3386
- April 15
  - [v25.4.0](https://github.com/getsentry/sentry/releases/tag/25.4.0) released

