### PR TITLE
chore(issue-views): Remove EA banner from issue views docs

### DIFF
--- a/docs/product/issues/issue-views/index.mdx
+++ b/docs/product/issues/issue-views/index.mdx
@@ -6,12 +6,6 @@ description: "Learn how to create, customize, and share your Issues experience i
 
 Issue views let you customize and share your issue stream, so you and your teammates can quickly see the issues that are most relevant to you.
 
-<Alert>
-  This feature is only available if your organization has enabled [early adopter features](/organization/early-adopter-features/). Early adopter features are still in-progress and may have bugs. We recognize the irony. If you’re interested in participating, enable early adopter features in [organization settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/organization).
-</Alert>
-
-
-
 ## Creating Your First View
 
 To create your first custom issue view, navigate to the [**All Views**](https://sentry.io/orgredirect/organizations/:orgslug/issues/views/) page and click the **`+ Create View`** button on the top right.


### PR DESCRIPTION
Removes the EA banner from the issue views docs page. 