### PR TITLE
Unreal Engine: Add game consoles page

### DIFF
--- a/docs/platforms/unreal/game-consoles/index.mdx
+++ b/docs/platforms/unreal/game-consoles/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Game Consoles
+description: "Learn how to configure your SDK to capture errors on game consoles."
+sidebar_order: 7
+---
+
+Sentry supports Xbox and PlayStaytion via the Unreal Engine SDK extensions. The access to these is given by sending an invite to private repositories on GitHub after you complete the middleware verification process.
+
+## Xbox
+
+To start using Sentry Unreal Engine SDK extension in your Xbox games [complete Microsoft Game Development Kit (GDK) Middleware verification process](https://developer.microsoft.com/en-us/games/support/request-gdkx-middleware).
+
+We'll receive your request and get back to you with the next steps.
+
+----
+
+"Microsoft", "Xbox" are trademarks of the Microsoft group of companies.
+
+## PlayStation
+
+To start using Sentry Unreal Engine SDK extension in your PS5 games head over to [PlayStation Partners](https://partners.playstation.net/) - *Development* -> *Tools & Middleware* and confirm your developer status after locating *Sentry* in the *Network* category by clicking on *Confirm developer status*.
+
+We'll receive your request and get back to you with the next steps.
+
+----
+
+"PlayStation", "PS5" are registered trademarks or trademarks of Sony Interactive Entertainment Inc.


### PR DESCRIPTION
This PR adds a separate 'Game Consoles' page to the Unreal SDK docs to help devs get started with using Sentry in their UE games on Xbox, PlayStation and Switch.

Closes https://github.com/getsentry/sentry-docs/issues/13584 and https://github.com/getsentry/sentry-docs/issues/13861