### PR TITLE
Remove 'Set Up' prefix from sidebar titles across all platforms

### DIFF
--- a/docs/platforms/android/metrics/index.mdx
+++ b/docs/platforms/android/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Android app."
 sidebar_order: 5500
 sidebar_hidden: true

--- a/docs/platforms/android/profiling/index.mdx
+++ b/docs/platforms/android/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
 ---

--- a/docs/platforms/android/session-replay/index.mdx
+++ b/docs/platforms/android/session-replay/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Session Replay
+sidebar_title: Session Replay
 sidebar_order: 5500
 notSupported:
 description: "Learn how to enable Session Replay in your mobile app."

--- a/docs/platforms/android/tracing/index.mdx
+++ b/docs/platforms/android/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app so you can get valuable performance insights about your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/android/user-feedback/index.mdx
+++ b/docs/platforms/android/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/apple/common/metrics/index.mdx
+++ b/docs/platforms/apple/common/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your app."
 sidebar_order: 5500
 sidebar_hidden: true

--- a/docs/platforms/apple/common/profiling/index.mdx
+++ b/docs/platforms/apple/common/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app."
 sidebar_order: 5000
 supported:

--- a/docs/platforms/apple/common/tracing/index.mdx
+++ b/docs/platforms/apple/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and get valuable performance insights about your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/apple/common/user-feedback/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn how to enable User Feedback in your Cocoa app."
 sidebar_order: 6000
 ---

--- a/docs/platforms/apple/guides/ios/session-replay/index.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Session Replay
+sidebar_title: Session Replay
 sidebar_order: 5500
 notSupported:
 description: "Learn how to enable Session Replay in your mobile app."

--- a/docs/platforms/dart/common/metrics/index.mdx
+++ b/docs/platforms/dart/common/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Dart app."
 sidebar_order: 6000
 sidebar_hidden: true

--- a/docs/platforms/dart/common/tracing/index.mdx
+++ b/docs/platforms/dart/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and get valuable performance insights about your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/dart/common/user-feedback/index.mdx
+++ b/docs/platforms/dart/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/dart/guides/flutter/metrics/index.mdx
+++ b/docs/platforms/dart/guides/flutter/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Flutter app."
 sidebar_order: 6000
 sidebar_hidden: true

--- a/docs/platforms/dart/guides/flutter/profiling/index.mdx
+++ b/docs/platforms/dart/guides/flutter/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
 ---

--- a/docs/platforms/dart/guides/flutter/session-replay/index.mdx
+++ b/docs/platforms/dart/guides/flutter/session-replay/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Session Replay
+sidebar_title: Session Replay
 sidebar_order: 5500
 notSupported:
 description: "Learn how to enable Session Replay in your mobile app."

--- a/docs/platforms/dart/guides/flutter/tracing/index.mdx
+++ b/docs/platforms/dart/guides/flutter/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/dart/guides/flutter/user-feedback/index.mdx
+++ b/docs/platforms/dart/guides/flutter/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/dotnet/common/crons/index.mdx
+++ b/docs/platforms/dotnet/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/dotnet/common/profiling/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
 ---

--- a/docs/platforms/dotnet/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/dotnet/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/dotnet/common/tracing/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/dotnet/common/user-feedback/index.mdx
+++ b/docs/platforms/dotnet/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/elixir/crons/index.mdx
+++ b/docs/platforms/elixir/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/elixir/security-policy-reporting/index.mdx
+++ b/docs/platforms/elixir/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/elixir/user-feedback/index.mdx
+++ b/docs/platforms/elixir/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/go/common/crons/index.mdx
+++ b/docs/platforms/go/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Learn how to set up Crons with the Go SDK to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/go/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/go/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/go/common/tracing/index.mdx
+++ b/docs/platforms/go/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/go/common/user-feedback/index.mdx
+++ b/docs/platforms/go/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/java/common/crons/index.mdx
+++ b/docs/platforms/java/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/java/common/metrics/index.mdx
+++ b/docs/platforms/java/common/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Java app."
 sidebar_order: 5500
 sidebar_hidden: true

--- a/docs/platforms/java/common/metrics/index.mdx
+++ b/docs/platforms/java/common/metrics/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: Set Up Metrics
-sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Java app."
 sidebar_order: 5500
 sidebar_hidden: true
@@ -151,4 +150,22 @@ Sentry.metrics().gauge(
         "page" to "/home"
     )
 )
+```
+
+## Emit a Timer
+
+Timers can be used to measure the execution time of a specific block of code. They're implemented like distributions, but measured in seconds.
+
+To emit a timer, do the following:
+
+```Java
+Sentry.metrics().timing("load_user_profile", () -> {
+    // db.load() ...
+});
+```
+
+```Kotlin
+Sentry.metrics().timing("load_user_profile") {
+    // db.load() ...
+}
 ```

--- a/docs/platforms/java/common/metrics/index.mdx
+++ b/docs/platforms/java/common/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Java app."
 sidebar_order: 5500
 sidebar_hidden: true
@@ -150,22 +151,4 @@ Sentry.metrics().gauge(
         "page" to "/home"
     )
 )
-```
-
-## Emit a Timer
-
-Timers can be used to measure the execution time of a specific block of code. They're implemented like distributions, but measured in seconds.
-
-To emit a timer, do the following:
-
-```Java
-Sentry.metrics().timing("load_user_profile", () -> {
-    // db.load() ...
-});
-```
-
-```Kotlin
-Sentry.metrics().timing("load_user_profile") {
-    // db.load() ...
-}
 ```

--- a/docs/platforms/java/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/java/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/java/common/tracing/index.mdx
+++ b/docs/platforms/java/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 supported:

--- a/docs/platforms/java/common/user-feedback/index.mdx
+++ b/docs/platforms/java/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/javascript/common/crons/index.mdx
+++ b/docs/platforms/javascript/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 supported:

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Feature Flags
+sidebar_title: Feature Flags
 sidebar_order: 7000
 notSupported:
   - javascript.aws-lambda

--- a/docs/platforms/javascript/common/profiling/index.mdx
+++ b/docs/platforms/javascript/common/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations. Get started with profiling to understand your application's performance."
 notSupported:

--- a/docs/platforms/javascript/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/javascript/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/javascript/common/session-replay/index.mdx
+++ b/docs/platforms/javascript/common/session-replay/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Session Replay
+sidebar_title: Session Replay
 sidebar_order: 5500
 notSupported:
   - javascript.cordova
@@ -98,7 +99,6 @@ function paint() {
   Sentry.getClient().getIntegrationByName("ReplayCanvas").snapshot(canvasRef);
 }
 ```
-
 </PlatformSection>
 
 ### Content Security Policy (CSP)
@@ -176,3 +176,4 @@ Once testing is complete, **we recommend lowering this value in production**. We
 ## Next Steps
 
 <PageGrid />
+

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app."
 sidebar_order: 4000
 ---

--- a/docs/platforms/javascript/common/user-feedback/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn how to enable User Feedback in your app."
 sidebar_order: 6000
 ---

--- a/docs/platforms/javascript/guides/astro/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/astro/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/gatsby/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/nextjs/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/nuxt/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/react-router/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/remix/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/remix/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/solidstart/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/sveltekit/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/javascript/guides/tanstackstart-react/profiling/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 sidebar_order: 5000
 description: "Collect & view performance insights for JavaScript programs with Sentry's Profiling integrations."
 ---

--- a/docs/platforms/native/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/native/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/native/common/tracing/index.mdx
+++ b/docs/platforms/native/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 notSupported:

--- a/docs/platforms/native/user-feedback/index.mdx
+++ b/docs/platforms/native/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn how to view user feedback submissions which, paired with the original event, give you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/php/common/crons/index.mdx
+++ b/docs/platforms/php/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/php/common/profiling/index.mdx
+++ b/docs/platforms/php/common/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 sidebar_order: 5000
 ---

--- a/docs/platforms/php/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/php/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/php/common/tracing/index.mdx
+++ b/docs/platforms/php/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing in PHP
+sidebar_title: Tracing
 description: "Learn how to set up and enable tracing in your PHP app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/php/common/user-feedback/index.mdx
+++ b/docs/platforms/php/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/php/guides/laravel/profiling/index.mdx
+++ b/docs/platforms/php/guides/laravel/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 sidebar_order: 5000
 ---

--- a/docs/platforms/php/guides/symfony/profiling/index.mdx
+++ b/docs/platforms/php/guides/symfony/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn more about how to configure our Profiling integration and start profiling your code."
 sidebar_order: 5000
 ---

--- a/docs/platforms/powershell/tracing/index.mdx
+++ b/docs/platforms/powershell/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/python/crons/index.mdx
+++ b/docs/platforms/python/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Feature Flags
+sidebar_title: Feature Flags
 sidebar_order: 7000
 description: With Feature Flags, Sentry tracks feature flag evaluations in your application, keeps an audit log of feature flag changes, and reports any suspicious updates that may have caused an error.
 ---

--- a/docs/platforms/python/profiling/index.mdx
+++ b/docs/platforms/python/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
 ---
@@ -119,7 +120,7 @@ sentry_sdk.init(
 
 The <PlatformIdentifier name="profiles_sample_rate" /> setting is _relative_ to the <PlatformIdentifier name="traces_sample_rate" /> setting.
 
-For transaction-based profiling to work, you have to first enable [Sentry’s tracing](/concepts/key-terms/tracing/) via `traces_sample_rate` (like in the example above). Read our <PlatformLink to="/tracing/">tracing setup documentation</PlatformLink> to learn how to configure sampling. If you set your sample rate to 1.0, all transactions will be captured.
+For transaction-based profiling to work, you have to first enable [Sentry's tracing](/concepts/key-terms/tracing/) via `traces_sample_rate` (like in the example above). Read our <PlatformLink to="/tracing/">tracing setup documentation</PlatformLink> to learn how to configure sampling. If you set your sample rate to 1.0, all transactions will be captured.
 
 </Alert>
 

--- a/docs/platforms/python/security-policy-reporting/index.mdx
+++ b/docs/platforms/python/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/python/tracing/index.mdx
+++ b/docs/platforms/python/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "With Tracing, Sentry tracks your software performance, measuring metrics like throughput and latency, and displays the impact of errors across multiple systems."
 sidebar_order: 4000
 ---

--- a/docs/platforms/python/user-feedback/index.mdx
+++ b/docs/platforms/python/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/react-native/metrics/index.mdx
+++ b/docs/platforms/react-native/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your React Native app."
 sidebar_order: 5500
 sidebar_hidden: true

--- a/docs/platforms/react-native/profiling/index.mdx
+++ b/docs/platforms/react-native/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
 ---

--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Session Replay
+sidebar_title: Session Replay
 sidebar_order: 5500
 notSupported:
 description: "Learn how to enable Session Replay in your mobile app."

--- a/docs/platforms/react-native/tracing/index.mdx
+++ b/docs/platforms/react-native/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/react-native/user-feedback/index.mdx
+++ b/docs/platforms/react-native/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn how to enable User Feedback in your app."
 sidebar_order: 6000
 ---

--- a/docs/platforms/ruby/common/crons/index.mdx
+++ b/docs/platforms/ruby/common/crons/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Crons
+sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
 sidebar_order: 5750
 ---

--- a/docs/platforms/ruby/common/profiling/index.mdx
+++ b/docs/platforms/ruby/common/profiling/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Profiling
+sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
 sidebar_order: 5000
 ---

--- a/docs/platforms/ruby/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/ruby/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/ruby/common/tracing/index.mdx
+++ b/docs/platforms/ruby/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/ruby/common/user-feedback/index.mdx
+++ b/docs/platforms/ruby/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/rust/common/security-policy-reporting/index.mdx
+++ b/docs/platforms/rust/common/security-policy-reporting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Security Policy Reporting
+sidebar_title: Security Policy Reporting
 sidebar_order: 7500
 description: "Learn how Sentry can help manage Content-Security-Policy violations, CSP reports, Expect-CT, and HTTP Public Key Pinning (HPKP) failures here."
 ---

--- a/docs/platforms/rust/common/tracing/index.mdx
+++ b/docs/platforms/rust/common/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/rust/common/user-feedback/index.mdx
+++ b/docs/platforms/rust/common/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/unity/metrics/index.mdx
+++ b/docs/platforms/unity/metrics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Metrics
+sidebar_title: Metrics
 description: "Learn how to measure the data points you care about by configuring Metrics in your Unity project."
 sidebar_order: 5500
 sidebar_hidden: true

--- a/docs/platforms/unity/tracing/index.mdx
+++ b/docs/platforms/unity/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/unity/user-feedback/index.mdx
+++ b/docs/platforms/unity/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---

--- a/docs/platforms/unreal/tracing/index.mdx
+++ b/docs/platforms/unreal/tracing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Tracing
+sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
 sidebar_order: 4000
 ---

--- a/docs/platforms/unreal/user-feedback/index.mdx
+++ b/docs/platforms/unreal/user-feedback/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up User Feedback
+sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
 ---


### PR DESCRIPTION
## DESCRIBE YOUR PR
Removing the setup prefix from the side bar on all platforms in the SDK docs. 

Fixes DOCS-2080

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
