### PR TITLE
fix: update link to cron creation

### DIFF
--- a/docs/product/crons/getting-started/http/index.mdx
+++ b/docs/product/crons/getting-started/http/index.mdx
@@ -10,7 +10,7 @@ Sentry Crons allows you to monitor the uptime and performance of any scheduled, 
 
 To begin monitoring your recurring, scheduled job:
 
-1. [Create a new monitor](https://sentry.io/crons/create/) in Sentry.
+1. [Create a new monitor](https://sentry.io/issues/alerts/new/crons/) in Sentry.
 2. Configure check-ins or a heartbeat for your job.
 
 Optionally, you can skip the first step and [create or update (upsert) a monitor through a check-in](#creating-or-updating-a-monitor-through-a-check-in-optional). See more below.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

sentry.io/crons/create/ -> sentry.io/issues/alerts/new/crons/

sentry.io/crons/create/ takes me to a page that seems to not exist, but I found (i think) the right think in https://sentry.io/issues/alerts/new/crons/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
