### PR TITLE
Update min python version to be 2.28.0

### DIFF
--- a/platform-includes/logs/requirements/python.mdx
+++ b/platform-includes/logs/requirements/python.mdx
@@ -1,4 +1,4 @@
-Logs for Python are supported in Sentry Python SDK version `2.27.0` and above.
+Logs for Python are supported in Sentry Python SDK version `2.28.0` and above.
 
 ```bash {tabTitle:pip}
 pip install "sentry-sdk"


### PR DESCRIPTION
https://github.com/getsentry/sentry-python/releases/tag/2.28.0

This moves off of using `otel_log`, which we want to avoid sdk users sending.