### PR TITLE
feat(menu): Add ellipsis to cut long menu items

### DIFF
--- a/src/components/sidebarTableOfContents/index.tsx
+++ b/src/components/sidebarTableOfContents/index.tsx
@@ -33,7 +33,18 @@ function recursiveRender(items: TocItem[]) {
           } as React.CSSProperties
         }
       >
-        <a href={`${i.url}`}>{i.title}</a>
+        <a
+          href={`${i.url}`}
+          style={{
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            display: 'block',
+          }}
+          title={i.title}
+        >
+          {i.title}
+        </a>
         {i.children && <ul>{recursiveRender(i.children)}</ul>}
       </li>
     );

--- a/src/components/sidebarTableOfContents/index.tsx
+++ b/src/components/sidebarTableOfContents/index.tsx
@@ -33,18 +33,7 @@ function recursiveRender(items: TocItem[]) {
           } as React.CSSProperties
         }
       >
-        <a
-          href={`${i.url}`}
-          style={{
-            textOverflow: 'ellipsis',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            display: 'block',
-          }}
-          title={i.title}
-        >
-          {i.title}
-        </a>
+        <a href={`${i.url}`}>{i.title}</a>
         {i.children && <ul>{recursiveRender(i.children)}</ul>}
       </li>
     );

--- a/src/components/sidebarTableOfContents/style.module.scss
+++ b/src/components/sidebarTableOfContents/style.module.scss
@@ -18,6 +18,10 @@
     position: relative;
     line-height: 1.5;
     display: block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+
     color: var(--link-color);
     padding: 0.25em 0;
     opacity: 0.8;


### PR DESCRIPTION
## DESCRIBE YOUR PR

Instead of enlarging the text to two rows, long menu items get an ellipsis at the end, like here:

![image](https://github.com/user-attachments/assets/2003c987-9127-4e8f-b6d2-90afe3aef103)


closes https://github.com/getsentry/sentry-docs/issues/13766
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

