### PR TITLE
fix: devservices use local not LOCAL

### DIFF
--- a/develop-docs/development-infrastructure/devservices.mdx
+++ b/develop-docs/development-infrastructure/devservices.mdx
@@ -97,22 +97,22 @@ devservices toggle snuba
 or you can specify the runtime explicitly:
 
 ```shell
-devservices toggle snuba LOCAL
+devservices toggle snuba local
 ```
 
 This tells devservices to treat Snuba as a service that should be started alongside dependent services like Sentry. Dependencies of Snuba, such as Redis, Kafka, and Clickhouse, will still run as containers.
 
 <Alert title="Note">
-  Toggling to LOCAL does not start the dev server for that service. You'll need to start that manually.
+  Toggling to `local` does not start the dev server for that service. You'll need to start that manually.
 </Alert>
 
 ### What happens when you toggle
 
-If Sentry is already running, toggling Snuba to LOCAL will:
+If Sentry is already running, toggling Snuba to `local` will:
 1. Stop Snuba's containers (unless shared by another service)
 2. Start Snuba's non-local dependencies (Redis, Kafka, Clickhouse) as containers
 
-If Sentry is not yet running, the next time `devservices up` is run, Snuba (and any other services you toggle to LOCAL) will be automatically started as local services alongside Sentry.
+If Sentry is not yet running, the next time `devservices up` is run, Snuba (and any other services you toggle to `local`) will be automatically started as local services alongside Sentry.
 
 If you want to bring up Snuba, or other local runtime dependencies in a non-default mode, you can:
 1. Tell devservices to not bring them up automatically by passing the `--exclude-local` flag to `devservices up`.


### PR DESCRIPTION
```
➜ devservices toggle snuba LOCAL
usage: devservices [-h] [--version] COMMAND ... toggle [-h] [--debug] [service_name] [{local,containerized}]
devservices [-h] [--version] COMMAND ... toggle: error: argument runtime: invalid choice: 'LOCAL' (choose from local, containerized)
```

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
