### PR TITLE
feat(vercelai): include input/output options

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -27,17 +27,23 @@ supported:
 
 <Alert>
 
-This integration only works in the Node.js and Bun runtimes. Requires SDK version `8.43.0` or higher.
+This integration only works in the Node.js and Bun runtimes. Requires SDK version `9.30.0` or higher.
 
 </Alert>
 
 _Import name: `Sentry.vercelAIIntegration`_
 
-The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) library by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
+The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry). Get started with the following snippet:
 
 ```javascript
 Sentry.init({
-  integrations: [Sentry.vercelAIIntegration()],
+  tracesSampleRate: 1.0,
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
 });
 ```
 
@@ -45,7 +51,7 @@ To enhance the spans collected by this integration, we recommend providing a `fu
 
 ```javascript
 const result = await generateText({
-  model: openai("gpt-4-turbo"),
+  model: openai("gpt-4o"),
   experimental_telemetry: {
     isEnabled: true,
     functionId: "my-awesome-function",
@@ -93,7 +99,7 @@ By default this integration adds tracing support to all `ai` function callsites.
 
 ```javascript
 const result = await generateText({
-  model: openai("gpt-4-turbo"),
+  model: openai("gpt-4o"),
   experimental_telemetry: { isEnabled: false },
 });
 ```
@@ -102,7 +108,7 @@ If you set `experimental_telemetry.recordInputs` and `experimental_telemetry.rec
 
 ```javascript
 const result = await generateText({
-  model: openai("gpt-4-turbo"),
+  model: openai("gpt-4o"),
   experimental_telemetry: {
     isEnabled: true,
     recordInputs: true,


### PR DESCRIPTION
- Updates the top snippet to include `recordInputs` and `recordOutputs` options.
- Switches the model used in other snippets