### PR TITLE
remove version from provided url

### DIFF
--- a/platform-includes/getting-started-install/unity.mdx
+++ b/platform-includes/getting-started-install/unity.mdx
@@ -1,8 +1,10 @@
 Install the package via the [Unity Package Manager using a Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html) to Sentry's SDK repository:
 
 ```
-https://github.com/getsentry/unity.git#{{@inject packages.version('sentry.dotnet.unity', '0.0.5') }}
+https://github.com/getsentry/unity.git
 ```
+
+If you want to use a specific version of the SDK, you can append `#{{@inject packages.version('sentry.dotnet.unity', '0.0.5') }}` with the version you want to use to the URL.
 
 <Alert>
 


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry-unity/issues/2162

Not adding the version by default allows users to make use of the `Update` button, since the package is no longer pinned to that specific version.