### PR TITLE
chore(replay): Cleanup docs related to replay accessibility feature

### DIFF
--- a/docs/product/explore/session-replay/web/replay-details.mdx
+++ b/docs/product/explore/session-replay/web/replay-details.mdx
@@ -28,8 +28,6 @@ Every replay has a detailed view that contains the embedded video player and ric
 - **Trace:** Connects all the [trace(s)](/product/sentry-basics/tracing/distributed-tracing#traces-transactions-and-spans) that happened during the replay.
   - Due to transaction sampling, this view may be missing traces.
 
-- **Accessibility:** Session Replay can be used to ensure that your pages follow common [accessibility](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/What_is_accessibility) standards and are [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) (WCAG) compliant. At any point in the replay, you can click "Run validation for `<timestamp>`" to run accessibility checks (powered by [axe-core](https://github.com/dequelabs/axe-core)) for the page or page state at that specific timestamp. Sentry will then surface any accessibility issues or let you know if there are none detected.
-
 - **Memory:** The view shows a heap size chart displaying the total amount of memory being used by JavaScript objects.
   - This view is only available when the replay was recorded on a Chromium-based browser.
 


### PR DESCRIPTION
That accessibility feature didn't get much use, and was recently removed from the product.

Removed: https://github.com/getsentry/sentry/pull/79155
