### PR TITLE
docs(options): Promote usage of in_random_rollout

### DIFF
--- a/develop-docs/backend/application-domains/options.mdx
+++ b/develop-docs/backend/application-domains/options.mdx
@@ -23,8 +23,8 @@ Follow these rules when adding new options:
 The value of an option can be any pickleable value.
 
 <Alert>
-  It is safe to declare and use an option in the same pull request, you don't
-  need to split them up.
+  It is safe to declare and use an option in the same pull request, you don't need to
+  split them up.
 </Alert>
 
 ## Using Options
@@ -56,8 +56,8 @@ options.set("performance.some-feature-rate", 0.01)
 ```
 
 <Alert>
-  If you do not have access to the shell, you'll need to contact OPS to set the
-  option value for you.
+  If you do not have access to the shell, you'll need to contact OPS to set the option
+  value for you.
 </Alert>
 
 ### Options UI
@@ -124,6 +124,6 @@ options.delete("performance.some-feature-rate")
 ```
 
 <Alert>
-  If you do not have access to the shell, you'll need to contact OPS to remove
-  the option for you.
+  If you do not have access to the shell, you'll need to contact OPS to remove the option
+  for you.
 </Alert>


### PR DESCRIPTION

## DESCRIBE YOUR PR
I wasn't aware that this helper exists, and as it was proposed to me in this [PR](https://github.com/getsentry/sentry/pull/88885), we can just use `in_random_rollout` when dealing with options and want to do rollout.
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+



