### PR TITLE
feat(develop): Allow to pass `user_agent` as browser context

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -402,6 +402,12 @@ The `type` and default key is `"browser"`.
 
 : _Optional_. Version string of the browser.
 
+`user_agent`
+
+: _Optional_. The user agent of the browser. If this is set, `name` may also be omitted (as it will be derived from the user agent).
+
+- Example: `"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"`
+
 ## GPU Context
 
 GPU context describes the GPU of the device.


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-docs/pull/13203

Today, the browser context is inferred in relay from `event.request.headers['user-agent']`. This is slightly weird in the context of a browser event, as the page is not really the request - we want to replace this with something more explicit.

In order to make this possible, we propose to allow client SDKs to send a partial `browser` context with only user-agent, and have relay infer the rest of the data from this, if it exists (instead of from `event.request`). 