### PR TITLE
fix: Improve `<TableOfContents>` to allow empty sections

### DIFF
--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -48,8 +48,7 @@ export function TableOfContents({ignoreIds = []}: Props) {
       .filter(Boolean) as TreeNode[];
 
     // Now group them together
-    // We only support 2 levels of nesting,
-    // where the first level is assumed to be headings, and the second one is assumed to be options
+    // We only support 2 levels of nesting for now
     const _tocItems: TreeItem[] = [];
     let currentItem: TreeItem | undefined;
     for (let node of nodes) {
@@ -70,7 +69,7 @@ export function TableOfContents({ignoreIds = []}: Props) {
     }
 
     // Remove groups without children
-    setTreeItems(_tocItems.filter(item => item.children.length > 0));
+    setTreeItems(_tocItems);
   }, [ignoreIds]);
 
   return (


### PR DESCRIPTION
Not sure why I even added this, but this seems unnecessary!

Closes https://github.com/getsentry/sentry-docs/issues/13159