### PR TITLE
feat(native): support modifying attachments after init

### DIFF
--- a/platform-includes/enriching-events/add-attachment/native.mdx
+++ b/platform-includes/enriching-events/add-attachment/native.mdx
@@ -25,3 +25,13 @@ sentry_capture_event_with_scope(event, scope);
 ```
 
 <Alert>☝ When using the `crashpad` backend on macOS, the list of attachments that will be added at the time of a hard crash will be frozen at the time of `sentry_init`, and later modifications will not be reflected.</Alert>
+
+### Removing Scoped Attachments
+
+To remove attachments from the global scope, you can use the `sentry_attachment_t` handle returned by `sentry_attach_file`. After removing the attachment, the file will no longer be uploaded with any future events or crashes and the handle becomes invalid.
+
+```c
+sentry_attachment_t *attachment = sentry_attach_file("/var/temp.log");
+/* ... */
+sentry_remove_attachment(attachment);
+```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Adds documentation for Native SDK PR
- https://github.com/getsentry/sentry-native/pull/1266

> Platforms / Native / Enriching Events / Attachments

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
