### PR TITLE
ref(docs): rm session health from early adopter

### DIFF
--- a/docs/organization/early-adopter-features/index.mdx
+++ b/docs/organization/early-adopter-features/index.mdx
@@ -22,5 +22,3 @@ Limitations:
 - [Span Summary](/product/insights/overview/transaction-summary/#span-summary)
 - [Dynamic Alerts](/product/alerts/create-alerts/metric-alert-config/#dynamic-alerts)
 - [New Trace Explorer With Span Metrics](/product/explore/new-trace-explorer/)
-- [Frontend Session Health on Insights](/product/insights/frontend/session-health/)
-- [Mobile Session Health on Insights](/product/insights/mobile/session-health/)

--- a/includes/insights-session-health-body.mdx
+++ b/includes/insights-session-health-body.mdx
@@ -1,5 +1,3 @@
-<Include name="feature-available-for-user-group-early-adopter.mdx" />
-
 If you have [sessions and releases](/product/releases/setup/) enabled on Sentry, you can take full advantage of the Session Health tab on Insights. The Session Health tab contains a variety of data visualizations to help you discover insights about how your sessions are performing. A session on most web or mobile applications is created for every page (or view) load and on every navigation change. Read more [here](/product/releases/health/#sessions).
 
 The charts help you understand trends for your sessions over time, and the customized chart views and toggleable legends allow you to drill down into the metrics you care about most.


### PR DESCRIPTION
we GA'd session health on insights