### PR TITLE
Add Expo Integrations Docs

### DIFF
--- a/docs/organization/integrations/deployment/expo/index.mdx
+++ b/docs/organization/integrations/deployment/expo/index.mdx
@@ -1,0 +1,53 @@
+---
+title: Expo
+sidebar_order: 2
+description: "Learn how to integrate Sentry with Expo Application Services (EAS) to view crash reports and session replays for your Expo app deployments."
+---
+
+## Sentry Integration with EAS
+
+<Alert level="warning">
+
+If you make changes to your organization slug, you'll need to update your configuration for this integration. Learn more in our [troubleshooting guide](/organization/integrations/troubleshooting).
+
+</Alert>
+
+The Sentry integration with Expo allows you to view crash reports and [Session Replays](/platforms/react-native/session-replay/) for your Expo app deployments directly within your Expo Application Services (EAS) dashboard. This integration provides a direct link to Sentry stack traces with full context, sessions replays, and debugging capabilities.
+
+### Install
+
+<Alert>
+
+Sentry owner, manager, or admin permissions are required to install this integration.
+
+</Alert>
+
+1. Log into EAS and open **Account Settings > Overview** in EAS (e.g., `https://expo.dev/accounts/[your-account]/settings`).
+2. Locate the **Connections** section and click **Connect** next to Sentry.
+3. Login to Sentry and accept the integration into your organization. You will be redirected back to Account Settings > Overview.
+
+### Configure
+
+#### Link Your Projects
+
+After connecting your accounts, you need to link your EAS Project to your Sentry Project:
+
+1. Open **Projects > [Your Project] > Configuration > Project settings** in EAS.
+2. Click **Link** and select your Sentry Project from the dropdown.
+
+### Usage
+
+To see your Sentry data in EAS:
+
+1. Open **Projects > [Your Project] > Updates > Deployments > [Deployment]** to view Sentry data from a Release.
+
+
+<Alert level="info">
+  To take advantage of this integration, you need to add the Sentry React Native SDK to your Expo application. You can easily set up the SDK by running the Sentry wizard:
+
+  ```bash
+  npx @sentry/wizard@latest -i reactNative
+  ```
+
+  For more details on using Sentry with Expo, refer to the [Sentry documentation](https://docs.sentry.io/platforms/react-native/) for React Native applications.
+</Alert>

--- a/docs/organization/integrations/deployment/expo/index.mdx
+++ b/docs/organization/integrations/deployment/expo/index.mdx
@@ -4,7 +4,7 @@ sidebar_order: 2
 description: "Learn how to integrate Sentry with Expo Application Services (EAS) to view crash reports and session replays for your Expo app deployments."
 ---
 
-## Sentry Integration with EAS
+## Sentry Integration With EAS
 
 <Alert level="warning">
 

--- a/docs/organization/integrations/deployment/expo/index.mdx
+++ b/docs/organization/integrations/deployment/expo/index.mdx
@@ -4,7 +4,7 @@ sidebar_order: 2
 description: "Learn how to integrate Sentry with Expo Application Services (EAS) to view crash reports and session replays for your Expo app deployments."
 ---
 
-## Sentry Integration With EAS
+## Sentry Integration With Expo dashboard
 
 <Alert level="warning">
 
@@ -22,7 +22,7 @@ Sentry owner, manager, or admin permissions are required to install this integra
 
 </Alert>
 
-1. Log into EAS and open **Account Settings > Overview** in EAS (`https://expo.dev/accounts/[your-account]/settings`).
+1. Log in to your Expo dashboard and open **Account Settings > Overview** (`https://expo.dev/accounts/[your-account]/settings`).
 2. Locate the **Connections** section and click **Connect** next to Sentry.
 3. Login to Sentry and accept the integration into your organization. You will be redirected back to Account Settings > Overview.
 
@@ -30,14 +30,14 @@ Sentry owner, manager, or admin permissions are required to install this integra
 
 #### Link Your Projects
 
-After connecting your accounts, you need to link your EAS Project to your Sentry Project:
+After connecting your accounts, you need to link your Expo dashboard Project to your Sentry Project:
 
-1. Open **Projects > [Your Project] > Configuration > Project settings** in EAS.
+1. Open **Projects > [Your Project] > Configuration > Project settings** in Expo dashboard.
 2. Click **Link** and select your Sentry Project from the dropdown.
 
 ### Usage
 
-To see your Sentry Issues and Replays in EAS, you'll first need to ensure you've created a [EAS channel](https://docs.expo.dev/eas-update/how-it-works/) and assigned builds to it to create a [EAS deployment](https://docs.expo.dev/eas-update/deployment/). Once this is done, you can view your Sentry data by: 
+To see your Sentry Issues and Replays in Expo dashboard, you'll first need to ensure you've created a [Expo dashboard channel](https://docs.expo.dev/eas-update/how-it-works/) and assigned builds to it to create an [EAS deployment](https://docs.expo.dev/eas-update/deployment/). Once this is done, you can view your Sentry data by: 
 
 1. Open **Projects > [Your Project] > Updates > Deployments > [Deployment]** to view Sentry data from a Release.
 

--- a/docs/organization/integrations/deployment/expo/index.mdx
+++ b/docs/organization/integrations/deployment/expo/index.mdx
@@ -22,7 +22,7 @@ Sentry owner, manager, or admin permissions are required to install this integra
 
 </Alert>
 
-1. Log into EAS and open **Account Settings > Overview** in EAS (e.g., `https://expo.dev/accounts/[your-account]/settings`).
+1. Log into EAS and open **Account Settings > Overview** in EAS (`https://expo.dev/accounts/[your-account]/settings`).
 2. Locate the **Connections** section and click **Connect** next to Sentry.
 3. Login to Sentry and accept the integration into your organization. You will be redirected back to Account Settings > Overview.
 

--- a/docs/organization/integrations/deployment/expo/index.mdx
+++ b/docs/organization/integrations/deployment/expo/index.mdx
@@ -37,7 +37,7 @@ After connecting your accounts, you need to link your EAS Project to your Sentry
 
 ### Usage
 
-To see your Sentry data in EAS:
+To see your Sentry Issues and Replays in EAS, you'll first need to ensure you've created a [EAS channel](https://docs.expo.dev/eas-update/how-it-works/) and assigned builds to it to create a [EAS deployment](https://docs.expo.dev/eas-update/deployment/). Once this is done, you can view your Sentry data by: 
 
 1. Open **Projects > [Your Project] > Updates > Deployments > [Deployment]** to view Sentry data from a Release.
 

--- a/docs/organization/integrations/deployment/index.mdx
+++ b/docs/organization/integrations/deployment/index.mdx
@@ -5,6 +5,7 @@ description: "Learn more about Sentry's deployment integrations."
 ---
 
 - [Bitbucket Pipelines](/product/releases/setup/release-automation/bitbucket-pipelines/)
+- [Expo](/organization/integrations/deployment/expo/)
 - [GitHub Actions](/product/releases/setup/release-automation/github-actions/)
 - [GitHub Deployment Gates](/product/releases/setup/release-automation/github-deployment-gates/)
 - [Heroku](/organization/integrations/deployment/heroku/)


### PR DESCRIPTION
We are in process of shipping an integration with the Expo EAS platform. Serves to document and reference setting up the integrations with Sentry.

[Preview](https://sentry-docs-git-featadd-expo-integration.sentry.dev/organization/integrations/deployment/expo/)