### PR TITLE
feat(browser): Document `unregisterOriginalCallbacks` option in `browserApiErrors` integration page

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
@@ -116,7 +116,7 @@ List of default event targets:
 
 _Type: `boolean`_
 
-Unregister the original callbacks of `EventTarget.addEventListener` callbacks.
+Unregister the original `EventTarget.addEventListener` callbacks.
 If you experience issues with this integration (or the SDK) causing double invocations of an `addEventListener` callback, set this option to `true`.
 This is usually a sign of the SDK being initialized too late in the lifecycle of the page.
 If this is the case, you might want to consider initializing the SDK as early as possible to avoid this issue.

--- a/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browserapierrors.mdx
@@ -40,6 +40,7 @@ Sentry.init({
       requestAnimationFrame: true,
       XMLHttpRequest: true,
       eventTarget: true,
+      unregisterOriginalCallbacks: true,
     }),
   ],
 });
@@ -110,3 +111,12 @@ List of default event targets:
 - `XMLHttpRequest`
 - `XMLHttpRequestEventTarget`
 - `XMLHttpRequestUpload`
+
+### `unregisterOriginalCallbacks`
+
+_Type: `boolean`_
+
+Unregister the original callbacks of `EventTarget.addEventListener` callbacks.
+If you experience issues with this integration (or the SDK) causing double invocations of an `addEventListener` callback, set this option to `true`.
+This is usually a sign of the SDK being initialized too late in the lifecycle of the page.
+If this is the case, you might want to consider initializing the SDK as early as possible to avoid this issue.

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -389,6 +389,18 @@ Remember to pass in `true` as the second parameter to `addEventListener()`. With
 </Expandable>
 </PlatformCategorySection>
 
+<PlatformCategorySection supported={['browser']}>
+
+<Expandable permalink title="SDK causes double invocations of `addEventListener` (e.g. duplicated click events)">
+
+In very rare cases, the SDK can cause callbacks added via `addEventListener` to an event target (e.g. a button) to be invoked twice.
+This is usually a sign of the SDK being intialized too late in the lifecycle of the page. If you can, try initializing the SDK as earlier.
+
+If this is not possible or doesn't apply to your use case, set the `unregisterOriginalCallbacks` option in the [`browserApiErrors` integration](../configuration/integrations/browserapierrors) to `true`.
+
+</Expandable>
+</PlatformCategorySection>
+
 <Expandable permalink title="Build errors with vite">
 
 If you're using the [Vite Bundler](https://vitejs.dev/) and a Sentry NPM package, and you see the following error:

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -393,8 +393,8 @@ Remember to pass in `true` as the second parameter to `addEventListener()`. With
 
 <Expandable permalink title="SDK causes double invocations of `addEventListener` (e.g. duplicated click events)">
 
-In very rare cases, the SDK can cause callbacks added via `addEventListener` to an event target (e.g. a button) to be invoked twice.
-This is usually a sign of the SDK being intialized too late in the lifecycle of the page. If you can, try initializing the SDK as earlier.
+In very rare cases, the SDK can cause callbacks added via `addEventListener` to an event target (such as a button) to be invoked twice.
+This is usually a sign of the SDK being intialized too late in the lifecycle of the page. If you can, try initializing the SDK earlier in your application.
 
 If this is not possible or doesn't apply to your use case, set the `unregisterOriginalCallbacks` option in the [`browserApiErrors` integration](../configuration/integrations/browserapierrors) to `true`.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Documents a new option added via https://github.com/getsentry/sentry-javascript/pull/16412. Also added a troubleshooting section as adding this option was the result of investigating a user-reported SDK issue (https://github.com/getsentry/sentry-javascript/issues/16398)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
