### PR TITLE
ref(js): Move "Special Use Cases" down in sidebar order

### DIFF
--- a/docs/platforms/javascript/common/best-practices/index.mdx
+++ b/docs/platforms/javascript/common/best-practices/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Special Use Cases
 description: "Learn how to set up Sentry for several specific use cases with these best practice guides."
-sidebar_order: 6
+sidebar_order: 8000
 notSupported:
   - javascript.node
   - javascript.aws-lambda

--- a/docs/platforms/javascript/common/migration/index.mdx
+++ b/docs/platforms/javascript/common/migration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migration Guide
 description: "Migrate from an older version of our Sentry JavaScript SDK."
-sidebar_order: 8000
+sidebar_order: 8100
 notSupported:
   - javascript.capacitor
   - javascript.cordova


### PR DESCRIPTION
IMHO this page is less important as the general setup pages, so it makes sense to move this down.
