### PR TITLE
ref(pii): add example for wildcard selector

### DIFF
--- a/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
@@ -142,6 +142,40 @@ You can combine sources using boolean logic.
 - `**` matches all subpaths, so that `foo.**` matches all JSON keys within `foo`.
 - `*` matches a single path item, so that `foo.*` matches all JSON keys one level below `foo`.
 
+When using `**` selectors in scrubbing rules, be aware that they only apply to the [default event PII fields](/security-legal-pii/scrubbing//server-side-scrubbing/event-pii-fields/). Fields not on that list will not be scrubbed automatically when using `**`.
+
+For example, given the following event payload:
+
+```json
+{
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "An error occurred",
+        "stacktrace": {
+          "frames": [
+            {
+              "filename": "test/example/script.js",
+              "abs_path": "test/example/script.js?id=12345"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Using the scrubbing rule `[Mask] [Anything] from [$frame.**]` will not scrub the filename or abs_path fields, since they're not included in the default PII field list.
+
+To scrub those fields, use one of the following rules:
+```
+[Mask] [Anything] from [$frame.*]
+[Mask] [Anything] from [$frame.filename]
+[Mask] [Anything] from [$frame.abs_path]
+```
+
 ### Value Types
 
 Select subsections by JSON-type using the following:

--- a/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
@@ -167,7 +167,7 @@ For example, given the following event payload:
 }
 ```
 
-Using the scrubbing rule `[Mask] [Anything] from [$frame.**]` will not scrub the filename or abs_path fields, since they're not included in the default PII field list.
+Using the scrubbing rule `[Mask] [Anything] from [$frame.**]` will not scrub the `filename` or `abs_path` fields, since they're not included in the default PII field list.
 
 To scrub those fields, use one of the following rules:
 ```

--- a/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
@@ -142,7 +142,7 @@ You can combine sources using boolean logic.
 - `**` matches all subpaths, so that `foo.**` matches all JSON keys within `foo`.
 - `*` matches a single path item, so that `foo.*` matches all JSON keys one level below `foo`.
 
-When using `**` selectors in scrubbing rules, be aware that they only apply to the [default event PII fields](/security-legal-pii/scrubbing//server-side-scrubbing/event-pii-fields/). Fields not on that list will not be scrubbed automatically when using `**`.
+When using `**` selectors in scrubbing rules, be aware that they only apply to the [default event PII fields](/security-legal-pii/scrubbing/server-side-scrubbing/event-pii-fields/). Fields not on that list will **not** be scrubbed automatically, even if matched by a `**` selector.
 
 For example, given the following event payload:
 


### PR DESCRIPTION
Adds an example to better visualise the behaviour of the deep wildcard selector (`**`) if used in a sub-path.

closes RELAY-15

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
