### PR TITLE
docs(api): Use correct HTTP method for specific issue

### DIFF
--- a/develop-docs/backend/api/design.mdx
+++ b/develop-docs/backend/api/design.mdx
@@ -124,19 +124,19 @@ Resources can get complicated when you need to expose batch operations vs single
 Let's say for example we have an endpoint that mutates an issue:
 
 ```
-POST /api/0/organizations/{org}/issues/{issue}/
+PUT /api/0/organizations/{org}/issues/{issue}/
 ```
 
 When designing a batch interface, we simply expose it on the collection instead of the individual resource:
 
 ```
-POST /api/0/organizations/{org}/issues/
+PUT /api/0/organizations/{org}/issues/
 ```
 
 You may also need to expose selectors on batch resources, which can be done through normal request parameters:
 
 ```
-POST /api/0/organizations/{org}/issues/
+PUT /api/0/organizations/{org}/issues/
 {
   "issues": [1, 2, 3]
 }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
While going through the API docs page, I noticed that the example around mutating issues uses the POST method, but earlier on this docs page, it explicitly states that any endpoints whose purpose is to just update should be a PUT. Moreover, the endpoints in this example are real and there is no POST for them.

## IS YOUR CHANGE URGENT?  
No
