### PR TITLE
docs(migrations): Update timeout to 10s

### DIFF
--- a/develop-docs/backend/application-domains/database-migrations/index.mdx
+++ b/develop-docs/backend/application-domains/database-migrations/index.mdx
@@ -565,7 +565,7 @@ Post-deploy migrations are run manually by engineers **after** a migration has b
 Post-deploy migrations are ideal for:
 
 * Adding indexes to large tables, where adding the index would take longer than
-  5 seconds in any given region.
+  10 seconds in any given region.
 * Doing data backfills or mutations on tables with more than 50,000 rows.
 
 Post-deploy migrations **should not** be used for:


### PR DESCRIPTION

## DESCRIBE YOUR PR
In https://github.com/getsentry/getsentry/pull/17329 we have bumped `ZERO_DOWNTIME_MIGRATIONS_LOCK_TIMEOUT` to 10s, which should also be reflected in our docs. 

Out of precaution, i didn't change threshold of 50k rows that would be mutated, even though the timeout was increased. We can still keep the same threshold, and for every mutation over that number of rows do a post-deployment migration. 
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ x ] None: Not urgent, can wait up to 1 week+
