### PR TITLE
Add `postPublish` hooks removal to `sentry-expo` migration guide

### DIFF
--- a/docs/platforms/react-native/migration/sentry-expo.mdx
+++ b/docs/platforms/react-native/migration/sentry-expo.mdx
@@ -24,7 +24,7 @@ pnpm remove sentry-expo
 
 ### Remove `sentry-expo/upload-sourcemaps` from `postPublish` hooks
 
-Remove the Sentry Source Maps Upload hook from your Expo Application configuration, `expo.hooks.postPublish`. The new methods of uploading source maps are described in the [new Expo guide](/platforms/react-native/manual-setup/expo/), the last step of this migration at the bottom of this page.
+Remove the Sentry Source Maps Upload hook from your Expo Application configuration, `expo.hooks.postPublish`. The new methods of uploading source maps are described in the [new Expo guide](/platforms/react-native/manual-setup/expo/), as part of the final step of the migration [at the bottom of the page](/platforms/react-native/migration/sentry-expo/#set-up-the-sentryreact-native-expo-and-metro-plugins).
 
 ## Install `@sentry/react-native`
 

--- a/docs/platforms/react-native/migration/sentry-expo.mdx
+++ b/docs/platforms/react-native/migration/sentry-expo.mdx
@@ -22,7 +22,11 @@ yarn remove sentry-expo
 pnpm remove sentry-expo
 ```
 
-### Install `@sentry/react-native`
+### Remove `sentry-expo/upload-sourcemaps` from `postPublish` hooks
+
+Remove the Sentry Source Maps Upload hook from your Expo Application configuration, `expo.hooks.postPublish`. The new methods of uploading source maps are described in the [new Expo guide](/platforms/react-native/manual-setup/expo/), the last step of this migration at the bottom of this page.
+
+## Install `@sentry/react-native`
 
 Install the `@sentry/react-native` package:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

closes: https://linear.app/getsentry/issue/RN-195/what-to-do-with-the-post-publish-hook-in-appconfigjs-when-migrating-to

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
