### PR TITLE
docs(nextjs): Add App Router pageload-SSR span linking limitation note

### DIFF
--- a/docs/platforms/javascript/common/tracing/distributed-tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/distributed-tracing/index.mdx
@@ -31,7 +31,7 @@ If you run any JavaScript applications in your distributed system, make sure tha
 
 <Alert>
 
-Pageload to SSR span linking is not supported on the App Router with Next.js versions up to and including 14.
+Pageload to SSR tracing is currently not supported on the App Router with Next.js versions up to and including 14.
 
 </Alert>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Update docs to reflect trace propagation investigation results for Next.js versions 14 and earlier with the App Router: Page load to SSR span linking is not supported.

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
