### PR TITLE
Add org to config options

### DIFF
--- a/docs/platforms/javascript/guides/astro/index.mdx
+++ b/docs/platforms/javascript/guides/astro/index.mdx
@@ -80,6 +80,7 @@ export default defineConfig({
     sentry({
       sourceMapsUploadOptions: {
         project: "___PROJECT_SLUG___",
+        org: "___ORG_SLUG___",
         authToken: process.env.SENTRY_AUTH_TOKEN,
       },
     }),


### PR DESCRIPTION
Source map upload configuration is missing organisation slug, added it. 