### PR TITLE
dotnet userfeedback

### DIFF
--- a/docs/platforms/unity/user-feedback/index.mdx
+++ b/docs/platforms/unity/user-feedback/index.mdx
@@ -15,18 +15,11 @@ User Feedback for **[ASP.NET](/platforms/dotnet/guides/aspnet/user-feedback/#int
 
 </Alert>
 
-You can create a form to collect the user input in your preferred framework, and use the SDK's API to send the information to Sentry. You can also use the widget, as described below. If you'd prefer an alternative to the widget or do not have a JavaScript frontend, you can use this API:
+You can create a form to collect the user input in your preferred framework, and use the SDK's API to send the information to Sentry. You can also use the widget, as described below. If you'd prefer an alternative to the widget or do not have a web frontend, you can use this API:
 
 ```csharp {tabTitle:C#}
 var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
 
-SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");
+SentrySdk.CaptureFeedback(eventId, "user@example.com", "It broke.", "The User");
 ```
 
-```fsharp {tabTitle:F#}
-open Sentry
-
-let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
-
-SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User")
-```


### PR DESCRIPTION
We should do a rename on all of the docs for `CaptureUserFeedback` since the API is deprecated.

@jamescrosswell does this overload exist? I quickly looked the API and it takes `UserFeedback` as an argument.
Calling `CaptureFeedback(new Feedback` is pretty cumbersome 