### PR TITLE
Fix Laravel log driver name

### DIFF
--- a/platform-includes/logs/setup/php.laravel.mdx
+++ b/platform-includes/logs/setup/php.laravel.mdx
@@ -23,7 +23,7 @@ Optionally, you can set the logging level:
 'channels' => [
     // ...
     'sentry' => [
-        'driver' => 'sentry',
+        'driver' => 'sentry_logs',
         // The minimum logging level at which this handler will be triggered
         // Available levels: debug, info, notice, warning, error, critical, alert, emergency
         'level' => env('LOG_LEVEL', 'error'),


### PR DESCRIPTION
The current example uses the previous log driver, which creates issues instead of logs.