### PR TITLE
docs(sdk): Clarify HTTP response codes considered successful

### DIFF
--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -232,16 +232,16 @@ This feature is also known as 'Offline Caching'.
 
 Write events to disk before attempting to send, so that they can be retried in the event of a temporary network failure. Needs to implement a cap on the number of stored events. This is mostly useful on mobile and desktop(e.g: laptop) apps, where stable connectivity is often not available.
 
-### Dealing with network failures
+### Dealing With Network Failures
 
-A `HTTP 2xx` response status code response from Sentry is considered a successful send. It's important to note that retry is only considered in the event of a network failure. For example:
+An `HTTP 2xx` status code response from Sentry is considered a successful send. It's important to note that retry is only considered in the event of a network failure. For example:
 
 * Connection timeout
 * DSN resolution failure
 * Connection reset by peer
 
 Other failures, like those caused by processing the file in the SDK itself, the payload should be discarded since those are likely to end up on an endless retry.
-If the event reached Sentry and a HTTP response status code was received, even in the event of a `HTTP 500` status code, the event should be discarded.
+If the event reached Sentry and an HTTP response status code was received, even in the event of an `HTTP 500` status code, the event should be discarded.
 
 
 #### Additional capabilities

--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -232,16 +232,17 @@ This feature is also known as 'Offline Caching'.
 
 Write events to disk before attempting to send, so that they can be retried in the event of a temporary network failure. Needs to implement a cap on the number of stored events. This is mostly useful on mobile and desktop(e.g: laptop) apps, where stable connectivity is often not available.
 
-#### Dealing with failures
+### Dealing with network failures
 
-It's important to note that retry is only considered in the event of a network failure. For example:
+A `HTTP 2xx` response status code response from Sentry is considered a successful send. It's important to note that retry is only considered in the event of a network failure. For example:
 
 * Connection timeout
 * DSN resolution failure
 * Connection reset by peer
 
 Other failures, like those caused by processing the file in the SDK itself, the payload should be discarded since those are likely to end up on an endless retry.
-If the event reached Sentry and a HTTP response status code was received, even in the event of a `500` response, the event should be discarded.
+If the event reached Sentry and a HTTP response status code was received, even in the event of a `HTTP 500` status code, the event should be discarded.
+
 
 #### Additional capabilities
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
As part of https://github.com/getsentry/team-sdks/issues/109#issuecomment-2775965613 we want to clarify that any `HTTP 2xx` should be treated as succesfull.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
