### PR TITLE
feat: Keep the Platform/Language/Framework dropdown visible and scroll nav below it

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -86,7 +86,7 @@ export async function Sidebar({path, versions}: SidebarProps) {
     <aside className={styles.sidebar}>
       <input type="checkbox" id={sidebarToggleId} className="hidden" />
       <style>{':root { --sidebar-width: 300px; }'}</style>
-      <div className="md:flex flex-col items-stretch">
+      <div className="md:flex flex-col items-stretch overflow-auto">
         <div className="platform-selector">
           <div className="mb-3">
             <PlatformSelector

--- a/src/components/sidebar/style.module.scss
+++ b/src/components/sidebar/style.module.scss
@@ -70,6 +70,7 @@
   }
 
   .toc {
+    overflow: auto;
     font-size: 0.875rem;
     flex: 1;
     overflow-y: hidden;


### PR DESCRIPTION
**Problem Statement**
The framework you’ve picked is really important, but it scrolls away. So if you arrived at docs via a search you might be looking at instructions for a random framework and not realize it. Other hints on the page are:
- The url (not a huge hint if you’re looking at javascript but want NextJS),  
- ‘Home / Platforms / JavaScript / Next.js’ breadcrumb but that scrolls away too
- Package details in the right column, hard to spot that.

**Solution**
When the window is wide the navigation sidebar will now have a sticky Platform dropdown. So that dropdown is always visible, and users can easily see what docs are they reading. The nav links below will scroll behind the platform dropdown.

In narrow modes, when you have to click to see this whole nav column, the scrolling is the same as before, the platform list will move out of the way so you can find the link you're looking for.


| Wide | Narrow |
| --- | --- |
| ![SCR-20250407-ohrm](https://github.com/user-attachments/assets/6ebd0292-eeb3-40d1-a8d3-833e99562bab) | ![SCR-20250407-ohxo](https://github.com/user-attachments/assets/ecde694a-373e-432c-a034-e87a94073a6d)
