### PR TITLE
Unreal Engine plugin docs update

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -103,6 +103,19 @@ By the time <PlatformIdentifier name="before-send" /> is executed, all scope dat
 
 </ConfigKey>
 
+<ConfigKey name="before-breadcrumb">
+
+This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
+The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
+
+<Alert>
+
+Currently, hints are supported only on Android.
+
+</Alert>
+
+</ConfigKey>
+
 ## Tracing Options
 
 <ConfigKey name="traces-sample-rate">

--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -93,6 +93,8 @@ The support for screenshot attachment on crash events is limited to Windows and 
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
 
+The callbacks you set as hooks will be called on the thread where the event happened. If the event occurs on a non-game thread during garbage collection the callback will not be invoked.
+
 <ConfigKey name="before-send">
 
 This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.

--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -89,6 +89,20 @@ The support for screenshot attachment on crash events is limited to Windows and 
 
 </ConfigKey>
 
+<ConfigKey name="attach-game-log">
+
+When enabled, game log filr is automatically attached to all events captured if current build configuration allows logging.
+
+This option is turned off by default.
+
+<Alert>
+
+Game log attachments for crash events are not supported on macOS and iOS.
+
+</Alert>
+
+</ConfigKey>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.

--- a/docs/platforms/unreal/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/unreal/enriching-events/breadcrumbs/index.mdx
@@ -37,3 +37,29 @@ The same result can be achieved by calling corresponding function in blueprint:
 The Unreal Engine SDK can capture certain types of breadcrumbs automatically. Those can be enabled using the Sentry configuration window at **Project Settings > Plugins > Sentry**.
 
 ![Sentry automatic breadcrumbs](./img/unreal_automatic_breadcrumbs.png)
+
+## Customize Breadcrumbs
+
+SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook (the corresponding handler class can be set in the plugin settings).
+
+This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `nullptr`:
+
+```cpp
+UCLASS()
+class UCustomBeforeBreadcrumbHandler : public USentryBeforeBreadcrumbHandler
+{
+	GENERATED_BODY()
+
+public:
+	virtual USentryBreadcrumb* HandleBeforeBreadcrumb_Implementation(USentryBreadcrumb* Breadcrumb, USentryHint* Hint)
+    {
+        if (Breadcrumb->GetCategory() == "Spammy.Logger")
+        {
+            // Discard breadcrumb
+            return nullptr;
+        }
+
+        return Breadcrumb;
+    }
+};
+```

--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -75,6 +75,12 @@ Currently, this method is available only for C++ UE projects. Blueprint projects
 
 </Alert>
 
+<Alert>
+
+To avoid warnings during the build for licensee versions of Unreal Engine, the `EngineVersion` key is not set in the `Sentry.uplugin` for the `github` package.
+
+</Alert>
+
 ### Installing from Fab
 
 Sentry SDK can be downloaded via the [standard installation process](https://dev.epicgames.com/documentation/en-us/unreal-engine/working-with-plugins-in-unreal-engine#installingpluginsfromtheunrealenginemarketplace) from its [Epic Games Fab page](https://www.fab.com/listings/eaa89d9d-8d39-450c-b75f-acee010890a2).

--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -56,6 +56,7 @@ The table below highlights some key differences between different versions of th
 | Backend (Windows)          | Crashpad             | Breakpad            | Crashpad       |
 | `on_crash` hook (Windows)  | Supported            | Not supported       | Supported      |
 | Sentry CLI **              | Included             | Manual download     | Included       |
+| Fast-fail crash capturing  | Supported            | Not supported       | Supported      |
 
 Legend:
 `*`: Recommended version of the SDK


### PR DESCRIPTION
This PR introduces the following changes to Unreal SDK docs:
- Added `beforeBreadcrumb` hook description (https://github.com/getsentry/sentry-unreal/pull/814)
- Added [notice](https://github.com/getsentry/sentry-unreal/pull/860#pullrequestreview-2739676422) that hooks can't be invoked during garbage collection in Unreal
- Added fast-fail crash capturing to the feature comparison table for different plugin versions (https://github.com/getsentry/sentry-unreal/pull/828)
- Added game log attachment option description mentioning it's not supported for Mac/iOS
- Added [notice](https://github.com/getsentry/sentry-unreal/pull/812#issuecomment-2706951322) about `EngineVersion` key in the plugin's descriptor file for GitHub package