### PR TITLE
feat(develop): Clean up contexts page structure

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -8,7 +8,7 @@ related to the current user and the environment. For example, the device or
 application version. Its canonical name is `contexts`.
 
 The `contexts` type can be used to define arbitrary contextual data on the
-event. It accepts an object of key/value pairs. The key is the “alias” of the
+event. It accepts an object of key/value pairs. The key is the "alias" of the
 context and can be freely chosen. However, as per policy, it should match the
 type of the context unless there are two values for a type. You can omit `type`
 if the key name is the type.
@@ -273,7 +273,7 @@ To summarize:
 
 : _Optional_. Typically provides the full name, full version, and release alias. This maps to `PRETTY_NAME` in [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#PRETTY_NAME=) (examples: `Ubuntu 22.04.4 LTS`, `Raspian GNU/Linux 10 (buster)`).
 
-### Example OS Context
+**Example OS Context**
 
 The OS Context for the 3 major OSs should look like this:
 
@@ -468,7 +468,7 @@ Examples: `"Apple Metal"` or `"Direct3D11"`
 
 : _Optional_. Are geometry shaders available on the device?
 
-### Example GPU Context
+**Example GPU Context**
 
 ```json
 {
@@ -496,7 +496,7 @@ The `type` and default key is `"state"`.
 
 : **Required**. Object with two keys: _Optional_ `type` for naming the state library (e.g.: Redux, MobX, Vuex) and **Required** `value` that holds the state object.
 
-### Example State Context
+**Example State Context**
 
 ```json
 {
@@ -598,7 +598,7 @@ The `type` and default key is `"cloud_resource"`.
 
 - Example: `t4g.medium`
 
-### Example Cloud Resource Context
+**Example Cloud Resource Context**
 
 The following example illustrates the contexts part of the <Link to="/sdk/data-model/event-payloads/">event payload</Link> and omits other attributes for simplicity.
 
@@ -720,7 +720,7 @@ The `route` currently supports the following predefined fields if it's a map:
 
 If the route is set to a string (e.g. `"route": "foo"`), it will be normalized into a map (e.g. `"route": {"name": "foo"}`) server-side.
 
-### Example Trace Context
+**Example Trace Context**
 
 ```json
 {
@@ -766,7 +766,7 @@ envelope endpoint.
 
 : **Required**. The replay_id associated with the event.
 
-### Example Replay Context
+**Example Replay Context**
 
 ```json
 {
@@ -792,7 +792,7 @@ This is mostly set on transactions in a web server environment where one transac
 
 - Example: `200`
 
-### Example Response Context
+**Example Response Context**
 
 ```json
 {
@@ -822,7 +822,7 @@ The required field is `package` which should contain the package or framework wh
 
 - Example: `true`
 
-### Example Response Context
+**Example Response Context**
 
 ```json
 {
@@ -852,7 +852,7 @@ The feature flag context contains information about the flags evaluated prior to
 - Example: `false`
 
 
-### Example Feature Flag Context
+**Example Feature Flag Context**
 
 ```json
 {


### PR DESCRIPTION
The h3 for the examples kind of messed up the sidebar hierarchy, making it harder to parse.

Before:

![Screenshot 2025-04-02 at 16 08 16](https://github.com/user-attachments/assets/cfaf07c9-7be7-41d2-837f-2bde71ff174b)

After:

![Screenshot 2025-04-02 at 16 07 48](https://github.com/user-attachments/assets/549ec1e9-cf02-4211-bf72-469941b0346c)

