### PR TITLE
chore(apple): Remove enableExperimentalViewRenderer after GA

### DIFF
--- a/docs/platforms/apple/guides/ios/session-replay/index.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/index.mdx
@@ -41,9 +41,6 @@ SentrySDK.start(configureOptions: { options in
 
   options.sessionReplay.onErrorSampleRate = 1.0
   options.sessionReplay.sessionSampleRate = 0.1
-
-  // We recommend the ~5x more performant experimental view renderer
-  options.sessionReplay.enableExperimentalViewRenderer = true
 })
 ```
 

--- a/docs/platforms/apple/guides/ios/session-replay/performance-overhead.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/performance-overhead.mdx
@@ -72,3 +72,9 @@ SentrySDK.start(configureOptions: { options in
   options.sessionReplay.enableViewRendererV2 = false
 })
 ```
+
+<Alert title="✨ Note">
+
+The old view renderer will be deprecated and removed in a future release.
+
+</Alert>

--- a/docs/platforms/apple/guides/ios/session-replay/performance-overhead.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/performance-overhead.mdx
@@ -61,20 +61,15 @@ SentrySDK.start(configureOptions: { options in
 })
 ```
 
-### Enable Experimental View Renderer
-
-<Alert>
-  In case you are noticing issues with the experimental view renderer, please
-  report the issue on [GitHub](https://github.com/getsentry/sentry-cocoa).
-</Alert>
+### Disable View Renderer V2
 
 Starting with v8.47.0 you can enable the up-to-5x-faster new view renderer, reducing the impact of Session Replay on the main thread and potential frame drops.
+As of v8.50.0, the new view renderer is enabled by default.
 
-While we do recommend the new view renderer, it's currently considered an experimental feature to further evaluate its stability.
-After the evaluation phase we are going to enable it by default.
+While we do recommend the new view renderer, if you are experiencing issues, you can disable it by setting the following flag:
 
 ```swift
 SentrySDK.start(configureOptions: { options in
-  options.sessionReplay.enableExperimentalViewRenderer = true
+  options.sessionReplay.enableViewRendererV2 = false
 })
 ```

--- a/docs/platforms/apple/guides/ios/session-replay/performance-overhead.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/performance-overhead.mdx
@@ -63,10 +63,9 @@ SentrySDK.start(configureOptions: { options in
 
 ### Disable View Renderer V2
 
-Starting with v8.47.0 you can enable the up-to-5x-faster new view renderer, reducing the impact of Session Replay on the main thread and potential frame drops.
-As of v8.50.0, the new view renderer is enabled by default.
+Starting with v8.50.0, the up-to-5x-faster view renderer V2 is used by default, reducing the impact of Session Replay on the main thread and potential frame drops. In previous versions (v8.47.0 and above), you can already enable it by setting `enableExperimentalViewRenderer=true`.
 
-While we do recommend the new view renderer, if you are experiencing issues, you can disable it by setting the following flag:
+While we do recommend the new view renderer, if you are experiencing issues, you can opt out of using it by setting the following flag:
 
 ```swift
 SentrySDK.start(configureOptions: { options in

--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -41,10 +41,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
-  integrations: [Sentry.mobileReplayIntegration({
-    // We recommend the ~5x more performant experimental view renderer
-    enableExperimentalViewRenderer: true,
-  })],
+  integrations: [Sentry.mobileReplayIntegration()],
 });
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Starting with sentry-cocoa v8.50.0 the experimental view renderer is now considered GA and enabled by default. It is possible to opt-out by setting the option `options.sessionReplay.enableViewRendererV2 = false`

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)