### PR TITLE
fix(flutter): Remove outdated manual TTID API

### DIFF
--- a/includes/dart-integrations/routing-instrumentation.mdx
+++ b/includes/dart-integrations/routing-instrumentation.mdx
@@ -99,21 +99,8 @@ final GoRouter _router = GoRouter(
 ## Time to Initial Display
 
 Time to initial display (TTID) provides insight into how long it takes your Widget to launch and draw their first frame. This is measured by adding a span for navigation to a Widget. The SDK then sets the span operation to `ui.load.initial-display` and the span description to the Widget's route name, followed by initial display (for example, `MyWidget initial display`).
-There are two ways to set up TTID:
 
-### Default Versus Manual Setup
-
-The default setup is enabled automatically, but only provides an approximation of TTID. To set a more accurate TTID, manually wrap the desired widget with `SentryDisplayWidget`, as shown below:
-
-```dart
-SentryDisplayWidget(
-  child: MyWidget(),
-)
-```
-
-### Combining the Two Approaches
-
-If you have some Widgets that need accurate measurements while the rest can be automatically approximated, you can use a combination of both the default and the manual method.
+TTID is enabled by default.
 
 ## Time to Full Display
 


### PR DESCRIPTION
We'll remove support for manual TTID, we can remove the docs of it.