### PR TITLE
feat(js): Update product pages to drop `Set up` prefix in navigation

### DIFF
--- a/docs/platforms/javascript/common/crons/index.mdx
+++ b/docs/platforms/javascript/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 supported:

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Feature Flags
+sidebar_title: Feature Flags
 sidebar_order: 7000
 notSupported:
   - javascript.aws-lambda

--- a/docs/platforms/javascript/common/profiling/index.mdx
+++ b/docs/platforms/javascript/common/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations. Get started with browser and Node.js profiling to understand your application's performance."
 notSupported:

--- a/docs/platforms/javascript/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/javascript/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Session Replay
+sidebar_title: Session Replay
 sidebar_order: 5500
 notSupported:
   - javascript.cordova

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app."
 sidebar_order: 4000
 ---

--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn how to enable User Feedback in your app."
 sidebar_order: 6000
 ---

--- a/docs/platforms/javascript/config.yml
+++ b/docs/platforms/javascript/config.yml
@@ -1,5 +1,6 @@
 title: Browser JavaScript
 platformTitle: JavaScript
+sidebar_title: JavaScript
 caseStyle: camelCase
 supportLevel: production
 sdk: 'sentry.javascript.browser'

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -14,7 +14,10 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
   for (let node: DocNode | undefined = leafNode; node; node = node.parent) {
     if (node && !node.missing) {
       const to = node.path === '/' ? node.path : `/${node.path}/`;
-      const title = node.frontmatter.platformTitle ?? node.frontmatter.sidebar_title ?? node.frontmatter.title;
+      const title =
+        node.frontmatter.platformTitle ??
+        node.frontmatter.sidebar_title ??
+        node.frontmatter.title;
 
       breadcrumbs.unshift({
         to,

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -14,7 +14,7 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
   for (let node: DocNode | undefined = leafNode; node; node = node.parent) {
     if (node && !node.missing) {
       const to = node.path === '/' ? node.path : `/${node.path}/`;
-      const title = node.frontmatter.platformTitle ?? node.frontmatter.title;
+      const title = node.frontmatter.platformTitle ?? node.frontmatter.sidebar_title ?? node.frontmatter.title;
 
       breadcrumbs.unshift({
         to,


### PR DESCRIPTION
Also make sure to use this in breadcrumbs instead of the actual page heading.

Note that the pages themselves keep their "Set up XXX" heading, which makes sense IMHO.