### PR TITLE
Clarify placeholder value instructions

### DIFF
--- a/docs/platforms/javascript/common/best-practices/micro-frontends.mdx
+++ b/docs/platforms/javascript/common/best-practices/micro-frontends.mdx
@@ -74,6 +74,10 @@ module.exports = {
 };
 ```
 
+<Alert>
+  **Replace `__MODULE_DSN__` with your actual Sentry project DSN.** You can find your DSN in your Sentry project settings under Client Keys (DSN).
+</Alert>
+
 Once metadata has been injected into modules, the `moduleMetadataIntegration`
 can be used to look up that metadata and attach it to stack frames with
 matching file names. This metadata is then available in the `beforeSend` callback
@@ -198,6 +202,10 @@ init({
 </script>
 ```
 
+<Alert>
+  **Replace `__DEFAULT_DSN__` with your actual Sentry project DSN.** This should be the DSN for your default/fallback Sentry project. You can find your DSN in your Sentry project settings under Client Keys (DSN).
+</Alert>
+
 Once this is set up, errors - both handled and unhandled - will be automatically routed to the right project.
 
 <Alert>
@@ -242,6 +250,15 @@ init({
   }),
 });
 ```
+
+<Alert>
+  **Replace the placeholder DSN values with your actual Sentry project DSNs:**
+  - Replace `__FALLBACK_DSN__` with the DSN for your fallback/default Sentry project
+  - Replace `__CART_DSN__` with the DSN for your cart micro frontend's Sentry project  
+  - Replace `__GALLERY_DSN__` with the DSN for your gallery micro frontend's Sentry project
+  
+  You can find your DSNs in each Sentry project's settings under Client Keys (DSN).
+</Alert>
 
 You can then set tags/contexts on events in individual micro-frontends to decide which Sentry project to send the event to as follows:
 


### PR DESCRIPTION
In `docs/platforms/javascript/common/best-practices/micro-frontends.mdx`, `<Alert>` components were added to clarify placeholder DSN values.

*   An alert was inserted after the webpack config example, instructing users to replace `__MODULE_DSN__`.
*   Another alert was added after the automatic routing examples, specifying that `__DEFAULT_DSN__` should be replaced with the default/fallback DSN.
*   A comprehensive alert was placed after the manual routing example, detailing the replacement of `__FALLBACK_DSN__`, `__CART_DSN__`, and `__GALLERY_DSN__`.

The alerts explicitly state that these are placeholder DSNs and provide instructions on locating actual DSNs within the Sentry project settings (Client Keys). This change ensures users clearly understand that the provided DSNs are not functional and must be customized, improving the clarity and usability of the documentation.