### PR TITLE
docs: remove outdated/misleading warning

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/console.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/console.mdx
@@ -28,12 +28,6 @@ supported:
   - javascript.tanstackstart-react
 ---
 
-<Alert>
-
-This integration only works inside server environments (Node.js, Bun, Deno).
-
-</Alert>
-
 _Import name: `Sentry.consoleIntegration`_
 
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).


### PR DESCRIPTION
## DESCRIBE YOUR PR
As per https://github.com/getsentry/sentry-javascript/issues/15439#issuecomment-2786624106 this warning is no longer needed as of [9.13.0](https://github.com/getsentry/sentry-javascript/releases/tag/9.13.0
) where Cloudflare/Vercel (edge) support was added. Not entirely sure if there are other platforms that are still not supported will leave that one with you.

![Screen Shot 2025-04-23 at 2 34 40 PM](https://github.com/user-attachments/assets/dfac4bf1-fb2e-49ad-ab81-0989d9979320)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.