### PR TITLE
ref(nextjs): Point out `next dev --turbo` minimum required NextJS version

### DIFF
--- a/includes/nextjs-turbopack-warning-expandable.mdx
+++ b/includes/nextjs-turbopack-warning-expandable.mdx
@@ -4,7 +4,7 @@ The Sentry SDK doesn't yet fully support Turbopack production builds (`next buil
 
 If you upgraded the Sentry SDK to the latest version and installed Next.js on version `15.3.0` or later, the SDK will capture all data as expected, however, it is currently not possible to apply sourcemaps to Turbopack production builds.
 
-Turbopack in dev-mode (`next dev --turbopack`) is fully supported.
+Turbopack in dev-mode (`next dev --turbopack`) is fully supported for Next.js 15.3.0 and later. To verify your Sentry setup, temporarily remove the `--turbo` if you're on older Next.js versions.
 
 Check the latest information on [Sentry's support for Turbopack on GitHub](https://github.com/getsentry/sentry-javascript/issues/8105).
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

As pointed out in https://github.com/getsentry/sentry-wizard/issues/1001#issuecomment-2905580172, the wizard tells users to temporarily remove the `--turbo` flag to verify the SDK setup. However, we don't show the same information in the docs which is potentially confusing. This PR points out that `next dev --turbo` is only fully supported from Next 15.3.0 onwards. This is because `instrumentation-client.ts` is only picked up by turbo from this version onwards and we can't inject it like in webpack for older Next versions. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
