### PR TITLE
Detected package version outside of dependency constraint

### DIFF
--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -30,7 +30,7 @@ to help you locate the source of an exception.
 
 In .NET for Android applications the Sentry SDK needs to make use of a limited number of Android APIs that form part of the operating system. Implicitly, Sentry depends on [various Java packages](https://github.com/getsentry/sentry-dotnet/blob/ebc1115d6c928ff56244afa3a1ce1d79b078fbf4/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj#L45-L56) then.
 
-If you are using third party libraries that depend on different versions of these same Java packages, you may see you see `NU1605`, `NU1608` and/or `NU1107` warnings when trying to run `dotnet restore`.
+If you are using third party libraries that depend on different versions of these same Java packages, you may see `NU1605`, `NU1608` and/or `NU1107` warnings when trying to run `dotnet restore`.
 
 Sentry itself only specifies a minimum version of the Java packages that it depends on, so is compatible with any higher versions of the same Java packages. However, these Java packages come with their own dependencies, which are therefore transitive dependencies for Sentry. The transitive dependencies of the Sentry SDK can sometimes be incompatible with the transitive dependencies of other third party libraries and NuGet isn't smart enough to resolve those conflicts without a bit of guidance.
 

--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -26,6 +26,49 @@ will not be sent to Sentry. If Sentry cannot locate symbols, then it cannot perf
 This means that for some types of projects (depending on configuration), you may not see filenames and line numbers
 to help you locate the source of an exception.
 
+## Detected package version outside of dependency constraint
+
+In .NET for Android applications the Sentry SDK needs to make use of a limited number of Android APIs that form part of the operating system. Implicitly, Sentry depends on [various Java packages](https://github.com/getsentry/sentry-dotnet/blob/ebc1115d6c928ff56244afa3a1ce1d79b078fbf4/src/Sentry.Bindings.Android/Sentry.Bindings.Android.csproj#L45-L56) then.
+
+If you are using third party libraries that depend on different versions of these same Java packages, you may see you see `NU1605`, `NU1608` and/or `NU1107` warnings when trying to run `dotnet restore`.
+
+Sentry itself only specifies a minimum version of the Java packages that it depends on, so is compatible with any higher versions of the same Java packages. However, these Java packages come with their own dependencies, which are therefore transitive dependencies for Sentry. The transitive dependencies of the Sentry SDK can sometimes be incompatible with the transitive dependencies of other third party libraries and NuGet isn't smart enough to resolve those conflicts without a bit of guidance.
+
+Such problems need to be resolved on a case by case basis but the following example should demonstrate how you can resolve these issues if you run into them in your own application.
+
+### Example Problem
+
+If you use `Sentry` `5.7.0` in a .NET for Android application targeting `net9.0-android` then Sentry will have various [direct dependencies](https://www.nuget.org/packages/Sentry/5.7.0#dependencies-body-tab). However those direct dependencies come with their own dependencies, which for Sentry are transitive dependencies.
+
+If you also use `Microsoft.Maui.Essentials` version `9.0.50`, ultimately it depends on conflicting version of those same transitive dependencies.
+
+In this scenario you would see a warning or an error like the following when running `dotnet restore`:
+```
+NU1608: Detected package version outside of dependency constraint: Xamarin.AndroidX.Lifecycle.Common.Java8 2.8.5.1 requires Xamarin.AndroidX.Lifecycle.Common (>= 2.8.5.1 && < 2.8.6) but version Xamarin.AndroidX.Lifecycle.Common 2.8.7.2 was resolved.
+```
+
+### Example Solution
+
+To resolve the problem above, you can use [Transitive Pinning](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#transitive-pinning) to resolve explicit versions of transitive dependencies (rather than letting NuGet resolve these automatically).
+
+To enable Transitive Pinning, add the following to your `csproj` or `Directory.Build.props` file:
+
+```xml
+<PropertyGroup>
+  <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+</PropertyGroup>
+```
+
+You can then pin the appropriate versions of the transitive dependency that's causing you problems:
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.7.2" />
+</ItemGroup>
+```
+
+Although the Sentry SDK only needs `Xamarin.AndroidX.Lifecycle.Common.Java8 2.8.5.1`, that version is problematic since it locks the transitive dependency `Xamarin.AndroidX.Lifecycle.Common` into the range `(>= 2.8.5.1 && < 2.8.6)`. By explicitly pinning `Xamarin.AndroidX.Lifecycle.Common.Java8` to `2.8.7.2` to match the version used by `Microsoft.Maui.Essentials`, we can resolve the conflict.
+
 ## Updating to 4.12.0 broke my .NET iOS App
 
 Support for Xcode 16.0 was added on version 4.12.0 of the Sentry SDK for .NET


### PR DESCRIPTION
## DESCRIBE YOUR PR

Added docs on troubleshooting "Detected package version outside of dependency constraint" errors. 

Resolves https://github.com/getsentry/sentry-dotnet/issues/4095 (see [comment](https://github.com/getsentry/sentry-dotnet/issues/4095#issuecomment-2834487925))

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- cc: @Flash0ver 
## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)