### PR TITLE
fix(docs): fix 404 on sourcemaps

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/hosting-publicly.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/hosting-publicly.mdx
@@ -18,7 +18,7 @@ notSupported:
 
 <Alert>
 
-The most reliable way to provide your source maps to Sentry is to [upload them](..), because it cuts down on network traffic and ensures the correct version of the code and source maps will be used.
+The most reliable way to provide your source maps to Sentry is to upload them, because it cuts down on network traffic and ensures the correct version of the code and source maps will be used.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/hosting-publicly.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/hosting-publicly.mdx
@@ -18,7 +18,7 @@ notSupported:
 
 <Alert>
 
-The most reliable way to provide your source maps to Sentry is to upload them, because it cuts down on network traffic and ensures the correct version of the code and source maps will be used.
+The most reliable way to provide your source maps to Sentry is to [upload them](../), because it cuts down on network traffic and ensures the correct version of the code and source maps will be used.
 
 </Alert>
 


### PR DESCRIPTION
the weird thing is the doc link works on prod, but it failed the lint 404 test on CI

https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/hosting-publicly/