### PR TITLE
feat(js): Add clarification for `beforeSendSpan` argument

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -377,6 +377,8 @@ This function is called with a serialized span object, and can return a modified
 This function is only called for root spans and all children.
 If you want to drop the root span, including all of its child spans, use [`beforeSendTransaction`](#beforeSendTransaction) instead.
 
+Please note that the `span` you receive as an argument is a serialized object, not a `Span` class instance.
+
 </SdkOption>
 
 <SdkOption name="ignoreTransactions" type='Array<string | RegExp>' defaultValue='[]'>


### PR DESCRIPTION
This may be a bit confusing, that this is not the same type of span as you get in e.g. `startSpan` callbacks.