### PR TITLE
fix(node-profiling): Remove tracesSampleRate from manual lifecycle sn…

### DIFF
--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -86,12 +86,14 @@ Sentry.init({
     // Add our Profiling integration
 +   nodeProfilingIntegration(),
   ],
+  tracesSampleRate: 1.0,
 + profileSessionSampleRate: 1.0,
 + profileLifecycle: 'manual',
 });
 
 Sentry.profiler.startProfiler();
 // Code executed between these two calls will be profiled
+// All spans (unless those discarded by sampling) will have profiling data attached to them.
 Sentry.profiler.stopProfiler();
 ```
 

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -86,12 +86,10 @@ Sentry.init({
     // Add our Profiling integration
 +   nodeProfilingIntegration(),
   ],
-  tracesSampleRate: 1.0,
 + profileSessionSampleRate: 1.0,
 + profileLifecycle: 'manual',
 });
 
-// All spans (unless those discarded by sampling) will have profiling data attached to them.
 Sentry.profiler.startProfiler();
 // Code executed between these two calls will be profiled
 Sentry.profiler.stopProfiler();
@@ -115,6 +113,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
 + profileSessionSampleRate: 0.0
 });
+```
 
 
 ## How Does It Work?


### PR DESCRIPTION
Remove `tracesSampleRate` from manual lifecycle snippet as it creates the impression it is required.
Fix code snippet without ending sequence.