### PR TITLE
Cleanup none-supported fields from trace context

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -674,30 +674,6 @@ Additional information that allows Sentry to connect multiple transactions, span
   | `data_loss`                  | Unrecoverable data loss or corruption                                                                        | 500                         |
   | `unauthenticated`            | The requester doesn't have valid authentication credentials for the operation                                | 401                         |
 
-`exclusive_time`
-
-: _Optional_. The amount of time in milliseconds spent in this transaction span, excluding its immediate child spans.
-
-- Example: `1.035`
-
-`client_sample_rate`
-
-: _Optional_. The client-side sample rate. This field will be populated by relay; incoming values are ignored.
-
-- Example: `0.1`
-
-`tags`
-
-: _Optional_. A map or list of tags for this event. Each tag must be less than 200 characters.
-
-- Example: `{ "deviceMemory": "8 GB", "effectiveConnectionType": "4g", "routing.instrumentation": "react-router-v3" }`
-
-`dynamic_sampling_context`
-
-: _Optional_. The [Dynamic Sampling Context](/sdk/performance/dynamic-sampling-context/).
-
-- Example: `{ "trace_id": "12312012123120121231201212312012", "sample_rate": "1.0", "public_key": "93D0D1125146288EAEE2A9B3AF4F96CCBE3CB316" },`
-
 `origin`
 
 : _Optional_. The origin of the trace indicates what created the trace. For more details, see [trace origin](/sdk/performance/trace-origin/).
@@ -731,16 +707,6 @@ If the route is set to a string (e.g. `"route": "foo"`), it will be normalized i
       "parent_span_id": null,
       "description": "<OrganizationContext>",
       "op": "http.server",
-      "tags": {
-        "deviceMemory": "8 GB",
-        "effectiveConnectionType": "4g",
-        "routing.instrumentation": "react-router-v3"
-      },
-      "dynamic_sampling_context": {
-        "trace_id": "12312012123120121231201212312012",
-        "sample_rate": "1.0",
-        "public_key": "93D0D1125146288EAEE2A9B3AF4F96CCBE3CB316"
-      },
       "origin": "auto.http.http_client_5",
       "data": {
         "route": {


### PR DESCRIPTION
Develop docs for the trace context include fields that are not supported or not supposed to be ingested.