### PR TITLE
fix(react-native): removed floating `decluttering Sentry` header

### DIFF
--- a/docs/platforms/react-native/configuration/filtering.mdx
+++ b/docs/platforms/react-native/configuration/filtering.mdx
@@ -71,10 +71,6 @@ You can use the <PlatformIdentifier name="ignore-errors" /> option to filter out
 
 <PlatformContent includePath="configuration/ignore-errors" />
 
-### Decluttering Sentry
-
-<PlatformContent includePath="configuration/decluttering" />
-
 ## Filtering Transaction Events
 
 To prevent certain transactions from being reported to Sentry, use the <PlatformIdentifier name="traces-sampler" /> or <PlatformIdentifier name="before-send-transaction" /> configuration option, which allows you to provide a function to evaluate the current transaction and drop it if it's not one you want.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Going through the RN docs I found [this heading](https://docs.sentry.io/platforms/react-native/configuration/filtering/#decluttering-sentry) with empty content. 

A few other SDKs have a paragraph here ([Android](https://docs.sentry.io/platforms/android/configuration/filtering/#decluttering-sentry), [Python](https://docs.sentry.io/platforms/python/configuration/filtering/#decluttering-sentry), [Java](https://docs.sentry.io/platforms/java/configuration/filtering/#decluttering-sentry)), so either RN is just missing content or it doesn't need the section.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+
