### PR TITLE
ref(docs): update instances of yarn dev-ui to be pnpm

### DIFF
--- a/develop-docs/development-infrastructure/environment/index.mdx
+++ b/develop-docs/development-infrastructure/environment/index.mdx
@@ -113,7 +113,7 @@ getsentry devserver --workers
 
 **Note**: You **cannot** have both sentry and getsentry devserver running at the same time.
 
-After the server warms up, access it at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/). Using localhost won't work. Note that the **http** protocol is used, not **https**. If you encounter a certificate error while accessing it locally, it might be because your browser has remembered that `dev.getsentry.net` previously used the https protocol (possibly while running `yarn dev-ui`) and is now redirecting all http requests to https. To resolve this, open the site in an **incognito window** of your browser.
+After the server warms up, access it at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/). Using localhost won't work. Note that the **http** protocol is used, not **https**. If you encounter a certificate error while accessing it locally, it might be because your browser has remembered that `dev.getsentry.net` previously used the https protocol (possibly while running `pnpm dev-ui`) and is now redirecting all http requests to https. To resolve this, open the site in an **incognito window** of your browser.
 
 If you need to overwrite configuration options for your local
 environment, you can create `getsentry/conf/settings/devlocal.py` and put the

--- a/develop-docs/development-infrastructure/frontend-development-server.mdx
+++ b/develop-docs/development-infrastructure/frontend-development-server.mdx
@@ -8,7 +8,7 @@ sidebar_order: 30
 You have the ability to only run a frontend development server that will proxy all API requests to Sentry's production servers. In order to do so, run the following command:
 
 ```shell
-yarn dev-ui
+pnpm dev-ui
 ```
 
 The development server can be viewed at [https://dev.getsentry.net:7999](https://dev.getsentry.net:7999). `dev.getsentry.net` is an alias for `localhost` and it's preferred because it supports subdomains. You can also create your own domain alias, as with ngrok, if you like.
@@ -32,7 +32,7 @@ You can either grant a temporary exception in your browser, or create and instal
 
 Follow the steps [To Enable HTTPS for your devserver](/development/environment/#enabling-https).
 
-You can now run the dev server with `yarn dev-ui` and open [https://localhost:7999](https://localhost:7999). There should not see a warning about your connection not being private. You should also see a lock or similar icon in the address bar of your browser.
+You can now run the dev server with `pnpm dev-ui` and open [https://localhost:7999](https://localhost:7999). There should not see a warning about your connection not being private. You should also see a lock or similar icon in the address bar of your browser.
 
 ![lock icon in address bar](../img/addressBarLockIcon.png)
 

--- a/develop-docs/frontend/component-library.mdx
+++ b/develop-docs/frontend/component-library.mdx
@@ -21,7 +21,7 @@ The Component Library is implemented as a webpage inside the main sentry applica
     Log in and then visit [`/stories/`](https://sentry.io/orgredirect/organizations/:orgslug/stories/) on your existing Sentry Org. This works the same on sentry.io or for self-hosted installations.
 
 - **Dev Access**<br />
-    Whether you are using `yarn dev-ui` to start a development server, or `sentry devserver` to spin up all the services locally, you can access the Component Library by logging in and changing the path from `/issues/` (the default landing page) to `/stories/`.
+    Whether you are using `pnpm dev-ui` to start a development server, or `sentry devserver` to spin up all the services locally, you can access the Component Library by logging in and changing the path from `/issues/` (the default landing page) to `/stories/`.
 
 ## Ownership
 

--- a/develop-docs/frontend/upgrade-policies.mdx
+++ b/develop-docs/frontend/upgrade-policies.mdx
@@ -149,7 +149,7 @@ For example, some dependencies such as `webpack` fall both into the app build **
 
    - Does `sentry devserver` still correctly run the client-side application?
 
-   - Does `yarn dev-ui` still run the client-only version of the application?
+   - Does `pnpm dev-ui` still run the client-only version of the application?
 
    Depending on what package you’re upgrading, you’ll what to consider what to test. For example, if you upgraded `fork-ts-checker-webpack-plugin` you’ll want to validate that types are still being checked in development.
 

--- a/develop-docs/frontend/working-on-getting-started-docs.mdx
+++ b/develop-docs/frontend/working-on-getting-started-docs.mdx
@@ -47,14 +47,14 @@ The structure for the documentation is built on React and follows the following 
 1. Locate the language folder within [gettingStartedDocs](https://github.com/getsentry/sentry/tree/master/static/app/gettingStartedDocs).
 2. Update the file `index.tsx` with the necessary changes.
 3. You might need to update the tests present in the file `index.spec.tsx`
-4. Finally, before concluding, please run Sentry locally or use the command `yarn dev-ui` [Frontend Development Server](https://develop.sentry.dev/frontend/development-server/) and perform a manual test to ensure that the getting started documentation renders correctly in both the onboarding process of a new organization and in the project creation flow. This step is essential for verifying the proper functioning and visual appearance of the documentation.
+4. Finally, before concluding, please run Sentry locally or use the command `pnpm dev-ui` [Frontend Development Server](https://develop.sentry.dev/frontend/development-server/) and perform a manual test to ensure that the getting started documentation renders correctly in both the onboarding process of a new organization and in the project creation flow. This step is essential for verifying the proper functioning and visual appearance of the documentation.
 
 ### Framework
 
 1. Locate the framework's language folder within [gettingStartedDocs](https://github.com/getsentry/sentry/tree/master/static/app/gettingStartedDocs).
 2. Within the folder, find the file named after the framework's slug and update it with the necessary changes.
 3. You might need to update the tests present in the file named after the framework’s slug with the extension `.spec.tsx`
-4. Finally, before concluding, please run Sentry locally or use the command `yarn dev-ui` and perform a manual test to ensure that the getting started documentation renders correctly in both the onboarding process of a new organization and in the project creation flow. This step is essential for verifying the proper functioning and visual appearance of the documentation.
+4. Finally, before concluding, please run Sentry locally or use the command `pnpm dev-ui` and perform a manual test to ensure that the getting started documentation renders correctly in both the onboarding process of a new organization and in the project creation flow. This step is essential for verifying the proper functioning and visual appearance of the documentation.
 
 ## Notes
 


### PR DESCRIPTION
since we moved over to `pnpm`, `yarn dev-ui` no longer works and we have to do `pnpm dev-ui`. updating the dev docs to reflect this