### PR TITLE
feat(native): improve custom instrumentation docs with child span creation

### DIFF
--- a/platform-includes/performance/enable-manual-instrumentation/native.mdx
+++ b/platform-includes/performance/enable-manual-instrumentation/native.mdx
@@ -17,16 +17,24 @@ sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
 sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
 // Transactions can have child spans (and those spans can have child spans as well)
-sentry_span_t *span = sentry_transaction_start_child(
+sentry_span_t *child_span = sentry_transaction_start_child(
     tx,
     "child operation",
     "child description"
 );
 
+// Starting a child of a span requires the function `sentry_span_start_child` instead
+sentry_span_t *grandchild_span = sentry_span_start_child(
+    child_span,
+    "grandchild operation",
+    "grandchild description"
+);
+
 // ...
-// (Perform the operation represented by the span/transaction)
+// (Perform the operation represented by the spans/transaction)
 // ...
 
-sentry_span_finish(span); // Mark the span as finished
+sentry_span_finish(grandchild_span); // Mark the spans as finished
+sentry_span_finish(child_span);
 sentry_transaction_finish(tx); // Mark the transaction as finished and send it to Sentry
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Someone noticed that we didn't actually document how to start a child span of a span (since this is different from starting a child span of a transaction). The feature itself has existed for a while and is demonstrated on the [sentry-native example](https://github.com/getsentry/sentry-native/blob/master/examples/example.c#L473-L490).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
