### PR TITLE
unreal engine: note on xbox and playstation support

### DIFF
--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -20,6 +20,7 @@ Unreal Engine SDK builds on top of other Sentry SDKs and extends them with Unrea
 - Windows (UE 5.2+) and Linux by using the [Native SDK](/platforms/native/) to support C and C++ with minidumps
 - macOS by using the [macOS SDK](/platforms/apple/guides/macos/) to support Objective-C, Swift, C and C++
 - Compatible with [Crash Reporter Client](/platforms/unreal/configuration/setup-crashreporter/) provided along with Unreal Engine
+- PlayStation and Xbox support
 - [Release health](/platforms/unreal/configuration/releases/) to keep track of crash free users and sessions
 
 <Alert level="warning">


### PR DESCRIPTION
We still need a proper section on the docs describing how to get access, and some level of detail to it as much as we're allowed to add