### PR TITLE
fix(react): Fix react tracing example

### DIFF
--- a/platform-includes/performance/configure-sample-rate/javascript.react.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.react.mdx
@@ -23,3 +23,8 @@ Sentry.init({
   tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
 });
 ```
+
+<Alert>
+  See [React Router](/platforms/javascript/guides/react/features/react-router/)
+  for more information on how to configure tracing with React Router.
+</Alert>


### PR DESCRIPTION
Noticed that the example for react sample rate configuration is wrong, you cannot/should not copy-paste this, so adjusted it.