### PR TITLE
Fix broken link in Cloudflare docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
@@ -15,7 +15,7 @@ _Import name: `Sentry.fetchIntegration`_
 
 This integration is enabled by default. If you want to disable it, you can [modify your default integrations](./../#modifying-default-integrations).
 
-The `fetchIntegration` creates spans and attaches tracing headers to fetch requests in Cloudflare Workers.
+The `fetchIntegration` creates [spans](/concepts/key-terms/tracing/distributed-tracing/#traces-transactions-and-spans) and attaches tracing headers to fetch requests in Cloudflare Workers.
 
 ```JavaScript
 Sentry.init({

--- a/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
@@ -1,0 +1,68 @@
+---
+title: FetchIntegration
+description: "Creates spans and attaches tracing headers to fetch requests in Cloudflare Workers. (default)"
+supported:
+  - javascript.cloudflare
+---
+
+<Alert>
+
+This integration only works in Cloudflare Workers runtime.
+
+</Alert>
+
+_Import name: `Sentry.fetchIntegration`_
+
+This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
+
+The `fetchIntegration` creates spans and attaches tracing headers to fetch requests in Cloudflare Workers.
+
+```JavaScript
+Sentry.init({
+  integrations: [Sentry.fetchIntegration()],
+});
+```
+
+## Options
+
+### `breadcrumbs`
+
+_Type: `boolean`_
+
+If set to false, no breadcrumbs will be captured.
+
+### `shouldCreateSpanForRequest`
+
+_Type: `(url: string) => boolean`_
+
+Allows you to define a method to determine whether or not to create spans to track outgoing requests to the given URL. By default, spans will be created for all outgoing requests.
+
+```JavaScript
+Sentry.init({
+  integrations: [
+    Sentry.fetchIntegration({
+      shouldCreateSpanForRequest: (url) => {
+        // Only create spans for external API calls
+        return url.includes('api.example.com');
+      },
+    }),
+  ],
+});
+```
+
+## Usage
+
+The fetch integration automatically instruments all `fetch()` calls made within your Cloudflare Worker. This includes:
+
+- Creating performance spans for outgoing HTTP requests
+- Adding tracing headers to continue distributed traces
+- Capturing breadcrumbs for debugging purposes
+- Tracking request duration and response status
+
+The integration works with both the standard `fetch()` API and any libraries that use fetch under the hood.
+
+<Alert>
+
+**Note:** If you need to disable fetch instrumentation for specific requests, use the `shouldCreateSpanForRequest` option to filter out unwanted requests.
+
+</Alert>

--- a/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
@@ -13,7 +13,7 @@ This integration only works inside the Cloudflare Workers runtime.
 
 _Import name: `Sentry.fetchIntegration`_
 
-This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
+This integration is enabled by default. If you want to disable it, you can [modify your default integrations](./../#modifying-default-integrations).
 
 The `fetchIntegration` creates spans and attaches tracing headers to fetch requests in Cloudflare Workers.
 

--- a/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
@@ -7,7 +7,7 @@ supported:
 
 <Alert>
 
-This integration only works in Cloudflare Workers runtime.
+This integration only works inside the Cloudflare Workers runtime.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx
@@ -1,6 +1,6 @@
 ---
 title: FetchIntegration
-description: "Creates spans and attaches tracing headers to fetch requests in Cloudflare Workers. (default)"
+description: "A default integration that creates spans and attaches tracing headers to fetch requests in Cloudflare Workers."
 supported:
   - javascript.cloudflare
 ---

--- a/platform-includes/configuration/integrations/javascript.cloudflare.mdx
+++ b/platform-includes/configuration/integrations/javascript.cloudflare.mdx
@@ -7,7 +7,7 @@
 | [`functionToStringIntegration`](./functiontostring)  |        ✓         |            |             |          |                        |
 | [`inboundFiltersIntegration`](./inboundfilters)      |        ✓         |     ✓      |             |          |                        |
 | [`linkedErrorsIntegration`](./linkederrors)          |        ✓         |     ✓      |             |          |                        |
-| [`requestDataIntegration`](./requestDataIntegration) |        ✓         |            |             |          |           ✓            |
+| [`requestDataIntegration`](./requestdata)            |        ✓         |            |             |          |           ✓            |
 | [`captureConsoleIntegration`](./captureconsole)      |                  |            |             |          |           ✓            |
 | [`extraErrorDataIntegration`](./extraerrordata)      |                  |            |             |          |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)        |                  |     ✓      |             |          |                        |


### PR DESCRIPTION
[Cursor created PR - Reviewed by me]

Broken links in the Cloudflare configuration documentation have been resolved.

*   A new file, `docs/platforms/javascript/common/configuration/integrations/fetchIntegration.mdx`, was created.
    *   This addresses a 404 error caused by a missing page referenced by `fetchIntegration` in the integrations table.
    *   The file includes metadata, documentation for `Sentry.fetchIntegration`, configuration options (`breadcrumbs`, `shouldCreateSpanForRequest`), and usage examples, specifically noting its relevance to Cloudflare Workers.
*   The link for `requestDataIntegration` in `platform-includes/configuration/integrations/javascript.cloudflare.mdx` was updated.
    *   The previous link, `./requestDataIntegration`, had incorrect casing and pointed to a non-existent path.
    *   The link was corrected to `./requestdata` to match the actual filename `requestdata.mdx`, ensuring consistency with other integration links.

All links in the Cloudflare integrations table now correctly point to existing documentation files.