### PR TITLE
feat(js): Better document tag key/value requirements

### DIFF
--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -310,7 +310,11 @@ Messages show up as issues on your issue stream, with the message as the issue n
   signature="function setTag(key: string, value: string): void"
   parameters={[]}
 >
-  Set a tag to be sent with Sentry events.
+Set a tag to be sent with Sentry events.
+
+- Tag keys have a maximum length of 32 characters and can contain only letters (`a-zA-Z`), numbers (`0-9`), underscores (`_`), periods (`.`), colons (`:`), and dashes (`-`).
+- Tag values have a maximum length of 200 characters and they cannot contain the newline (`\n`) character.
+
 </SdkApi>
 
 <SdkApi

--- a/docs/platforms/javascript/common/enriching-events/tags/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/tags/index.mdx
@@ -9,6 +9,8 @@ We’ll automatically index all tags for an event, as well as the frequency and 
 
 _Tag keys_ have a maximum length of 32 characters and can contain only letters (`a-zA-Z`), numbers (`0-9`), underscores (`_`), periods (`.`), colons (`:`), and dashes (`-`).
 
+<Alert level="warning">Spaces in tag keys are not allowed.</Alert>
+
 _Tag values_ have a maximum length of 200 characters and they cannot contain the newline (`\n`) character.
 
 Defining tags is easy, and will bind them to the [isolation scope](../scopes/) ensuring all future events within scope contain the same tags.


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/FE-394/user-feedback-tags-with-spaces-cause-problems