### PR TITLE
remove version pinning Unity repo

### DIFF
--- a/platform-includes/getting-started-install/unity.mdx
+++ b/platform-includes/getting-started-install/unity.mdx
@@ -1,7 +1,7 @@
 Install the package via the [Unity Package Manager using a Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html) to Sentry's SDK repository:
 
 ```
-https://github.com/getsentry/unity.git#{{@inject packages.version('sentry.dotnet.unity', '0.0.5') }}
+https://github.com/getsentry/unity.git
 ```
 
 <Alert>


### PR DESCRIPTION
See:
* https://github.com/getsentry/sentry-unity/issues/2162
