### PR TITLE
Fix: What http headers are collected in the Python SDK

### DIFF
--- a/docs/platforms/python/data-management/data-collected.mdx
+++ b/docs/platforms/python/data-management/data-collected.mdx
@@ -10,11 +10,11 @@ The category types and amount of data collected vary, depending on the integrati
 
 ## HTTP Headers
 
-By default, the Sentry SDK is sending HTTP headers to Sentry but filters out any headers that contain sensitive data. (See the [list of headers](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/_wsgi_common.py#L28-L35) that are filtered).
+By default, the Sentry SDK sends HTTP headers to Sentry but filters out any headers that contain sensitive data. (See the [list of headers](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/_wsgi_common.py#L28-L35) that are filtered).
 
 To send all HTTP headers, set `send_default_pii=True` in the `sentry_sdk.init()` call.
 
-Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) is removing sensitive data from headers (and a lot of other fields) right before sending data to Sentry.
+Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) removes sensitive data from headers (and a lot of other fields) right before sending data to Sentry.
 
 ## Cookies
 
@@ -22,7 +22,7 @@ By default, the Sentry SDK doesn't send cookies. Sentry tries to remove any cook
 
 If you want to send cookies, set `send_default_pii=True` in the `sentry_sdk.init()` call.
 
-Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) is removing sensitive data from cookies (and a lot of other fields) right before sending data to Sentry.
+Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) removes sensitive data from cookies (and a lot of other fields) right before sending data to Sentry.
 
 ## Information About Logged-in User
 

--- a/docs/platforms/python/data-management/data-collected.mdx
+++ b/docs/platforms/python/data-management/data-collected.mdx
@@ -10,15 +10,19 @@ The category types and amount of data collected vary, depending on the integrati
 
 ## HTTP Headers
 
-By default, the Sentry SDK doesn't send any HTTP headers. Even when sending HTTP headers is enabled, we have a [denylist](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/_wsgi_common.py#L19-L26) in place, which filters out any headers that contain sensitive data.
+By default, the Sentry SDK is sending HTTP headers to Sentry but filters out any headers that contain sensitive data. (See the [list of headers](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/_wsgi_common.py#L28-L35) that are filtered).
 
-To start sending HTTP headers, set `send_default_pii=True` in the `sentry_sdk.init()` call.
+To send all HTTP headers, set `send_default_pii=True` in the `sentry_sdk.init()` call.
+
+Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) is removing sensitive data from headers (and a lot of other fields) right before sending data to Sentry.
 
 ## Cookies
 
 By default, the Sentry SDK doesn't send cookies. Sentry tries to remove any cookies that contain sensitive information, such as the Session ID and CSRF Token cookies in Django.
 
 If you want to send cookies, set `send_default_pii=True` in the `sentry_sdk.init()` call.
+
+Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) is removing sensitive data from cookies (and a lot of other fields) right before sending data to Sentry.
 
 ## Information About Logged-in User
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The documentation was wrong in this case. We always do send headers, but we filter sensitive information.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
