### PR TITLE
Update documentation for event payload

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/sdk.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/sdk.mdx
@@ -69,6 +69,14 @@ activated integrations. Each package consists of a `name` in the format
 `identifier` should be a checkout link and the `version` should be a Git
 reference (branch, tag or SHA).
 
+`settings`
+
+: _Optional_. A collection of settings that are used to control behaviour.
+- `infer_ip`: Controls the behaviour of IP address inferrence based on request information. Following values are allowed:
+  - `auto`: infer the IP address based on available request information. This is equal to [setting the IP address to `{{auto}}`](https://develop.sentry.dev/sdk/data-model/event-payloads/user/#automatic-ip-addresses).
+  - `never`: Do not infer the IP address from the request. This is the default if an invalid value for `infer_ip` was sent.
+  - `legacy`: Infer the IP address only if the value is `{{auto}}`. For Javascript and Cocoa it will also infer if `ip_address` is empty. This is the default if no value was sent.
+
 ## Example
 
 The following example illustrates the SDK part of the <Link to="/sdk/data-model/event-payloads/">event payload</Link> and omits other
@@ -90,7 +98,10 @@ attributes for simplicity.
         "name": "git:https://github.com/getsentry/sentry-cocoa.git",
         "version": "4.1.0"
       }
-    ]
+    ],
+    "settings": {
+      "infer_ip": "auto"
+    }
   }
 }
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This PR adds documentation for `settings` in the `sdk` context.  This enables the SDK to control certain mechanisms without relying on "magic values" like `{{auto}}` for `ip_address`.

Currently only `infer_ip` is implemented but new fields might be introduced in the future.

See https://github.com/getsentry/relay/pull/4623
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
