### PR TITLE
Update Link for Replays for BE Errors.mdx

### DIFF
--- a/docs/product/explore/session-replay/mobile/index.mdx
+++ b/docs/product/explore/session-replay/mobile/index.mdx
@@ -6,7 +6,7 @@ description: "Use Session Replay for Mobile to get reproductions of user session
 
 Session Replay allows you to see reproductions of user sessions, which can help you understand what happened before, during, and after an error or performance issue occurred. As you play back each session, you'll be able to see every user interaction in relation to network requests, frontend and backend errors, backend spans, and more.
 
-Replays help you see exactly how the user experience is impacted by errors. Because they're integrated with our Issues product, you'll be able to see session replays connected to error events on the [Issue Details](/product/issues/issue-details/) page in Sentry. To make sure backend errors are also included in the replay, see our [backend set up instructions](/product/explore/session-replay/getting-started/#replays-for-backend-errors).
+Replays help you see exactly how the user experience is impacted by errors. Because they're integrated with our Issues product, you'll be able to see session replays connected to error events on the [Issue Details](/product/issues/issue-details/) page in Sentry. To make sure backend errors are also included in the replay, see our [backend set up instructions](/product/explore/session-replay/web/getting-started/#replays-for-backend-errors).
 
 ![Session Replay User Interface](./img/session-replay.png)
 


### PR DESCRIPTION
The previous link brought users to the Replay docs homepage: https://docs.sentry.io/product/explore/session-replay/, as opposed to the specific replay for BE errors instructions.


