### PR TITLE
feat(platform): Explicitly disable kapa tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,6 +58,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
           data-font-family="var(--font-rubik)"
           data-modal-disclaimer="Please note: This is a tool that searches publicly available sources. Do not include any sensitive or personal information in your queries. For more on how Sentry handles your data, see our [Privacy Policy](https://sentry.io/privacy/)."
           data-modal-example-questions="How to set up Sentry for Next.js?,What are tracePropagationTargets?"
+          data-user-analytics-cookie-enabled="false"
         />
       </body>
     </html>


### PR DESCRIPTION
ref https://docs.kapa.ai/integrations/website-widget/user-tracking#disabling-user-tracking

> As of June 25th 2025, Kapa's widget will use opt-out tracking by default, rather than the current opt-in approach. This means [anonymous user tracking](https://docs.kapa.ai/integrations/website-widget/user-tracking#anonymous-user-tracking) is enabled automatically unless [explicitly disabled](https://docs.kapa.ai/integrations/website-widget/user-tracking#disabling-user-tracking). This change helps provide better analytics and user journey insights while still maintaining privacy compliance options. Review the configuration options below to ensure your implementation aligns with your privacy requirements.

This PR disables tracking.

@stephanie-anderson fyi