### PR TITLE
fix(nextjs): Fix docs link

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -146,8 +146,8 @@ You can work around our CDN bundles being blocked by [using our NPM packages](#u
 <PlatformSection supported={["javascript.nextjs"]}>
 
 The Sentry Next.js SDK has a separate option to make setting up tunnels very
-straight-forward, allowing you to skip the setup below. See <PlatformLink to="/manual-setup/#configure-tunneling-to-avoid-ad-blockers">
-Configure Tunneling to avoid Ad-Blockers</PlatformLink> to learn how to set up tunneling on Next.js.
+straight-forward, allowing you to skip the setup below. See <PlatformLink to="/configuration/build/#tunnelRoute">
+`tunnelRoute`</PlatformLink> to learn how to set up tunneling on Next.js.
 
 If you do not want to configure `tunnelRoute`, you can follow the guide below.
 


### PR DESCRIPTION
Noticed this was incorrectly pointing to the old place.