### PR TITLE
docs(python): add uv option to python install instructions

### DIFF
--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -31,8 +31,11 @@ categories:
 
 Install the Sentry SDK using [`pip`](https://pip.pypa.io/en/stable/):
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -32,10 +32,10 @@ categories:
 Install the Sentry SDK using [`pip`](https://pip.pypa.io/en/stable/):
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install 'sentry-sdk'
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add 'sentry-sdk'
 ```
 
 ## Configure

--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -32,10 +32,10 @@ categories:
 Install the Sentry SDK using [`pip`](https://pip.pypa.io/en/stable/):
 
 ```bash {tabTitle:pip}
-pip install 'sentry-sdk'
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add 'sentry-sdk'
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/aiohttp/aiohttp-client.mdx
+++ b/docs/platforms/python/integrations/aiohttp/aiohttp-client.mdx
@@ -13,8 +13,11 @@ This integration also supports AIOHTTP servers. See <PlatformLink to="/integrati
 
 Install `sentry-sdk` from PyPI with the `aiohttp` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[aiohttp]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[aiohttp]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[aiohttp]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/aiohttp/aiohttp-client.mdx
+++ b/docs/platforms/python/integrations/aiohttp/aiohttp-client.mdx
@@ -14,10 +14,10 @@ This integration also supports AIOHTTP servers. See <PlatformLink to="/integrati
 Install `sentry-sdk` from PyPI with the `aiohttp` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[aiohttp]
+pip install "sentry-sdk[aiohttp]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[aiohttp]
+uv add "sentry-sdk[aiohttp]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/aiohttp/index.mdx
+++ b/docs/platforms/python/integrations/aiohttp/index.mdx
@@ -11,14 +11,21 @@ If you use AIOHTTP as your HTTP client and want to instrument outgoing HTTP requ
 
 Install `sentry-sdk` from PyPI with the `aiohttp` extra:
 
-```bash
-pip install --upgrade sentry-sdk[aiohttp]
+```bash {tabTitle:pip}
+pip install sentry-sdk[aiohttp]
 ```
+```bash {tabTitle:uv}
+uv add sentry-sdk[aiohttp]
+```
+
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:
 
-```bash
-pip install --upgrade aiocontextvars
+```bash {tabTitle:pip}
+pip install aiocontextvars
+```
+```bash {tabTitle:uv}
+uv add aiocontextvars
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/aiohttp/index.mdx
+++ b/docs/platforms/python/integrations/aiohttp/index.mdx
@@ -12,10 +12,10 @@ If you use AIOHTTP as your HTTP client and want to instrument outgoing HTTP requ
 Install `sentry-sdk` from PyPI with the `aiohttp` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[aiohttp]
+pip install "sentry-sdk[aiohttp]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[aiohttp]
+uv add "sentry-sdk[aiohttp]"
 ```
 
 

--- a/docs/platforms/python/integrations/aiohttp/index.mdx
+++ b/docs/platforms/python/integrations/aiohttp/index.mdx
@@ -22,10 +22,10 @@ uv add "sentry-sdk[aiohttp]"
 If you're on Python 3.6, you also need the `aiocontextvars` package:
 
 ```bash {tabTitle:pip}
-pip install aiocontextvars
+pip install "aiocontextvars"
 ```
 ```bash {tabTitle:uv}
-uv add aiocontextvars
+uv add "aiocontextvars"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/airflow/index.mdx
+++ b/docs/platforms/python/integrations/airflow/index.mdx
@@ -9,8 +9,12 @@ description: "Learn about using Sentry with Apache Airflow."
 
 Install the `apache-airflow` package with the `sentry` requirement.
 
-```py
-pip install 'apache-airflow[sentry]'
+
+```bash {tabTitle:pip}
+pip install apache-airflow[sentry]
+```
+```bash {tabTitle:uv}
+uv add apache-airflow[sentry]
 ```
 
 Then, add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under the `[sentry]` field.

--- a/docs/platforms/python/integrations/airflow/index.mdx
+++ b/docs/platforms/python/integrations/airflow/index.mdx
@@ -11,10 +11,10 @@ Install the `apache-airflow` package with the `sentry` requirement.
 
 
 ```bash {tabTitle:pip}
-pip install apache-airflow[sentry]
+pip install "apache-airflow[sentry]"
 ```
 ```bash {tabTitle:uv}
-uv add apache-airflow[sentry]
+uv add "apache-airflow[sentry]"
 ```
 
 Then, add your Sentry DSN to your configuration file (ex. `airflow.cfg`) under the `[sentry]` field.

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -25,10 +25,10 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 Install `sentry-sdk` from PyPI with the `anthropic` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[anthropic]
+pip install "sentry-sdk[anthropic]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[anthropic]
+uv add "sentry-sdk[anthropic]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -24,8 +24,11 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 
 Install `sentry-sdk` from PyPI with the `anthropic` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[anthropic]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[anthropic]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[anthropic]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/ariadne/index.mdx
+++ b/docs/platforms/python/integrations/ariadne/index.mdx
@@ -11,8 +11,11 @@ in [Sentry](https://sentry.io).
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/ariadne/index.mdx
+++ b/docs/platforms/python/integrations/ariadne/index.mdx
@@ -12,10 +12,10 @@ in [Sentry](https://sentry.io).
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/arq/index.mdx
+++ b/docs/platforms/python/integrations/arq/index.mdx
@@ -10,10 +10,10 @@ The arq integration adds support for the [arq job queue system](https://arq-docs
 Install `sentry-sdk` from PyPI with the `arq` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[arq]
+pip install "sentry-sdk[arq]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[arq]
+uv add "sentry-sdk[arq]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/arq/index.mdx
+++ b/docs/platforms/python/integrations/arq/index.mdx
@@ -9,8 +9,11 @@ The arq integration adds support for the [arq job queue system](https://arq-docs
 
 Install `sentry-sdk` from PyPI with the `arq` extra.
 
-```bash
-pip install --upgrade "sentry-sdk[arq]"
+```bash {tabTitle:pip}
+pip install sentry-sdk[arq]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[arq]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asgi/index.mdx
+++ b/docs/platforms/python/integrations/asgi/index.mdx
@@ -13,8 +13,11 @@ Please check our list of [supported integrations](/platforms/python/integrations
 
 ## Install
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asgi/index.mdx
+++ b/docs/platforms/python/integrations/asgi/index.mdx
@@ -14,10 +14,10 @@ Please check our list of [supported integrations](/platforms/python/integrations
 ## Install
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asyncio/index.mdx
+++ b/docs/platforms/python/integrations/asyncio/index.mdx
@@ -8,10 +8,10 @@ The `AsyncioIntegration` integrates with applications doing concurrent code exec
 ## Install
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asyncio/index.mdx
+++ b/docs/platforms/python/integrations/asyncio/index.mdx
@@ -7,8 +7,11 @@ The `AsyncioIntegration` integrates with applications doing concurrent code exec
 
 ## Install
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asyncpg/index.mdx
+++ b/docs/platforms/python/integrations/asyncpg/index.mdx
@@ -10,8 +10,11 @@ The `AsyncPGIntegration` captures queries from
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk[asyncpg]
+```bash {tabTitle:pip}
+pip install sentry-sdk[asyncpg]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[asyncpg]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asyncpg/index.mdx
+++ b/docs/platforms/python/integrations/asyncpg/index.mdx
@@ -11,10 +11,10 @@ The `AsyncPGIntegration` captures queries from
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[asyncpg]
+pip install "sentry-sdk[asyncpg]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[asyncpg]
+uv add "sentry-sdk[asyncpg]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/boto3/index.mdx
+++ b/docs/platforms/python/integrations/boto3/index.mdx
@@ -9,8 +9,11 @@ The Boto3 integration instruments requests made to Amazon Web Services done with
 
 Install `sentry-sdk` from PyPI:
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/boto3/index.mdx
+++ b/docs/platforms/python/integrations/boto3/index.mdx
@@ -10,10 +10,10 @@ The Boto3 integration instruments requests made to Amazon Web Services done with
 Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/bottle/index.mdx
+++ b/docs/platforms/python/integrations/bottle/index.mdx
@@ -12,10 +12,10 @@ However the integration with the development version (0.13) doesn't work properl
 Install `sentry-sdk` from PyPI with the `bottle` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[bottle]
+pip install "sentry-sdk[bottle]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[bottle]
+uv add "sentry-sdk[bottle]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/bottle/index.mdx
+++ b/docs/platforms/python/integrations/bottle/index.mdx
@@ -11,8 +11,11 @@ However the integration with the development version (0.13) doesn't work properl
 
 Install `sentry-sdk` from PyPI with the `bottle` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[bottle]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[bottle]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[bottle]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/celery/index.mdx
+++ b/docs/platforms/python/integrations/celery/index.mdx
@@ -10,10 +10,10 @@ The Celery integration adds support for the [Celery Task Queue System](https://d
 Install `sentry-sdk` from PyPI with the `celery` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[celery]
+pip install "sentry-sdk[celery]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[celery]
+uv add "sentry-sdk[celery]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/celery/index.mdx
+++ b/docs/platforms/python/integrations/celery/index.mdx
@@ -9,8 +9,11 @@ The Celery integration adds support for the [Celery Task Queue System](https://d
 
 Install `sentry-sdk` from PyPI with the `celery` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[celery]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[celery]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[celery]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/chalice/index.mdx
+++ b/docs/platforms/python/integrations/chalice/index.mdx
@@ -8,10 +8,10 @@ description: "Learn about using Sentry with Chalice."
 Install `sentry-sdk` from PyPI with the `chalice` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[chalice]
+pip install "sentry-sdk[chalice]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[chalice]
+uv add "sentry-sdk[chalice]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/chalice/index.mdx
+++ b/docs/platforms/python/integrations/chalice/index.mdx
@@ -7,8 +7,11 @@ description: "Learn about using Sentry with Chalice."
 
 Install `sentry-sdk` from PyPI with the `chalice` extra:
 
-```bash
-pip install --upgrade sentry-sdk[chalice]
+```bash {tabTitle:pip}
+pip install sentry-sdk[chalice]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[chalice]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/clickhouse-driver/index.mdx
+++ b/docs/platforms/python/integrations/clickhouse-driver/index.mdx
@@ -12,10 +12,10 @@ The integration is available for clickhouse-driver 0.2.0 or later.
 Install `sentry-sdk` with the `clickhouse-driver` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[clickhouse-driver]
+pip install "sentry-sdk[clickhouse-driver]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[clickhouse-driver]
+uv add "sentry-sdk[clickhouse-driver]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/clickhouse-driver/index.mdx
+++ b/docs/platforms/python/integrations/clickhouse-driver/index.mdx
@@ -11,8 +11,11 @@ The integration is available for clickhouse-driver 0.2.0 or later.
 
 Install `sentry-sdk` with the `clickhouse-driver` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[clickhouse-driver]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[clickhouse-driver]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[clickhouse-driver]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/cloudresourcecontext/index.mdx
+++ b/docs/platforms/python/integrations/cloudresourcecontext/index.mdx
@@ -9,8 +9,11 @@ The Cloud Resource Context integration adds information about the cloud platform
 
 To install it, run:
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/cloudresourcecontext/index.mdx
+++ b/docs/platforms/python/integrations/cloudresourcecontext/index.mdx
@@ -10,10 +10,10 @@ The Cloud Resource Context integration adds information about the cloud platform
 To install it, run:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/cohere/index.mdx
+++ b/docs/platforms/python/integrations/cohere/index.mdx
@@ -25,10 +25,10 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 Install `sentry-sdk` and `cohere` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk cohere
+pip install "sentry-sdk cohere"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk cohere
+uv add "sentry-sdk cohere"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/cohere/index.mdx
+++ b/docs/platforms/python/integrations/cohere/index.mdx
@@ -25,10 +25,10 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 Install `sentry-sdk` and `cohere` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk cohere"
+pip install "sentry-sdk" "cohere"
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk cohere"
+uv add "sentry-sdk" "cohere"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/cohere/index.mdx
+++ b/docs/platforms/python/integrations/cohere/index.mdx
@@ -24,8 +24,11 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 
 Install `sentry-sdk` and `cohere` from PyPI:
 
-```bash
-pip install --upgrade 'sentry-sdk' 'cohere'
+```bash {tabTitle:pip}
+pip install sentry-sdk cohere
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk cohere
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -17,8 +17,11 @@ If you're using Python 3.7, Django applications with `channels` 2.0 will be corr
 
 Install `sentry-sdk` from PyPI with the `django` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[django]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[django]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[django]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -18,10 +18,10 @@ If you're using Python 3.7, Django applications with `channels` 2.0 will be corr
 Install `sentry-sdk` from PyPI with the `django` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[django]
+pip install "sentry-sdk[django]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[django]
+uv add "sentry-sdk[django]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/dramatiq/index.mdx
+++ b/docs/platforms/python/integrations/dramatiq/index.mdx
@@ -17,8 +17,11 @@ The Dramatiq integration only reports errors. Tracing is not yet supported. If y
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/dramatiq/index.mdx
+++ b/docs/platforms/python/integrations/dramatiq/index.mdx
@@ -18,10 +18,10 @@ The Dramatiq integration only reports errors. Tracing is not yet supported. If y
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/falcon/index.mdx
+++ b/docs/platforms/python/integrations/falcon/index.mdx
@@ -10,8 +10,11 @@ The integration has been confirmed to work with Falcon 1.4 and 2.0.
 
 Install `sentry-sdk` from PyPI with the `falcon` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[falcon]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[falcon]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[falcon]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/falcon/index.mdx
+++ b/docs/platforms/python/integrations/falcon/index.mdx
@@ -11,10 +11,10 @@ The integration has been confirmed to work with Falcon 1.4 and 2.0.
 Install `sentry-sdk` from PyPI with the `falcon` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[falcon]
+pip install "sentry-sdk[falcon]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[falcon]
+uv add "sentry-sdk[falcon]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -9,8 +9,11 @@ The FastAPI integration adds support for the [FastAPI Framework](https://fastapi
 
 Install `sentry-sdk` from PyPI with the `fastapi` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[fastapi]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[fastapi]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[fastapi]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -10,10 +10,10 @@ The FastAPI integration adds support for the [FastAPI Framework](https://fastapi
 Install `sentry-sdk` from PyPI with the `fastapi` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[fastapi]
+pip install "sentry-sdk[fastapi]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[fastapi]
+uv add "sentry-sdk[fastapi]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -10,10 +10,10 @@ The Flask integration adds support for the [Flask Web Framework](https://flask.p
 Install `sentry-sdk` from PyPI with the `flask` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[flask]
+pip install "sentry-sdk[flask]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[flask]
+uv add "sentry-sdk[flask]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -9,8 +9,11 @@ The Flask integration adds support for the [Flask Web Framework](https://flask.p
 
 Install `sentry-sdk` from PyPI with the `flask` extra:
 
-```bash
-pip install --upgrade "sentry-sdk[flask]"
+```bash {tabTitle:pip}
+pip install sentry-sdk[flask]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[flask]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/gnu_backtrace/index.mdx
+++ b/docs/platforms/python/integrations/gnu_backtrace/index.mdx
@@ -12,10 +12,10 @@ It is currently tested to work with server exceptions raised by [`clickhouse-dri
 Install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/gnu_backtrace/index.mdx
+++ b/docs/platforms/python/integrations/gnu_backtrace/index.mdx
@@ -11,8 +11,11 @@ It is currently tested to work with server exceptions raised by [`clickhouse-dri
 
 Install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/gql/index.mdx
+++ b/docs/platforms/python/integrations/gql/index.mdx
@@ -13,8 +13,11 @@ The [GQL](https://gql.readthedocs.io/en/stable/) integration allows you to monit
 
 Make sure you have the latest version of the Sentry SDK installed:
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/gql/index.mdx
+++ b/docs/platforms/python/integrations/gql/index.mdx
@@ -14,10 +14,10 @@ The [GQL](https://gql.readthedocs.io/en/stable/) integration allows you to monit
 Make sure you have the latest version of the Sentry SDK installed:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/graphene/index.mdx
+++ b/docs/platforms/python/integrations/graphene/index.mdx
@@ -11,8 +11,11 @@ in [Sentry](https://sentry.io).
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/graphene/index.mdx
+++ b/docs/platforms/python/integrations/graphene/index.mdx
@@ -12,10 +12,10 @@ in [Sentry](https://sentry.io).
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/grpc/index.mdx
+++ b/docs/platforms/python/integrations/grpc/index.mdx
@@ -12,8 +12,11 @@ and ensure traces are properly propagated to downstream services.
 
 Install `sentry-sdk` from PyPI with the `grpcio` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[grpcio]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[grpcio]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[grpcio]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/grpc/index.mdx
+++ b/docs/platforms/python/integrations/grpc/index.mdx
@@ -13,10 +13,10 @@ and ensure traces are properly propagated to downstream services.
 Install `sentry-sdk` from PyPI with the `grpcio` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[grpcio]
+pip install "sentry-sdk[grpcio]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[grpcio]
+uv add "sentry-sdk[grpcio]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/httpx/index.mdx
+++ b/docs/platforms/python/integrations/httpx/index.mdx
@@ -11,8 +11,11 @@ Use this integration to create spans for outgoing requests and ensure traces are
 
 Install `sentry-sdk` from PyPI with the `httpx` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[httpx]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[httpx]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[httpx]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/httpx/index.mdx
+++ b/docs/platforms/python/integrations/httpx/index.mdx
@@ -12,10 +12,10 @@ Use this integration to create spans for outgoing requests and ensure traces are
 Install `sentry-sdk` from PyPI with the `httpx` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[httpx]
+pip install "sentry-sdk[httpx]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[httpx]
+uv add "sentry-sdk[httpx]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/huey/index.mdx
+++ b/docs/platforms/python/integrations/huey/index.mdx
@@ -10,8 +10,11 @@ The huey integration adds support for the
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/huey/index.mdx
+++ b/docs/platforms/python/integrations/huey/index.mdx
@@ -11,10 +11,10 @@ The huey integration adds support for the
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -23,8 +23,11 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 
 Install `sentry-sdk` from PyPI with the `huggingface_hub` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[huggingface_hub]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[huggingface_hub]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[huggingface_hub]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -24,10 +24,10 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 Install `sentry-sdk` from PyPI with the `huggingface_hub` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[huggingface_hub]
+pip install "sentry-sdk[huggingface_hub]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[huggingface_hub]
+uv add "sentry-sdk[huggingface_hub]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -21,10 +21,10 @@ The integration has been confirmed to work with Langchain 0.1.11.
 Install `sentry-sdk` from PyPI and the appropriate langchain packages:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk langchain-openai langchain-core
+pip install "sentry-sdk" "langchain-openai" "langchain-core"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk langchain-openai langchain-core
+uv add "sentry-sdk" "langchain-openai" "langchain-core"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -20,8 +20,11 @@ The integration has been confirmed to work with Langchain 0.1.11.
 
 Install `sentry-sdk` from PyPI and the appropriate langchain packages:
 
-```bash
-pip install --upgrade 'sentry-sdk' 'langchain-openai' 'langchain-core'
+```bash {tabTitle:pip}
+pip install sentry-sdk langchain-openai langchain-core
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk langchain-openai langchain-core
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -11,8 +11,11 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 
 Install `sentry-sdk` from PyPI with the `launchdarkly` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[launchdarkly]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[launchdarkly]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[launchdarkly]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -12,10 +12,10 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 Install `sentry-sdk` from PyPI with the `launchdarkly` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[launchdarkly]
+pip install "sentry-sdk[launchdarkly]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[launchdarkly]
+uv add "sentry-sdk[launchdarkly]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/litestar/index.mdx
+++ b/docs/platforms/python/integrations/litestar/index.mdx
@@ -10,10 +10,10 @@ The Litestar integration adds support for the [Litestar framework](https://docs.
 Install `sentry-sdk` from PyPI with the `litestar` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[litestar] uvicorn
+pip install "sentry-sdk[litestar]" uvicorn
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[litestar] uvicorn
+uv add "sentry-sdk[litestar]" uvicorn
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/litestar/index.mdx
+++ b/docs/platforms/python/integrations/litestar/index.mdx
@@ -10,10 +10,10 @@ The Litestar integration adds support for the [Litestar framework](https://docs.
 Install `sentry-sdk` from PyPI with the `litestar` extra:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[litestar]" uvicorn
+pip install "sentry-sdk[litestar]" "uvicorn"
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[litestar]" uvicorn
+uv add "sentry-sdk[litestar]" "uvicorn"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/litestar/index.mdx
+++ b/docs/platforms/python/integrations/litestar/index.mdx
@@ -9,8 +9,11 @@ The Litestar integration adds support for the [Litestar framework](https://docs.
 
 Install `sentry-sdk` from PyPI with the `litestar` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[litestar]' uvicorn
+```bash {tabTitle:pip}
+pip install sentry-sdk[litestar] uvicorn
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[litestar] uvicorn
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -9,8 +9,11 @@ Adds support for Python logging.
 
 Install `sentry-sdk` from PyPI:
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -10,10 +10,10 @@ Adds support for Python logging.
 Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -12,10 +12,10 @@ The [`logging`](/platforms/python/integrations/logging) integration provides mos
 Install `sentry-sdk` from PyPI with the `loguru` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[loguru]
+pip install "sentry-sdk[loguru]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[loguru]
+uv add "sentry-sdk[loguru]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -11,8 +11,11 @@ The [`logging`](/platforms/python/integrations/logging) integration provides mos
 
 Install `sentry-sdk` from PyPI with the `loguru` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[loguru]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[loguru]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[loguru]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -24,8 +24,11 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 
 Install `sentry-sdk` from PyPI with the `openai` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[openai]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[openai]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[openai]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -25,10 +25,10 @@ Sentry LLM Monitoring will automatically collect information about prompts, toke
 Install `sentry-sdk` from PyPI with the `openai` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[openai]
+pip install "sentry-sdk[openai]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[openai]
+uv add "sentry-sdk[openai]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -11,8 +11,11 @@ The [OpenFeature](https://openfeature.dev/) integration tracks feature flag eval
 
 Install `sentry-sdk` from PyPI with the `openfeature` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[openfeature]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[openfeature]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[openfeature]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -12,10 +12,10 @@ The [OpenFeature](https://openfeature.dev/) integration tracks feature flag eval
 Install `sentry-sdk` from PyPI with the `openfeature` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[openfeature]
+pip install "sentry-sdk[openfeature]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[openfeature]
+uv add "sentry-sdk[openfeature]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pure_eval/index.mdx
+++ b/docs/platforms/python/integrations/pure_eval/index.mdx
@@ -10,10 +10,10 @@ This integration uses [`pure_eval`](https://github.com/alexmojaki/pure_eval) to 
 Install `sentry-sdk` from PyPI with the `pure_eval` extra or `pip install pure_eval executing asttokens`.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[pure_eval]
+pip install "sentry-sdk[pure_eval]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[pure_eval]
+uv add "sentry-sdk[pure_eval]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pure_eval/index.mdx
+++ b/docs/platforms/python/integrations/pure_eval/index.mdx
@@ -9,8 +9,11 @@ This integration uses [`pure_eval`](https://github.com/alexmojaki/pure_eval) to 
 
 Install `sentry-sdk` from PyPI with the `pure_eval` extra or `pip install pure_eval executing asttokens`.
 
-```bash
-pip install --upgrade 'sentry-sdk[pure_eval]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[pure_eval]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[pure_eval]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pymongo/index.mdx
+++ b/docs/platforms/python/integrations/pymongo/index.mdx
@@ -9,8 +9,11 @@ The PyMongo integration adds support for [PyMongo](https://www.mongodb.com/docs/
 
 Install `sentry-sdk` from PyPI with the `pymongo` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[pymongo]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[pymongo]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[pymongo]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pymongo/index.mdx
+++ b/docs/platforms/python/integrations/pymongo/index.mdx
@@ -10,10 +10,10 @@ The PyMongo integration adds support for [PyMongo](https://www.mongodb.com/docs/
 Install `sentry-sdk` from PyPI with the `pymongo` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[pymongo]
+pip install "sentry-sdk[pymongo]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[pymongo]
+uv add "sentry-sdk[pymongo]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pyramid/index.mdx
+++ b/docs/platforms/python/integrations/pyramid/index.mdx
@@ -9,8 +9,11 @@ The Pyramid integration adds support for the [Pyramid Web Framework](https://try
 
 Install `sentry-sdk` from PyPI:
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pyramid/index.mdx
+++ b/docs/platforms/python/integrations/pyramid/index.mdx
@@ -10,10 +10,10 @@ The Pyramid integration adds support for the [Pyramid Web Framework](https://try
 Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/quart/index.mdx
+++ b/docs/platforms/python/integrations/quart/index.mdx
@@ -10,10 +10,10 @@ The Quart integration adds support for the [Quart Web Framework](https://gitlab.
 Install `sentry-sdk` from PyPI with the `quart` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[quart]
+pip install "sentry-sdk[quart]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[quart]
+uv add "sentry-sdk[quart]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/quart/index.mdx
+++ b/docs/platforms/python/integrations/quart/index.mdx
@@ -9,8 +9,11 @@ The Quart integration adds support for the [Quart Web Framework](https://gitlab.
 
 Install `sentry-sdk` from PyPI with the `quart` extra:
 
-```bash
-pip install --upgrade sentry-sdk[quart]
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/quart/index.mdx
+++ b/docs/platforms/python/integrations/quart/index.mdx
@@ -10,10 +10,10 @@ The Quart integration adds support for the [Quart Web Framework](https://gitlab.
 Install `sentry-sdk` from PyPI with the `quart` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install sentry-sdk[quart]
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add sentry-sdk[quart]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/ray/index.mdx
+++ b/docs/platforms/python/integrations/ray/index.mdx
@@ -9,8 +9,11 @@ The Ray integration adds support for the [Ray](https://www.ray.io/) unified comp
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/ray/index.mdx
+++ b/docs/platforms/python/integrations/ray/index.mdx
@@ -10,10 +10,10 @@ The Ray integration adds support for the [Ray](https://www.ray.io/) unified comp
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/redis/index.mdx
+++ b/docs/platforms/python/integrations/redis/index.mdx
@@ -8,10 +8,10 @@ The [Redis](https://redis.io/) integration hooks into the [Redis client for Pyth
 ## Install
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/redis/index.mdx
+++ b/docs/platforms/python/integrations/redis/index.mdx
@@ -7,8 +7,11 @@ The [Redis](https://redis.io/) integration hooks into the [Redis client for Pyth
 
 ## Install
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/rq/index.mdx
+++ b/docs/platforms/python/integrations/rq/index.mdx
@@ -10,10 +10,10 @@ The RQ integration adds support for the [RQ job queue system](https://python-rq.
 Install `sentry-sdk` from PyPI with the `rq` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[rq]
+pip install "sentry-sdk[rq]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[rq]
+uv add "sentry-sdk[rq]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/rq/index.mdx
+++ b/docs/platforms/python/integrations/rq/index.mdx
@@ -9,8 +9,11 @@ The RQ integration adds support for the [RQ job queue system](https://python-rq.
 
 Install `sentry-sdk` from PyPI with the `rq` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[rq]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[rq]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[rq]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/rust_tracing/index.mdx
+++ b/docs/platforms/python/integrations/rust_tracing/index.mdx
@@ -30,10 +30,10 @@ In your Rust native extension, you'll need three crates as dependencies in `Carg
 ### Python
 In your Python project, you'll need to install the Sentry SDK from PyPI.
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/rust_tracing/index.mdx
+++ b/docs/platforms/python/integrations/rust_tracing/index.mdx
@@ -29,8 +29,11 @@ In your Rust native extension, you'll need three crates as dependencies in `Carg
 
 ### Python
 In your Python project, you'll need to install the Sentry SDK from PyPI.
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sanic/index.mdx
+++ b/docs/platforms/python/integrations/sanic/index.mdx
@@ -10,19 +10,19 @@ The Sanic integration adds support for the [Sanic Web Framework](https://sanic.d
 Install `sentry-sdk` from PyPI with the `sanic` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[sanic]
+pip install "sentry-sdk[sanic]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[sanic]
+uv add "sentry-sdk[sanic]"
 ```
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:
 
 ```bash {tabTitle:pip}
-pip install aiocontextvars
+pip install "aiocontextvars"
 ```
 ```bash {tabTitle:uv}
-uv add aiocontextvars
+uv add "aiocontextvars"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sanic/index.mdx
+++ b/docs/platforms/python/integrations/sanic/index.mdx
@@ -9,14 +9,20 @@ The Sanic integration adds support for the [Sanic Web Framework](https://sanic.d
 
 Install `sentry-sdk` from PyPI with the `sanic` extra:
 
-```bash
-pip install --upgrade sentry-sdk[sanic]
+```bash {tabTitle:pip}
+pip install sentry-sdk[sanic]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[sanic]
 ```
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:
 
-```bash
-pip install --upgrade aiocontextvars
+```bash {tabTitle:pip}
+pip install aiocontextvars
+```
+```bash {tabTitle:uv}
+uv add aiocontextvars
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/serverless/index.mdx
+++ b/docs/platforms/python/integrations/serverless/index.mdx
@@ -16,8 +16,11 @@ If you use a serverless provider not directly supported by the SDK, you can use 
 
 Install `sentry-sdk` from PyPI:
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/serverless/index.mdx
+++ b/docs/platforms/python/integrations/serverless/index.mdx
@@ -17,10 +17,10 @@ If you use a serverless provider not directly supported by the SDK, you can use 
 Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/socket/index.mdx
+++ b/docs/platforms/python/integrations/socket/index.mdx
@@ -9,8 +9,11 @@ Use this integration to create spans for DNS resolves and socket connection crea
 
 Install `sentry-sdk`` from PyPI.
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/socket/index.mdx
+++ b/docs/platforms/python/integrations/socket/index.mdx
@@ -10,10 +10,10 @@ Use this integration to create spans for DNS resolves and socket connection crea
 Install `sentry-sdk`` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sqlalchemy/index.mdx
+++ b/docs/platforms/python/integrations/sqlalchemy/index.mdx
@@ -9,8 +9,11 @@ The SQLAlchemy integration captures queries from [SQLAlchemy](https://www.sqlalc
 
 Install `sentry-sdk` from PyPI with the `sqlalchemy` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[sqlalchemy]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[sqlalchemy]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[sqlalchemy]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sqlalchemy/index.mdx
+++ b/docs/platforms/python/integrations/sqlalchemy/index.mdx
@@ -10,10 +10,10 @@ The SQLAlchemy integration captures queries from [SQLAlchemy](https://www.sqlalc
 Install `sentry-sdk` from PyPI with the `sqlalchemy` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[sqlalchemy]
+pip install "sentry-sdk[sqlalchemy]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[sqlalchemy]
+uv add "sentry-sdk[sqlalchemy]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -10,10 +10,10 @@ The Starlette integration adds support for the [Starlette Framework](https://www
 Install `sentry-sdk` from PyPI with the `starlette` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[starlette]
+pip install "sentry-sdk[starlette]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[starlette]
+uv add "sentry-sdk[starlette]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -9,8 +9,11 @@ The Starlette integration adds support for the [Starlette Framework](https://www
 
 Install `sentry-sdk` from PyPI with the `starlette` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[starlette]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[starlette]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[starlette]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/starlite/index.mdx
+++ b/docs/platforms/python/integrations/starlite/index.mdx
@@ -10,10 +10,10 @@ The Starlite integration adds support for the [Starlite framework](https://docs.
 Install `sentry-sdk` from PyPI with the `starlite` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[starlite] uvicorn
+pip install "sentry-sdk[starlite]" "uvicorn"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[starlite] uvicorn
+uv add "sentry-sdk[starlite]" "uvicorn"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/starlite/index.mdx
+++ b/docs/platforms/python/integrations/starlite/index.mdx
@@ -9,8 +9,11 @@ The Starlite integration adds support for the [Starlite framework](https://docs.
 
 Install `sentry-sdk` from PyPI with the `starlite` extra:
 
-```bash
-pip install --upgrade 'sentry-sdk[starlite]' uvicorn
+```bash {tabTitle:pip}
+pip install sentry-sdk[starlite] uvicorn
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[starlite] uvicorn
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/statsig/index.mdx
+++ b/docs/platforms/python/integrations/statsig/index.mdx
@@ -12,10 +12,10 @@ The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluati
 Install `sentry-sdk` from PyPI with the `statsig` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[statsig]
+pip install "sentry-sdk[statsig]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[statsig]
+uv add "sentry-sdk[statsig]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/statsig/index.mdx
+++ b/docs/platforms/python/integrations/statsig/index.mdx
@@ -11,8 +11,11 @@ The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluati
 
 Install `sentry-sdk` from PyPI with the `statsig` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[statsig]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[statsig]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[statsig]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/strawberry/index.mdx
+++ b/docs/platforms/python/integrations/strawberry/index.mdx
@@ -11,8 +11,11 @@ in [Sentry](https://sentry.io).
 
 To get started, install `sentry-sdk` from PyPI.
 
-```bash
-pip install --upgrade sentry-sdk
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/strawberry/index.mdx
+++ b/docs/platforms/python/integrations/strawberry/index.mdx
@@ -12,10 +12,10 @@ in [Sentry](https://sentry.io).
 To get started, install `sentry-sdk` from PyPI.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sys_exit/index.mdx
+++ b/docs/platforms/python/integrations/sys_exit/index.mdx
@@ -8,10 +8,10 @@ The `SysExitIntegration` records `sys.exit` calls by capturing the `SystemExit` 
 ## Install
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sys_exit/index.mdx
+++ b/docs/platforms/python/integrations/sys_exit/index.mdx
@@ -7,8 +7,11 @@ The `SysExitIntegration` records `sys.exit` calls by capturing the `SystemExit` 
 
 ## Install
 
-```bash
-pip install --upgrade "sentry-sdk"
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/tornado/index.mdx
+++ b/docs/platforms/python/integrations/tornado/index.mdx
@@ -19,10 +19,10 @@ uv add sentry-sdk[tornado]
 If you're on Python 3.6, you also need the `aiocontextvars` package:
 
 ```bash {tabTitle:pip}
-pip install aiocontextvars
+pip install "aiocontextvars"
 ```
 ```bash {tabTitle:uv}
-uv add aiocontextvars
+uv add "aiocontextvars"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/tornado/index.mdx
+++ b/docs/platforms/python/integrations/tornado/index.mdx
@@ -10,10 +10,10 @@ The Tornado integration adds support for the [Tornado Web Framework](https://www
 Install `sentry-sdk` from PyPI with the `tornado` extra:
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[tornado]
+pip install "sentry-sdk[tornado]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[tornado]
+uv add "sentry-sdk[tornado]"
 ```
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:

--- a/docs/platforms/python/integrations/tornado/index.mdx
+++ b/docs/platforms/python/integrations/tornado/index.mdx
@@ -9,14 +9,20 @@ The Tornado integration adds support for the [Tornado Web Framework](https://www
 
 Install `sentry-sdk` from PyPI with the `tornado` extra:
 
-```bash
-pip install --upgrade sentry-sdk[tornado]
+```bash {tabTitle:pip}
+pip install sentry-sdk[tornado]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[tornado]
 ```
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:
 
-```bash
-pip install --upgrade aiocontextvars
+```bash {tabTitle:pip}
+pip install aiocontextvars
+```
+```bash {tabTitle:uv}
+uv add aiocontextvars
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/typer/index.mdx
+++ b/docs/platforms/python/integrations/typer/index.mdx
@@ -9,8 +9,11 @@ The `TyperIntegration` captures exceptions raised when using [Typer CLI](https:/
 
 Install Typer and the Sentry Python SDK.
 
-```bash
-pip install --upgrade "sentry-sdk" typer
+```bash {tabTitle:pip}
+pip install sentry-sdk typer
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk typer
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/typer/index.mdx
+++ b/docs/platforms/python/integrations/typer/index.mdx
@@ -10,10 +10,10 @@ The `TyperIntegration` captures exceptions raised when using [Typer CLI](https:/
 Install Typer and the Sentry Python SDK.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk typer
+pip install "sentry-sdk" "typer"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk typer
+uv add "sentry-sdk" "typer"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -11,8 +11,11 @@ The [Unleash](https://www.getunleash.io/) integration tracks feature flag evalua
 
 Install `sentry-sdk` from PyPI with the `unleash` extra.
 
-```bash
-pip install --upgrade 'sentry-sdk[unleash]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[unleash]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[unleash]
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -12,10 +12,10 @@ The [Unleash](https://www.getunleash.io/) integration tracks feature flag evalua
 Install `sentry-sdk` from PyPI with the `unleash` extra.
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[unleash]
+pip install "sentry-sdk[unleash]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[unleash]
+uv add "sentry-sdk[unleash]"
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/wsgi/index.mdx
+++ b/docs/platforms/python/integrations/wsgi/index.mdx
@@ -12,8 +12,11 @@ Please check our list of [supported integrations](/platforms/python/integrations
 
 ## Install
 
-```bash
-pip install --upgrade 'sentry-sdk'
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/wsgi/index.mdx
+++ b/docs/platforms/python/integrations/wsgi/index.mdx
@@ -13,10 +13,10 @@ Please check our list of [supported integrations](/platforms/python/integrations
 ## Install
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk
+pip install "sentry-sdk"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk
+uv add "sentry-sdk"
 ```
 
 ## Configure

--- a/platform-includes/performance/opentelemetry-install/python.mdx
+++ b/platform-includes/performance/opentelemetry-install/python.mdx
@@ -5,8 +5,8 @@ Sentry requires `opentelemetry-distro` version `0.350b0` or higher.
 </Alert>
 
 ```bash {tabTitle:pip}
-pip install sentry-sdk[opentelemetry]
+pip install "sentry-sdk[opentelemetry]"
 ```
 ```bash {tabTitle:uv}
-uv add sentry-sdk[opentelemetry]
+uv add "sentry-sdk[opentelemetry]"
 ```

--- a/platform-includes/performance/opentelemetry-install/python.mdx
+++ b/platform-includes/performance/opentelemetry-install/python.mdx
@@ -4,6 +4,9 @@ Sentry requires `opentelemetry-distro` version `0.350b0` or higher.
 
 </Alert>
 
-```bash
-pip install --upgrade 'sentry-sdk[opentelemetry]'
+```bash {tabTitle:pip}
+pip install sentry-sdk[opentelemetry]
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk[opentelemetry]
 ```


### PR DESCRIPTION
- Removes the `--upgrade` parameter from all installation commands
- Adds a second tab to the install section with instructions for `uv`

Closes TET-349

Before:
<img width="755" alt="Screenshot 2025-04-25 at 10 11 03" src="https://github.com/user-attachments/assets/0c2f77db-5f8c-4b09-a3b3-2aa996a53c40" />

After:
<img width="765" alt="Screenshot 2025-04-25 at 10 10 52" src="https://github.com/user-attachments/assets/f57efbe8-3dea-4d7a-9f0b-fc546d76a1db" />
