### PR TITLE
Simplifying Trace Propagation Examples; Adding origin callout.

### DIFF
--- a/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -26,19 +26,17 @@ Sentry.init({
   tracesSampleRate: 1.0,
   tracePropagationTargets: [
     "https://api.myecommerce.com",
-    "https://auth.myecommerce.com",
-    /^\/internal-api\//
+    "https://auth.myecommerce.com"
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -6,7 +6,7 @@ When you are interacting with other external API systems, you might have to defi
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -4,9 +4,9 @@ When you are interacting with other external API systems, you might have to defi
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.astro.mdx
@@ -2,6 +2,14 @@ If you're using our Astro SDK, distributed tracing will work out of the box for 
 
 When you are interacting with other external API systems, you might have to define `tracePropagationTargets` to get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript
 // sentry.client.config.js
 Sentry.init({

--- a/platform-includes/distributed-tracing/how-to-use/javascript.cloudflare.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.cloudflare.mdx
@@ -2,7 +2,7 @@ The Sentry Cloudflare SDK has out of the box support for distributed tracing if 
 
 ### Custom Instrumentation
 
-If you don't want to use tracing, you can set up <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
+If you don't want to use the default tracing setup, you can set up <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
 
 ### Disabling Distributed Tracing
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.cloudflare.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.cloudflare.mdx
@@ -29,19 +29,17 @@ Sentry.init({
   tracesSampleRate: 1.0,
   tracePropagationTargets: [
     "https://api.myecommerce.com",
-    "https://auth.myecommerce.com",
-    /^\/internal-api\//
+    "https://auth.myecommerce.com"
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -6,7 +6,7 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -46,18 +46,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -4,9 +4,9 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.mdx
@@ -2,6 +2,14 @@ If you're using the current version of our JavaScript SDK and have enabled the `
 
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, define your `tracePropagationTargets`.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -6,7 +6,7 @@ For client-side, when you are interacting with other external API systems, you m
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -4,9 +4,9 @@ For client-side, when you are interacting with other external API systems, you m
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -2,6 +2,14 @@ If you're using the current version of our Next.js SDK, distributed tracing will
 
 For client-side, when you are interacting with other external API systems, you might have to define `tracePropagationTargets` to get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript
 // sentry.client.config.js
 Sentry.init({

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -25,18 +25,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -12,7 +12,7 @@ Sentry.init({
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -20,18 +20,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -8,9 +8,17 @@ Sentry.init({
 });
 ```
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ### Custom Instrumentation
 
-If you don't want to use tracing, you can set up <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
+If you don't want to use the default tracing setup, you can set up <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Instrumentation</PlatformLink> for distributed tracing.
 
 #### Example 1: Microservices E-commerce Platform
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -10,9 +10,9 @@ Sentry.init({
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -6,7 +6,7 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -21,18 +21,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -2,6 +2,14 @@ If you're using the current version of our Nuxt SDK, distributed tracing will wo
 
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` for client-side.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript {filename:sentry.client.config.(js|ts)}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -4,9 +4,9 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -35,9 +35,9 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -37,7 +37,7 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -33,6 +33,14 @@ The `name` attributes must be the strings `"sentry-trace"` and `"baggage"` and t
 
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` on the client side. See <PlatformLink to="/tracing/trace-propagation/dealing-with-cors-issues/">Dealing with CORS Issues</PlatformLink> for more information.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript
 // entry.client.tsx
 Sentry.init({

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -58,18 +58,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -27,6 +27,14 @@ export default defineConfig({
 
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` for client-side.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript
 // hooks.client.js
 Sentry.init({

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -31,7 +31,7 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -52,18 +52,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -29,9 +29,9 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -2,6 +2,14 @@ If you're using the current version of our SvelteKit SDK, distributed tracing wi
 
 When you are interacting with other external API systems, you might have to define `tracePropagationTargets` to get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues.
 
+<Alert>
+
+When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+
+</Alert>
+
 ```javascript
 // hooks.client.js
 Sentry.init({

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -29,18 +29,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myecommerce.com",
     "https://auth.myecommerce.com",
-    /^\/internal-api\//
   ],
 });
 ```
 
-This tells Sentry to track user journeys across three places:
+This tells Sentry to pass trace headers across the following paths:
 
 * Your main API server (where product data comes from)
 * Your authentication server (where logins happen)
-* Any API calls that start with "/internal-api/" on your current domain
 
-This way, if a customer experiences an error during checkout, you can see the complete path their request took across these different services.
+This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
 #### Example 2: Mobile App with Backend Services
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -6,7 +6,7 @@ When you are interacting with other external API systems, you might have to defi
 
 Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
+For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
 </Alert>
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -4,9 +4,9 @@ When you are interacting with other external API systems, you might have to defi
 
 <Alert>
 
-When testing locally, you may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your local services if they have different port numbers. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
 
-For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, you'll need to add `http://localhost:5173` and `http://localhost:3000` to the `tracePropagationTargets` array.
+For example, if you have a Vite frontend running on `http://localhost:5173` and a Bun backend running on `http://localhost:3000`, both `http://localhost:5173` and `http://localhost:3000` should be added to the `tracePropagationTargets` array.
 
 </Alert>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Simplifying initial trace propagation example to not use a regex based example. Creates a more gradual increase in complexity through the other examples. 

Added a callout that for services running on different ports on the same origin.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [X] None: Not urgent, can wait up to 1 week+
