### PR TITLE
feat(logs): Expand attributes section for logs spec and specify defaults for every platform

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -371,6 +371,12 @@ For mobile, desktop, and native SDKs (Android, Apple, Electron, etc.), the SDKs 
 }
 ```
 
+#### Future Default Attributes
+
+The SDKs should aim to minimize the number of default attributes attached to a log. Logs are intended to be lightweight, and we want to try to keep the average byte size of a log as small as possible as users will be charged per byte size of logs sent.
+
+We are trying to settle on a balance of debuggability vs. smaller byte size for logs which is why new default attributes should only be added after significant feedback from users and discussion internally with the SDK and ingest teams. There is no hard rule about what exact attributes are allowed, every proposed new attribute will be evaluated on a case-by-case basis.
+
 ### Data Category and Rate Limiting
 
 A new data category for logs has been added to Relay, `log_item`. Both the `log` envelope and `otel_log` envelope is covered by this data category. This will need to implemented in the SDK. Rate limiting applies as usual, there is no special rate limit or rate limiting behaviour for logs. With this data category, client outcomes should be tracked by the SDKs to track how often logs are dropped by the SDK.


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-28

After testing with some SDKs and getting feedback, we've decided on a list of default attributes the SDKs should try to attach to logs.

This includes
1. user attributes from https://develop.sentry.dev/sdk/data-model/event-payloads/user/ 
2. browser attributes, parsed from user agents (https://github.com/getsentry/relay/pull/4757)
3. os and device attributes attached to mobile, desktop, and native sdks, based on https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/

I also re-organized this section to make things a bit more clear.