### PR TITLE
ref(replay): clarify web & mobile distinction in product docs

### DIFF
--- a/docs/product/explore/session-replay/index.mdx
+++ b/docs/product/explore/session-replay/index.mdx
@@ -8,7 +8,7 @@ Sentry supports Session Replay for Web and Mobile. This includes browser-based a
 
 For browser-based applications (Web replay), this includes static websites, single-page applications, and also server-side rendered applications. This includes platforms such as Electron, Next.js, and Remix. The only prerequisite is that your application uses Sentry JavaScript SDK (version 7.2.0 or greater) either with NPM/Yarn or with our JS Loader script.
 
-To learn more about which SDKs we support, please visit our docs for [Web](/web/getting-started/#supported-sdks) and [Mobile](mobile/#sdks-supported).
+To learn more about which SDKs we support, please visit our docs for [Web](web/getting-started/#supported-sdks) and [Mobile](mobile/#sdks-supported).
 
 Learn more about Session Replay:
 

--- a/docs/product/explore/session-replay/index.mdx
+++ b/docs/product/explore/session-replay/index.mdx
@@ -4,9 +4,13 @@ sidebar_order: 70
 description: "Use Session Replay to get reproductions of user sessions to improve your app experience."
 ---
 
-Sentry has Session Replay for both Web and Mobile. Both are generally available and stable.
+Sentry supports Session Replay for Web and Mobile. This includes browser-based applications and certain native mobile platforms, such as Android, iOS, and React Native. Both versions of Replay (Web and Mobile) are generally available and stable.
 
-Learn more here:
+For browser-based applications (Web replay), this includes static websites, single-page applications, and also server-side rendered applications. This includes platforms such as Electron, Next.js, and Remix. The only prerequisite is that your application uses Sentry JavaScript SDK (version 7.2.0 or greater) either with NPM/Yarn or with our JS Loader script.
+
+To learn more about which SDKs we support, please visit our docs for [Web](/web/getting-started/#supported-sdks) and [Mobile](mobile/#sdks-supported).
+
+Learn more about Session Replay:
 
 * [Session Replay for Web](web/)
 * [Session Replay for Mobile](mobile/)

--- a/docs/product/explore/session-replay/index.mdx
+++ b/docs/product/explore/session-replay/index.mdx
@@ -6,7 +6,7 @@ description: "Use Session Replay to get reproductions of user sessions to improv
 
 Sentry supports Session Replay for Web and Mobile. This includes browser-based applications and certain native mobile platforms, such as Android, iOS, and React Native. Both versions of Replay (Web and Mobile) are generally available and stable.
 
-For browser-based applications (Web replay), this includes static websites, single-page applications, and also server-side rendered applications. This includes platforms such as Electron, Next.js, and Remix. The only prerequisite is that your application uses Sentry JavaScript SDK (version 7.2.0 or greater) either with NPM/Yarn or with our JS Loader script.
+For browser-based applications (Web replay), this includes static websites, single-page applications, and also server-side rendered applications -- for example, platforms such as Electron, Next.js, and Remix.
 
 To learn more about which SDKs we support, please visit our docs for [Web](web/getting-started/#supported-sdks) and [Mobile](mobile/#sdks-supported).
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-docs/issues/13445
