### PR TITLE
Update documentation for uint64 handling in logs

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -89,7 +89,7 @@ It consists of the following fields:
 
 : **Object, optional**. A dictionary of key-value pairs of arbitrary data attached to the log. Attributes must also declare the type of the value. The following types are supported: `string`, `boolean`, `integer`, `double`. In the future arrays will be supported (`string[]`, `boolean[]`, `integer[]`, `double[]`).
 
-Integers should be a 64-bit signed integer, while doubles should be a 64-bit floating point number. For 64-bit unsigned integers, use the `string` type to avoid overflow issues.
+Integers should be a 64-bit signed integer, while doubles should be a 64-bit floating point number. For 64-bit unsigned integers, use the `string` type to avoid overflow issues. In the future we will support 64-bit unsigned integers.
 
 Example:
 


### PR DESCRIPTION
ref convos in https://github.com/getsentry/relay/pull/4689

The `attributes` section in `develop-docs/sdk/telemetry/logs.mdx` was updated to clarify handling of 64-bit unsigned integers.

*   Initially, the text "In the future we will support 64-bit unsigned integers." was replaced with "For 64-bit unsigned integers, use the `string` type to avoid overflow issues."
    *   This change was made to provide immediate guidance based on internal discussions, recommending `string` conversion to prevent data loss or precision issues.
*   Subsequently, the documentation was further refined to include both the current guidance and the future roadmap.
    *   The line now reads: "For 64-bit unsigned integers, use the `string` type to avoid overflow issues. In the future we will support 64-bit unsigned integers."
    *   This ensures SDK developers and third-party integration authors have clear instructions for current implementation while also being aware of planned native support.