### PR TITLE
Merge Vue 2 and 3 code blocks

### DIFF
--- a/docs/platforms/javascript/guides/vue/index.mdx
+++ b/docs/platforms/javascript/guides/vue/index.mdx
@@ -18,7 +18,7 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 
 <OnboardingOptionButtons options={["error-monitoring", "performance", "session-replay"]} />
 
-Sentry captures data by using an SDK within your application’s runtime.
+Sentry captures data by using an SDK within your application's runtime.
 
 ```bash {tabTitle:npm}
 npm install @sentry/vue --save
@@ -38,9 +38,7 @@ Configuration should happen as early as possible in your application's lifecycle
 
 To initialize Sentry in your Vue application, add the following code snippet to your `main.js`:
 
-### Vue 3
-
-```javascript {filename:main.js} {"onboardingOptions": {"performance": "16, 19-25", "session-replay": "17, 29-35"}}
+```javascript {tabTitle:Vue 3} {filename:main.js} {"onboardingOptions": {"performance": "16, 19-25", "session-replay": "17, 29-35"}}
 import { createApp } from "vue";
 import { createRouter } from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -82,9 +80,7 @@ app.use(router);
 app.mount("#app");
 ```
 
-### Vue 2
-
-```javascript {filename:main.js} {"onboardingOptions": {"performance": "15, 18-24", "session-replay": "16, 28-34"}}
+```javascript {tabTitle:Vue 2} {filename:main.js} {"onboardingOptions": {"performance": "15, 18-24", "session-replay": "16, 28-34"}}
 import Vue from "vue";
 import Router from "vue-router";
 import * as Sentry from "@sentry/vue";


### PR DESCRIPTION
There are 2 separate code blocks which take up a lot of space on the page. This change combines them into one, with tabs.

### before:

![image](https://github.com/user-attachments/assets/8c770cae-303e-4889-872a-9432012e8a94)

### after:
![image](https://github.com/user-attachments/assets/a3780650-0a65-4124-8cd3-31f73dd57e7c)
