### PR TITLE
docs(python): Mention logger log level is respected for logs

### DIFF
--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -7,19 +7,51 @@ import sentry_sdk
 import logging
 
 sentry_sdk.init(
-  dsn="___PUBLIC_DSN___",
-  _experiments={
-      "enable_logs": True
-  }
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "enable_logs": True
+    }
 )
 
 # Your existing logging setup
-my_logger = logging.Logger("some-logger")
+my_logger = logging.getLogger(__name__)
+my_logger.setLevel(logging.INFO)
 
 my_value = 42
 my_logger.debug('In this example debug events will not be sent to Sentry logs. my_value=%s', my_value)
 my_logger.info('But info events will be sent to Sentry logs. my_value=%s', my_value)
 ```
+
+By default, the logging integration sends INFO-level logs and higher to Sentry logs. You can set a different threshold via the `LoggingIntegration`'s `sentry_logs_level` parameter. However, regardless of the `sentry_logs_level` setting, the SDK only sends logs if they are at or above the logger's level.
+
+```python
+import sentry_sdk
+import logging
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "enable_logs": True
+    },
+    integrations=[
+        # Only send WARNING (and higher) logs to Sentry logs,
+        # even if the logger is set to a lower level.
+        LoggingIntegration(sentry_logs_level=logging.WARNING),
+    ]
+)
+
+my_logger = logging.getLogger(__name__)
+my_logger.setLevel(logging.INFO)
+
+my_value = 42
+my_logger.info('This will not be sent to Sentry logs, even though the logger is set to INFO. my_value=%s', my_value)
+my_logger.warning('This will be sent to Sentry logs. my_value=%s', my_value)
+
+my_logger.setLevel(logging.ERROR)
+my_logger.warning('Now, this log message will not be sent to Sentry logs, since the logger is set to ERROR.')
+```
+
 
 The logging integration automatically monkeypatches a handler into all loggers except for the root logger. If you'd like to manually configure the handler, you can do that like so:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarify that the Logging Integration respects the logger's configured log level when using Sentry logs.

Fixes #13829

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)