### PR TITLE
feat(python): Add sentry_logs_level option to Loguru, Logging integration

### DIFF
--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -72,8 +72,9 @@ sentry_sdk.init(
     # ...
     integrations=[
         LoggingIntegration(
-            level=logging.INFO,        # Capture info and above as breadcrumbs
-            event_level=logging.INFO   # Send records as events
+            level=logging.INFO,                 # Capture INFO and above as breadcrumbs
+            event_level=logging.INFO            # Send INFO records as events
+            sentry_logs_level=logging.WARNING,  # Capture WARNING and above as logs
         ),
     ],
 )
@@ -84,6 +85,15 @@ You can pass the following keyword arguments to `LoggingIntegration()`:
 - `level` (default `INFO`): The Sentry Python SDK will record log records with a level higher than or equal to `level` as breadcrumbs. Inversely, the SDK completely ignores any log record with a level lower than this one. If a value of `None` occurs, the SDK won't send log records as breadcrumbs.
 
 - `event_level` (default `ERROR`): The Sentry Python SDK will report log records with a level higher than or equal to `event_level` as events as long as the logger itself is set to output records of those log levels (see note below). If a value of `None` occurs, the SDK won't send log records as events.
+
+- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as logs as long as the `enable_logs` experimental option is `True`:
+
+  ```python
+  sentry_sdk.init(
+      # ...
+      _experiments={"enable_logs": True},
+  )
+  ```
 
 <Alert title="Note">
 

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -108,15 +108,14 @@ from loguru import logger
 from sentry_sdk.integrations.loguru import LoguruIntegration
 from sentry_sdk.integrations.loguru import LoggingLevels
 
-sentry_loguru = LoguruIntegration(
-    level=LoggingLevels.INFO.value,        # Capture info and above as breadcrumbs
-    event_level=LoggingLevels.ERROR.value  # Send errors as events
-)
-
 sentry_sdk.init(
     # ...
     integrations=[
-        sentry_loguru,
+        LoguruIntegration(
+            level=LoggingLevels.INFO.value,               # Capture INFO and above as breadcrumbs
+            event_level=LoggingLevels.ERROR.value,        # Send ERROR logs as events
+            sentry_logs_level=LoggingLevels.ERROR.value,  # Capture WARNING and above as logs
+        )
     ],
 )
 ```
@@ -132,6 +131,22 @@ sentry_sdk.init(
   The Sentry Python SDK will report log records with a level higher than or equal to `event_level` as events. If set to `None`, the SDK won't send log records as events.
 
   Default: `ERROR`
+
+- `sentry_logs_level`
+
+  The Sentry Python SDK will capture log records with a level higher than or equal to `sentry_logs_level` as logs. If set to `None`, the SDK won't send records as logs.
+
+  This option is used for fine-tuning the Sentry logs experience. You need to have the experimental `enable_logs` option set to `True` to capture Loguru logs.
+
+  ```python
+  sentry_sdk.init(
+      # ...
+      _experiments={"enable_logs": True},
+  )
+  ```
+
+  Default: `INFO`
+
 
 ## Supported Versions
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Since we started supporting Sentry logs via the logging integration (and more recently Loguru), we haven't added the new `sentry_logs_level` option used to fine-tune which logs should be captured. Adding it here.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
