### PR TITLE
feat(platform): Use `sidebar_title` for breadcrumbs

### DIFF
--- a/docs/platforms/javascript/config.yml
+++ b/docs/platforms/javascript/config.yml
@@ -1,5 +1,6 @@
 title: Browser JavaScript
 platformTitle: JavaScript
+sidebar_title: JavaScript
 caseStyle: camelCase
 supportLevel: production
 sdk: 'sentry.javascript.browser'

--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -14,7 +14,7 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
   for (let node: DocNode | undefined = leafNode; node; node = node.parent) {
     if (node && !node.missing) {
       const to = node.path === '/' ? node.path : `/${node.path}/`;
-      const title = node.frontmatter.platformTitle ?? node.frontmatter.title;
+      const title = node.frontmatter.sidebar_title ?? node.frontmatter.title;
 
       breadcrumbs.unshift({
         to,


### PR DESCRIPTION
E.g. for this change: https://github.com/getsentry/sentry-docs/pull/13392

It makes more sense to have the `sidebar_title` be in the breadcrumbs, than the page title.