### PR TITLE
fix(azure-functions): Show correct installation snippet

### DIFF
--- a/platform-includes/getting-started-install/javascript.azure-functions.mdx
+++ b/platform-includes/getting-started-install/javascript.azure-functions.mdx
@@ -1,0 +1,31 @@
+<OnboardingOption optionId="profiling" hideForThisOption>
+
+```bash {tabTitle:npm}
+npm install @sentry/node --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node
+```
+
+</OnboardingOption>
+
+<OnboardingOption optionId="profiling">
+
+```bash {tabTitle:npm}
+npm install @sentry/node @sentry/profiling-node --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/node @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node
+```
+
+</OnboardingOption>


### PR DESCRIPTION
noticed that we showed the generic browser JS (CDN and NPM package) installation instructions instead of the `@sentry/node` SDK for Azure. This PR adds an `azure-functions` specific install snippet.