### PR TITLE
:wrench: chore: remove api tsc from open api hash file codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,6 @@
 # Requiring review from security team for Content-Security-Policy changes
 **/vercel.json @getsentry/security
 
-# owners-api is tagged here but anyone can just approve the SHA Bump PRs
-/src/build/resolveOpenAPI.ts @getsentry/owners-api
-
 # Codeowners listed below are used as a reference for the Sentry team to know who to contact for a given area of the codebase.
 
 # /src/platforms/android/ @getsentry/team-mobile-core


### PR DESCRIPTION
the getsantry bot now auto merges the prs on this file, so we don't need to manually approve the prs. 

currently its jut creating noise and noone looks at the prs anyway so removing api-tsc