### PR TITLE
feat(native): reflect windows support for crashpad-wait-for-upload in…

### DIFF
--- a/docs/platforms/native/advanced-usage/container-environments/index.mdx
+++ b/docs/platforms/native/advanced-usage/container-environments/index.mdx
@@ -8,9 +8,9 @@ sidebar_order: 2000
 The Sentry Native SDK uses a [database path](https://docs.sentry.io/platforms/native/configuration/options/#database-path) to store events and crash reports. When you are using a containerized environment, you may want to mount a volume to persist the database across container restarts to avoid losing this data.
 
 ## Waiting for `Crashpad` to Finish
-Starting with SDK version [0.8.3](https://github.com/getsentry/sentry-native/releases/tag/0.8.3) for Linux and [0.8.6](https://github.com/getsentry/sentry-native/releases/tag/0.8.6) for Windows, the [option `crashpad_wait_for_upload`](https://docs.sentry.io/platforms/native/configuration/options/#crashpad-wait-for-upload) allows the application to wait for the `crashpad_handler` to finish before a shutdown-after-crash.
+Starting with SDK version [0.8.3](https://github.com/getsentry/sentry-native/releases/tag/0.8.3) for Linux and [0.9.0](https://github.com/getsentry/sentry-native/releases/tag/0.9.0) for Windows, the [option `crashpad_wait_for_upload`](https://docs.sentry.io/platforms/native/configuration/options/#crashpad-wait-for-upload) allows the application to wait for the `crashpad_handler` to finish before a shutdown-after-crash.
 
-In SDK versions older than `0.8.3`/`0.8.6`, you could use a script similar to the example below to tie container shutdown to the `crashpad_handler` process:
+In SDK versions older than `0.8.3`/`0.9.0`, you could use a script similar to the example below to tie container shutdown to the `crashpad_handler` process:
 ```bash
 #!/bin/bash
 

--- a/docs/platforms/native/advanced-usage/container-environments/index.mdx
+++ b/docs/platforms/native/advanced-usage/container-environments/index.mdx
@@ -8,9 +8,9 @@ sidebar_order: 2000
 The Sentry Native SDK uses a [database path](https://docs.sentry.io/platforms/native/configuration/options/#database-path) to store events and crash reports. When you are using a containerized environment, you may want to mount a volume to persist the database across container restarts to avoid losing this data.
 
 ## Waiting for `Crashpad` to Finish
-Starting with SDK version [0.8.3](https://github.com/getsentry/sentry-native/releases/tag/0.8.3), the [option `crashpad_wait_for_upload`](https://docs.sentry.io/platforms/native/configuration/options/#crashpad-wait-for-upload) allows the application (on Linux) to wait for the `crashpad_handler` to finish before a shutdown-after-crash.
+Starting with SDK version [0.8.3](https://github.com/getsentry/sentry-native/releases/tag/0.8.3) for Linux and [0.8.6](https://github.com/getsentry/sentry-native/releases/tag/0.8.6) for Windows, the [option `crashpad_wait_for_upload`](https://docs.sentry.io/platforms/native/configuration/options/#crashpad-wait-for-upload) allows the application to wait for the `crashpad_handler` to finish before a shutdown-after-crash.
 
-In SDK versions older than 0.8.3, you could use a script similar to the example below to tie container shutdown to the `crashpad_handler` process:
+In SDK versions older than `0.8.3`/`0.8.6`, you could use a script similar to the example below to tie container shutdown to the `crashpad_handler` process:
 ```bash
 #!/bin/bash
 
@@ -28,4 +28,21 @@ if [ -n "$crashpad_pid" ]; then
         echo "The crashpad process finished successfully"
     fi
 fi
+```
+on Linux, or for Windows PowerShell
+```powershell
+# Start-Process -FilePath ".\main-app.exe" -Wait
+
+$crashpadTimeoutSec = 10
+$crashpadProcessName = "crashpad_handler"
+$crashpadProcess = Get-Process -Name $crashpadProcessName -ErrorAction SilentlyContinue | Sort-Object StartTime -Descending | Select-Object -First 1
+if ($null -ne $crashpadProcess) {
+    Write-Output "Waiting for crashpad to finish..."
+    $finished = $crashpadProcess.WaitForExit($crashpadTimeoutSec * 1000)
+    if (-not $finished) {
+        Write-Output "The crashpad process did not finish within $crashpadTimeoutSec seconds"
+    } else {
+        Write-Output "The crashpad process finished successfully"
+    }
+}
 ```


### PR DESCRIPTION
… container usage.

This relates to https://github.com/getsentry/sentry-native/pull/1255 where the crashpad_wait_for_upload option supports Windows (primarily used in Windows Docker containers). 

This adds a `PowerShell` script for users in older versions that acts equivalently to the bash script. It also adds Windows as a supported container platform and links it to a preliminary release.

This should only be merged when https://github.com/getsentry/sentry-native/pull/1255 is released.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
