### PR TITLE
Fix typo in Next.js documentation

### DIFF
--- a/platform-includes/llm-rules-platform/javascript.nextjs.mdx
+++ b/platform-includes/llm-rules-platform/javascript.nextjs.mdx
@@ -21,7 +21,7 @@ These examples should be used as guidance when configuring Sentry functionality 
 
 ## Custom Span instrumentation in component actions
 
-- The `name` and `op` properties should be meaninful for the activities in the call.
+- The `name` and `op` properties should be meaningful for the activities in the call.
 - Attach attributes based on relevant information and metrics from the request
 
 ```javascript
@@ -56,7 +56,7 @@ function TestComponent() {
 
 ## Custom span instrumentation in API calls
 
-- The `name` and `op` properties should be meaninful for the activities in the call.
+- The `name` and `op` properties should be meaningful for the activities in the call.
 - Attach attributes based on relevant information and metrics from the request
 
 ```javascript


### PR DESCRIPTION
A typo was corrected in the `platform-includes/llm-rules-platform/javascript.nextjs.mdx` file.

*   The word "meaninful" was changed to "meaningful" in two instances.
*   The corrections were made on lines 23 and 58 within comments describing span properties.
*   This file is a shared partial that contains AI Rules for Code Editors.
*   Correcting the typo in this partial ensures the fix is applied across all documentation pages where this content is included, including the `Next.js` guide.