### PR TITLE
unity: note on tracing powering errors

### DIFF
--- a/docs/platforms/unity/tracing/index.mdx
+++ b/docs/platforms/unity/tracing/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to enable tracing in your app and discover valuable perf
 sidebar_order: 4000
 ---
 
-With [tracing](/product/insights/overview/), Sentry tracks your software performance, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems. Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
+With [tracing](/product/insights/overview/), Sentry is able to connect events from different parts of your game as well as the backend. Helping debugging hard problems that involve issues in C# scripts as well as native layers of all platforms. It also allows tracking your game's performance, measuring metrics like game initialization time, time spent by game objects and ANRs. Besides connecting different errors together, Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
 <Alert>
 

--- a/docs/platforms/unity/tracing/index.mdx
+++ b/docs/platforms/unity/tracing/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to enable tracing in your app and discover valuable perf
 sidebar_order: 4000
 ---
 
-With [tracing](/product/insights/overview/), Sentry is able to connect events from different parts of your game as well as the backend. Helping debugging hard problems that involve issues in C# scripts as well as native layers of all platforms. It also allows tracking your game's performance, measuring metrics like game initialization time, time spent by game objects and ANRs. Besides connecting different errors together, Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
+With [tracing](/product/insights/overview/), Sentry is able to [connect events coming from different parts of your game](/platforms/unity/usage/automatic-error-capture/#connecting-errors-captured-on-different-layers), whether it's native plugins or a backend. It helps you debug hard problems that involve C# scripts as well as the native layer on all platforms. It also allows you to monitor your game's performance, measuring metrics like initialization time, time spent on scene loading, and ANRs. Besides connecting different errors together, Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services. Learn more about our model in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/).
 
 <Alert>
 


### PR DESCRIPTION
I think here we could improve a lot what tracing does for Unith game devs.

That blurb is clearly some copy paste of whatever backend framework this was written for.
Linking to you ur new doc on tracing is also a good opportunity.

@bitsandfoxes Feel free to close this PR and take over if u have more ideas

Relates to: https://github.com/getsentry/sentry-docs/pull/13516/