### PR TITLE
ref(pii): update event fields that are scrubbed by default.

### DIFF
--- a/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
@@ -76,6 +76,7 @@ Sentry does not know if a local variable that looks like a credit card number ac
 Selectors allow you to restrict rules to certain parts of the event. This is useful to unconditionally remove certain data by event attribute, and can also be used to conservatively test rules on real data. A few examples:
 
 - `**` to scrub [all default event PII fields](/security-legal-pii/scrubbing//server-side-scrubbing/event-pii-fields/) (other fields, like the span description, require specific selectors)
+- `$error.value` to scrub in the exception message
 - `$message` to scrub the event-level log message
 - `extra.'My Value'` to scrub the key `My Value` in "Additional Data"
 - `extra.**` to scrub everything in "Additional Data"
@@ -101,6 +102,31 @@ For example, what is called "Additional Data" in the UI is called `extra` in the
 
 ```
 [Remove] [Anything] from [extra.foo]
+```
+
+Another example. Sentry knows about two kinds of error messages: the exception message, and the top-level log message. Here is an example of how such an event payload as sent by the SDK (and downloadable from the UI) would look like:
+
+```json
+{
+  "logentry": {
+    "formatted": "Failed to roll out the dinglebop"
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "ZeroDivisionError",
+        "value": "integer division or modulo by zero"
+      }
+    ]
+  }
+}
+```
+
+Since the "error message" is taken from the `exception`'s `value`, and the "message" is taken from `logentry`, we would have to write the following to remove both from the event:
+
+```
+[Remove] [Anything] from [exception.values.*.value]
+[Remove] [Anything] from [logentry.formatted]
 ```
 
 ### Boolean Logic


### PR DESCRIPTION
Adds new items to the list of fields that are scrubbed by default that have been added since the list was updated the last time.

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
