### PR TITLE
feat(platform): Set `sentry.source` to `custom` for edge requests

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -18,6 +18,19 @@ export function register() {
       tracesSampleRate: 1,
       debug: false,
       environment: process.env.NODE_ENV === 'development' ? 'development' : undefined,
+      // temporary change for investigating edge middleware tx names
+      beforeSendTransaction(event) {
+        if (
+          event.transaction?.includes('middleware GET') &&
+          event.contexts?.trace?.data
+        ) {
+          event.contexts.trace.data = {
+            ...event.contexts.trace.data,
+            'sentry.source': 'custom',
+          };
+        }
+        return event;
+      },
     });
   }
 }


### PR DESCRIPTION
This is a temporary change to evaluate effects on grouping in Sentry.