### PR TITLE
docs(js): Fix metadata propagation in nestjs interceptor

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -157,26 +157,26 @@ const serviceImplementation = {
 function createGrpcClient() {
   // Create client with interceptor
   return new MyServiceClient(address, grpc.credentials.createInsecure(), {
-    interceptors: [(options, nextCall) => {
-      // Return a new InterceptingCall, which allows us to modify the call's metadata
-      return new grpc.InterceptingCall(nextCall(options), {
-        start: (callMetadata, listener, next) => {
-          // `callMetadata` is the metadata object for the outgoing gRPC call.
-          // We will add our Sentry tracing headers to this object.
-          
-          // Get current trace information from Sentry
-          const traceData = Sentry.getTraceData();
-          
-          // Add Sentry trace and baggage headers to the call's metadata
-          if (traceData) {
-            callMetadata.set('sentry-trace', traceData['sentry-trace']);
-            callMetadata.set('baggage', traceData['baggage']);
+    interceptors: [
+      (options, nextCall) => {
+        return new grpc.InterceptingCall(nextCall(options), {
+          start: (callMetadata, listener, next) => {
+            // `callMetadata` is the metadata object for the outgoing gRPC call.
+            // We will add our Sentry tracing headers to this object.
+            
+            // Get current trace information from Sentry
+            const traceData = Sentry.getTraceData();
+            
+            // Add Sentry trace and baggage headers to the call's metadata
+            if (traceData) {
+              callMetadata.set('sentry-trace', traceData['sentry-trace']);
+              callMetadata.set('baggage', traceData['baggage']);
+            }
+            
+            // Proceed with the call, now including the Sentry headers in its metadata
+            next(callMetadata, listener);
           }
-          
-          // Proceed with the call, now including the Sentry headers in its metadata
-          next(callMetadata, listener);
-        }
-      });
+        });
     }]
   });
 }


### PR DESCRIPTION
- Add to the existing one instead of recreating

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

We need to continue passing metadata in this interceptor instead of replacing it. 

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/054143a9-5609-4d2a-a5a9-3021eca63c3a" />


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
