### PR TITLE
remove note that workflow notifications alert on new feedback

### DIFF
--- a/docs/product/alerts/notifications/index.mdx
+++ b/docs/product/alerts/notifications/index.mdx
@@ -21,7 +21,6 @@ Sentry sends workflow notifications to let you know about [issue state](/product
 - **Regressions**: A regression happens when the state of an issue changes from Resolved back to Unresolved. An email is sent to all project team members.
 - **Comments**: When a team member adds a new comment in the “Activity” tab of the detail page for the issue.
 - **Assignment**: When an issue is assigned or unassigned.
-- **User Feedback**: When an issue has new <PlatformLink to="/user-feedback/">user feedback</PlatformLink>.
 - **Event Processing Problems**: When there's a problem with processing error events you've sent to Sentry.
 
 You receive workflow notifications when you subscribe to an issue in one of the following ways by:


### PR DESCRIPTION
Remove note that Sentry alerts on new feedback attached to issue:

That is, unless there was supposed to be one and I'm just unaware. 
See: https://github.com/getsentry/sentry/issues/47002