### PR TITLE
docs: Mention availability of Developer plan

### DIFF
--- a/docs/organization/integrations/deployment/vercel/index.mdx
+++ b/docs/organization/integrations/deployment/vercel/index.mdx
@@ -83,41 +83,39 @@ This issue typically occurs if you have an ad blocker blocking the conversation 
 
 ## Vercel Marketplace
 
-The Vercel Marketplace integration allows existing Vercel users to onboard to Sentry with a one-click workflow. This setup is designed for **new Sentry users** and unifies billing within the Vercel platform. 
+The Vercel Marketplace integration allows existing Vercel users to onboard to Sentry with a one-click workflow. This setup is designed for **new Sentry users** and unifies billing within the Vercel platform.
 
 There is no path for existing Sentry organizations to use the Vercel Marketplace integration.
 
-When you configure Sentry using the Vercel Marketplace, you'll be able to set the name of your new Sentry Organization (referred to as an "Installation" in Vercel) and projects (Resources/Products in Vercel) during the setup process. 
+When you configure Sentry using the Vercel Marketplace, you'll be able to set the name of your new Sentry Organization (referred to as an "Installation" in Vercel) and projects (Resources/Products in Vercel) during the setup process.
 
-### Billing Settings 
+### Billing Settings
 
-When using the Vercel Marketplace native integration, users can modify their organizations billing information from within the Vercel platform, or within Sentry directly. Credit card settings can only be modified within Vercel. 
+When using the Vercel Marketplace native integration, users can modify their organizations billing information from within the Vercel platform, or within Sentry directly. Credit card settings can only be modified within Vercel.
 
-Subscription settings can only be modified within Sentry. During setup, organizations can choose between Team or Business plans. Pay-as-you-go budgets can be set after the initial setup is completed.
+Subscription settings can only be modified within Sentry. During setup, organizations can choose between Developer, Team or Business plans. Pay-as-you-go budgets can be set after the initial setup is completed.
 
 ### User Access
 
-Vercel users will have single sign-on access to Sentry using the "Open in Sentry" button within Vercel, and will be able to create new projects in either Vercel or Sentry. 
+Vercel users will have single sign-on access to Sentry using the "Open in Sentry" button within Vercel, and will be able to create new projects in either Vercel or Sentry.
 
 Users will still be able to login to their Sentry organization directly, without using the Vercel single-sign on, by using the login they configured during the setup process. For non social based login (Google, Github, etc.) users, Sentry will prompt for password creation.
 
 ### Automatically Configured Environment Variables
 
-For every project configured, the following environment variables will be set within the Vercel deployment: 
+For every project configured, the following environment variables will be set within the Vercel deployment:
 
 - **SENTRY_PROJECT**
 - **SENTRY_AUTH_TOKEN**
 - **NEXT_PUBLIC_SENTRY_DSN**
-- **SENTRY_ORG** 
+- **SENTRY_ORG**
 
-### Integration Deletion 
+### Integration Deletion
 
-If the integration is deleted within Vercel, the Sentry organization **will not** be deleted. The deletion will permanently remove the connection between the Vercel account and the Sentry account, and is **irreversible**. 
+If the integration is deleted within Vercel, the Sentry organization **will not** be deleted. The deletion will permanently remove the connection between the Vercel account and the Sentry account, and is **irreversible**.
 
-Preserving the Sentry organization allows teams to still access historical data from within Sentry, even if they are not sending monitoring data anymore. 
+Preserving the Sentry organization allows teams to still access historical data from within Sentry, even if they are not sending monitoring data anymore.
 
-If the native integration is deleted, teams are still able to leverage the non-native Vercel integration described at the top of this document. Only one integration can be active at a time. 
+If the native integration is deleted, teams are still able to leverage the non-native Vercel integration described at the top of this document. Only one integration can be active at a time.
 
 For more information, see the [Introducing the Vercel Marketplace blog post](https://vercel.com/blog/introducing-the-vercel-marketplace).
-
-


### PR DESCRIPTION
Although it wasn't possible in the beginning, we are now allowing users to provision an organization on Developer plan too.

This is just a small update to mention in our docs that Developer plans are available too