### PR TITLE
ref(js-aws-lambda): Reword installation method selection

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/index.mdx
@@ -20,10 +20,10 @@ On this page you'll get an overview how to install, configure and use Sentry in 
 
 ## Installation
 
-Depending on your setup, there are different ways to install and use Sentry in your Lambda functions. We recommend one of the following options:
+Depending on your setup, there are different ways to install and use Sentry in your Lambda functions:
 
-- [Install the Sentry AWS Lambda Layer](./install/cjs-layer) if your Lambda functions are written in CommonJS (CJS) using `require` syntax.
-- [Install the Sentry AWS NPM package](./install/esm-npm) if your Lambda functions are running in EcmaScript Modules (ESM) using `import` syntax.
+- If your Lambda functions are running in CommonJS (CJS) using `require` syntax, [install the Sentry AWS Lambda Layer](./install/cjs-layer)
+- If your Lambda functions are running in EcmaScript Modules (ESM) using `import` syntax, [install the Sentry AWS NPM package](./install/esm-npm)
 
 If you're not sure which installation method to use or want an overview of all available options to use Sentry in your Lambda functions, read the [installation methods overview](./install).
 

--- a/docs/platforms/javascript/guides/aws-lambda/install/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/index.mdx
@@ -19,7 +19,7 @@ Note that TypeScript can also be configured to output ESM, in which case you sho
 
 ### My Lambda function uses `require`
 
-If you are using `require()` in your function, you should follow the CommonJS instructions. You can choose between [using our Lambda Layer (recommended)](./cjs-layer) or [installing the Sentry AWS NPM package](./cjs-layer).
+If you are using `require()` in your function, follow the CommonJS instructions. Choose between [using our Lambda Layer (recommended)](./cjs-layer) or [installing the Sentry AWS NPM package](./cjs-layer).
 
 ### My Lambda function uses `import`
 

--- a/docs/platforms/javascript/guides/aws-lambda/install/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/index.mdx
@@ -4,9 +4,8 @@ sidebar_order: 1
 description: "Review all installation methods for using Sentry in AWS Lambda functions"
 ---
 
-<PageGrid />
 
-## How To Decide Which Installation Method To Use
+## Which Installation Method Should I Use?
 
 Choosing the right installation method for using Sentry in your AWS Lambda functions depends on a couple of factors.
 
@@ -15,16 +14,16 @@ For Sentry to work correctly, you need to follow the guide for the format in whi
 
 ### My Lambda function is written in TypeScript
 
-If you're using TypeScript, your lambda function is likely transpiled to CommonJS before running it. In this case, you should follow the CommonJS instructions.
-Note that TypeScript can also be configured to output ESM, in which case you should follow the ESM instructions.
+If you're using TypeScript, your lambda function is likely transpiled to CommonJS before running it. In this case, follow the [CommonJS instructions](#my-lambda-function-uses-require).
+Note that TypeScript can also be configured to output ESM, in which case you should follow the [ESM instructions](#my-lambda-function-uses-import).
 
 ### My Lambda function uses `require`
 
-If you are using `require()` in your function, you should follow the CommonJS instructions. You can choose between manually setting up Sentry or using the Lambda Layer.
+If you are using `require()` in your function, you should follow the CommonJS instructions. You can choose between [using our Lambda Layer (recommended)](./cjs-layer) or [installing the Sentry AWS NPM package](./cjs-layer).
 
 ### My Lambda function uses `import`
 
-If you're using `import` syntax in your function and you're _not_ transpiling the code to CommonJS, you should follow the ESM instructions.
+If you're using `import` syntax in your function and you're _not_ transpiling the code to CommonJS, follow the [ESM instructions](./esm-npm).
 
 ### Can I use the Lambda layer for ESM functions?
 


### PR DESCRIPTION
After a quick convo with @mydea, this PR rewords and restructures the Node AWS Lambda installation methods sections.

* On the main page, I turned around the sentence to more clearly see which method to follow for which setup
* on the installation methods page:
  * removed PageGrid as it was distracting from the actually important information
  * added missing links 
  * shortened some sentences and removed indecisive language ("you should...")