### PR TITLE
Add tabs to reflect the new binaries available

### DIFF
--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -50,10 +50,48 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 
 Sentry captures data by using an SDK within your application's runtime. These are platform-specific and allow Sentry to have a deep understanding of how your application works.
 
-We recommend installing the SDK through our [Sentry Wizard](https://github.com/getsentry/sentry-wizard) by running the following command inside your project directory:
+We recommend installing the SDK through our [Sentry Wizard](https://github.com/getsentry/sentry-wizard) by running one of the following commands inside your project directory:
 
-```bash
+```bash {tabTitle:brew}
 brew install getsentry/tools/sentry-wizard && sentry-wizard -i android
+```
+
+```bash {tabTitle:npx}
+npx @sentry/wizard@latest -i android
+```
+
+```bash {tabTitle:macOS (Intel/x64)}
+downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v4.0.1/sentry-wizard-darwin-x64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i android
+```
+
+```bash {tabTitle:macOS (Apple Silicon/arm64)}
+downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v4.0.1/sentry-wizard-darwin-arm64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i android
+```
+
+```bash {tabTitle:Linux (x64)}
+downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v4.0.1/sentry-wizard-linux-x64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i android
+```
+
+```bash {tabTitle:Linux (arm64)}
+downloadUrl="https://github.com/getsentry/sentry-wizard/releases/download/v4.0.1/sentry-wizard-linux-arm64"
+curl -L $downloadUrl -o sentry-wizard
+chmod +x sentry-wizard
+./sentry-wizard -i android
+```
+
+```powershell {tabTitle:Windows}
+$downloadUrl = "https://github.com/getsentry/sentry-wizard/releases/download/v4.0.1/sentry-wizard-win-x64.exe"
+Invoke-WebRequest $downloadUrl -OutFile sentry-wizard.exe
+./sentry-wizard.exe -i android
 ```
 
 This will patch your project and configure the SDK. You only need to patch the project once, then you can add the patched files to your version control system.


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/85861

This PR only updates android. The prio of order of tabs could be changed, and this could be applied to flutter and iOS install in docs. PRs welcome:)

<img width="813" alt="image" src="https://github.com/user-attachments/assets/f0b3487e-08f7-43b7-9a22-d037372b779d" />
