### PR TITLE
Update IP ranges documentation for Sentry's Uptime Monitoring, including dynamic IP retrieval and guidance for hosting providers

### DIFF
--- a/docs/security-legal-pii/security/ip-ranges.mdx
+++ b/docs/security-legal-pii/security/ip-ranges.mdx
@@ -58,7 +58,6 @@ Organizations in the EU Data Storage Location are unable to ingest events via
 `sentry.io` or `app.getsentry.com`. You can use
 `o<number>.ingest.de.sentry.io` instead.
 
-
 ## Outbound Requests
 
 In some circumstances the Hosted Sentry infrastructure might send HTTP requests your way. Primarily this is relevant to [_JavaScript Source Maps_](/platforms/javascript/sourcemaps/), but also affects things like webhooks and other integrations.
@@ -127,9 +126,7 @@ These IP addresses are only for Sentry use.
 
 ## Uptime Monitoring
 
-Sentry uses the following IP addresses for uptime checks:
-
-US
+Sentry uses the following IP addresses for uptime checks for all regions:
 
 ```plaintext
 34.123.33.225
@@ -137,19 +134,39 @@ US
 34.169.179.115
 35.237.134.233
 34.85.249.57
-```
-
-EU
-
-```plaintext
 34.159.197.47
 35.242.231.10
 34.107.93.3
 35.204.169.245
 ```
 
+### Dynamic IP Address Retrieval
+
+For the most up-to-date list of Uptime Monitoring IP addresses, you can query the following API endpoint:
+
+```plaintext
+https://us.sentry.io/api/0/uptime-ips/
+```
+
+This endpoint returns a newline-separated list of all current Uptime Monitoring IP addresses (for all regions) that can be programmatically processed in your allowlist configurations.
+
 <Alert title="Note" level="warning">
 
 Uptime Monitoring IP addresses may change over time. If you need to programmatically verify whether a visitor is a Sentry bot, we recommend checking the [user agent](/product/alerts/uptime-monitoring/troubleshooting/#user-agent) instead.
 
 </Alert>
+
+### Information for Hosting Providers
+
+If you're a hosting provider (like Vercel, Netlify, or similar platforms), please consider the following guidance regarding Sentry's Uptime Monitoring:
+
+Many organizations use Sentry to monitor the uptime of their websites and applications. When Sentry's monitoring IPs are blocked, it creates false outage alerts for all customers trying to monitor sites on your platform.
+
+**Recommended actions for hosting providers:**
+
+1. Allowlist Sentry's monitoring IP addresses in your platform's security rules
+2. Configure your firewall to recognize Sentry's monitoring user agent and IP ranges as legitimate traffic
+3. Ensure rate limiting policies do not inadvertently block Sentry's monitoring capabilities
+4. Consider implementing automatic updates of allowlisted IPs using our API endpoint
+
+By ensuring Sentry can properly monitor sites on your platform, you'll improve the reliability monitoring experience for all your customers who use Sentry.


### PR DESCRIPTION
Adds two new section to uptime's IP ranges page on our dynamically generated IP retrieval and guidance for hosting providers.