### PR TITLE
Remove note about 40M SourceMap Limit

### DIFF
--- a/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
@@ -221,12 +221,6 @@ new sourceMap.SourceMapConsumer(rawSourceMap).then(function (smc) {
 
 If you have the same (incorrect) results locally as you do via Sentry, double-check your source map generation configuration.
 
-## Verify your source files are not too large
-
-For an individual artifact, Sentry accepts a max filesize of **40 MB**.
-
-Often users hit this limit because they are transmitting source files at an interim build stage. For example, after your bundler has combined all your source files, but before minification has taken place. If possible, send the original source files.
-
 ## Verify artifacts are not gzipped
 
 The Sentry API currently only works with source maps and source files that are uploaded as plain text (UTF-8 encoded). If the files are uploaded in a compressed format (for example, gzip), they will be not be interpreted correctly.

--- a/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -446,7 +446,7 @@ Finally, if your file is similar to:
 
 then your uploaded artifact should be named `https://example.com/dist/maps/script.min.js.map` (or `~/dist/maps/script.min.js.map`).
 
-###Verify Artifacts Are Uploaded Before Errors Occur
+### Verify Artifacts Are Uploaded Before Errors Occur
 
 Sentry expects that source code and source maps in a given release are uploaded to Sentry **before** errors occur in that release.
 
@@ -493,12 +493,6 @@ new sourceMap.SourceMapConsumer(rawSourceMap).then(function (smc) {
 ```
 
 If you have the same (incorrect) results locally as you do via Sentry, double-check your source map generation configuration.
-
-### Verify your source files are not too large
-
-For an individual artifact, Sentry accepts a max filesize of **40 MB**.
-
-Often users hit this limit because they are transmitting source files at an interim build stage. For example, after your bundler has combined all your source files, but before minification has taken place. If possible, send the original source files.
 
 ### Verify artifacts are not gzipped
 

--- a/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -137,12 +137,6 @@ new sourceMap.SourceMapConsumer(rawSourceMap).then(function (smc) {
 
 If you have the same (incorrect) results locally as you do via Sentry, double-check your source map generation configuration.
 
-### Verify Your Source Files Aren't Too Large
-
-For an individual artifact, Sentry accepts a max filesize of **40 MB**.
-
-Often users hit this limit because they are transmitting source files at an interim build stage. For example, after your bundler has combined all your source files, but before minification has taken place. If possible, send the original source files.
-
 ### Verify That Artifacts Aren't Gzipped
 
 The Sentry API currently only works with source maps and source files that are uploaded as plain text (UTF-8 encoded). If the files are uploaded in a compressed format (for example, gzip), they will be not be interpreted correctly.


### PR DESCRIPTION
Noone can point to where such a limit is actually defined if we indeed have one.

At least for the supported `sentry-cli` based SourceMap upload flow. It is quite possible that the 40M limit refers to the legacy "single release file upload" endpoints which are deprecated and rarely used, and we would rather work towards removing those endpoints altogether.

---

While working on this, I noticed that the 3 files I touched are pretty much ~90% the same. I don’t know enough about the docs to maybe work towards merging those pages, so I didn’t touch that.