### PR TITLE
fix: remove new method from tedious docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
@@ -41,7 +41,7 @@ The `tediousIntegration` adds instrumentation for the `tedious` library to captu
 
 ```javascript
 Sentry.init({
-  integrations: [new Sentry.tediousIntegration()],
+  integrations: [Sentry.tediousIntegration()],
 });
 ```
 


### PR DESCRIPTION
`new` is incorrect here