### PR TITLE
feat(react-native): Add Browser replay init to the RN docs

### DIFF
--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -33,7 +33,7 @@ pnpm add @sentry/react-native
 
 To set up the integration, add the following to your Sentry initialization.
 
-```javascript
+```javascript {tabTitle:Mobile}
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
@@ -41,6 +41,24 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   integrations: [Sentry.mobileReplayIntegration()],
+});
+```
+
+```javascript {tabTitle:Browser}
+import * as Sentry from '@sentry/react-native';
+import { Platform } from 'react-native';
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  integrations: (integrations) => {
+    if (Platform.OS === 'web') {
+      integrations.push(Sentry.browserReplayIntegration());
+    }
+    integrations.push(Sentry.mobileReplayIntegration());
+    return integrations;
+  },
 });
 ```
 
@@ -76,7 +94,7 @@ If you encounter any data not being redacted with the default settings, please l
 
 To disable redaction altogether (not to be used on applications with sensitive data):
 
-```javascript
+```javascript {tabTitle:Mobile}
 // You can pass options to the mobileReplayIntegration function during init:
 integrations: [
   Sentry.mobileReplayIntegration({
@@ -85,6 +103,24 @@ integrations: [
     maskAllVectors: false,
   }),
 ]
+```
+
+```javascript {tabTitle:Browser}
+// You can pass options to the browserReplayIntegration function during init:
+integrations: (integrations) => {
+  if (Platform.OS === 'web') {
+    integrations.push(Sentry.browserReplayIntegration({
+      maskAllText: true,
+      maskAllInputs: true,
+    }));
+  }
+  integrations.push(Sentry.mobileReplayIntegration({
+    maskAllText: false,
+    maskAllImages: false,
+    maskAllVectors: false,
+  }));
+  return integrations;
+}
 ```
 
 ## React Component Names

--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -95,8 +95,8 @@ If you encounter any data not being redacted with the default settings, please l
 To disable redaction altogether (not to be used on applications with sensitive data):
 
 ```javascript {tabTitle:Mobile}
-// You can pass options to the mobileReplayIntegration function during init:
 integrations: [
+  // You can pass options to the mobileReplayIntegration function during init:
   Sentry.mobileReplayIntegration({
     maskAllText: false,
     maskAllImages: false,
@@ -106,14 +106,15 @@ integrations: [
 ```
 
 ```javascript {tabTitle:Browser}
-// You can pass options to the browserReplayIntegration function during init:
 integrations: (integrations) => {
   if (Platform.OS === 'web') {
+    // You can pass options to the browserReplayIntegration function during init:
     integrations.push(Sentry.browserReplayIntegration({
       maskAllText: true,
       maskAllInputs: true,
     }));
   }
+  // You can pass options to the mobileReplayIntegration function during init:
   integrations.push(Sentry.mobileReplayIntegration({
     maskAllText: false,
     maskAllImages: false,


### PR DESCRIPTION
RN SDK supports browser replay, but it was not part of the docs.

