### PR TITLE
feat(insights): Updates queues instrumentation for python to use transaction set status

### DIFF
--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
@@ -132,5 +132,5 @@ with sentry_sdk.start_transaction(transaction):
             process_message(message)
         except Exception:
             # In case of an error set the status to "internal_error"
-            span.set_status("internal_error")
+            transaction.set_status("internal_error")
 ```

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/queues-module.mdx
@@ -83,7 +83,7 @@ To start capturing performance metrics, use the `sentry_sdk.start_span()` functi
 
 Your `queue.process` span must exist inside a transaction in order to be recognized as a consumer span. If you are using a <PlatformLink to="/integrations/#web-frameworks">supported web framework</PlatformLink>, the transaction is created by the integration. If you use plain Python, you can start a new one using `sentry_sdk.start_transaction()`.
 
-Use `sentry_sdk.continue_trace()` to connect your consumer spans to their associated producer spans, and `span.set_status()` to mark the trace of your message as success or failed.
+Use `sentry_sdk.continue_trace()` to connect your consumer spans to their associated producer spans, and `transaction.set_status()` to mark the trace of your message as success or failed.
 
 
 ```python


### PR DESCRIPTION
Updates the python queues module instrumentation to correctly use `transaction.set_status()` instead.