### PR TITLE
Python hint about changed grouping by changing of an option

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -119,6 +119,8 @@ When enabled, the SDK will capture a snapshot of local variables to send with th
 
 When capturing errors, Sentry stack traces typically only include frames that start the moment an error occurs. But if the `add_full_stack` option is enabled (set to `True`), all frames from the start of execution will be included in the stack trace sent to Sentry.
 
+Note: Grouping of issues in Sentry is based on stack traces. If you change this value in an existing Sentry setup new groups for already known errors will be created.
+
 </SdkOption>
 
 <SdkOption name="max_stack_frames" type='int' defaultValue='100'>
@@ -400,7 +402,7 @@ sentry_sdk.init(custom_repr=custom_repr)
 
 <SdkOption name="profile_lifecycle" type='str' defaultValue='manual'>
 
-Determines how the profiler will run, accepts two values: `manual` or `trace`. 
+Determines how the profiler will run, accepts two values: `manual` or `trace`.
 
 In `manual` mode, you control when the profiler collects data by explicitly calling `sentry_sdk.profiler.start_profiler` and `sentry_sdk.profiler.stop_profiler`. You are entirely in control of when the profiler runs.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
A small hint that changing this option will result in changed grouping of errors into issue. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
