### PR TITLE
feat(native): add `crashpad-wait-for-upload` option

### DIFF
--- a/docs/platforms/native/advanced-usage/backend-tradeoffs/index.mdx
+++ b/docs/platforms/native/advanced-usage/backend-tradeoffs/index.mdx
@@ -37,7 +37,7 @@ Sentry decided on `crashpad` as the default on all platforms because there are a
 
 In the above cases, if you cannot loosen the requirements of your environment, you have to choose an in-process backend (meaning either `breakpad` or `inproc`).
 
-When your deployment scenario should wait for the `crashpad_handler` to finish its work before a shutdown-after-crash (systemd, Docker), you can enable the option `crashpad_wait_for_upload` to delay application shutdown until the upload of the crash report is completed.
+When your deployment scenario should wait for the `crashpad_handler` to finish its work before a shutdown-after-crash (systemd, Docker), you can enable the option [`crashpad_wait_for_upload`](/platforms/native/configuration/options/#crashpad-wait-for-upload) to delay application shutdown until the upload of the crash report is completed.
 
 ### How do I decide between `breakpad` or `inproc`?
 

--- a/docs/platforms/native/advanced-usage/backend-tradeoffs/index.mdx
+++ b/docs/platforms/native/advanced-usage/backend-tradeoffs/index.mdx
@@ -32,11 +32,12 @@ Sentry decided on `crashpad` as the default on all platforms because there are a
 * you cannot package or deploy an additional executable (the `crashpad_handler`)
 * you cannot allow a secondary process to connect via `ptrace` to your application (AWS Lambda, Flatpak-, Snap-Sandboxes)
 * IPC between your process and the `crashpad_handler` is inhibited by security settings or not available in your deployment target
-* your deployment scenario cannot wait for the `crashpad_handler` to finish its work before a shutdown-after-crash (systemd, Docker)
 * you want to distribute your application via the macOS App Store
 * you want to define crash hooks on macOS because there, error handling happens entirely in the `crashpad_handler`, whereas on Linux and Windows, at least the initial handling happens in your process, after which `crashpad_handler` takes over and snapshots the process to send a crash report
 
 In the above cases, if you cannot loosen the requirements of your environment, you have to choose an in-process backend (meaning either `breakpad` or `inproc`).
+
+When your deployment scenario should wait for the `crashpad_handler` to finish its work before a shutdown-after-crash (systemd, Docker), you can enable the option `crashpad_wait_for_upload` to delay application shutdown until the upload of the crash report is completed.
 
 ### How do I decide between `breakpad` or `inproc`?
 

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -60,6 +60,12 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 </ConfigKey>
 
+<ConfigKey name="crashpad-wait-for-upload">
+
+Whether Crashpad should delay application shutdown until the upload of the crash report in the `crashpad_handler` is complete. This is useful for deployment in `Docker` or `systemd`, where the life cycle of additional processes is bound by the application life cycle.
+
+</ConfigKey>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Related to https://github.com/getsentry/sentry-native/pull/1153

Updated pages' preview
- [Backend tradeoffs](https://sentry-docs-git-feat-nativecrashpad-wait-for-upload.sentry.dev/platforms/native/advanced-usage/backend-tradeoffs/#when-shouldnt-i-use-the-crashpad-backend)

- [Options](https://sentry-docs-git-feat-nativecrashpad-wait-for-upload.sentry.dev/platforms/native/configuration/options/#crashpad-wait-for-upload)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
