### PR TITLE
fix(js): Fix link to AWS lambda layer configuration

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/install/cjs-layer.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/cjs-layer.mdx
@@ -4,7 +4,7 @@ description: "Learn how to add the Sentry Node Lambda Layer to use Sentry in you
 sidebar_order: 1
 ---
 
-The easiest way to get started with Sentry is to use the Sentry [Lambda Layer](https://docs.aws.amazon.com/Lambda/latest/dg/configuration-layers.html) instead of adding `@sentry/aws-serverless` with `npm` or `yarn` [manually](../cjs-npm).
+The easiest way to get started with Sentry is to use the Sentry [Lambda Layer](https://docs.aws.amazon.com/lambda/latest/dg/adding-layers.html) instead of adding `@sentry/aws-serverless` with `npm` or `yarn` [manually](../cjs-npm).
 If you follow this guide, you don't have to worry about deploying Sentry dependencies alongside your function code.
 To actually start the SDK, you can decide between setting up the SDK using environment variables or in your Lambda function code. We recommend using environment variables as it's the easiest way to get started. [Initializing the SDK in code](#alternative-initialize-the-sdk-in-code) instead of setting environment variables gives you more control over the SDK setup if you need it.
 


### PR DESCRIPTION
I noticed that this link was dead!