### PR TITLE
flutter: Add note to app start integration

### DIFF
--- a/includes/dart-integrations/app-start-instrumentation.mdx
+++ b/includes/dart-integrations/app-start-instrumentation.mdx
@@ -46,6 +46,22 @@ Before starting, ensure:
 
 This instrumentation is automatically enabled. There is no need for further configuration.
 
+<Alert>
+
+App start instrumentation is designed specifically for pure Flutter applications and requires UI rendering to function properly. If you're using Flutter in an add-to-app integration scenario, the app start metrics will not provide accurate measurements. In such cases, we recommend disabling this instrumentation.
+
+```dart
+// ignore: implementation_imports
+import 'package:sentry_flutter/src/integrations/native_app_start_integration.dart';
+
+// in SentryFlutter.init
+final integration = options.integrations.firstWhere(
+  (integration) => integration is NativeAppStartIntegration);
+options.removeIntegration(integration);
+```
+
+</Alert>
+
 ## Verify
 
 ### 1. Launch Your App:


### PR DESCRIPTION
Add note that in some cases app starts might not be accurate and should be disabled