### PR TITLE
chore(webhooks): remove the 1000 -> timeout message

### DIFF
--- a/docs/organization/integrations/integration-platform/webhooks.mdx
+++ b/docs/organization/integrations/integration-platform/webhooks.mdx
@@ -130,7 +130,7 @@ The actor is who, if anyone, triggered the webhook. If a user in Sentry triggere
 
 ## Response
 
-Webhooks should respond within 1 second. Otherwise, the response is considered a timeout. If a webhook has 1000 timeouts within 24 hours, the webhook will be unsubscribed from receiving events.
+Webhooks should respond within 1 second. Otherwise, the response is considered a timeout.
 
 ## Event Types
 


### PR DESCRIPTION
We disabled the logic for this: https://github.com/getsentry/sentry/pull/88216