### PR TITLE
docs(llm-rules-platform): fix two same typos in 3 mdx files

### DIFF
--- a/platform-includes/llm-rules-platform/_default.mdx
+++ b/platform-includes/llm-rules-platform/_default.mdx
@@ -3,7 +3,7 @@
 Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-These examples should be used as guidance when configuring Sentry functionlaity within a project.
+These examples should be used as guidance when configuring Sentry functionality within a project.
 
 # Error / Exception Tracking
 
@@ -12,7 +12,7 @@ These examples should be used as guidance when configuring Sentry functionlaity 
 
 # Tracing Examples
 
-- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
+- Spans should be created for meaningful actions within an application like button clicks, API calls, and function calls
 - Use the `Sentry.startSpan` function to create a span
 - Child spans can exist within a parent span
 

--- a/platform-includes/llm-rules-platform/javascript.node.mdx
+++ b/platform-includes/llm-rules-platform/javascript.node.mdx
@@ -3,7 +3,7 @@
 Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-These examples should be used as guidance when configuring Sentry functionlaity within a project.
+These examples should be used as guidance when configuring Sentry functionality within a project.
 
 # Error / Exception Tracking
 
@@ -12,7 +12,7 @@ These examples should be used as guidance when configuring Sentry functionlaity 
 
 # Tracing Examples
 
-- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
+- Spans should be created for meaningful actions within an application like button clicks, API calls, and function calls
 - Ensure you are creating custom spans with meaningful names and operations
 - Use the `Sentry.startSpan` function to create a span
 - Child spans can exist within a parent span

--- a/platform-includes/llm-rules-platform/javascript.react.mdx
+++ b/platform-includes/llm-rules-platform/javascript.react.mdx
@@ -3,7 +3,7 @@
 Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration.
 
 ````markdown {filename:rules.md}
-These examples should be used as guidance when configuring Sentry functionlaity within a project.
+These examples should be used as guidance when configuring Sentry functionality within a project.
 
 # Error / Exception Tracking
 
@@ -12,7 +12,7 @@ These examples should be used as guidance when configuring Sentry functionlaity 
 
 # Tracing Examples
 
-- Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
+- Spans should be created for meaningful actions within an application like button clicks, API calls, and function calls
 - Ensure you are creating custom spans with meaningful names and operations
 - Use the `Sentry.startSpan` function to create a span
 - Child spans can exist within a parent span


### PR DESCRIPTION
## DESCRIBE YOUR PR
PR fixes two typos in `_default.mdx`, `javascript.node.mdx`, and `javascript.react.mdx`:
* "functionlaity" → "functionality"
* "an applications" → "an application"

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
