### PR TITLE
fix(github): Correct instructions on GHE docs

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -5,12 +5,12 @@ description: "Learn more about Sentry's GitHub integration and how it can track 
 ---
 
 There are two types of GitHub integrations, so make sure you're choosing the correct one:
-- [GitHub](#installing-github) - For most GitHub accounts, these will have URLs like `https://github.com/org-name`. **Most Github Enterprise Cloud customers should be able to use this integration. **Follow the '[Installing GitHub](#installing-github)' instructions, **do not use the GitHub Enterprise integration**.
-- [GitHub Enterprise](#installing-github-enterprise) - For GitHub Enterprise instances that **cannot be accessed from `https://github.com`**. For example, if you use a custom domain, or the `ghe` subdomain:
+- [GitHub](#installing-github) - For most GitHub accounts, these will have URLs like `https://github.com/org-name`. **Most Github Enterprise Cloud customers should be able to use this integration. **Follow the '[Installing GitHub](#installing-github)' instructions, **do not use the GitHub Enterprise integration and please begin the installation from Sentry**.
+- [GitHub Enterprise](#installing-github-enterprise) - For GitHub Enterprise instances that **cannot be accessed from `https://github.com`**. For example, a custom domain:
   - `https://github.example.com`
-  - `https://example.ghe.com/`
+  - `https://ghe.example.com/`
 
-You may also need to follow the Enterprise instructions if your organization cannot access the [Sentry's GitHub App](https://github.com/apps/sentry-io) for whatever reason. For these accounts, follow the '[Installing GitHub Enterprise](#installing-github-enterprise)' instructions; it'll guide you through making your own GitHub App and allowing Sentry to use it for access to your organization. **Do not use the regular GitHub integration**.
+ For these accounts, and if your organization cannot access the [Sentry's GitHub App](https://github.com/apps/sentry-io) for whatever reason, follow the '[Installing GitHub Enterprise](#installing-github-enterprise)' instructions; it'll guide you through making your own GitHub App and allowing Sentry to use it for access to your organization. **Do not use the regular GitHub integration**.
 
 ## Installing GitHub
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
My change from https://github.com/getsentry/sentry-docs/pull/13393 were a bit overzealous. I think it used to be possible to be a GHE Cloud customer but self-hosted and managed via GitHub, in an on-premise type situation. Most GHE Cloud customers should _not_ be using the enterprise integration, as the hosted app will be much easier. Added verbiage to clarify the only thing we care about is the base URL and app credentials.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
