### PR TITLE
fix(js): Fix LLM instruction docs

### DIFF
--- a/platform-includes/llm-rules-logs/javascript.nextjs.mdx
+++ b/platform-includes/llm-rules-logs/javascript.nextjs.mdx
@@ -6,6 +6,7 @@
 # Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/nextjs"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-logs/javascript.nextjs.mdx
+++ b/platform-includes/llm-rules-logs/javascript.nextjs.mdx
@@ -3,11 +3,10 @@
 
 ````markdown {filename:rules.md}
 
-# Logs 
+# Logs
 
-- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/nextjs"` 
+- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/nextjs"`
 - Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
 ## Configuration
@@ -25,7 +24,7 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
-  
+
 });
 ```
 
@@ -41,7 +40,7 @@ Sentry.init({
 });
 ```
 
-## Logger Examples 
+## Logger Examples
 
 ```javascript
 import * as Sentry from "@sentry/nextjs";

--- a/platform-includes/llm-rules-logs/javascript.node.mdx
+++ b/platform-includes/llm-rules-logs/javascript.node.mdx
@@ -6,6 +6,7 @@
 # Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/node"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-logs/javascript.node.mdx
+++ b/platform-includes/llm-rules-logs/javascript.node.mdx
@@ -3,11 +3,10 @@
 
 ````markdown {filename:rules.md}
 
-# Logs 
+# Logs
 
-- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/node"` 
+- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/node"`
 - Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
 ## Configuration
@@ -25,7 +24,7 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
-  
+
 });
 ```
 
@@ -41,7 +40,7 @@ Sentry.init({
 });
 ```
 
-## Logger Examples 
+## Logger Examples
 
 ```javascript
 import * as Sentry from "@sentry/node";
@@ -65,4 +64,4 @@ logger.fatal("Database connection pool exhausted", {
 });
 ```
 ````
-</Expandable> 
+</Expandable>

--- a/platform-includes/llm-rules-logs/javascript.react.mdx
+++ b/platform-includes/llm-rules-logs/javascript.react.mdx
@@ -3,11 +3,10 @@
 
 ````markdown {filename:rules.md}
 
-# Logs 
+# Logs
 
-- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/react"` 
+- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/react"`
 - Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
 ## Configuration
@@ -23,7 +22,7 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
-  
+
 });
 ```
 
@@ -39,7 +38,7 @@ Sentry.init({
 });
 ```
 
-## Logger Examples 
+## Logger Examples
 
 ```javascript
 import * as Sentry from "@sentry/react";

--- a/platform-includes/llm-rules-logs/javascript.react.mdx
+++ b/platform-includes/llm-rules-logs/javascript.react.mdx
@@ -6,6 +6,7 @@
 # Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/react"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-platform/_default.mdx
+++ b/platform-includes/llm-rules-platform/_default.mdx
@@ -75,6 +75,7 @@ async function fetchUserData(userId) {
 # Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/browser"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-platform/_default.mdx
+++ b/platform-includes/llm-rules-platform/_default.mdx
@@ -1,9 +1,8 @@
 <Expandable title="AI Rules for Cursor or Windsurf" copy={true}>
 
-Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration. 
+Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-
 These examples should be used as guidance when configuring Sentry functionlaity within a project.
 
 # Error / Exception Tracking
@@ -11,11 +10,72 @@ These examples should be used as guidance when configuring Sentry functionlaity 
 - Use `Sentry.captureException(error)` to capture an exception and log the error in Sentry.
 - Use this in try catch blocks or areas where exceptions are expected
 
-# Logs 
+# Tracing Examples
 
-- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/browser"` 
+- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
+- Use the `Sentry.startSpan` function to create a span
+- Child spans can exist within a parent span
+
+## Custom Span instrumentation in component actions
+
+- Name custom spans with meaningful names and operations.
+- Attach attributes based on relevant information and metrics from the request
+
+```javascript
+function TestComponent() {
+  const handleTestButtonClick = () => {
+    // Create a transaction/span to measure performance
+    Sentry.startSpan(
+      {
+        op: "ui.click",
+        name: "Test Button Click",
+      },
+      (span) => {
+        const value = "some config";
+        const metric = "some metric";
+
+        // Metrics can be added to the span
+        span.setAttribute("config", value);
+        span.setAttribute("metric", metric);
+
+        doSomething();
+      }
+    );
+  };
+
+  return (
+    <button type="button" onClick={handleTestButtonClick}>
+      Test Sentry
+    </button>
+  );
+}
+```
+
+## Custom span instrumentation in API calls
+
+- Name custom spans with meaningful names and operations.
+- Attach attributes based on relevant information and metrics from the request
+
+```javascript
+async function fetchUserData(userId) {
+  return Sentry.startSpan(
+    {
+      op: "http.client",
+      name: `GET /api/users/${userId}`,
+    },
+    async () => {
+      const response = await fetch(`/api/users/${userId}`);
+      const data = await response.json();
+      return data;
+    }
+  );
+}
+```
+
+# Logs
+
+- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/browser"`
 - Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
 - Sentry offers a `consoleLoggingIntegration` that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
 ## Configuration
@@ -31,7 +91,6 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
-  
 });
 ```
 
@@ -47,7 +106,7 @@ Sentry.init({
 });
 ```
 
-## Logger Examples 
+## Logger Examples
 
 ```javascript
 import * as Sentry from "@sentry/browser";
@@ -69,75 +128,6 @@ logger.fatal("Database connection pool exhausted", {
   database: "users",
   activeConnections: 100,
 });
-```
-
-# Tracing Examples
-
-- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-- Use the `Sentry.startSpan` function to create a span
-- Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-- Name custom spans with meaningful names and operations.
-- Attach attributes based on relevant information and metrics from the request
-
-```javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan({ 
-      op: "ui.click", 
-      name: "Test Button Click" 
-    }, async (span) => {
-       
-      const value = "some config"
-      const metric = "some metric"
-      
-      // Metrics can be added to the span
-      span.setAttribute("config", value)
-      span.setAttribute("metric", metric)
-      
-      doSomething();
-    });
-  };
-
-  return (
-    <button 
-      type="button" 
-      onClick={handleTestButtonClick}
-    >
-      Test Sentry
-    </button>
-  );
-}
-```
-
-## Custom span instrumentation in API calls
-
-- Name custom spans with meaningful names and operations.
-- Attach attributes based on relevant information and metrics from the request
-
-```javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: `GET /api/users/${userId}`,
-    },
-    async () => {
-      try {
-        const response = await fetch(`/api/users/${userId}`);
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        // Capture error with the current span
-        Sentry.captureException(error);
-        throw error;
-      }
-    }
-  );
-}
 ```
 ````
 

--- a/platform-includes/llm-rules-platform/javascript.nextjs.mdx
+++ b/platform-includes/llm-rules-platform/javascript.nextjs.mdx
@@ -1,73 +1,14 @@
 <Expandable title="AI Rules for Cursor or Windsurf" copy={true}>
 
-Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration. 
+Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-
 These examples should be used as guidance when configuring Sentry functionality within a project.
 
 # Exception Catching
 
 - Use `Sentry.captureException(error)` to capture an exception and log the error in Sentry.
 - Use this in try catch blocks or areas where exceptions are expected
-
-# Logs 
-
-- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/nextjs"`
-- Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
-- Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
-
-## Configuration
-
-- In NextJS the client side Sentry initialization is in `instrumentation-client.ts`, the server initialization is in `sentry.edge.config.ts` and the edge initialization is in `sentry.server.config.ts`
-- Initialization does not need to be repeated in other files, it only needs to happen the files mentioned above. You should use `import * as Sentry from "@sentry/nextjs"` to reference Sentry functionality
-
-### Baseline
-
-```javascript
-import * as Sentry from "@sentry/nextjs";
-
-Sentry.init({
-  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-
-  _experiments: {
-    enableLogs: true,
-  },
-  
-});
-```
-
-### Logger Integration
-```javascript
-Sentry.init({
-  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
-  ],
-});
-```
-
-## Logger Examples 
-
-```javascript
-logger.trace("Starting database connection", { database: "users" });
-logger.debug("Cache miss for user", { userId: 123 });
-logger.info("Updated profile", { profileId: 345 });
-logger.warn("Rate limit reached for endpoint", {
-  endpoint: "/api/results/",
-  isEnterprise: false,
-});
-logger.error("Failed to process payment", {
-  orderId: "order_123",
-  amount: 99.99,
-});
-logger.fatal("Database connection pool exhausted", {
-  database: "users",
-  activeConnections: 100,
-});
-```
 
 # Tracing Examples
 
@@ -84,27 +25,26 @@ logger.fatal("Database connection pool exhausted", {
 function TestComponent() {
   const handleTestButtonClick = () => {
     // Create a transaction/span to measure performance
-    Sentry.startSpan({ 
-      op: "ui.click", 
-      name: "Test Button Click" 
-    }, async (span) => {
-       
-      const value = "some config"
-      const metric = "some metric"
-      
-      // Metrics can be added to the span
-      span.setAttribute("config", value)
-      span.setAttribute("metric", metric)
-      
-      doSomething();
-    });
+    Sentry.startSpan(
+      {
+        op: "ui.click",
+        name: "Test Button Click",
+      },
+      (span) => {
+        const value = "some config";
+        const metric = "some metric";
+
+        // Metrics can be added to the span
+        span.setAttribute("config", value);
+        span.setAttribute("metric", metric);
+
+        doSomething();
+      }
+    );
   };
 
   return (
-    <button 
-      type="button" 
-      onClick={handleTestButtonClick}
-    >
+    <button type="button" onClick={handleTestButtonClick}>
       Test Sentry
     </button>
   );
@@ -124,18 +64,69 @@ async function fetchUserData(userId) {
       name: `GET /api/users/${userId}`,
     },
     async () => {
-      try {
-        const response = await fetch(`/api/users/${userId}`);
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        // Capture error with the current span
-        Sentry.captureException(error);
-        throw error;
-      }
+      const response = await fetch(`/api/users/${userId}`);
+      const data = await response.json();
+      return data;
     }
   );
 }
+```
+
+# Logs
+
+- Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/nextjs"`
+- Reference the logger using `const { logger } = Sentry`
+- Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
+
+## Configuration
+
+- In NextJS the client side Sentry initialization is in `instrumentation-client.ts`, the server initialization is in `sentry.edge.config.ts` and the edge initialization is in `sentry.server.config.ts`
+- Initialization does not need to be repeated in other files, it only needs to happen the files mentioned above. You should use `import * as Sentry from "@sentry/nextjs"` to reference Sentry functionality
+
+### Baseline
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+
+  _experiments: {
+    enableLogs: true,
+  },
+});
+```
+
+### Logger Integration
+
+```javascript
+Sentry.init({
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  integrations: [
+    // send console.log, console.error, and console.warn calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+  ],
+});
+```
+
+## Logger Examples
+
+```javascript
+logger.trace("Starting database connection", { database: "users" });
+logger.debug("Cache miss for user", { userId: 123 });
+logger.info("Updated profile", { profileId: 345 });
+logger.warn("Rate limit reached for endpoint", {
+  endpoint: "/api/results/",
+  isEnterprise: false,
+});
+logger.error("Failed to process payment", {
+  orderId: "order_123",
+  amount: 99.99,
+});
+logger.fatal("Database connection pool exhausted", {
+  database: "users",
+  activeConnections: 100,
+});
 ```
 ````
 

--- a/platform-includes/llm-rules-platform/javascript.nextjs.mdx
+++ b/platform-includes/llm-rules-platform/javascript.nextjs.mdx
@@ -75,6 +75,7 @@ async function fetchUserData(userId) {
 # Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/nextjs"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-platform/javascript.node.mdx
+++ b/platform-includes/llm-rules-platform/javascript.node.mdx
@@ -70,6 +70,7 @@ async function fetchUserData(userId) {
 # Logs
 
 - Where logs are used, ensure they are imported using `import * as Sentry from "@sentry/node"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-platform/javascript.node.mdx
+++ b/platform-includes/llm-rules-platform/javascript.node.mdx
@@ -1,9 +1,8 @@
 <Expandable title="AI Rules for Cursor or Windsurf" copy={true}>
 
-Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration. 
+Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-
 These examples should be used as guidance when configuring Sentry functionlaity within a project.
 
 # Error / Exception Tracking
@@ -11,11 +10,67 @@ These examples should be used as guidance when configuring Sentry functionlaity 
 - Use `Sentry.captureException(error)` to capture an exception and log the error in Sentry.
 - Use this in try catch blocks or areas where exceptions are expected
 
-# Logs 
+# Tracing Examples
+
+- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
+- Ensure you are creating custom spans with meaningful names and operations
+- Use the `Sentry.startSpan` function to create a span
+- Child spans can exist within a parent span
+
+## Custom Span instrumentation in component actions
+
+```javascript
+function TestComponent() {
+  const handleTestButtonClick = () => {
+    // Create a transaction/span to measure performance
+    Sentry.startSpan(
+      {
+        op: "ui.click",
+        name: "Test Button Click",
+      },
+      (span) => {
+        const value = "some config";
+        const metric = "some metric";
+
+        // Metrics can be added to the span
+        span.setAttribute("config", value);
+        span.setAttribute("metric", metric);
+
+        doSomething();
+      }
+    );
+  };
+
+  return (
+    <button type="button" onClick={handleTestButtonClick}>
+      Test Sentry
+    </button>
+  );
+}
+```
+
+## Custom span instrumentation in API calls
+
+```javascript
+async function fetchUserData(userId) {
+  return Sentry.startSpan(
+    {
+      op: "http.client",
+      name: `GET /api/users/${userId}`,
+    },
+    async () => {
+      const response = await fetch(`/api/users/${userId}`);
+      const data = await response.json();
+      return data;
+    }
+  );
+}
+```
+
+# Logs
 
 - Where logs are used, ensure they are imported using `import * as Sentry from "@sentry/node"`
 - Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
 - Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
 ## Configuration
@@ -33,7 +88,6 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
-  
 });
 ```
 
@@ -49,7 +103,7 @@ Sentry.init({
 });
 ```
 
-## Logger Examples 
+## Logger Examples
 
 ```javascript
 logger.trace("Starting database connection", { database: "users" });
@@ -67,70 +121,6 @@ logger.fatal("Database connection pool exhausted", {
   database: "users",
   activeConnections: 100,
 });
-```
-
-# Tracing Examples
-
-- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-- Ensure you are creating custom spans with meaningful names and operations
-- Use the `Sentry.startSpan` function to create a span
-- Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-```javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan({ 
-      op: "ui.click", 
-      name: "Test Button Click" 
-    }, async (span) => {
-       
-      const value = "some config"
-      const metric = "some metric"
-      
-      // Metrics can be added to the span
-      span.setAttribute("config", value)
-      span.setAttribute("metric", metric)
-      
-      doSomething();
-    });
-  };
-
-  return (
-    <button 
-      type="button" 
-      onClick={handleTestButtonClick}
-    >
-      Test Sentry
-    </button>
-  );
-}
-```
-
-## Custom span instrumentation in API calls
-
-```javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: `GET /api/users/${userId}`,
-    },
-    async () => {
-      try {
-        const response = await fetch(`/api/users/${userId}`);
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        // Capture error with the current span
-        Sentry.captureException(error);
-        throw error;
-      }
-    }
-  );
-}
 ```
 ````
 

--- a/platform-includes/llm-rules-platform/javascript.react.mdx
+++ b/platform-includes/llm-rules-platform/javascript.react.mdx
@@ -70,6 +70,7 @@ async function fetchUserData(userId) {
 # Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/react"`
+- Enable logging in Sentry using `Sentry.init({ _experiments: { enableLogs: true } })`
 - Reference the logger using `const { logger } = Sentry`
 - Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 

--- a/platform-includes/llm-rules-platform/javascript.react.mdx
+++ b/platform-includes/llm-rules-platform/javascript.react.mdx
@@ -1,9 +1,8 @@
 <Expandable title="AI Rules for Cursor or Windsurf" copy={true}>
 
-Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration. 
+Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-
 These examples should be used as guidance when configuring Sentry functionlaity within a project.
 
 # Error / Exception Tracking
@@ -11,11 +10,67 @@ These examples should be used as guidance when configuring Sentry functionlaity 
 - Use `Sentry.captureException(error)` to capture an exception and log the error in Sentry.
 - Use this in try catch blocks or areas where exceptions are expected
 
-# Logs 
+# Tracing Examples
+
+- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
+- Ensure you are creating custom spans with meaningful names and operations
+- Use the `Sentry.startSpan` function to create a span
+- Child spans can exist within a parent span
+
+## Custom Span instrumentation in component actions
+
+```javascript
+function TestComponent() {
+  const handleTestButtonClick = () => {
+    // Create a transaction/span to measure performance
+    Sentry.startSpan(
+      {
+        op: "ui.click",
+        name: "Test Button Click",
+      },
+      (span) => {
+        const value = "some config";
+        const metric = "some metric";
+
+        // Metrics can be added to the span
+        span.setAttribute("config", value);
+        span.setAttribute("metric", metric);
+
+        doSomething();
+      }
+    );
+  };
+
+  return (
+    <button type="button" onClick={handleTestButtonClick}>
+      Test Sentry
+    </button>
+  );
+}
+```
+
+## Custom span instrumentation in API calls
+
+```javascript
+async function fetchUserData(userId) {
+  return Sentry.startSpan(
+    {
+      op: "http.client",
+      name: `GET /api/users/${userId}`,
+    },
+    async () => {
+      const response = await fetch(`/api/users/${userId}`);
+      const data = await response.json();
+      return data;
+    }
+  );
+}
+```
+
+# Logs
 
 - Where logs are used, ensure Sentry is imported using `import * as Sentry from "@sentry/react"`
 - Reference the logger using `const { logger } = Sentry`
-- Sentry initialization needs to be updated to include the `logger` integration.
 - Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
 
 ## Configuration
@@ -31,7 +86,6 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
-  
 });
 ```
 
@@ -47,7 +101,7 @@ Sentry.init({
 });
 ```
 
-## Logger Examples 
+## Logger Examples
 
 ```javascript
 logger.trace("Starting database connection", { database: "users" });
@@ -65,70 +119,6 @@ logger.fatal("Database connection pool exhausted", {
   database: "users",
   activeConnections: 100,
 });
-```
-
-# Tracing Examples
-
-- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-- Ensure you are creating custom spans with meaningful names and operations
-- Use the `Sentry.startSpan` function to create a span
-- Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-```javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan({ 
-      op: "ui.click", 
-      name: "Test Button Click" 
-    }, async (span) => {
-       
-      const value = "some config"
-      const metric = "some metric"
-      
-      // Metrics can be added to the span
-      span.setAttribute("config", value)
-      span.setAttribute("metric", metric)
-      
-      doSomething();
-    });
-  };
-
-  return (
-    <button 
-      type="button" 
-      onClick={handleTestButtonClick}
-    >
-      Test Sentry
-    </button>
-  );
-}
-```
-
-## Custom span instrumentation in API calls
-
-```javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: `GET /api/users/${userId}`,
-    },
-    async () => {
-      try {
-        const response = await fetch(`/api/users/${userId}`);
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        // Capture error with the current span
-        Sentry.captureException(error);
-        throw error;
-      }
-    }
-  );
-}
 ```
 ````
 


### PR DESCRIPTION
This fixes some content that was added in https://github.com/getsentry/sentry-docs/pull/13752:

1. Moves logs down below tracing, as that is IMHO more important (and stable - logs is still experimental 😬 ) (should not affect LLMs too much, but for consistency sake with other things...)
2. Remove the line about adding the `logger` integration, which does not exist
3. Fix the tracing snippets to be better - what we recommended there was actually not what we would want users to do.