### PR TITLE
docs(react-router): Update source maps section for a PR

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -317,7 +317,7 @@ Update the `start` and `dev` script to include the instrumentation file:
 
 ## Source Maps Upload
 
-Update `vite.config.ts` to include the `sentryReactRouter` plugin. Also add your `SentryReactRouterBuildOptions` config options to the Vite config (this is required for uploading source maps at the end of the build):
+Update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it:
 
 <OrgAuthTokenNote />
 
@@ -338,7 +338,6 @@ const sentryConfig: SentryReactRouterBuildOptions = {
 export default defineConfig(config => {
   return {
 +   plugins: [reactRouter(),sentryReactRouter(sentryConfig, config)],
-+   sentryConfig, // Also pass the config here!
   };
 });
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Should document changes made in https://github.com/getsentry/sentry-javascript/pull/16197

TL;DR: Users no longer need to pass SentryOptions to the Vite global config—this is now handled under the hood by the React Router Vite plugin.

<img width="762" alt="Screenshot 2025-05-06 at 10 44 20 AM" src="https://github.com/user-attachments/assets/e7618662-dcc2-45c0-abed-c4c71a259762" />


## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
