### PR TITLE
Add set_trace example

### DIFF
--- a/platform-includes/performance/add-spans-example/native.mdx
+++ b/platform-includes/performance/add-spans-example/native.mdx
@@ -37,3 +37,14 @@ void perform_checkout() {
 ```
 
 This example will send a transaction named `checkout` to Sentry. The transaction will contain a `validation` span that measures how long `validate_shopping_cart()` took and a `process` span that measures `process_shopping_cart()`. Finally, the call to `sentry_transaction_finish()` will finish the transaction and send it to Sentry.
+
+By default, transactions will inherit the `trace_id` and `parent_span_id` from the `propagation_context` as generated during SDK initialization. These values can be overridden by calling `sentry_set_trace()`, for example from a downstream SDK or to define a manual trace boundary:
+
+```c
+// Set the trace propagation_context which will be used
+//  for all events and transactions/spans
+const char *trace_id = "2674eb52d5874b13b560236d6c79ce8a";
+const char *parent_span_id = "a0f9fdf04f1a63df";
+
+sentry_set_trace(trace_id, parent_span_id);
+```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

[Vercel Preview](https://sentry-docs-htn2uy3fb.sentry.dev/platforms/native/tracing/instrumentation/custom-instrumentation/#:~:text=it%20to%20Sentry.-,By%20default%2C,-transactions%20will%20inherit)

## DESCRIBE YOUR PR
Related to the feature added in https://github.com/getsentry/sentry-native/pull/1137 & the update to native tracing in https://github.com/getsentry/sentry-native/pull/1200

Since transactions no longer create a new `trace_id`, we want to document how to set up a trace boundary with `sentry_set_trace()`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
