### PR TITLE
fix: Reflect most recent node version support for node profiling

### DIFF
--- a/platform-includes/profiling/node-profiling/javascript.mdx
+++ b/platform-includes/profiling/node-profiling/javascript.mdx
@@ -115,11 +115,11 @@ Under the hood, the Sentry profiler uses V8's [CpuProfiler](https://v8docs.nodes
 
 ## Precompiled Binaries
 
-Starting from version `0.1.0`, the `@sentry/profiling-node` package precompiles binaries for a number of common architectures. This minimizes the tooling required to run the package and avoids compiling the package from source in most cases, which speeds up installation. Currently, we ship prebuilt binaries for the following architectures and Node versions:
+The `@sentry/profiling-node` package precompiles binaries for a number of common architectures. This minimizes the tooling required to run the package and avoids compiling the package from source in most cases, which speeds up installation. Currently, we ship prebuilt binaries for the following architectures and Node versions:
 
-- macOS x64: Node v16, v18, v20, v22
-- Linux ARM64 (musl): Node v16, v18, v20, v22
-- Linux x64 (glibc): Node v16, v18, v20, v22
-- Windows x64: Node v16, v18, v20, v22
+- macOS x64: Node v18, v20, v22, v24
+- Linux ARM64 (musl): Node v18, v20, v22, v24
+- Linux x64 (glibc): Node v18, v20, v22, v24
+- Windows x64: Node v18, v20, v22, v24
 
 The set of common architectures should cover a wide variety of use cases, but if you have feedback or experience different behavior, please open an issue in the [Sentry JavaScript SDK](https://github.com/getsentry/sentry-javascript) repository.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

We dont support Node 16 in the SDK anymore, and Node 24 was just added.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
