### PR TITLE
fix(style): Ensure scrollbar is consistent

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -81,11 +81,11 @@ export async function Sidebar({path, versions}: SidebarProps) {
       });
 
   return (
-    <aside className={styles.sidebar}>
+    <aside className={`${styles.sidebar} py-3`}>
       <input type="checkbox" id={sidebarToggleId} className="hidden" />
       <style>{':root { --sidebar-width: 300px; }'}</style>
       <div className="md:flex flex-col items-stretch overflow-auto">
-        <div className="platform-selector">
+        <div className="platform-selector px-3">
           <div className="mb-3">
             <PlatformSelector
               platforms={platforms}
@@ -98,7 +98,7 @@ export async function Sidebar({path, versions}: SidebarProps) {
             </div>
           )}
         </div>
-        <div className={styles.toc}>
+        <div className={`${styles.toc} px-3`}>
           <ScrollActiveLink activeLinkSelector={activeLinkSelector} />
           <SidebarLinks path={path} />
         </div>

--- a/src/components/sidebar/style.module.scss
+++ b/src/components/sidebar/style.module.scss
@@ -13,7 +13,6 @@
   flex-direction: column;
   width: 100%;
   z-index: 10;
-  padding: 1.5rem 1rem;
   border-right: 1px solid var(--border-color);
   position: fixed;
   display: none;
@@ -70,16 +69,9 @@
   }
 
   .toc {
-    overflow: auto;
     font-size: 0.875rem;
     flex: 1;
-    overflow-y: hidden;
-    overflow-x: hidden;
-
-    // https://stackoverflow.com/questions/35484742/hide-useless-scrollbars-that-show-up-on-windows-only
-    &:hover {
-      overflow-y: auto;
-    }
+    overflow: auto;
 
     @media only screen and (min-width: 768px) {
       display: block;


### PR DESCRIPTION
This removes the "hack" to only show the scrollbar on hover. Which is nice in theory, but got really jumpy now.
IMHO it is ok to just always show this, def. better than the current jumpy version!

I also aligned the padding on top so it is consistent around for the sidebar.

## Previously

https://github.com/user-attachments/assets/f5fe550e-2775-4675-858d-2b256ee46f88

## With this change

https://github.com/user-attachments/assets/354034ec-64f5-43f8-aed1-8bee55ffcd6c

