### PR TITLE
fix(flutter): Update logs snippet

### DIFF
--- a/platform-includes/logs/usage/dart.mdx
+++ b/platform-includes/logs/usage/dart.mdx
@@ -7,9 +7,9 @@ You can pass additional attributes directly to the logging functions. These prop
 ```dart
 Sentry.logger.info("A simple log message");
 Sentry.logger.warn("This is a warning log with attributes.", attributes: {
-  'string-attribute': SentryLogAttribute.string('string'),
-  'int-attribute': SentryLogAttribute.int(1),
-  'double-attribute': SentryLogAttribute.double(1.0),
-  'bool-attribute': SentryLogAttribute.bool(true),
+  'attribute1': SentryLogAttribute.string('string'),
+  'attribute2': SentryLogAttribute.int(1),
+  'attribute3': SentryLogAttribute.double(1.0),
+  'attribute4': SentryLogAttribute.bool(true),
 });
 ```


### PR DESCRIPTION
Updates snippets since currently attributes with hyphens cant be filtered so let's not make it harder for the user to figure out why and give them a snippet with immediate success