### PR TITLE
ref(js): Mention debug ids in sourcemap docs

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/troubleshooting_js/debug-ids/index.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/troubleshooting_js/debug-ids/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: What are Debug IDs
-sidebar_order: 7
+sidebar_order: 1
 ---
 
 This documentation provides an in-depth look at Debug IDs, explaining how they work and why Sentry recommends using them. Visit [Uploading Source Maps](https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/uploading/) if you're looking for our guides on how to upload source maps.

--- a/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.mdx
@@ -16,6 +16,12 @@ This guide assumes you are using a Browser JavaScript SDK. For instructions on h
 
 If you want to configure source maps to upload manually, follow the guide for your bundler or build tool below.
 
+<Alert>
+
+By default, Sentry will link source maps by injecting <PlatformLink to="/sourcemaps/troubleshooting_js/debug-ids/">Debug IDs</PlatformLink> into your build output. Alternatively, there are also <PlatformLink to="/sourcemaps/troubleshooting_js/legacy-uploading-methods/">other methods</PlatformLink> to associate source maps with Sentry that do not require modifying your build output.
+
+</Alert>
+
 <PlatformSection supported={["javascript.react"]}>
 
 ### Create React App


### PR DESCRIPTION
This PR:

* Reorders the source maps troubleshooting docs to have the debug ids section first (makes more sense imho?)
* Adds a section mentioning debug ids

Closes https://linear.app/getsentry/issue/FE-398/user-feedback-debug-ids-tooling