### PR TITLE
chore(deps): bump platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "next-plausible": "^3.12.4",
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^1.6.6",
-    "platformicons": "^8.0.3",
+    "platformicons": "^8.0.4",
     "prism-sentry": "^1.0.2",
     "query-string": "^6.13.1",
     "react": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10561,10 +10561,10 @@ pkg-types@^1.2.1:
     mlly "^1.7.2"
     pathe "^1.1.2"
 
-platformicons@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.3.tgz#edd373277f1d9cf58edff23f2917a79525c3e814"
-  integrity sha512-0gAjZxu9CMKkjrE90bOQNgIxKmhDOKPyK5T27RxlTXJxBfrcycm+QrCMdUMqRgU5oBxNWeFg/gnP9Egvuqbg+Q==
+platformicons@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.4.tgz#f26e79b7bfbce1d8ae3af382215efe0ad6e19fcf"
+  integrity sha512-hvIWouaTtmnHv/JD42LwOg4MOd020q8Vf1Xs8uzqiA5+cqsiYqhR22WNV+Vzx6+T1K8ZLO9LV8+FvpFargKdlw==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
Bumps `platformicons` to the latest version.
The Rust and Actix icons have been improved, plus some new icons have been added.