### PR TITLE
feat(develop): Add `outgoing_request` context

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -778,6 +778,42 @@ envelope endpoint.
 }
 ```
 
+## Page Context
+
+Page context contains information about the page that the event occurred on.
+
+`url`
+
+: **Required.** The URL of the page that the event occurred on.
+
+- Example: `https://sentry.io/issues?page=1`
+
+`user_agent`
+
+: _Optional_. The user agent of the page that the event occurred on.
+
+- Example: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36`
+
+`referer`
+
+: _Optional_. The referer of the page that the event occurred on.
+
+- Example: `https://sentry.io/`
+
+### Example Page Context
+
+```json
+{
+  "contexts": {
+    "page": {
+      "url": "https://sentry.io/issues?page=1",
+      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+      "referer": "https://sentry.io/"
+    }
+  }
+}
+```
+
 ## Response Context
 
 Response context contains information about the HTTP response associated with the event.
@@ -829,7 +865,7 @@ The required field is `package` which should contain the package or framework wh
   "contexts": {
     "missing_instrumentation": {
       "package": "express",
-      "javascript.is_cjs": true,
+      "javascript.is_cjs": true
     }
   }
 }

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -828,6 +828,55 @@ Page context contains information about the page that the event occurred on.
 }
 ```
 
+## Outgoing Request Context
+
+Outgoing request context contains information about the outgoing request associated with the event.
+It should only be set for events that are associated with an outgoing request - for example, a `failed to fetch` error on a web page.
+
+`url`
+
+: **Required.** The URL of the outgoing request.
+
+- Example: `https://sentry.io/api/0/projects/sentry/sentry/issues/?page=1`
+
+`method`
+
+: **Required.** The HTTP method of the outgoing request.
+
+- Example: `GET`
+
+`headers`
+
+: **Optional.** The headers of the outgoing request.
+
+- Example: `{ "Content-Type": "application/json" }`
+
+`data`
+
+: **Optional.** The data of the outgoing request.
+
+- Example: `{ "name": "John Doe", "email": "john.doe@example.com" }`
+
+### Example Outgoing Request Context
+
+```json
+{
+  "contexts": {
+    "outgoing_request": {
+      "url": "https://sentry.io/api/0/projects/sentry/sentry/issues/?page=1",
+      "method": "GET",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "data": {
+        "name": "John Doe",
+        "email": "john.doe@example.com"
+      }
+    }
+  }
+}
+```
+
 ## Response Context
 
 Response context contains information about the HTTP response associated with the event.

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -782,17 +782,29 @@ envelope endpoint.
 
 Page context contains information about the page that the event occurred on.
 
-`url`
+`full.url`
 
-: **Required.** The URL of the page that the event occurred on.
+: **Required.** The URL of the page that the event occurred on, including query parameters.
 
-- Example: `https://sentry.io/issues?page=1`
+- Example: `https://sentry.io/issues?page=1#123`
 
-`user_agent`
+`http.url`
 
-: _Optional_. The user agent of the page that the event occurred on.
+: **Required.** The URL of the page that the event occurred on, excluding query parameters.
 
-- Example: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36`
+- Example: `https://sentry.io/issues`
+
+`http.query`
+
+: **Optional.** The query parameters of the page that the event occurred on.
+
+- Example: `?page=1`
+
+`http.fragment`
+
+: **Optional.** The fragment of the page that the event occurred on.
+
+- Example: `#123`
 
 `referer`
 
@@ -806,8 +818,10 @@ Page context contains information about the page that the event occurred on.
 {
   "contexts": {
     "page": {
-      "url": "https://sentry.io/issues?page=1",
-      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+      "full.url": "https://sentry.io/issues?page=1#123",
+      "http.url": "https://sentry.io/issues",
+      "http.query": "?page=1",
+      "http.fragment": "#123",
       "referer": "https://sentry.io/"
     }
   }

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -887,7 +887,7 @@ It should only be set for events that are associated with an outgoing request - 
 
 - Example: `{ "name": "John Doe", "email": "john.doe@example.com" }`
 
-### Example Outgoing Request Context
+**Example Outgoing Request Context**
 
 ```json
 {

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -812,7 +812,7 @@ Page context contains information about the page that the event occurred on.
 
 - Example: `https://sentry.io/`
 
-### Example Page Context
+**Example Page Context**
 
 ```json
 {

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -901,7 +901,6 @@ The feature flag context contains information about the flags evaluated prior to
 
 - Example: `false`
 
-
 **Example Feature Flag Context**
 
 ```json

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -833,25 +833,55 @@ Page context contains information about the page that the event occurred on.
 Outgoing request context contains information about the outgoing request associated with the event.
 It should only be set for events that are associated with an outgoing request - for example, a `failed to fetch` error on a web page.
 
-`url`
+`full.url`
 
-: **Required.** The URL of the outgoing request.
+: **Required.** The full URL of the outgoing request, including query parameters.
 
 - Example: `https://sentry.io/api/0/projects/sentry/sentry/issues/?page=1`
 
-`method`
+`http.request.url`
+
+: **Required.** The full URL of the outgoing request, excluding query parameters.
+
+- Example: `https://sentry.io/api/0/projects/sentry/sentry/issues/`
+
+`http.request.method`
 
 : **Required.** The HTTP method of the outgoing request.
 
 - Example: `GET`
 
-`headers`
+`http.request.query`
+
+: **Optional.** The query parameters of the outgoing request.
+
+- Example: `?page=1`
+
+`http.request.headers`
 
 : **Optional.** The headers of the outgoing request.
 
 - Example: `{ "Content-Type": "application/json" }`
 
-`data`
+`http.request.data`
+
+: **Optional.** The data of the outgoing request.
+
+- Example: `{ "name": "John Doe", "email": "john.doe@example.com" }`
+
+`http.response.status_code`
+
+: **Optional.** The status code of the outgoing request.
+
+- Example: `200`
+
+`http.response.headers`
+
+: **Optional.** The headers of the outgoing request.
+
+- Example: `{ "Content-Type": "application/json" }`
+
+`http.response.data`
 
 : **Optional.** The data of the outgoing request.
 
@@ -863,12 +893,22 @@ It should only be set for events that are associated with an outgoing request - 
 {
   "contexts": {
     "outgoing_request": {
-      "url": "https://sentry.io/api/0/projects/sentry/sentry/issues/?page=1",
-      "method": "GET",
-      "headers": {
+      "full.url": "https://sentry.io/api/0/projects/sentry/sentry/issues/?page=1",
+      "http.request.url": "https://sentry.io/api/0/projects/sentry/sentry/issues/",
+      "http.request.query": "?page=1",
+      "http.request.method": "GET",
+      "http.request.headers": {
         "Content-Type": "application/json"
       },
-      "data": {
+      "http.request.data": {
+        "name": "John Doe",
+        "email": "john.doe@example.com"
+      },
+      "http.response.status_code": 200,
+      "http.response.headers": {
+        "Content-Type": "application/json"
+      },
+      "http.response.data": {
         "name": "John Doe",
         "email": "john.doe@example.com"
       }

--- a/develop-docs/sdk/data-model/event-payloads/request.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/request.mdx
@@ -4,9 +4,8 @@ sidebar_order: 8
 ---
 
 The Request interface contains information on a HTTP request related to the
-event. In client SDKs, this can be an outgoing request, or the request that
-rendered the current web page. On server SDKs, this could be the incoming web
-request that is being handled.
+event. In client SDKs, this can be an outgoing request (use the [page context](../contexts/#page-context) to track the page that the request was made from).
+On server SDKs, this could be the incoming web request that is being handled.
 
 The data variable should only contain the request body (not the query string).
 It can either be a dictionary (for standard HTTP requests) or a raw request

--- a/develop-docs/sdk/data-model/event-payloads/request.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/request.mdx
@@ -3,9 +3,10 @@ title: Request Interface
 sidebar_order: 8
 ---
 
-The Request interface contains information on a HTTP request related to the
-event. In client SDKs, this can be an outgoing request (use the [page context](../contexts/#page-context) to track the page that the request was made from).
-On server SDKs, this could be the incoming web request that is being handled.
+The Request interface contains information on an incoming HTTP request related to the
+event. For outgoing requests, use the [outgoing request context](../contexts/#outgoing-request-context).
+
+In client SDKs, use the [page context](../contexts/#page-context) instead.
 
 The data variable should only contain the request body (not the query string).
 It can either be a dictionary (for standard HTTP requests) or a raw request


### PR DESCRIPTION
This should replace `event.request` on the client completely.

Draft on top of https://github.com/getsentry/sentry-docs/pull/13203