### PR TITLE
fix: Remove new keyword from js integrations

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/amqplib.mdx
@@ -41,7 +41,7 @@ The `amqplibIntegration` adds instrumentation for the `amqplib` library to captu
 
 ```JavaScript
 Sentry.init({
-  integrations: [new Sentry.amqplibIntegration()],
+  integrations: [Sentry.amqplibIntegration()],
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/bunserver.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/bunserver.mdx
@@ -21,6 +21,6 @@ The `bunServerIntegration` instruments [`Bun.serve` API](https://bun.sh/docs/api
 import * as Sentry from '@sentry/bun';
 
 Sentry.init({
-  integrations: [new Sentry.bunServerIntegration()],
+  integrations: [Sentry.bunServerIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/connect.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/connect.mdx
@@ -22,7 +22,7 @@ The `connectIntegration` adds instrumentation for the Hapi framework to capture 
 
 ```JavaScript
 Sentry.init({
-  integrations: [new Sentry.connectIntegration()],
+  integrations: [Sentry.connectIntegration()],
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/fastify.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fastify.mdx
@@ -22,7 +22,7 @@ The `fastifyIntegration` adds instrumentation for the Fastify framework to captu
 
 ```JavaScript
 Sentry.init({
-  integrations: [new Sentry.fastifyIntegration()],
+  integrations: [Sentry.fastifyIntegration()],
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/hapi.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/hapi.mdx
@@ -22,7 +22,7 @@ The `hapiIntegration` adds instrumentation for the Hapi framework to capture spa
 
 ```JavaScript
 Sentry.init({
-  integrations: [new Sentry.hapiIntegration()],
+  integrations: [Sentry.hapiIntegration()],
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/koa.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/koa.mdx
@@ -22,7 +22,7 @@ The `koaIntegration` adds instrumentation for the Koa framework to capture spans
 
 ```JavaScript
 Sentry.init({
-  integrations: [new Sentry.koaIntegration()],
+  integrations: [Sentry.koaIntegration()],
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/lrumemoizer.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/lrumemoizer.mdx
@@ -41,7 +41,7 @@ The `lruMemoizerIntegration` adds instrumentation for the `lru-memoizer` library
 
 ```javascript
 Sentry.init({
-  integrations: [new Sentry.lruMemoizerIntegration()],
+  integrations: [Sentry.lruMemoizerIntegration()],
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/tedious.mdx
@@ -41,7 +41,7 @@ The `tediousIntegration` adds instrumentation for the `tedious` library to captu
 
 ```javascript
 Sentry.init({
-  integrations: [new Sentry.tediousIntegration()],
+  integrations: [Sentry.tediousIntegration()],
 });
 ```
 


### PR DESCRIPTION
We don't use class based integrations so these aren't needed anymore
