### PR TITLE
fix(develop): clarify trace context's client_sample_rate

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -682,7 +682,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 `client_sample_rate`
 
-: _Optional_. The client-side sample rate.
+: _Optional_. The client-side sample rate. This field will be populated by relay. Incoming values are ignored.
 
 - Example: `0.1`
 

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -682,7 +682,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 `client_sample_rate`
 
-: _Optional_. The client-side sample rate. This field will be populated by relay. Incoming values are ignored.
+: _Optional_. The client-side sample rate. This field will be populated by relay; incoming values are ignored.
 
 - Example: `0.1`
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
When reading the Trace Context docs, I assumed that `client_sample_rate` (like all the other fields) was expected to be set by the client. Instead, this field is generated in Relay. If a client sets this field, it will be ignored and overwritten. Added a note to the docs for this field to clarify how it is meant to be used.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)