### PR TITLE
fix(apple): Not taking screenshots for all crashes

### DIFF
--- a/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
@@ -10,7 +10,7 @@ notSupported:
   - apple.watchos
 ---
 
-Sentry makes it possible to automatically take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink> when a user experiences an error, an exception or a crash. When a crash occurs on Apple operating systems, there is no guarantee that the Cocoa SDK can still capture a screenshot because, strictly speaking, you're not allowed to call any async unsafe code. Still, it works in most cases, but we can't guarantee screenshots for all types of crashes.
+Sentry makes it possible to automatically take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink> when a user experiences an error, an exception or a crash. When a crash occurs on Apple operating systems, there is no guarantee that the Cocoa SDK can still capture a screenshot since you're technically not allowed to call any async unsafe code. While it still works in most cases, we can't guarantee screenshots for all types of crashes.
 
 This feature is only available for SDKs with a user interface, like the ones for mobile and desktop applications. It's also limited by whether taking a screenshot is possible or not. For example, in some environments, like native iOS, taking a screenshot requires the UI thread, which often isn't available in the event of a crash. Another example where a screenshot might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 

--- a/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
@@ -10,7 +10,7 @@ notSupported:
   - apple.watchos
 ---
 
-Sentry makes it possible to automatically take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink> when a user experiences an error, an exception or a crash.
+Sentry makes it possible to automatically take a screenshot and include it as an <PlatformLink to="/enriching-events/attachments/">attachment</PlatformLink> when a user experiences an error, an exception or a crash. When a crash occurs on Apple operating systems, there is no guarantee that the Cocoa SDK can still capture a screenshot because, strictly speaking, you're not allowed to call any async unsafe code. Still, it works in most cases, but we can't guarantee screenshots for all types of crashes.
 
 This feature is only available for SDKs with a user interface, like the ones for mobile and desktop applications. It's also limited by whether taking a screenshot is possible or not. For example, in some environments, like native iOS, taking a screenshot requires the UI thread, which often isn't available in the event of a crash. Another example where a screenshot might not be available is when the event happens before the screen starts to load. So inherently, this feature is a best effort solution.
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Explain why the Cocoa SDK can't capture screenshots for all types of crashes.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

