### PR TITLE
feat(js): Streamline links for explanations about tracing sampling

### DIFF
--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -4,7 +4,7 @@ description: "Learn how to enable tracing in your app."
 sidebar_order: 4000
 ---
 
-With [tracing](/product/insights/overview/), Sentry automatically tracks your software performance across your application services, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. 
+With [tracing](/product/insights/overview/), Sentry automatically tracks your software performance across your application services, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems.
 
 <PlatformCategorySection supported={["server", "serverless"]}>
   <Alert>
@@ -45,7 +45,7 @@ With [tracing](/product/insights/overview/), Sentry automatically tracks your so
 
 The two options are mutually exclusive. If both are set, <PlatformIdentifier name="traces-sampler" /> will take precedence.
 
-Learn more about tracing <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
+You can find more in-depth explanations and examples about sampling configuration in [Configure Sampling](./configure-sampling).
 
 ## Distributed Tracing
 


### PR DESCRIPTION
Since we have a dedicated page about this, we should link there instead of to the generic options, which have less information than other places.

Generally, I wonder if it really makes sense to have the "Configure Sample Rate" page under "Set Up Tracing" as well as the "Sampling" page under configuration, which have almost-but-not-quite the same information as of now 🤔 IMHO one of these should stay and the other should go (personally I would vote for configuration/sampling and linking there from the tracing docs)