### PR TITLE
Unreal: Document and add `SendDefaultPii = true` to onboarding docs

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -76,6 +76,22 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </ConfigKey>
 
+<ConfigKey name="send-default-pii">
+
+If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
+
+<Alert>
+
+If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
+
+</Alert>
+
+This option is turned off by default.
+
+If you enable this option, be sure to manually remove what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
+
+</ConfigKey>
+
 <ConfigKey name="attach-screenshot">
 
 Takes a screenshot of the application when an error happens and includes it as an attachment.

--- a/platform-includes/getting-started-config/unreal.mdx
+++ b/platform-includes/getting-started-config/unreal.mdx
@@ -21,3 +21,22 @@ The window can be accessed by going to editor's menu: **Project Settings > Plugi
 By default, the SDK is automatically initialized on application startup. Alternatively, the `Initialize SDK automatically` option can be disabled and in this case, explicit SDK initialization is required.
 
 To override SDK settings at runtime, use the `InitializeWithSettings` method of the `SentrySubsystem` class.
+
+```cpp
+FConfigureSettingsDelegate OnConfigureSettings;
+OnConfigureSettings.BindDynamic(this, &UMyGameInstance::ConfigureSentrySettings);
+
+void UMyGameInstance::ConfigureSentrySettings(USentrySettings* Settings)
+{
+	Settings->Dsn = TEXT("DSN");
+
+  // Add data like request headers, user ip address and device name,
+  // see https://docs.sentry.io/platforms/android/data-management/data-collected/ for more info
+  Settings->SendDefaultPii = true;
+  SentrySubsystem->InitializeWithSettings(OnConfigureSettings);
+}
+
+...
+
+USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
+```

--- a/platform-includes/getting-started-config/unreal.mdx
+++ b/platform-includes/getting-started-config/unreal.mdx
@@ -30,8 +30,7 @@ void UMyGameInstance::ConfigureSentrySettings(USentrySettings* Settings)
 {
 	Settings->Dsn = TEXT("DSN");
 
-  // Add data like request headers, user ip address and device name,
-  // see https://docs.sentry.io/platforms/android/data-management/data-collected/ for more info
+  // Add data like request headers, user ip address, device name, etc.
   Settings->SendDefaultPii = true;
 }
 

--- a/platform-includes/getting-started-config/unreal.mdx
+++ b/platform-includes/getting-started-config/unreal.mdx
@@ -33,10 +33,10 @@ void UMyGameInstance::ConfigureSentrySettings(USentrySettings* Settings)
   // Add data like request headers, user ip address and device name,
   // see https://docs.sentry.io/platforms/android/data-management/data-collected/ for more info
   Settings->SendDefaultPii = true;
-  SentrySubsystem->InitializeWithSettings(OnConfigureSettings);
 }
 
 ...
 
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
+SentrySubsystem->InitializeWithSettings(OnConfigureSettings);
 ```


### PR DESCRIPTION
This PR adds `SendDefaultPii` to Unreal Engine SDK options list and adds corresponding code snippet to the onboarding docs.

Related to https://github.com/getsentry/team-sdks/issues/121