### PR TITLE
fix(tanstackstart): added missing imports, highlights, and typos

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -132,9 +132,10 @@ Sentry.init({
 
 Wrap TanStack Start's `createRootRoute` function using `wrapCreateRootRouteWithSentry` to apply tracing to Server-Side Rendering (SSR):
 
-```tsx {filename:app/routes/__root.tsx} {5}
+```tsx {filename:app/routes/__root.tsx} {3,6}
 import type { ReactNode } from "react";
 import { createRootRoute } from "@tanstack/react-router";
+import { wrapCreateRootRouteWithSentry } from "@sentry/tanstackstart-router";
 
 // (Wrap `createRootRoute`, not its return value!)
 export const Route = wrapCreateRootRouteWithSentry(createRootRoute)({
@@ -195,7 +196,7 @@ class MyErrorBoundary extends React.Component {
   // ...
 }
 
-export const MySentryWrappedErrorBoundary = withErrorBoundary(MyErrorBoundary, {
+export const MySentryWrappedErrorBoundary = Sentry.withErrorBoundary(MyErrorBoundary, {
   // ... sentry error wrapper options
 });
 ```


### PR DESCRIPTION
I noticed a few missing imports, highlights, and also a typo in the TanStack Start guide:
- Missing `wrapCreateRootRouteWithSentry` import
- Missing Sentry prefix when defining an error boundary component

**Question**: a similar guide is shown in Sentry itself after you create a project. Would this PR fix that one as well, or should I open a separate PR on that repo?