### PR TITLE
fix(js): Fix redirects for sourcemap docs

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1332,15 +1332,11 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
   },
   {
     from: '/platforms/javascript/guides/:guide/sourcemaps/multiple-origins/',
-    to: '/platforms/javascript/sourcemaps/',
-  },
-  {
-    from: '/platforms/javascript/guides/:guide/sourcemaps/uploading/hosting-publicly/',
-    to: '/platforms/javascript/sourcemaps/',
+    to: '/platforms/javascript/guides/:guide/sourcemaps/',
   },
   {
     from: '/platforms/javascript/guides/:guide/sourcemaps/uploading-without-debug-ids/',
-    to: '/platforms/javascript/sourcemaps/',
+    to: '/platforms/javascript/guides/:guide/sourcemaps/',
   },
   {
     from: '/platforms/javascript/sourcemaps/uploading-without-debug-ids/',


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/13277

The middleware redirect was incorrect here!

(For the future @sfanahata this + the redirects.js file are the places to look at if redirects are incorrect, if you possibly want to fix something like this in the future :) )