### PR TITLE
fix(js): Fix incorrect `beforeSendSpan` callback type

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -385,10 +385,10 @@ This function is called with a transaction event object, and can return a modifi
 
 </SdkOption>
 
-<SdkOption name="beforeSendSpan" type='(span: SpanJSON) => SpanJSON | null'>
+<SdkOption name="beforeSendSpan" type='(span: SpanJSON) => SpanJSON'>
 
 This function is called with a serialized span object, and can return a modified span object. This might be useful for manually stripping PII from spans.
-This function is only called for root spans and all children.
+This function is called for root spans as well as for all child spans.
 If you want to drop the root span, including all of its child spans, use [`beforeSendTransaction`](#beforeSendTransaction) instead.
 
 Please note that the `span` you receive as an argument is a serialized object, not a `Span` class instance.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Implicitly reported via https://github.com/getsentry/sentry-javascript/pull/16439 that according to the type in the options page, the `beforeSendSpan` callback can return `null`. This is no longer the case since v9 of the SKD.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
