### PR TITLE
Add Laravel and Symfony to upcoming SDKs

### DIFF
--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -242,6 +242,11 @@ We're actively working on adding Log functionality to additional SDKs. Check out
     url="https://github.com/getsentry/sentry-elixir/issues/886"
   />
 - <LinkWithPlatformIcon
+    platform="php.laravel"
+    label="Laravel"
+    url="https://github.com/getsentry/sentry-laravel/issues/999"
+  />
+- <LinkWithPlatformIcon
     platform="react-native"
     label="React Native"
     url="https://github.com/getsentry/sentry-react-native/issues/4820"
@@ -250,6 +255,11 @@ We're actively working on adding Log functionality to additional SDKs. Check out
     platform="dotnet"
     label=".NET"
     url="https://github.com/getsentry/sentry-dotnet/issues/4132"
+  />
+- <LinkWithPlatformIcon
+    platform="php.symfony"
+    label="Symfony"
+    url="https://github.com/getsentry/sentry-symfony/issues/925"
   />
 - <LinkWithPlatformIcon
     platform="unity"


### PR DESCRIPTION
The `docs/product/explore/logs/getting-started/index.mdx` file was updated to include Laravel and Symfony in the "Upcoming SDKs" section.

*   Two new `<LinkWithPlatformIcon>` components were added:
    *   **Laravel**: Inserted with `platform="php.laravel"` and `url="https://github.com/getsentry/sentry-laravel/issues/999"`.
    *   **Symfony**: Inserted with `platform="php.symfony"` and `url="https://github.com/getsentry/sentry-symfony/issues/925"`.
*   The `platform` names `php.laravel` and `php.symfony` were chosen to align with existing Sentry documentation conventions for PHP frameworks.
*   Entries were placed in alphabetical order within the existing list to maintain consistency.