### PR TITLE
Troubleshooting Guide for mixed versions in Java / Android SDK

### DIFF
--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -318,3 +318,5 @@ This problem is only relevant to these specific versions: `sentry-android-core` 
 </Alert>
 
 Check [this issue](https://github.com/getsentry/sentry-android-gradle-plugin/issues/329) for more details.
+
+<PageGrid />

--- a/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
@@ -1,0 +1,48 @@
+---
+title: Mixed Versions
+description: "Troubleshoot and resolve mixed Android SDK dependency versions."
+sidebar_order: 1000
+---
+
+Using multiple Android SDK dependencies with mixed versions is not supported as it is very likely this leads to a crash later on. For this reason we chose to crash the application on SDK init instead.
+
+## Multiple Dependencies With Mixed Versions
+
+The following snippet shows a mix of version caused by using `sentry` with version `8.6.0` and `sentry-android` with version `8.7.0`. To fix the issue please set the same version for all dependencies or use `sentry-bom`. This may also happen if you are using an internal library which has a different version defined.
+
+```groovy {tabTitle:Gradle}{filename:build.gradle}
+implementation('io.sentry:sentry:8.6.0')
+implementation('io.sentry:sentry-android:8.7.0')
+```
+```xml {tabTitle:Maven}{filename:pom.xml}
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>8.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-android</artifactId>
+            <version>8.7.0</version>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## Build Plugin And Explicit Dependency
+
+When using our Gradle or Maven plugin and manually defining additional Sentry Android SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or use `sentry-bom`.
+
+```groovy {tabTitle:Gradle}{filename:build.gradle}
+dependencies {
+	implementation 'io.sentry:sentry-okhttp:8.1.0'
+}
+
+sentry {
+	autoInstallation {
+		sentryVersion = "8.0.0"
+	}
+}
+```

--- a/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
@@ -36,6 +36,8 @@ implementation('io.sentry:sentry-android:8.7.0')
 When using our Gradle or Maven plugin and manually defining additional Sentry Android SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or use `sentry-bom`.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
+plugins { id "io.sentry.android.gradle" version "5.3.0" }
+
 dependencies {
 	implementation 'io.sentry:sentry-okhttp:8.1.0'
 }

--- a/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
@@ -8,7 +8,7 @@ Using multiple Android SDK dependencies with mixed versions is not supported as 
 
 ## Multiple Dependencies With Mixed Versions
 
-The following snippet shows a mix of version caused by using `sentry` with version `8.6.0` and `sentry-android` with version `8.7.0`. To fix the issue please set the same version for all dependencies or use `sentry-bom`. This may also happen if you are using an internal library which has a different version defined.
+The following snippet shows a mix of version caused by using `sentry` with version `8.6.0` and `sentry-android` with version `8.7.0`. To fix the issue please set the same version for all dependencies or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>. This may also happen if you are using an internal library which has a different version defined.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
 implementation('io.sentry:sentry:8.6.0')
@@ -33,7 +33,7 @@ implementation('io.sentry:sentry-android:8.7.0')
 
 ## Build Plugin And Explicit Dependency
 
-When using our Gradle or Maven plugin and manually defining additional Sentry Android SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or use `sentry-bom`.
+When using our Gradle or Maven plugin and manually defining additional Sentry Android SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
 plugins { id "io.sentry.android.gradle" version "5.3.0" }

--- a/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/android/troubleshooting/mixed-versions/index.mdx
@@ -4,11 +4,11 @@ description: "Troubleshoot and resolve mixed Android SDK dependency versions."
 sidebar_order: 1000
 ---
 
-Using multiple Android SDK dependencies with mixed versions is not supported as it is very likely this leads to a crash later on. For this reason we chose to crash the application on SDK init instead.
+Using multiple Android SDK dependencies with mixed versions is not supported as it is very likely to lead to a crash later on. For this reason we chose to crash the application on SDK init instead.
 
 ## Multiple Dependencies With Mixed Versions
 
-The following snippet shows a mix of version caused by using `sentry` with version `8.6.0` and `sentry-android` with version `8.7.0`. To fix the issue please set the same version for all dependencies or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>. This may also happen if you are using an internal library which has a different version defined.
+The following snippet shows a mixed version conflict caused by using `sentry` with version `8.6.0` and `sentry-android` with version `8.7.0`. To fix the issue, set the same version for all dependencies or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>. This may also happen if you are using an internal library which has a different version defined.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
 implementation('io.sentry:sentry:8.6.0')
@@ -33,7 +33,7 @@ implementation('io.sentry:sentry-android:8.7.0')
 
 ## Build Plugin And Explicit Dependency
 
-When using our Gradle or Maven plugin and manually defining additional Sentry Android SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
+When using our Gradle or Maven plugin and manually defining additional Sentry Android SDK dependencies, it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is an additional dependency that has been set to version `8.1.0`. To fix the issue,  set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
 plugins { id "io.sentry.android.gradle" version "5.3.0" }

--- a/docs/platforms/java/common/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/troubleshooting/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Troubleshooting
+description: "Troubleshoot and resolve common issues with the Java SDK."
+sidebar_order: 9000
+---
+
+<PageGrid />

--- a/docs/platforms/java/common/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/java/common/troubleshooting/mixed-versions/index.mdx
@@ -4,11 +4,11 @@ description: "Troubleshoot and resolve mixed Java SDK dependency versions."
 sidebar_order: 1000
 ---
 
-Using multiple Java SDK dependencies with mixed versions is not supported as it is very likely this leads to a crash later on. For this reason we chose to crash the application on SDK init instead.
+Using multiple Java SDK dependencies with mixed versions is not supported as it is very likely to lead to a crash later on. For this reason we chose to crash the application on SDK init instead.
 
 ## Multiple Dependencies With Mixed Versions
 
-The following snippet shows a mix of version caused by using `sentry` with version `8.6.0` and `sentry-logback` with version `8.7.0`. To fix the issue please set the same version for all dependencies or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>. This may also happen if you are using an internal library which has a different version defined.
+The following snippet shows a mixed version conflict caused by using `sentry` with version `8.6.0` and `sentry-logback` with version `8.7.0`. To fix the issue please set the same version for all dependencies or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>. This may also happen if you are using an internal library which has a different version defined.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
 implementation('io.sentry:sentry:8.6.0')
@@ -33,7 +33,7 @@ implementation('io.sentry:sentry-logback:8.7.0')
 
 ## Build Plugin And Explicit Dependency
 
-When using our Gradle or Maven plugin and manually defining additional Sentry Java SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
+When using our Gradle or Maven plugin and manually defining additional Sentry Java SDK dependencies, it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0`, but there is an additional dependency that has been set to version `8.1.0`. To fix the issue, set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
 plugins { id "io.sentry.android.gradle" version "5.3.0" }
@@ -51,4 +51,4 @@ sentry {
 
 ## Agent Version And Build Time Version
 
-When using `sentry-opentelemetry-agent` you may end up using a version of the Agent that differs from other Sentry Java SDK dependencies you are using as dependencies. This is also not supported. Please use the same version for `sentry-opentelemetry-agent` and all other Java SDK dependencies.
+When using `sentry-opentelemetry-agent` you may end up using a version of the Agent that differs from other Sentry Java SDK dependencies you are using. This is also not supported. Use the same version for `sentry-opentelemetry-agent` and all other Java SDK dependencies.

--- a/docs/platforms/java/common/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/java/common/troubleshooting/mixed-versions/index.mdx
@@ -1,0 +1,52 @@
+---
+title: Mixed Versions
+description: "Troubleshoot and resolve mixed Java SDK dependency versions."
+sidebar_order: 1000
+---
+
+Using multiple Java SDK dependencies with mixed versions is not supported as it is very likely this leads to a crash later on. For this reason we chose to crash the application on SDK init instead.
+
+## Multiple Dependencies With Mixed Versions
+
+The following snippet shows a mix of version caused by using `sentry` with version `8.6.0` and `sentry-logback` with version `8.7.0`. To fix the issue please set the same version for all dependencies or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>. This may also happen if you are using an internal library which has a different version defined.
+
+```groovy {tabTitle:Gradle}{filename:build.gradle}
+implementation('io.sentry:sentry:8.6.0')
+implementation('io.sentry:sentry-logback:8.7.0')
+```
+```xml {tabTitle:Maven}{filename:pom.xml}
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>8.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-logback</artifactId>
+            <version>8.7.0</version>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## Build Plugin And Explicit Dependency
+
+When using our Gradle or Maven plugin and manually defining additional Sentry Java SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
+
+```groovy {tabTitle:Gradle}{filename:build.gradle}
+dependencies {
+	implementation 'io.sentry:sentry-opentelemetry-agentless-spring:8.1.0'
+}
+
+sentry {
+	autoInstallation {
+		sentryVersion = "8.0.0"
+	}
+}
+```
+
+## Agent Version And Build Time Version
+
+When using `sentry-opentelemetry-agent` you may end up using a version of the Agent that differs from other Sentry Java SDK dependencies you are using as dependencies. This is also not supported. Please use the same version for `sentry-opentelemetry-agent` and all other Java SDK dependencies.

--- a/docs/platforms/java/common/troubleshooting/mixed-versions/index.mdx
+++ b/docs/platforms/java/common/troubleshooting/mixed-versions/index.mdx
@@ -36,6 +36,8 @@ implementation('io.sentry:sentry-logback:8.7.0')
 When using our Gradle or Maven plugin and manually defining additional Sentry Java SDK dependencies it is also possible to end up with mixed versions. The following snippet shows the plugin being configured to use version `8.0.0` but there is also an additional dependency that has been set to version `8.1.0`. To fix the issue please set the same version or <PlatformLink to="/configuration/bill-of-materials/">use `sentry-bom`</PlatformLink>.
 
 ```groovy {tabTitle:Gradle}{filename:build.gradle}
+plugins { id "io.sentry.android.gradle" version "5.3.0" }
+
 dependencies {
 	implementation 'io.sentry:sentry-opentelemetry-agentless-spring:8.1.0'
 }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->
Using multiple Java SDK modules/dependencies with different versions is not supported, almost certainly leads to crashes at some point and in new SDK versions will result in an early crash of the SDK on `init`. This page shall help customers understand what's going on and how to resolve the issue.

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
