### PR TITLE
Fix uglify example command

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/uglifyjs.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/uglifyjs.mdx
@@ -17,7 +17,7 @@ First, configure UglifyJS to output source maps:
 
 ```
 uglifyjs app.js \
-  -o app.min.js.map \
+  -o app.min.js \
   --source-map url=app.min.js.map,includeSources
 ```
 


### PR DESCRIPTION
uglify's `-o` should point to the minified output, not to the sourcemap

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.


