### PR TITLE
fix(js): Update `denyUrls` text in filtering page

### DIFF
--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -32,13 +32,16 @@ See <PlatformLink to="/configuration/options/#beforeSend">beforeSend</PlatformLi
 
 ### Using `allowUrls` and `denyUrls`
 
-You can construct an allowed list of domains for errors. Only errors created within these domains will be captured. For example, if your scripts are loaded from `cdn.example.com` and your site is `example.com`, you can set `allowUrls` to:
+You can configure the SDK to avoid sending errors that originate in scripts from certain domains.
+For example, if your scripts are loaded from `cdn.example.com` and your site is `example.com`, you can can configure `allowUrls` as follows to avoid capturing errors from other domains:
 
 ```javascript
 Sentry.init({
   allowUrls: [/https?:\/\/((cdn|www)\.)?example\.com/],
 });
 ```
+
+Note that this filters errors based on their stack frames, not the URL of the page where the error occurred.
 
 You can also use `denyUrls` if you want to block errors created on specific URLs from being sent to Sentry.
 


### PR DESCRIPTION
Clarify that `denyUrl` applies to stack frame origin, not the page that an error comes from.