### PR TITLE
Update esm-npm.mdx to show correct config with AWS Lambda

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/install/esm-npm.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/esm-npm.mdx
@@ -142,7 +142,7 @@ export const handler = Sentry.wrapHandler(async (event, context) => {
 To load the SDK before your function starts, you need to preload the `instrument.mjs` by setting the `NODE_OPTIONS` environment variable:
 
 ```bash
-NODE_OPTIONS="--import instrument.mjs"
+NODE_OPTIONS="--import ./instrument.mjs"
 ```
 
 To set environment variables, navigate to your Lambda function, select **Configuration**, then **Environment variables**:


### PR DESCRIPTION
The `NODE_OPTIONS: "--import instrument.mjs"` example needs to be `NODE_OPTIONS: "--import ./instrument.mjs"` to work correctly. The example image is correct, but the docs are not.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
