### PR TITLE
fix(flutter): Add missing experimental for privacy options before GA

### DIFF
--- a/platform-includes/enriching-events/attach-screenshots/dart.flutter.mdx
+++ b/platform-includes/enriching-events/attach-screenshots/dart.flutter.mdx
@@ -40,7 +40,7 @@ await SentryFlutter.init((options) {
 
 ## Redact Screenshots via `masking`
 
-The masking feature is by default disabled for Screenshots. To enable masking, use the `options.privacy` parameter.
+The masking feature is by default disabled for Screenshots. To enable masking, use the `options.experimental.privacy` parameter.
 
 <Alert level="warning">
   Modifying this parameter will also affect `masking` for{" "}

--- a/platform-includes/replay/privacy-configuration/dart.flutter.mdx
+++ b/platform-includes/replay/privacy-configuration/dart.flutter.mdx
@@ -17,9 +17,9 @@ For example, you can explicitly mask or unmask widgets by type,
 or you can even have a callback to decide whether a specific widget instance should be masked:
 
 ```dart
-  options.privacy.mask<IconButton>();
-  options.privacy.unmask<Image>();
-  options.privacy.maskCallback<Text>(
+  options.experimental.privacy.mask<IconButton>();
+  options.experimental.privacy.unmask<Image>();
+  options.experimental.privacy.maskCallback<Text>(
       (Element element, Text widget) =>
           (widget.data?.contains('secret') ?? false)
               ? SentryMaskingDecision.mask


### PR DESCRIPTION
## DESCRIBE YOUR PR

The privacy options are still experimental but the example shows to access via `options.privacy`. This PR changes this to `options.experimental.privacy`

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
