### PR TITLE
fix(go): Remove usage of spaces

### DIFF
--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -15,8 +15,8 @@ func main() {
 		// Useful when getting started or trying to figure something out.
 		Debug: true,
 		// Adds request headers and IP for users,
-        // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-        SendDefaultPII: true,
+		// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
+		SendDefaultPII: true,
 	})
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)


### PR DESCRIPTION
Go uses tabs for indentation.