### PR TITLE
Unreal Engine: Add note on supported platforms for Crash Reporter

### DIFF
--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -21,6 +21,12 @@ Below we'll break down each step in detail.
 The UE Crash Reporter is provided out of the box by Epic Games. It is able to collect relevant
 information about the crash and send it to a service like Sentry to process.
 
+<Alert>
+
+Crash Reporter is supported only on desktop (Windows, Mac, Linux). In order to capture crashes on mobile and consoles, you need to use the Sentry SDK.
+
+</Alert>
+
 Adding it to your game means that in case a crash happens, the following dialog is displayed
 to the user:
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -23,7 +23,7 @@ information about the crash and send it to a service like Sentry to process.
 
 <Alert>
 
-Crash Reporter is supported only on desktop (Windows, Mac, Linux). In order to capture crashes on mobile and consoles, you need to use the Sentry SDK.
+Epic Games only provides the Crash Reporter Client on desktop (Windows, Mac, Linux). In order to capture crashes on mobile and consoles, you need to use the Sentry SDK, which support all platforms, including desktop.
 
 </Alert>
 


### PR DESCRIPTION
This PR adds a note about the platforms where `Crash Reporter` is supported as an addition to the `CRC vs Sentry SDK` comparison.