### PR TITLE
fix(ui): Only copy CodeBlock expandable content

### DIFF
--- a/src/components/codeBlock/index.tsx
+++ b/src/components/codeBlock/index.tsx
@@ -58,7 +58,7 @@ export function CodeBlock({filename, language, children}: CodeBlockProps) {
       <div className={styles.copied} style={{opacity: showCopied ? 1 : 0}}>
         Copied
       </div>
-      <div ref={codeRef}>
+      <div data-codeblock ref={codeRef}>
         {makeKeywordsClickable(makeHighlightBlocks(children, language))}
       </div>
     </div>

--- a/src/components/expandable/index.tsx
+++ b/src/components/expandable/index.tsx
@@ -80,8 +80,9 @@ export function Expandable({
 
       emit('Copy Expandable Content', {props: {page: window.location.pathname, title}});
 
-      // Attempt to get text from markdown code blocks if they exist
-      const codeBlocks = contentRef.current.querySelectorAll('code');
+      // Attempt to get text from markdown code blocks if they exist. Only
+      // targets CodeBlock components using the data-codeblock marker.
+      const codeBlocks = contentRef.current.querySelectorAll('[data-codeblock]');
       let contentToCopy = '';
 
       if (codeBlocks.length > 0) {


### PR DESCRIPTION
Prior to this change all `code` elements would be copied, so if the
markdown content inside a expandable alert included single-backtick
style `<code>whatever</code>` nodes, those would end up in the copied
content.

The intention of this component is definitely intended to just copy the
CodeBlock content.