### PR TITLE
fix(mdx): push last highlighted line when making highlight blocks

### DIFF
--- a/src/components/codeBlock/code-blocks.module.scss
+++ b/src/components/codeBlock/code-blocks.module.scss
@@ -57,6 +57,10 @@
     min-width: 100%;
   }
 
+  :global(.code-highlight > .highlight-block:last-child) {
+    margin-bottom: -10px;
+  }
+
   :global(.code-line) {
     display: block;
     float: left;
@@ -73,7 +77,6 @@
       display: inline;
     }
   }
-
 
   /* Diff highlighting, classes provided by rehype-prism-plus */
   /* Set inserted line (+) color */

--- a/src/components/codeHighlights/codeHighlights.tsx
+++ b/src/components/codeHighlights/codeHighlights.tsx
@@ -109,7 +109,7 @@ export function HighlightBlock({
   }
 
   return (
-    <HighlightBlockContainer>
+    <HighlightBlockContainer className="highlight-block">
       <CodeLinesContainer ref={codeRef}>{children}</CodeLinesContainer>
       <ClipBoardContainer onClick={copyCodeOnClick}>
         {showCopyButton && !copied && (

--- a/src/components/codeHighlights/codeHighlights.tsx
+++ b/src/components/codeHighlights/codeHighlights.tsx
@@ -42,9 +42,17 @@ export function makeHighlightBlocks(
 
     if (isHighlightedLine) {
       highlightedLineElements.push(element);
-    }
 
-    if (!isHighlightedLine || index === items.length - 1) {
+      // If it's the last line that's highlighted, push it
+      if (index === items.length - 1) {
+        arr.push(
+          <HighlightBlock key={highlightElementGroupCounter} language={language}>
+            {...highlightedLineElements}
+          </HighlightBlock>
+        );
+      }
+    } else {
+      // Check for an opened highlight group before pushing the new line
       if (highlightedLineElements.length > 0) {
         arr.push(
           <HighlightBlock key={highlightElementGroupCounter} language={language}>
@@ -53,9 +61,9 @@ export function makeHighlightBlocks(
         );
         highlightedLineElements = [];
         ++highlightElementGroupCounter;
-      } else {
-        arr.push(child);
       }
+
+      arr.push(child);
     }
 
     return arr;

--- a/src/components/codeHighlights/codeHighlights.tsx
+++ b/src/components/codeHighlights/codeHighlights.tsx
@@ -18,7 +18,7 @@ export function makeHighlightBlocks(
   let highlightedLineElements: ReactElement[] = [];
   let highlightElementGroupCounter = 0;
 
-  return items.reduce((arr: ChildrenItem[], child) => {
+  return items.reduce((arr: ChildrenItem[], child, index) => {
     if (typeof child !== 'object') {
       arr.push(child);
       return arr;
@@ -42,7 +42,9 @@ export function makeHighlightBlocks(
 
     if (isHighlightedLine) {
       highlightedLineElements.push(element);
-    } else {
+    }
+
+    if (!isHighlightedLine || index === items.length - 1) {
       if (highlightedLineElements.length > 0) {
         arr.push(
           <HighlightBlock key={highlightElementGroupCounter} language={language}>
@@ -51,8 +53,9 @@ export function makeHighlightBlocks(
         );
         highlightedLineElements = [];
         ++highlightElementGroupCounter;
+      } else {
+        arr.push(child);
       }
-      arr.push(child);
     }
 
     return arr;


### PR DESCRIPTION
## DESCRIBE YOUR PR
I noticed that in code blocks where the last line is highlighted it doesn't get shown. There's a good example in the TanStack Start React guide:
<img width="753" alt="image" src="https://github.com/user-attachments/assets/08f8e928-081f-418e-981b-6f3b585e18e0" />

The code block ends abruptly and it doesn't show how to wrap the `defaultStreamHandler` with Sentry's `wrapStreamHandlerWithSentry`. I checked the mdx page and noticed that there's only one missing line from the code block and it's also the highlighted one.

The changes I made ensure that we "flush" any started highlight groups at the end before returning the markup. The previous implementation relied on having a non-highlighted line that follows a highlighted one in order to "flush" the group.

This PR would fix any code blocks that highlight the last line(s). I'm not sure if there are other instances other than the TanStack Start one.

After the fix:

<img width="751" alt="image" src="https://github.com/user-attachments/assets/3b15cdb6-073e-4acb-b292-491a05eacb58" />

Additionally, this PR removes the bottom padding of codeblocks whose last child is a highlight:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/252e2c40-64f2-4708-b563-bb8b36facad2" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): no deadline, but we're missing critical instructions in docs without this fix
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)