### PR TITLE
Fix hard coded DSN in the dotnet docs

### DIFF
--- a/docs/platforms/dotnet/index.mdx
+++ b/docs/platforms/dotnet/index.mdx
@@ -84,7 +84,7 @@ To capture all errors, even the one during the startup of your application, you 
 ```csharp
 SentrySdk.Init(options =>
 {
-    options.Dsn = "https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.us.sentry.io/5428537";
+    options.Dsn = "___PUBLIC_DSN___";
     options.Debug = true;
     // Adds request URL and headers, IP and name for users, etc.
     options.SendDefaultPii = true;


### PR DESCRIPTION
## DESCRIBE YOUR PR

The main page for the .NET SDK docs currently includes a hard coded DSN... which would be confusing for users.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ X ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

cc: @vaind @bruno-garcia @Flash0ver 

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
