### PR TITLE
fix(rust): fix typo in source context docs

### DIFF
--- a/docs/platforms/rust/common/source-context/index.mdx
+++ b/docs/platforms/rust/common/source-context/index.mdx
@@ -14,7 +14,7 @@ description: "Learn about showing your source code as part of stack traces."
 
 Enable full debug information for your release build:
 ```toml {filename:Cargo.toml}
-[profiles.release]
+[profile.release]
 debug = true
 ```
 


### PR DESCRIPTION
Just a typo, it needs to be `profile` for it to work
