### PR TITLE
:sparkles: feat(integrations): add github domain checker

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -12,12 +12,21 @@ There are two types of GitHub integrations, so make sure you're choosing the cor
   - `https://ghe.example.com/`
 
   For these accounts, follow the '[Installing GitHub Enterprise](#installing-github-enterprise)' instructions.
+  
+
+### To determine which integration to use, enter your GitHub domain below:
+
+<GitHubDomainChecker />
+
+<br />
 
 <Alert>
 
 Sentry owner, manager, or admin permissions, and GitHub owner permissions are required to install this integration.
 
 </Alert>
+
+## Installing GitHub
 
 1. Navigate to **Settings > Integrations > [GitHub](https://sentry.io/orgredirect/organizations/:orgslug/settings/integrations/github)**.
 

--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -14,7 +14,9 @@ There are two types of GitHub integrations, so make sure you're choosing the cor
   For these accounts, follow the '[Installing GitHub Enterprise](#installing-github-enterprise)' instructions.
   
 
-### To determine which integration to use, enter your GitHub domain below:
+### Check Your Domain
+
+To determine which integration to use, enter your GitHub domain below:
 
 <GitHubDomainChecker />
 

--- a/src/components/githubDomainChecker.tsx
+++ b/src/components/githubDomainChecker.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import {useState} from 'react';
+
+const MAX_COMPONENTS_ON_PAGE = 100;
+
+export function GitHubDomainChecker() {
+  const [domain, setDomain] = useState('');
+  const [isValidDomain, setIsValidDomain] = useState(false);
+  
+  const isGitHubCom = domain.toLowerCase().trim() === 'github.com' || domain.toLowerCase().trim() === 'https://github.com';
+  const hasInput = domain.trim().length > 0;
+  
+  // Validate domain format
+  const validateDomain = (inputDomain: string) => {
+    const trimmedDomain = inputDomain.trim();
+    if (!trimmedDomain) {
+      setIsValidDomain(false);
+      return;
+    }
+    
+    // Check if it's github.com (valid)
+    if (trimmedDomain.toLowerCase() === 'github.com' || trimmedDomain.toLowerCase() === 'https://github.com') {
+      setIsValidDomain(true);
+      return;
+    }
+    
+    // For enterprise, check if it's a valid URL or domain format
+    const urlPattern = /^(https?:\/\/)?([\w\-\.]+\.[\w]{2,})(\/.*)?$/;
+    const isValidUrl = urlPattern.test(trimmedDomain);
+    setIsValidDomain(isValidUrl);
+  };
+  
+  const handleDomainChange = (ev) => {
+    const newDomain = ev.target.value;
+    setDomain(newDomain);
+    validateDomain(newDomain);
+  };
+  
+  const inputClassName =
+    'form-input w-full rounded-md border-[1.5px] focus:ring-2 focus:ring-accent-purple/20 border-gray-200';
+  
+  // This is to avoid in case multiple instances of this component are used on the page
+  const randomCounter = Math.round(Math.random() * MAX_COMPONENTS_ON_PAGE);
+
+  return (
+    <div className="space-y-4 p-6 border border-gray-100 rounded">
+      <div className="flex w-full">
+        <div className="flex items-center min-w-[16ch] px-4">
+          <label htmlFor={`gh-domain-${randomCounter}`} className="text-nowrap">
+            GitHub Domain
+          </label>
+        </div>
+        <input
+          id={`gh-domain-${randomCounter}`}
+          value={domain}
+          placeholder="https://github.com or https://ghe.example.com"
+          className={inputClassName}
+          onChange={handleDomainChange}
+        />
+      </div>
+
+      {hasInput && (
+        <div className="mt-4 p-4 rounded-md border">
+          <div className="text-sm font-medium mb-2">
+            Recommended Installation:
+          </div>
+          {isValidDomain ? (
+            isGitHubCom ? (
+              <div className="text-green-700 bg-green-50 p-3 rounded-md">
+                <div className="mb-2">
+                  <strong>GitHub</strong> - Use the standard GitHub integration for github.com
+                </div>
+              </div>
+            ) : (
+              <div className="text-blue-700 bg-blue-50 p-3 rounded-md">
+                <div className="mb-2">
+                  <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration for your domain
+                </div>
+              </div>
+            )
+          ) : (
+            <div className="text-red-700 bg-red-50 p-3 rounded-md">
+              <strong>Invalid Domain</strong> - Please enter a valid GitHub domain or URL
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/githubDomainChecker.tsx
+++ b/src/components/githubDomainChecker.tsx
@@ -114,14 +114,14 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
               <div className="text-sm font-medium mb-2">Recommended Installation:</div>
               {isGitHubCom ? (
                 <div className="text-green-700 bg-green-50 dark:text-green-300 dark:bg-green-900/30 p-3 rounded-md">
-                  <div className="mb-2">
+                  <div>
                     <strong>GitHub</strong> - Use the standard GitHub integration for
                     github.com
                   </div>
                 </div>
               ) : (
                 <div className="text-blue-700 bg-blue-50 dark:text-blue-300 dark:bg-blue-900/30 p-3 rounded-md">
-                  <div className="mb-2">
+                  <div>
                     <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration
                     for your domain
                   </div>

--- a/src/components/githubDomainChecker.tsx
+++ b/src/components/githubDomainChecker.tsx
@@ -2,15 +2,26 @@
 
 import {useState} from 'react';
 
-const MAX_COMPONENTS_ON_PAGE = 100;
+interface GitHubDomainCheckerProps {
+  id?: string;
+}
 
-export function GitHubDomainChecker() {
+export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
   const [domain, setDomain] = useState('');
   const [isValidDomain, setIsValidDomain] = useState(false);
-
-  const isGitHubCom =
-    domain.toLowerCase().trim() === 'github.com' ||
-    domain.toLowerCase().trim() === 'https://github.com';
+  
+  // Updated to handle github.com URLs with paths (e.g., github.com/user)
+  const isGitHubCom = (() => {
+    const trimmedDomain = domain.toLowerCase().trim();
+    if (!trimmedDomain) return false;
+    
+    // Remove protocol if present
+    const domainWithoutProtocol = trimmedDomain.replace(/^https?:\/\//, '');
+    
+    // Check if it starts with github.com (with or without path)
+    return domainWithoutProtocol.startsWith('github.com');
+  })();
+  
   const hasInput = domain.trim().length > 0;
 
   // Validate domain format
@@ -20,12 +31,9 @@ export function GitHubDomainChecker() {
       setIsValidDomain(false);
       return;
     }
-
-    // Check if it's github.com (valid)
-    if (
-      trimmedDomain.toLowerCase() === 'github.com' ||
-      trimmedDomain.toLowerCase() === 'https://github.com'
-    ) {
+    
+    // Check if it contains github.com (valid)
+    if (trimmedDomain.toLowerCase().includes('github.com')) {
       setIsValidDomain(true);
       return;
     }
@@ -41,23 +49,24 @@ export function GitHubDomainChecker() {
     setDomain(newDomain);
     validateDomain(newDomain);
   };
-
+  
+  // Improved input styling with dark mode support
   const inputClassName =
-    'form-input w-full rounded-md border-[1.5px] focus:ring-2 focus:ring-accent-purple/20 border-gray-200';
-
-  // This is to avoid in case multiple instances of this component are used on the page
-  const randomCounter = Math.round(Math.random() * MAX_COMPONENTS_ON_PAGE);
+    'form-input w-full rounded-md border-[1.5px] focus:ring-2 focus:ring-accent-purple/20 border-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400';
+  
+  // Use provided id or generate a fallback
+  const inputId = id || `gh-domain-${Date.now()}`;
 
   return (
-    <div className="space-y-4 p-6 border border-gray-100 rounded">
+    <div className="space-y-4 p-6 border border-gray-100 dark:border-gray-700 rounded">
       <div className="flex w-full">
         <div className="flex items-center min-w-[16ch] px-4">
-          <label htmlFor={`gh-domain-${randomCounter}`} className="text-nowrap">
+          <label htmlFor={inputId} className="text-nowrap">
             GitHub Domain
           </label>
         </div>
         <input
-          id={`gh-domain-${randomCounter}`}
+          id={inputId}
           value={domain}
           placeholder="https://github.com or https://ghe.example.com"
           className={inputClassName}
@@ -66,26 +75,28 @@ export function GitHubDomainChecker() {
       </div>
 
       {hasInput && (
-        <div className="mt-4 p-4 rounded-md border">
-          <div className="text-sm font-medium mb-2">Recommended Installation:</div>
+        <div className="mt-4 p-4 rounded-md border dark:border-gray-600">
           {isValidDomain ? (
-            isGitHubCom ? (
-              <div className="text-green-700 bg-green-50 p-3 rounded-md">
-                <div className="mb-2">
-                  <strong>GitHub</strong> - Use the standard GitHub integration for
-                  github.com
-                </div>
+            <div>
+              <div className="text-sm font-medium mb-2">
+                Recommended Installation:
               </div>
-            ) : (
-              <div className="text-blue-700 bg-blue-50 p-3 rounded-md">
-                <div className="mb-2">
-                  <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration
-                  for your domain
+              {isGitHubCom ? (
+                <div className="text-green-700 bg-green-50 dark:text-green-300 dark:bg-green-900/30 p-3 rounded-md">
+                  <div className="mb-2">
+                    <strong>GitHub</strong> - Use the standard GitHub integration for github.com
+                  </div>
                 </div>
-              </div>
-            )
+              ) : (
+                <div className="text-blue-700 bg-blue-50 dark:text-blue-300 dark:bg-blue-900/30 p-3 rounded-md">
+                  <div className="mb-2">
+                    <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration for your domain
+                  </div>
+                </div>
+              )}
+            </div>
           ) : (
-            <div className="text-red-700 bg-red-50 p-3 rounded-md">
+            <div className="text-red-700 bg-red-50 dark:text-red-300 dark:bg-red-900/30 p-3 rounded-md">
               <strong>Invalid Domain</strong> - Please enter a valid GitHub domain or URL
             </div>
           )}

--- a/src/components/githubDomainChecker.tsx
+++ b/src/components/githubDomainChecker.tsx
@@ -9,19 +9,19 @@ interface GitHubDomainCheckerProps {
 export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
   const [domain, setDomain] = useState('');
   const [isValidDomain, setIsValidDomain] = useState(false);
-  
+
   // Updated to handle github.com URLs with paths (e.g., github.com/user)
   const isGitHubCom = (() => {
     const trimmedDomain = domain.toLowerCase().trim();
     if (!trimmedDomain) return false;
-    
+
     // Remove protocol if present
     const domainWithoutProtocol = trimmedDomain.replace(/^https?:\/\//, '');
-    
+
     // Check if it starts with github.com (with or without path)
     return domainWithoutProtocol.startsWith('github.com');
   })();
-  
+
   const hasInput = domain.trim().length > 0;
 
   // Validate domain format
@@ -31,7 +31,7 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
       setIsValidDomain(false);
       return;
     }
-    
+
     // Check if it contains github.com (valid)
     if (trimmedDomain.toLowerCase().includes('github.com')) {
       setIsValidDomain(true);
@@ -49,11 +49,11 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
     setDomain(newDomain);
     validateDomain(newDomain);
   };
-  
+
   // Improved input styling with dark mode support
   const inputClassName =
     'form-input w-full rounded-md border-[1.5px] focus:ring-2 focus:ring-accent-purple/20 border-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400';
-  
+
   // Use provided id or generate a fallback
   const inputId = id || `gh-domain-${Date.now()}`;
 
@@ -78,19 +78,19 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
         <div className="mt-4 p-4 rounded-md border dark:border-gray-600">
           {isValidDomain ? (
             <div>
-              <div className="text-sm font-medium mb-2">
-                Recommended Installation:
-              </div>
+              <div className="text-sm font-medium mb-2">Recommended Installation:</div>
               {isGitHubCom ? (
                 <div className="text-green-700 bg-green-50 dark:text-green-300 dark:bg-green-900/30 p-3 rounded-md">
                   <div className="mb-2">
-                    <strong>GitHub</strong> - Use the standard GitHub integration for github.com
+                    <strong>GitHub</strong> - Use the standard GitHub integration for
+                    github.com
                   </div>
                 </div>
               ) : (
                 <div className="text-blue-700 bg-blue-50 dark:text-blue-300 dark:bg-blue-900/30 p-3 rounded-md">
                   <div className="mb-2">
-                    <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration for your domain
+                    <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration
+                    for your domain
                   </div>
                 </div>
               )}

--- a/src/components/githubDomainChecker.tsx
+++ b/src/components/githubDomainChecker.tsx
@@ -9,13 +9,15 @@ interface GitHubDomainCheckerProps {
 export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
   const [domain, setDomain] = useState('');
   const [isValidDomain, setIsValidDomain] = useState(false);
-  
+
   // Safe function to check if domain is github.com or its subdomain
   const isValidGitHubDomain = (input_domain: string): boolean => {
     try {
-      const url = new URL(input_domain.startsWith('http') ? input_domain : `https://${input_domain}`);
+      const url = new URL(
+        input_domain.startsWith('http') ? input_domain : `https://${input_domain}`
+      );
       const hostname = url.hostname.toLowerCase();
-      
+
       // Exact match for github.com or valid subdomain (like gist.github.com)
       return hostname === 'github.com' || hostname.endsWith('.github.com');
     } catch {
@@ -26,12 +28,18 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
   // Safe function to check if it's an enterprise GitHub domain
   const isValidEnterpriseDomain = (input_domain: string): boolean => {
     try {
-      const url = new URL(input_domain.startsWith('http') ? input_domain : `https://${input_domain}`);
+      const url = new URL(
+        input_domain.startsWith('http') ? input_domain : `https://${input_domain}`
+      );
       const hostname = url.hostname.toLowerCase();
-      
+
       // Must be a valid domain with TLD, but not github.com
       const domainPattern = /^[\w\-\.]+\.[\w]{2,}$/;
-      return domainPattern.test(hostname) && !hostname.endsWith('.github.com') && hostname !== 'github.com';
+      return (
+        domainPattern.test(hostname) &&
+        !hostname.endsWith('.github.com') &&
+        hostname !== 'github.com'
+      );
     } catch {
       return false;
     }
@@ -40,7 +48,7 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
   const isGitHubCom = (() => {
     const trimmedDomain = domain.toLowerCase().trim();
     if (!trimmedDomain) return false;
-    
+
     return isValidGitHubDomain(trimmedDomain);
   })();
 
@@ -53,7 +61,7 @@ export function GitHubDomainChecker({id}: GitHubDomainCheckerProps = {}) {
       setIsValidDomain(false);
       return;
     }
-    
+
     // Check if it's a valid GitHub.com domain or subdomain
     if (isValidGitHubDomain(trimmedDomain)) {
       setIsValidDomain(true);

--- a/src/components/githubDomainChecker.tsx
+++ b/src/components/githubDomainChecker.tsx
@@ -7,10 +7,12 @@ const MAX_COMPONENTS_ON_PAGE = 100;
 export function GitHubDomainChecker() {
   const [domain, setDomain] = useState('');
   const [isValidDomain, setIsValidDomain] = useState(false);
-  
-  const isGitHubCom = domain.toLowerCase().trim() === 'github.com' || domain.toLowerCase().trim() === 'https://github.com';
+
+  const isGitHubCom =
+    domain.toLowerCase().trim() === 'github.com' ||
+    domain.toLowerCase().trim() === 'https://github.com';
   const hasInput = domain.trim().length > 0;
-  
+
   // Validate domain format
   const validateDomain = (inputDomain: string) => {
     const trimmedDomain = inputDomain.trim();
@@ -18,28 +20,31 @@ export function GitHubDomainChecker() {
       setIsValidDomain(false);
       return;
     }
-    
+
     // Check if it's github.com (valid)
-    if (trimmedDomain.toLowerCase() === 'github.com' || trimmedDomain.toLowerCase() === 'https://github.com') {
+    if (
+      trimmedDomain.toLowerCase() === 'github.com' ||
+      trimmedDomain.toLowerCase() === 'https://github.com'
+    ) {
       setIsValidDomain(true);
       return;
     }
-    
+
     // For enterprise, check if it's a valid URL or domain format
     const urlPattern = /^(https?:\/\/)?([\w\-\.]+\.[\w]{2,})(\/.*)?$/;
     const isValidUrl = urlPattern.test(trimmedDomain);
     setIsValidDomain(isValidUrl);
   };
-  
-  const handleDomainChange = (ev) => {
+
+  const handleDomainChange = ev => {
     const newDomain = ev.target.value;
     setDomain(newDomain);
     validateDomain(newDomain);
   };
-  
+
   const inputClassName =
     'form-input w-full rounded-md border-[1.5px] focus:ring-2 focus:ring-accent-purple/20 border-gray-200';
-  
+
   // This is to avoid in case multiple instances of this component are used on the page
   const randomCounter = Math.round(Math.random() * MAX_COMPONENTS_ON_PAGE);
 
@@ -62,20 +67,20 @@ export function GitHubDomainChecker() {
 
       {hasInput && (
         <div className="mt-4 p-4 rounded-md border">
-          <div className="text-sm font-medium mb-2">
-            Recommended Installation:
-          </div>
+          <div className="text-sm font-medium mb-2">Recommended Installation:</div>
           {isValidDomain ? (
             isGitHubCom ? (
               <div className="text-green-700 bg-green-50 p-3 rounded-md">
                 <div className="mb-2">
-                  <strong>GitHub</strong> - Use the standard GitHub integration for github.com
+                  <strong>GitHub</strong> - Use the standard GitHub integration for
+                  github.com
                 </div>
               </div>
             ) : (
               <div className="text-blue-700 bg-blue-50 p-3 rounded-md">
                 <div className="mb-2">
-                  <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration for your domain
+                  <strong>GitHub Enterprise</strong> - Use GitHub Enterprise integration
+                  for your domain
                 </div>
               </div>
             )

--- a/src/mdxComponents.ts
+++ b/src/mdxComponents.ts
@@ -13,6 +13,7 @@ import {DefinitionList} from './components/definitionList';
 import {DevDocsCardGrid} from './components/devDocsCardGrid';
 import DocImage from './components/docImage';
 import {Expandable} from './components/expandable';
+import {GitHubDomainChecker} from './components/githubDomainChecker';
 import {GuideGrid} from './components/guideGrid';
 import {JsBundleList} from './components/jsBundleList';
 import {LambdaLayerDetail} from './components/lambdaLayerDetail';
@@ -60,6 +61,7 @@ export function mdxComponents(
     SdkApi,
     TableOfContents,
     CreateGitHubAppForm,
+    GitHubDomainChecker,
     ConfigValue,
     DefinitionList,
     Expandable,


### PR DESCRIPTION
folks are often confused about if they should use the Github Integration or the Github Enterprise Integration. to try to combat this, i added a component (based off of `CreateGitHubAppForm`) which parses the domain the user inputs and tells them what integration to install


https://github.com/user-attachments/assets/ed3890a4-26b4-40c4-ae8c-4fdba679105b

