### PR TITLE
docs(dotnet): add Proxy Server troubleshooting

### DIFF
--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -88,14 +88,15 @@ used by Sentry's SDK can pick it up.
 ```csharp
 (SentryOptions options) =>
 {
-    options.HttpProxy = new WebProxy("read the proxy's address from your Configuration");
+    // Read the proxy's address from, for example, your Configuration
+    options.HttpProxy = new WebProxy(new Uri("http://proxyserver:80/"));
 };
 ```
 
 Alternatively, you may configure the default proxy that all `HttpClient` instances use if no proxy is set explicitly.
 
 ```csharp
-System.Net.Http.HttpClient.DefaultProxy = new WebProxy("read the proxy's address from your Configuration");
+System.Net.Http.HttpClient.DefaultProxy = new WebProxy(new Uri("http://proxyserver:80/"));
 ```
 
 For more information, see the [HttpClient.DefaultProxy Property](https://learn.microsoft.com/dotnet/api/system.net.http.httpclient.defaultproxy).

--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -79,4 +79,25 @@ If you're working with obfuscated code, you have several options:
 
 3. **Contribute to Symbolic**: [Our symbolication library is open source](https://github.com/getsentry/symbolic). You could create a ticket to discuss adding support to it with the maintainers.
 
+## Proxy Server
+
+Often, your server can only access the internet through a proxy server.
+If that's the case, make sure your proxy server is configured so the `HttpClient`
+used by Sentry's SDK can pick it up.
+
+```csharp
+(SentryOptions options) =>
+{
+    options.HttpProxy = new WebProxy("read the proxy's address from your Configuration");
+};
+```
+
+Alternatively, you may configure the default proxy that all `HttpClient` instances use if no proxy is set explicitly.
+
+```csharp
+System.Net.Http.HttpClient.DefaultProxy = new WebProxy("read the proxy's address from your Configuration");
+```
+
+For more information, see the [HttpClient.DefaultProxy Property](https://learn.microsoft.com/dotnet/api/system.net.http.httpclient.defaultproxy).
+
 <PlatformContent includePath="troubleshooting" />


### PR DESCRIPTION
## DESCRIBE YOUR PR
Add troubleshooting entry when using Proxy Servers. Impacts all .NET SDKs.
See also getsentry/sentry-dotnet#4118

## IS YOUR CHANGE URGENT?
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST
*Make sure you've checked the following before merging your changes:*
- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
