### PR TITLE
chore(dsn): update reference to dsn settings from settings -> client keys to settings -> sdk setup -> client keys

### DIFF
--- a/docs/concepts/key-terms/dsn-explainer.mdx
+++ b/docs/concepts/key-terms/dsn-explainer.mdx
@@ -18,7 +18,7 @@ If an SDK is not initialized or if it is initialized with an empty DSN, the SDK 
 
 DSNs are safe to keep public because they only allow submission of new events and related event data; they do not allow read access to any information.
 
-While there is a risk of abusing a DSN, where any user can send events to your organization with any information they want, this is a rare occurrence. Sentry provides controls to [block IPs](/platform-redirect/?next=/configuration/options/) and similar concerns. You can also rotate (and revoke) DSNs by navigating to **[Project] > Settings > Client Keys (DSN)**.
+While there is a risk of abusing a DSN, where any user can send events to your organization with any information they want, this is a rare occurrence. Sentry provides controls to [block IPs](/platform-redirect/?next=/configuration/options/) and similar concerns. You can also rotate (and revoke) DSNs by navigating to **[Project] > Settings > SDK Setup > Client Keys (DSN)**.
 
 If your application is shipped to client devices, if possible, we recommend having a way to configure the DSN dynamically. In an ideal scenario, you can "ship" a new DSN to your application without the customer downloading the latest version. We recognize that this may not always be practical, but we cannot offer further advice as this scenario is implementation specific.
 
@@ -28,7 +28,7 @@ If you're in the process of setting up a project, you can find your DSN in the i
 
 ![DSN in code snippet](./img/create-new-project-04.png)
 
-You can also find the DSN in your project settings by navigating to **[Project] > Settings > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
+You can also find the DSN in your project settings by navigating to **[Project] > Settings > SDK Setup > Client Keys (DSN)** in [sentry.io](https://sentry.io/).
 
 ### The Parts of the Data Source Name (DSN)
 

--- a/docs/organization/getting-started/index.mdx
+++ b/docs/organization/getting-started/index.mdx
@@ -89,7 +89,7 @@ Automatic issue management is available only if your organization is on a Busine
 
 ## 4. Create Projects
 
-To start monitoring errors in your app with Sentry, you'll need to initialize the SDK with a DSN key. To obtain a key, add a new Sentry project by going to **Projects** and clicking "Create Project". Give the project a name and assign the responsible [team (or teams)](#2-set-up-teams). Then, retrieve the key in **[Project] > Settings > Client Keys (DSN)**.
+To start monitoring errors in your app with Sentry, you'll need to initialize the SDK with a DSN key. To obtain a key, add a new Sentry project by going to **Projects** and clicking "Create Project". Give the project a name and assign the responsible [team (or teams)](#2-set-up-teams). Then, retrieve the key in **[Project] > Settings > SDK Setup > Client Keys (DSN)**.
 
 ![Retrieve your project DSN key.](./img/project-dsn.png)
 

--- a/docs/pricing/quotas/index.mdx
+++ b/docs/pricing/quotas/index.mdx
@@ -66,7 +66,7 @@ Events and attachments that exceed your quota will not be accepted, so you may w
 
 ### Rate Limits
 
-You can add limits for error events on a per-project basis in **[Project] > Settings > Client Keys (DSN)**. If the event rate limit for a project has been exceeded, and your subscription allows, the event won't be counted. You can also rate limit attachments on an organization level in **Settings > Security & Privacy**. Learn more in [Manage Your Error Quota](/pricing/quotas/manage-event-stream-guide/#rate-limiting) and [Manage Your Attachments Quota](/pricing/quotas/manage-attachments-quota/#rate-limiting).
+You can add limits for error events on a per-project basis in **[Project] > Settings > SDK Setup > Client Keys (DSN)**. If the event rate limit for a project has been exceeded, and your subscription allows, the event won't be counted. You can also rate limit attachments on an organization level in **Settings > Security & Privacy**. Learn more in [Manage Your Error Quota](/pricing/quotas/manage-event-stream-guide/#rate-limiting) and [Manage Your Attachments Quota](/pricing/quotas/manage-attachments-quota/#rate-limiting).
 
 ### Event Repetition
 

--- a/docs/pricing/quotas/manage-event-stream-guide.mdx
+++ b/docs/pricing/quotas/manage-event-stream-guide.mdx
@@ -121,7 +121,7 @@ We strongly recommend that you make subscription changes **before** the last day
 
 Rate limiting allows you to set the maximum volume of error events a project key will accept during a period of time. For example, if you have a project in production that generates a lot of noise, a rate limit allows you to set the maximum amount of data, such as “500 events per minute”. Additionally, you can create a second key for the same project for your staging environment, which is unlimited, ensuring your QA process is still untouched.
 
-In **[Project] > Settings > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
+In **[Project] > Settings > SDK Setup > Client Keys (DSN)**, click "Configure", and you can create multiple DSN keys per project and assign different (or no) rate limits to each key. This will allow you to dynamically allocate keys (with varying thresholds) depending on release, environment, and so on.
 
 ![Per DSN Key rate limits](./img/manage-event-stream-11.png)
 
@@ -133,7 +133,7 @@ While rate limiting is quite useful for managing your monthly event quota, keep 
 
 A good way to set a project rate limit is by figuring out the expected event volume based on your average traffic. Here's how to do that:
 
-1. Go **[Project] > Settings > Client Keys (DSN)** and open the project DSN key configuration under by clicking "Configure".
+1. Go **[Project] > Settings > SDK Setup > Client Keys (DSN)** and open the project DSN key configuration under by clicking "Configure".
 1. In the "KEY USAGE IN THE LAST 30 DAYS" graph, look for the highest point, or the maximum daily rate. In the example below, the maximum daily rate in the last month is less than 34K:
    ![Calculating rate limits](./img/manage-event-stream-14-new.png)
    {/*<!-- image notes: Sentry, airflow, Santry, app-frontend -->*/}

--- a/docs/product/sentry-basics/distributed-tracing/create-new-project.mdx
+++ b/docs/product/sentry-basics/distributed-tracing/create-new-project.mdx
@@ -28,7 +28,7 @@ Follow the steps below to create a new Sentry project for a sample React applica
 
    - Click **Create Project**. This takes you to the quick Configure React SDK guide, which provides an overview of how to configure the SDK. This tutorial covers the SDK setup in more detail.
 
-   - You'll notice that the Sentry React SDK setup code has come pre-populated with the project's unique DSN (Data Source Name). The DSN tells the SDK where to send events, so events are associated with the right project. You'll need to paste the DSN key into the SDK configuration code later in the tutorial. You can make a note of it now, or you can also find a project's DSN anytime in **[Project] > Settings > Client Keys (DSN)**
+   - You'll notice that the Sentry React SDK setup code has come pre-populated with the project's unique DSN (Data Source Name). The DSN tells the SDK where to send events, so events are associated with the right project. You'll need to paste the DSN key into the SDK configuration code later in the tutorial. You can make a note of it now, or you can also find a project's DSN anytime in **[Project] > Settings > SDK Setup > Client Keys (DSN)**
 
 1. Click **Take me to Issues** to go to your new project's **Issues** page.
 
@@ -58,7 +58,7 @@ Next, follow the steps below to create a new Sentry project for a sample Backend
 
 1. Copy the DSN key and keep it handy.
 
-   > You can also find a project's DSN anytime in **[Project] > Settings > Client Keys (DSN)**.
+   > You can also find a project's DSN anytime in **[Project] > Settings > SDK Setup > Client Keys (DSN)**.
 
 1. Click **Take me to Issues** to go to your new project's **Issues** page.
 

--- a/docs/product/sentry-basics/integrate-backend/getting-started.mdx
+++ b/docs/product/sentry-basics/integrate-backend/getting-started.mdx
@@ -47,7 +47,7 @@ Follow the steps below to create a new Sentry project for a sample Django applic
 
 1. Copy the DSN key and keep it handy. Each project has a unique DSN (Data Source Name). The DSN tells the SDK where to send events, so events are associated with the right project. You'll need to paste the DSN key into your source code later so the errors generated in this tutorial go to your new project.
 
-   > You can also find a project's DSN anytime in **[Project] > Settings > Client Keys (DSN)**.
+   > You can also find a project's DSN anytime in **[Project] > Settings > SDK Setup > Client Keys (DSN)**.
 
 ## Step 2: Get the Code
 

--- a/docs/product/sentry-basics/integrate-frontend/create-new-project.mdx
+++ b/docs/product/sentry-basics/integrate-frontend/create-new-project.mdx
@@ -30,7 +30,7 @@ Follow the steps below to create a new Sentry project for a sample React applica
 
 1. Copy the DSN key and keep it handy. Each project has a unique DSN (Data Source Name). The DSN tells the SDK where to send events, so events are associated with the right project. You'll need to paste the DSN key into your source code later so the errors generated in this tutorial go to your new project.
 
-   > You can also find a project's DSN anytime in **[Project] > Settings > Client Keys (DSN)**.
+   > You can also find a project's DSN anytime in **[Project] > Settings > SDK Setup > Client Keys (DSN)**.
 
 1. Click **Take me to Issues** to go to your new project's **Issues** page.
 


### PR DESCRIPTION
- There was some feedback about not finding the client keys - looking at the settings, it makes sense that you would look only under Project > Settings > Project and not further down. 
- Not sure whether this is a conscious choice to not refer to the sub-group in settings. If this change is useful, we should probably also update all other project settings paths in the docs. 