### PR TITLE
Fix Vercel AI instructions

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -37,7 +37,7 @@ The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.
 
 ```javascript
 Sentry.init({
-  integrations: [new Sentry.vercelAIIntegration()],
+  integrations: [Sentry.vercelAIIntegration()],
 });
 ```
 


### PR DESCRIPTION
`Sentry.vercelAIIntegration` is not a constructor so drop the `new` keyword.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## IS YOUR CHANGE URGENT?  

None: Not urgent, can wait up to 1 week+


