### PR TITLE
fix: Remove manual config section from python span lifecycle page

### DIFF
--- a/docs/platforms/python/tracing/span-lifecycle/index.mdx
+++ b/docs/platforms/python/tracing/span-lifecycle/index.mdx
@@ -14,11 +14,6 @@ To add custom performance data to your application, you need to add custom instr
 
 <PlatformContent includePath="enriching-events/import" />
 
-There are two main approaches to creating spans in Python:
-
-- [Using the context manager](#using-the-context-manager): Creates a span with an automatic lifecycle (recommended).
-- [Manual span creation](#creating-spans-manually): Gives you more control over the span's lifecycle.
-
 ## Span Lifecycle
 
 In Python, spans are typically created using a context manager, which automatically manages the span's lifecycle. When you create a span using a context manager, the span automatically starts when entering the context and ends when exiting it. This is the recommended approach for most scenarios.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Removing the manual option from this doc
Fixes #13290 

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
