### PR TITLE
chore(profiling): move the sampling paragraph to the right place in python profiling docs

### DIFF
--- a/docs/platforms/python/profiling/index.mdx
+++ b/docs/platforms/python/profiling/index.mdx
@@ -91,6 +91,7 @@ sentry_sdk.profiler.start_profiler()
 
 sentry_sdk.profiler.stop_profiler()
 ```
+These new APIs do not offer any sampling functionality—every call to start the profiler will start it, and the same goes for launch profiles if you've configured that. If you are interested in reducing the amount of profiles that run, you must take care to do it at the callsites.
 
 For some applications such as web servers, it may be difficult to call `sentry_sdk.profiler.start_profiler` in every process. Instead, you can use the `profile_lifecycle` option to automatically profile anytime a transaction is active.
 
@@ -106,7 +107,5 @@ sentry_sdk.init(
     profile_lifecycle="trace",
 )
 ```
-
-These new APIs do not offer any sampling functionality—every call to start the profiler will start it, and the same goes for launch profiles if you've configured that. If you are interested in reducing the amount of profiles that run, you must take care to do it at the callsites.
 
 Continuous profiling has implications for your org's billing structure. This feature is only available for subscription plans that enrolled after June 5, 2024.


### PR DESCRIPTION
- Moves the paragraph about missing sampling when manually starting & stopping profiling to after the snippet where it should belong semantically.