### PR TITLE
Remove go and ruby from upcoming SDKs in logs getting started

### DIFF
--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -219,11 +219,6 @@ We're actively working on adding Log functionality to additional SDKs. Check out
     url="https://github.com/getsentry/sentry-php/issues/1824"
   />
 - <LinkWithPlatformIcon
-    platform="go"
-    label="Go"
-    url="https://github.com/getsentry/sentry-go/issues/1000"
-  />
-- <LinkWithPlatformIcon
     platform="ruby"
     label="Ruby"
     url="https://github.com/getsentry/sentry-ruby/issues/2600"

--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -207,7 +207,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
 
 ### Go
 
-- [Go](/platforms/go/logs/)
+- <LinkWithPlatformIcon platform="go" label="Go" url="/platforms/go/logs/" />
 
 ## Upcoming SDKs
 
@@ -217,11 +217,6 @@ We're actively working on adding Log functionality to additional SDKs. Check out
     platform="php"
     label="PHP"
     url="https://github.com/getsentry/sentry-php/issues/1824"
-  />
-- <LinkWithPlatformIcon
-    platform="ruby"
-    label="Ruby"
-    url="https://github.com/getsentry/sentry-ruby/issues/2600"
   />
 - <LinkWithPlatformIcon
     platform="dart"


### PR DESCRIPTION
Removing Go from Upcoming SDKs

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
