### PR TITLE
fix(remix): Remove deprecated `ErrorBoundary` options.

### DIFF
--- a/docs/platforms/javascript/guides/remix/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/remix/manual-setup.mdx
@@ -124,22 +124,6 @@ function App() {
 export default withSentry(App);
 ```
 
-You can disable or configure `ErrorBoundary` using a second parameter to `withSentry`.
-
-```tsx
-withSentry(App, {
-  wrapWithErrorBoundary: false,
-});
-
-// or
-
-withSentry(App, {
-  errorBoundaryOptions: {
-    fallback: <p>An error has occurred</p>,
-  },
-});
-```
-
 ### Server-side Configuration
 
 Create an instrumentation file (named here as `instrument.server.mjs`) in your project. Add your initialization code in this file for the server-side SDK.


### PR DESCRIPTION
Remix roots are not wrapped with `@sentry/react`'s `ErrorBoundary` starting from Remix version 2.

We dropped support for Remix v1, so the docs are not valid anymore.

Resolves: https://github.com/orgs/getsentry/projects/31/views/19?pane=issue&itemId=103941554&issue=getsentry%7Csentry-javascript%7C15883
