### PR TITLE
Unreal Engine: Add option to delay app shutdown until Crashpad completes crash report upload

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -133,6 +133,20 @@ On Windows, capturing GPU crashes requires [modifying the Unreal Engine source c
 
 </ConfigKey>
 
+<ConfigKey name="crashpad-wait-for-upload">
+
+When enabled, application shutdown is delayed until the upload of the crash report is complete. This is useful for deployment in `Docker` environment (Linux and Windows containers) where the life cycle of all processes is bound by the root process (typically the application being monitored).
+
+This option is turned off by default.
+
+<Alert>
+
+This feature is supported only for Crashpad backend on Windows and Linux (default for the `github` plugin package).
+
+</Alert>
+
+</ConfigKey>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-unreal/pull/953