### PR TITLE
feat(feature flags): Add feature flag integrations to js frameworks with Browser Integrations sections

### DIFF
--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -36,6 +36,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -25,20 +25,20 @@ Depending on whether an integration enhances the functionality of a particular r
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 

--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -36,6 +36,10 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 
 ### Node.js Integrations
 

--- a/platform-includes/configuration/integrations/javascript.mdx
+++ b/platform-includes/configuration/integrations/javascript.mdx
@@ -18,12 +18,12 @@
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.mdx
+++ b/platform-includes/configuration/integrations/javascript.mdx
@@ -16,14 +16,14 @@
 | [`captureConsoleIntegration`](./captureconsole)       |                  |     ✓      |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.mdx
+++ b/platform-includes/configuration/integrations/javascript.mdx
@@ -16,13 +16,13 @@
 | [`captureConsoleIntegration`](./captureconsole)       |                  |     ✓      |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
-| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -36,6 +36,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -25,20 +25,20 @@ Depending on whether an integration enhances the functionality of a particular r
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -36,6 +36,10 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 
 ### Server (Node.js, Edge) Integrations
 

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -24,20 +24,20 @@ Depending on whether an integration enhances the functionality of a particular r
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -35,6 +35,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -35,6 +35,10 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 
 ### Node.js Integrations
 

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -24,20 +24,20 @@ Depending on whether an integration enhances the functionality of a particular r
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -35,6 +35,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -35,6 +35,10 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 
 ### Node.js Integrations
 

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -24,20 +24,20 @@ Depending on whether an integration enhances the functionality of a particular r
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -35,6 +35,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -35,6 +35,10 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 
 ### Node.js Integrations
 

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -24,20 +24,20 @@ Depending on whether an integration enhances the functionality of a particular r
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -35,6 +35,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -35,6 +35,10 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |
 
 ### Node.js Integrations
 

--- a/platform-includes/configuration/integrations/javascript.vue.mdx
+++ b/platform-includes/configuration/integrations/javascript.vue.mdx
@@ -4,6 +4,7 @@
 | ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
+| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`dedupeIntegration`](./dedupe)                       |        ✓         |     ✓      |             |            |                        |
 | [`functionToStringIntegration`](./functiontostring)   |        ✓         |            |             |            |                        |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
@@ -12,19 +13,18 @@
 | [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
 | [`vueIntegration`](./vue)                             |        ✓         |     ✓      |      ✓      |            |                        |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
-| [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
 | [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
-| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
-| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
-| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
-| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
-| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
-| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
-| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
+| [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
+| [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
 | [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.vue.mdx
+++ b/platform-includes/configuration/integrations/javascript.vue.mdx
@@ -23,3 +23,7 @@
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
+| [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
+| [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |
+| [`unleashIntegration`](./unleash)                     |                  |            |             |            |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.vue.mdx
+++ b/platform-includes/configuration/integrations/javascript.vue.mdx
@@ -23,6 +23,7 @@
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`reportingObserverIntegration`](./reportingobserver) |                  |     ✓      |             |            |                        |
+| [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`statsigIntegration`](./statsig)                     |                  |            |             |            |           ✓            |


### PR DESCRIPTION
The change is on this page, for all the frameworks i found that have a specific Browser Integrations section
https://docs.sentry.io/platforms/javascript/configuration/integrations/

I've grouped all the FF integrations together. This is an improvement as-is because we're giving more reach to the FF integrations for JS frameworks with a browser component.

Pages will look like this now:

<img width="767" alt="SCR-20250404-ndiv" src="https://github.com/user-attachments/assets/ffae58fd-3e79-4295-b30e-9420588dd4f7" />
