### PR TITLE
fix(vue): Remove outdated Vue SDK options

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -306,7 +306,7 @@ When enabled, all props of the Vue component where the error was thrown in are a
   When `attachErrorHandler` is set to `false`, automatic error reporting is disabled.
 
   Usually, this option should stay enabled, unless you want to set up Sentry error reporting yourself.
-  For example, the Sentry Nuxt SDK does not attach an error handler as it's using the error hooks provided by Nuxt.
+  For example, the Sentry Nuxt SDK does not attach an error handler as it's capturing errors through the error hooks provided by Nuxt.
 </SdkOption>
 
 </PlatformSection>

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -294,14 +294,15 @@ By the time `beforeSend` is executed, all scope data has already been applied to
 
 <PlatformSection supported={["javascript.vue", "javascript.nuxt"]}>
 
-<SdkOption name="attachProps" type='boolean' defaultValue='true'>
+<SdkOption name="attachProps" type='boolean' defaultValue='true' categorySupported={['browser']}>
 
 When enabled, all props of the Vue component where the error was thrown in are attached to the event.
 
 </SdkOption>
 
-<SdkOption name="attachProps" type='boolean' defaultValue='true'>
-  By default, the SDK attaches an error handler to capture Vue exceptions and report them to Sentry.
+<SdkOption name="attachErrorHandler" type='boolean' defaultValue='true' categorySupported={['browser']}>
+  By default, the SDK attaches a [Vue error handler](https://vuejs.org/api/application.html#app-config-errorhandler)
+  to capture Vue exceptions and report them to Sentry.
   When `attachErrorHandler` is set to `false`, automatic error reporting is disabled.
 
   Usually, this option should stay enabled, unless you want to set up Sentry error reporting yourself.

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -292,6 +292,24 @@ By the time `beforeSend` is executed, all scope data has already been applied to
 
 </SdkOption>
 
+<PlatformSection supported={["javascript.vue", "javascript.nuxt"]}>
+
+<SdkOption name="attachProps" type='boolean' defaultValue='true'>
+
+When enabled, all props of the Vue component where the error was thrown in are attached to the event.
+
+</SdkOption>
+
+<SdkOption name="attachProps" type='boolean' defaultValue='true'>
+  By default, the SDK attaches an error handler to capture Vue exceptions and report them to Sentry.
+  When `attachErrorHandler` is set to `false`, automatic error reporting is disabled.
+
+  Usually, this option should stay enabled, unless you want to set up Sentry error reporting yourself.
+  For example, the Sentry Nuxt SDK does not attach an error handler as it's using the error hooks provided by Nuxt.
+</SdkOption>
+
+</PlatformSection>
+
 ## Tracing Options
 
 <SdkOption name="tracesSampleRate" type='number' envVar='SENTRY_TRACES_SAMPLE_RATE'>

--- a/docs/platforms/javascript/guides/vue/index.mdx
+++ b/docs/platforms/javascript/guides/vue/index.mdx
@@ -38,7 +38,7 @@ Configuration should happen as early as possible in your application's lifecycle
 
 To initialize Sentry in your Vue application, add the following code snippet to your `main.js`:
 
-```javascript {tabTitle:Vue 3} {filename:main.js} {"onboardingOptions": {"performance": "16, 19-25", "session-replay": "17, 29-35"}}
+```javascript {tabTitle:Vue 3} {filename:main.js} {3, 12-36} {"onboardingOptions": {"performance": "16, 19-25", "session-replay": "17, 29-35"} }
 import { createApp } from "vue";
 import { createRouter } from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -80,7 +80,7 @@ app.use(router);
 app.mount("#app");
 ```
 
-```javascript {tabTitle:Vue 2} {filename:main.js} {"onboardingOptions": {"performance": "15, 18-24", "session-replay": "16, 28-34"}}
+```javascript {tabTitle:Vue 2} {filename:main.js} {3, 11-35} {"onboardingOptions": {"performance": "15, 18-24", "session-replay": "16, 28-34"}}
 import Vue from "vue";
 import Router from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -126,14 +126,6 @@ new Vue({
 ```
 
 If you're creating more than one Vue 3 app within your application, check out how to initialize the SDK for [multiple apps](./features/multiple-apps).
-
-### Vue-Specific configuration
-
-The SDK accepts a few Vue-specific `Sentry.init` configuration options:
-
-- `attachProps` (defaults to `true`) - Includes all Vue components' props with the events.
-- `logErrors` (defaults to `true`) - Decides whether SDK should call Vue's original `logError` function as well.
-- Check out how to [Track Vue Components](./features/component-tracking) for performance.
 
 ### Late-Defined Vue Apps
 


### PR DESCRIPTION
This PR brings our Vue Getting Started page up to date. We changed options around a bit in v9 and forgot to remove some removed options from docs. Also did some minor improvements while I was at it.

- Removed the entire "Vue specific Options" subsection as it doesn't really make sense in a Vue-specific onboarding guide:
  - Removed `logErrors` as this is now just default behaviour
  - Removed `tracingOptions` 
  - Moved `attachProps` to general options page (`PlatformSection`ed of course)
  - Added `attachErrorHandler` to general options page (`PlatformSection`ed of course)
- Added highlighting to `Sentry.init` code block

closes https://github.com/getsentry/sentry-docs/issues/13157