### PR TITLE
Add Xbox to IL2CPP support list

### DIFF
--- a/docs/platforms/unity/configuration/il2cpp/index.mdx
+++ b/docs/platforms/unity/configuration/il2cpp/index.mdx
@@ -15,6 +15,7 @@ The Sentry SDK provides line number support for IL2CPP builds for the following 
 - Linux
 - Android
 - iOS
+- Xbox
 
 When you build with IL2CPP, errors in your game will happen in the native code. Also, the mapping between your C# code and the generated C++ code is part of the build process and isn't shipped with your game. That means the event the Sentry SDK reports can only contain the native stack trace. To provide you with C# line numbers, the Sentry server needs to have access to that line mapping through [Debug Information Files](/platforms/unity/data-management/debug-files/).
 


### PR DESCRIPTION
The documentation for IL2CPP support was updated to include Xbox in the list of supported platforms.

*   The file `docs/platforms/unity/configuration/il2cpp/index.mdx` was modified.
*   "Xbox" was added to the bulleted list of platforms that support IL2CPP line number support.
*   This change reflects confirmation that IL2CPP line number support functions on Xbox.

The updated list now includes:
*   Windows (*currently limited to Unity 2021.3 or newer)
*   macOS
*   Linux
*   Android
*   iOS
*   Xbox