### PR TITLE
feat(python): Add Loguru to Sentry logs docs

### DIFF
--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -54,6 +54,22 @@ main()
 - `"An exception happened"` will send the current exception from `sys.exc_info()` with the stack trace and everything to the Sentry Python SDK. If there's no exception, the current stack will be attached.
 - The debug message `"I am ignored"` will not surface anywhere. To capture it, you need to lower `level` to `DEBUG` (See below).
 
+Log records can additionally also be captured as [Sentry logs](/platforms/python/logs/) as long as the `enable_logs` experimental option is `True`.
+
+```python
+import logging
+import sentry_sdk
+
+sentry_sdk.init(
+    # ...
+    _experiments={
+        "enable_logs": True,
+    },
+)
+
+logging.info("I will be sent to Sentry logs")
+```
+
 ## Options
 
 To change the default behavior of the logging integration, instantiate the integration manually and pass it to Sentry's `init` function:

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -86,7 +86,7 @@ You can pass the following keyword arguments to `LoggingIntegration()`:
 
 - `event_level` (default `ERROR`): The Sentry Python SDK will report log records with a level higher than or equal to `event_level` as events as long as the logger itself is set to output records of those log levels (see note below). If a value of `None` occurs, the SDK won't send log records as events.
 
-- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as logs as long as the `enable_logs` experimental option is `True`:
+- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/) as long as the `enable_logs` experimental option is `True`.
 
   ```python
   sentry_sdk.init(

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -134,7 +134,7 @@ sentry_sdk.init(
 
 - `sentry_logs_level`
 
-  The Sentry Python SDK will capture log records with a level higher than or equal to `sentry_logs_level` as logs. If set to `None`, the SDK won't send records as logs.
+  The Sentry Python SDK will capture log records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/). If set to `None`, the SDK won't send records as logs.
 
   To capture Loguru log records as Sentry logs, you must enable the experimental `enable_logs` option when initializing the SDK (regardless of the `sentry_logs_level` setting).
 

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -68,6 +68,22 @@ logger.exception("An exception happened")
 - `"An exception happened"` will send the current exception from `sys.exc_info()` with the stack trace to Sentry. If there's no exception, the current stack will be attached.
 - The debug message `"I am ignored"` will not be captured by Sentry. To capture it, set `level` to `DEBUG` or lower in `LoguruIntegration`.
 
+Loguru log records can additionally also be captured as [Sentry logs](/platforms/python/logs/) as long as the `enable_logs` experimental option is `True`.
+
+```python
+import sentry_sdk
+from loguru import logger
+
+sentry_sdk.init(
+    # ...
+    _experiments={
+        "enable_logs": True,
+    },
+)
+
+logger.info("I will be sent to Sentry logs")
+```
+
 ### Ignoring a logger
 
 Loggers can be noisy. You can ignore a logger by calling `ignore_logger`.

--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -61,13 +61,13 @@ from sentry_sdk.integrations.logging import SentryLogsHandler
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 sentry_sdk.init(
-  dsn="...",
-  _experiments={
-      "enable_logs": True
-  },
-  integrations=[
-    LoggingIntegration(sentry_logs_level=None),  # Do not monkeypatch the sentry handler
-  ]
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "enable_logs": True
+    },
+    integrations=[
+        LoggingIntegration(sentry_logs_level=None),  # Do not monkeypatch the sentry handler
+    ],
 }
 
 # Instead, configure the root logger to send INFO-level logs to Sentry
@@ -83,7 +83,7 @@ import sentry_sdk
 from loguru import logger
 
 sentry_sdk.init(
-    dsn="__PUBLIC_DSN__",
+    dsn="___PUBLIC_DSN___",
     _experiments={
         "enable_logs": True,
     },
@@ -124,7 +124,7 @@ from loguru import logger
 from sentry_sdk.integrations.loguru import LoguruIntegration
 
 sentry_sdk.init(
-    dsn="__PUBLIC_DSN__",
+    dsn="___PUBLIC_DSN___",
     _experiments={
         # In general, we want to capture logs as Sentry logs...
         "enable_logs": True,

--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -1,8 +1,4 @@
-### Python Logger Integration
-
-Sentry automatically instruments Python loggers via its logging integrations.
-
-#### Standard library logging
+### Standard library logging
 
 The SDK's `LoggingIntegration` instruments standard library loggers in order to send Sentry structured logs to Sentry.
 
@@ -78,7 +74,7 @@ sentry_sdk.init(
 logging.basicConfig(level=logging.INFO, handlers=[SentryLogsHandler(level=logging.INFO)])
 ```
 
-#### Loguru
+### Loguru
 
 Loguru logs can also be automatically captured and sent to Sentry.
 

--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -1,6 +1,10 @@
 ### Python Logger Integration
 
-Sentry automatically instruments Python loggers via its `LoggingIntegration`.
+Sentry automatically instruments Python loggers via its logging integrations.
+
+#### Standard library logging
+
+The SDK's `LoggingIntegration` instruments standard library loggers in order to send Sentry structured logs to Sentry.
 
 ```python
 import sentry_sdk
@@ -9,8 +13,8 @@ import logging
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     _experiments={
-        "enable_logs": True
-    }
+        "enable_logs": True,
+    },
 )
 
 # Your existing logging setup
@@ -22,7 +26,7 @@ my_logger.debug('In this example debug events will not be sent to Sentry logs. m
 my_logger.info('But info events will be sent to Sentry logs. my_value=%s', my_value)
 ```
 
-By default, the logging integration sends INFO-level logs and higher to Sentry logs. You can set a different threshold via the `LoggingIntegration`'s `sentry_logs_level` parameter. However, regardless of the `sentry_logs_level` setting, the SDK only sends logs if they are at or above the logger's level.
+By default, the logging integration sends `INFO`-level logs and higher to Sentry logs. You can set a different threshold via the `LoggingIntegration`'s `sentry_logs_level` parameter. However, regardless of the `sentry_logs_level` setting, the SDK only sends logs if they are at or above the logger's level.
 
 ```python
 import sentry_sdk
@@ -72,4 +76,68 @@ sentry_sdk.init(
 
 # Instead, configure the root logger to send INFO-level logs to Sentry
 logging.basicConfig(level=logging.INFO, handlers=[SentryLogsHandler(level=logging.INFO)])
+```
+
+#### Loguru
+
+Loguru logs can also be automatically captured and sent to Sentry.
+
+```python
+import sentry_sdk
+from loguru import logger
+
+sentry_sdk.init(
+    dsn="__PUBLIC_DSN__",
+    _experiments={
+        "enable_logs": True,
+    },
+)
+
+loguru.debug("In this example, debug events will not be sent to Sentry logs.")
+loguru.info("On the other hand, info events will be sent to Sentry logs.")
+```
+
+By default, the Loguru integration sends `INFO`-level and higher logs to Sentry logs as long as `enable_logs` is `True`. A different threshold can be set via the `LoguruIntegration`'s `sentry_logs_level` parameter.
+
+```python
+import sentry_sdk
+from loguru import logger
+from sentry_sdk.integrations.loguru import LoggingLevels, LoguruIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "enable_logs": True
+    },
+    integrations=[
+        # Only send WARNING (and higher) logs to Sentry logs
+        LoguruIntegration(sentry_logs_level=LoggingLevels.WARNING.value),
+    ],
+)
+
+logger.info("This INFO log won't be sent to Sentry logs.")
+logger.warning("This WARNING log will be sent to Sentry logs.")
+```
+
+If you want other logging integrations to send logs to Sentry logs, but not Loguru, setting `sentry_logs_level` to `None` on the integration level will stop the Loguru integration for capturing Sentry logs.
+
+```python
+
+import sentry_sdk
+from loguru import logger
+from sentry_sdk.integrations.loguru import LoguruIntegration
+
+sentry_sdk.init(
+    dsn="__PUBLIC_DSN__",
+    _experiments={
+        # In general, we want to capture logs as Sentry logs...
+        "enable_logs": True,
+    },
+    integrations=[
+        # ...just not from Loguru
+        LoguruIntegration(sentry_logs_level=None),
+    ]
+)
+
+loguru.error("This won't be sent to Sentry logs.")
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

- add basic Loguru setup examples to the [Structured logs page](https://sentry-docs-git-ivana-pythonloguru-sentry-logs.sentry.dev/platforms/python/logs/#loguru)
- link to the logs docs page from the [Loguru integration page](https://sentry-docs-git-ivana-pythonloguru-sentry-logs.sentry.dev/platforms/python/integrations/loguru/)
- link to the logs docs page from the [logging integration page](https://sentry-docs-git-ivana-pythonloguru-sentry-logs.sentry.dev/platforms/python/integrations/logging/)

Closes https://github.com/getsentry/sentry-python/issues/4461

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): ASAP as the feature is out now
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
