### PR TITLE
:wrench: chore(integrations): recommend using service accounts when installing integrations that use personal tokens

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -13,7 +13,7 @@ Azure DevOps was formerly known as Visual Studio Team Services (VSTS).
   We recommend using a dedicated service account when installing this integration rather than a personal user account. 
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, all activities such as comments, work item creation, and commit associations will be attributed to the user who installed the integration. 
+  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration. 
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.

--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -8,6 +8,18 @@ Azure DevOps was formerly known as Visual Studio Team Services (VSTS).
 
 ## Install
 
+<Alert title="Note">
+  <p>
+  We recommend using a dedicated service account when installing this integration rather than a personal user account. 
+  </p>
+  <p>
+  Since the integration uses personal access tokens for authentication, all activities such as comments, work item creation, and commit associations will be attributed to the user who installed the integration. 
+  </p>
+  <p>
+  Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.
+  </p>
+</Alert>
+
 1. To install this integration, you need to have Sentry organization owner, manager, or admin permissions, as well as Azure organization owner permissions, or be a user in the Project Collections Administrators group.
 
 2. Go to your Azure Org's settings to make sure third-party access via OAuth is enabled - navigate to **Organization Settings > Security > Policies** and enable "Third-party application access via OAuth".

--- a/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
@@ -12,6 +12,18 @@ Sentry owner, manager, or admin permissions and GitLab owner or maintainer permi
 
 </Alert>
 
+<Alert title="Note">
+  <p>
+  We recommend using a dedicated service account when installing this integration rather than a personal user account. 
+  </p>
+  <p>
+  Since the integration uses personal access tokens for authentication, all activities such as comments, work item creation, and commit associations will be attributed to the user who installed the integration. 
+  </p>
+  <p>
+  Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.
+  </p>
+</Alert>
+
 1. Navigate to **Settings > Integrations > GitLab**.
 
    ![Install GitLab integration](./img/gitlab-overview.png)

--- a/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
@@ -8,16 +8,14 @@ description: "Learn more about Sentry’s GitLab integration and how it helps yo
 
 <Alert>
 
+<p>
 Sentry owner, manager, or admin permissions and GitLab owner or maintainer permissions are required to install this integration.
-
-</Alert>
-
-<Alert title="Note">
+</p>
   <p>
   We recommend using a dedicated service account when installing this integration rather than a personal user account. 
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, all activities such as comments, work item creation, and commit associations will be attributed to the user who installed the integration. 
+  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration. 
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.


### PR DESCRIPTION

## DESCRIBE YOUR PR

The Azure DevOps and Gitlab integration uses personal access tokens for authentication, which means all integration activities (comments, work item creation, commit associations) are attributed to the individual user who installed the integration. This can cause several issues:
* Activities appear to come from a specific person rather than the system
* Integration may break when that person leaves the organization


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

### Azure
![image](https://github.com/user-attachments/assets/e7a13aeb-99c9-45b7-91eb-89107cbb0e28)
### Gitlab
![image](https://github.com/user-attachments/assets/332e16af-6b64-4ed8-8c85-2e41a1ac267c)
