### PR TITLE
docs(cli): Clarify release commit range

### DIFF
--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -85,10 +85,10 @@ To see which repos are available for the organization, you can run `sentry-cli r
 
 Note that you need to refer to releases you need to use the actual full commit SHA. If you want to refer to tags or references (like _HEAD_), the repository needs to be checked out and reachable from the path where you invoke _sentry-cli_.
 
-If you also want to set a previous commit instead of letting the server use the previous release as the base point you can do that by setting a commit range:
+If you also want to set a previous commit instead of letting the server use the previous release as the base point you can do that by setting a commit range. Replace `<commit_of_previous_release>` and `<commit_of_current_release>` with the last commit of the previous release and the release you are creating, respectively.
 
 ```bash
-sentry-cli releases set-commits "$VERSION" --commit "repo-owner/repo-name@from..to"
+sentry-cli releases set-commits "$VERSION" --commit "repo-owner/repo-name@<commit_of_previous_release>..<commit_of_current_release>"
 ```
 
 ### Alternatively: Without a Repository Integration


### PR DESCRIPTION
Specifiy that the "from" commit is supposed to be the last commit of the previous release.

Fixes #10045