### PR TITLE
correct tag key char limit

### DIFF
--- a/develop-docs/sdk/expected-features/data-handling.mdx
+++ b/develop-docs/sdk/expected-features/data-handling.mdx
@@ -113,7 +113,7 @@ Fields in the event payload that allow user-specified or dynamic values are rest
 - Event IDs are limited to 36 characters and must be valid UUIDs.
 - Flag keys are limited to 32 characters.
 - Flag values are limited to 200 characters.
-- Tag keys are limited to 32 characters.
+- Tag keys are limited to 200 characters.
 - Tag values are limited to 200 characters.
 - Culprits are limited to 200 characters.
 - Context objects are limited to 8kB.


### PR DESCRIPTION
Tag key char limit was increased to 200: 
- https://github.com/getsentry/relay/blob/master/relay-event-normalization/src/lib.rs#L57-L66
- https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_metrics/consumers/indexer/tags_validator.py#L11-L12
- https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_metrics/configuration.py#L15-L17