### PR TITLE
docs: remove old DSC content

### DIFF
--- a/develop-docs/sdk/telemetry/traces/dynamic-sampling-context.mdx
+++ b/develop-docs/sdk/telemetry/traces/dynamic-sampling-context.mdx
@@ -273,12 +273,3 @@ Previously, we were using the [w3c Trace Context spec](https://www.w3.org/TR/tra
 We switched to the [w3c Baggage spec](https://www.w3.org/TR/baggage) though because it was easier to use, required less code on the SDK side, and had much more [liberal size limits](https://www.w3.org/TR/baggage/#limits) than the trace context spec.
 To make sure that we were not colliding with user defined keys as baggage is an open standard, we decided to prefix all sentry related keys with `sentry-` as a namespace.
 This allowed us to use baggage as an open standard while only having to worry about Sentry data.
-
-### Other Items
-
-TODO - Add some sort of Q&A section on the following questions, after evaluating if they still need to be answered:
-
-- Why must baggage be immutable before the second transaction has been started?
-- What are the consequences and impacts of the immutability of baggage on Dynamic Sampling UX?
-- Why can't we just make the decision for the whole trace in Relay after the trace is complete?
-- What are the differences between Dynamic Sampling on traces vs. transactions?


### PR DESCRIPTION
Seems like it should have been TODO comment in a first place, 3 years ago.

Since in 3 years it hasn't been touched, seems to be good to deleted