### PR TITLE
feat(develop): Add `driver_version` to GPU context

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -436,6 +436,10 @@ GPU context describes the GPU of the device.
 
 Examples: `"Apple Metal"` or `"Direct3D11"`
 
+`driver_version`
+
+: _Optional_. The driver version of the graphics device.
+
 `multi_threaded_rendering`
 
 : _Optional_. Whether the GPU has multi-threaded rendering or not.


### PR DESCRIPTION
The Electron SDK has started including this:
https://github.com/getsentry/sentry-electron/blob/bcfdbfec0c6d2f3eb28430fb8d0121d4b61123ac/src/main/integrations/gpu-context.ts#L20