### PR TITLE
docs(sdk): Add `runtime` to SDK interface

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/sdk.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/sdk.mdx
@@ -69,6 +69,18 @@ activated integrations. Each package consists of a `name` in the format
 `identifier` should be a checkout link and the `version` should be a Git
 reference (branch, tag or SHA).
 
+`runtime`
+
+: _Optional_. A string to identify the runtime environment where the code executes when
+it's not obvious from the SDK name alone. This field is particularly valuable in
+Meta-Frameworks (like Next.js, Nuxt or React Router) to distinguish between frontend
+and backend parts.
+Showing the value of this field in the issue details helps developers quickly identify where
+an issue occurred without needing to analyze the full error context.
+
+  - `"Frontend"` - For code running in the browser
+  - `"Backend"` - For server-side code, web workers or edge runtimes
+
 ## Example
 
 The following example illustrates the SDK part of the <Link to="/sdk/data-model/event-payloads/">event payload</Link> and omits other
@@ -94,3 +106,27 @@ attributes for simplicity.
   }
 }
 ```
+
+The following example shows the usage of the `runtime` label for Meta-Frameworks:
+
+```json
+{
+  "sdk": {
+    "name": "sentry.javascript.nuxt",
+    "version": "9.10.0",
+    "integrations": ["BrowserTracing", "Vue"],
+    "runtime": "Frontend",
+    "packages": [
+      {
+        "name": "npm:@sentry/nuxt",
+        "version": "9.10.0"
+      },
+      {
+        "name": "npm:@sentry/vue",
+        "version": "9.10.0"
+      }
+    ]
+  },
+}
+```
+

--- a/develop-docs/sdk/data-model/event-payloads/sdk.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/sdk.mdx
@@ -71,15 +71,13 @@ reference (branch, tag or SHA).
 
 `runtime`
 
-: _Optional_. A string to identify the runtime environment where the code executes when
-it's not obvious from the SDK name alone. This field is particularly valuable in
-Meta-Frameworks (like Next.js, Nuxt or React Router) to distinguish between frontend
-and backend parts.
-Showing the value of this field in the issue details helps developers quickly identify where
-an issue occurred without needing to analyze the full error context.
-
-  - `"Frontend"` - For code running in the browser
-  - `"Backend"` - For server-side code, web workers or edge runtimes
+: _Optional_. A string to identify the runtime environment when it's not obvious from
+the SDK name alone. This field is particularly valuable in Meta-Frameworks (like Next.js,
+Nuxt or React Router) to distinguish between frontend and backend parts.
+Displaying this field in issue details allows developers to quickly determine where an error
+occurred without examining the full error context. The following strings are available:
+  - `"Frontend"` - Code running in the browser
+  - `"Backend"` - Code running on servers, web workers, or edge runtimes
 
 ## Example
 


### PR DESCRIPTION
## Problem
Meta-Frameworks include a frontend as well as backend environment. They have the problem that the execution environment (frontend/backend) of their errors in Sentry are hard to distinguish. 

As all of their issues come into the same projects you don't know if this is a frontend or backend problem.

An issue for this was created here: [Discern Client vs Server Errors](https://github.com/getsentry/sentry/issues/85732)

## Solution

The idea is to include the platform to the SDK payload. The platform is a pre-defined set of allowed strings:
- Frontend: for anything that is happening in the browser
- Backend: for anything happening on the server, a worker or on edge.

The SDK payload currently includes things like name, version, integrations etc ([docs here](https://develop.sentry.dev/sdk/data-model/event-payloads/sdk)).

### Why is this information not added to the event context?

It can be added to the event context and in most cases, there is something added already (e.g. `event.context.runtime.name`). However, this runtime is added to all SDKs, not only the Meta-Frameworks. 


## Other naming suggestions

**environment**
- Could be confused with deployment environments (dev/prod/staging)
- Some might expect environment variables rather than runtime type

**platform**
- Could be confused with OS platforms (iOS, Android, Windows)
- "Frontend" and "backend" aren't typically described as platforms

## Further Reading

Develop Docs: [SDK Interface](https://develop.sentry.dev/sdk/data-model/event-payloads/sdk/)

Related PR: https://github.com/getsentry/sentry/pull/88312
