### PR TITLE
feat(native): reflect windows support for crashpad-wait-for-upload in…

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -62,7 +62,7 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 <ConfigKey name="crashpad-wait-for-upload">
 
-Whether Crashpad should delay application shutdown until the upload of the crash report in the `crashpad_handler` is complete. This is useful for deployment in `Docker` or `systemd`, where the life cycle of additional processes is bound by the application life cycle.
+Whether Crashpad should delay application shutdown until the upload of the crash report in the `crashpad_handler` is complete. This is useful for deployment in `Docker` (Linux and Windows containers) or `systemd`, where the life cycle of all processes is bound by the root process (typically the application being monitored).
 
 </ConfigKey>
 


### PR DESCRIPTION
… options configuration.

This relates to https://github.com/getsentry/sentry-native/pull/1255 where the `crashpad_wait_for_upload` option supports Windows (primarily used in Windows Docker containers). We have not yet explicitly mentioned that the current support only works for Linux, given that both technologies mentioned (Docker + systemd) mainly serve that operating system. However, increasingly, Sentry users show interest in support for Windows containers, so we must now reflect this in the user-facing option configuration.

This should only be merged when https://github.com/getsentry/sentry-native/pull/1255 is released.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ x ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
