### PR TITLE
fix(node-profiling): Code snippet without end sequence

### DIFF
--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -133,4 +133,3 @@ Starting from version `0.1.0`, the `@sentry/profiling-node` package precompiles 
 - Windows x64: Node v16, v18, v20, v22
 
 The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue in the [Sentry JavaScript SDK](https://github.com/getsentry/sentry-javascript) repository.
-```

--- a/docs/platforms/javascript/common/profiling/node-profiling.mdx
+++ b/docs/platforms/javascript/common/profiling/node-profiling.mdx
@@ -115,7 +115,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
 + profileSessionSampleRate: 0.0
 });
-
+```
 
 ## How Does It Work?
 


### PR DESCRIPTION
Prevent the code snippet from "eating" the rest of the page.

<img width="734" alt="Screenshot 2025-04-10 at 17 34 18" src="https://github.com/user-attachments/assets/e1f21997-9ceb-4e0c-a5ab-ed925e2205c9" />
