### PR TITLE
ref(member-docs): remove early access alert for adding members

### DIFF
--- a/docs/organization/membership/index.mdx
+++ b/docs/organization/membership/index.mdx
@@ -118,9 +118,6 @@ Projects can only be accessed by that project's team(s). Team Admins, Org Manage
 Any Org Member can get access to a project by joining the team that's associated with that project. Once you've joined a project you'll also be able to edit [ownership rules](/product/issues/ownership-rules/) for that project.
 
 ### Adding New Members
-<Alert>
-This feature is currently only available for [Early Adopters](/organization/early-adopter-features/).
-</Alert>
 
 Users with Manager and Owner-level permissions can add, remove, and change members for a project or organization. They can also toggle on the "Let Members Invite Others" setting to allow any org member to freely invite anyone they like without needing org owner or manager approval.
 


### PR DESCRIPTION
Deletes this alert 

![Screenshot 2025-04-04 at 12 44 21 PM](https://github.com/user-attachments/assets/51483bb4-d731-4f96-8690-08e7f97ada35)

located [here](https://docs.sentry.io/organization/membership/#adding-new-members)


I'm pretty sure adding members is no longer an EA feature 😅 