### PR TITLE
Fix old option name for the component annotation docs

### DIFF
--- a/docs/platforms/react-native/integrations/component-names.mdx
+++ b/docs/platforms/react-native/integrations/component-names.mdx
@@ -28,7 +28,7 @@ We're working to release more features that will leverage component name capturi
 
 ## Enable Component Name Capturing
 
-Add the `@sentry/react-native/metro` plugin to your Metro configuration and enable the `reactComponentAnnotation` option:
+Add the `@sentry/react-native/metro` plugin to your Metro configuration and enable the `annotateReactComponents` option:
 
 ```javascript {tabTitle:React Native} {filename:metro.config.js}
 const { getDefaultConfig } = require("@react-native/metro-config");


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*
The docs reference both "reactComponentAnnotation" and "annotateReactComponents", the latter one seems to be the correct one

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
