### PR TITLE
fix(apple): Getting started for watchOS

### DIFF
--- a/docs/platforms/apple/common/index.mdx
+++ b/docs/platforms/apple/common/index.mdx
@@ -83,7 +83,11 @@ If you prefer, you can also [set up the SDK manually](/platforms/apple/guides/io
 
 ## Configure
 
+<PlatformSection notSupported={[ "apple.watchos"]}>
+
 To capture all errors, initialize the SDK as soon as possible, such as in your `AppDelegate` `application:didFinishLaunchingWithOptions` method:
+
+</PlatformSection>
 
 <PlatformSection notSupported={["apple.tvos", "apple.watchos", "apple.visionos"]}>
 
@@ -106,7 +110,7 @@ func application(_ application: UIApplication,
         // We recommend adjusting this value in production.
         options.tracesSampleRate = 1
         // ___PRODUCT_OPTION_END___ performance
-        
+
         // ___PRODUCT_OPTION_START___ profiling
         options.configureProfiling = {
             $0.lifecycle = .trace
@@ -137,7 +141,7 @@ func application(_ application: UIApplication,
         // We recommend adjusting this value in production.
         options.tracesSampleRate = @1.f;
         // ___PRODUCT_OPTION_END___ performance
-        
+
         // ___PRODUCT_OPTION_START___ profiling
         options.configureProfiling = ^(SentryProfileOptions *profiling) {
             profiling.lifecycle = SentryProfileLifecycleTrace;
@@ -169,7 +173,7 @@ struct SwiftUIApp: App {
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1
             // ___PRODUCT_OPTION_END___ performance
-        
+
             // ___PRODUCT_OPTION_START___ profiling
             options.configureProfiling = {
                 $0.lifecycle = .trace
@@ -182,7 +186,7 @@ struct SwiftUIApp: App {
 ```
 </PlatformSection>
 
-<PlatformSection notSupported={["apple.ios", "apple.macos"]}>
+<PlatformSection notSupported={["apple.ios", "apple.macos", "apple.watchos"]}>
 
 ```swift {tabTitle:Swift}
 import Sentry
@@ -203,7 +207,7 @@ func application(_ application: UIApplication,
         // We recommend adjusting this value in production.
         options.tracesSampleRate = 1
         // ___PRODUCT_OPTION_END___ performance
-        
+
         // ___PRODUCT_OPTION_START___ profiling
         options.configureProfiling = {
             $0.lifecycle = .trace
@@ -234,7 +238,7 @@ func application(_ application: UIApplication,
         // We recommend adjusting this value in production.
         options.tracesSampleRate = @1.f;
         // ___PRODUCT_OPTION_END___ performance
-        
+
         // ___PRODUCT_OPTION_START___ profiling
         options.configureProfiling = ^(SentryProfileOptions *profiling) {
             profiling.lifecycle = SentryProfileLifecycleTrace;
@@ -266,7 +270,7 @@ struct SwiftUIApp: App {
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1
             // ___PRODUCT_OPTION_END___ performance
-        
+
             // ___PRODUCT_OPTION_START___ profiling
             options.configureProfiling = {
                 $0.lifecycle = .trace
@@ -278,6 +282,33 @@ struct SwiftUIApp: App {
 }
 ```
 
+</PlatformSection>
+
+
+<PlatformSection supported={[ "apple.watchos"]}>
+
+To capture all errors, initialize the SDK as soon as possible, such as in your `WKExtensionDelegate.applicationDidFinishLaunching` method:
+
+```swift
+import Sentry
+
+func applicationDidFinishLaunching() {
+    SentrySDK.start { options in
+        options.dsn = "___PUBLIC_DSN___"
+        options.debug = true // Enabled debug when first installing is always helpful
+
+        // Adds IP for users.
+        // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+        options.sendDefaultPii = true
+
+        // ___PRODUCT_OPTION_START___ performance
+        // Set tracesSampleRate to 1 to capture 100% of transactions for performance monitoring.
+        // We recommend adjusting this value in production.
+        options.tracesSampleRate = 1
+        // ___PRODUCT_OPTION_END___ performance
+    }
+}
+```
 </PlatformSection>
 
 ## Verify


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The watchOS getting started page showed instructions for the AppDelegate, which doesn't exist on watchOS. This is fixed now by explaining how to start the SDK in the WKExtensionDelegate.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
