### PR TITLE
Fix Logs (Beta) button functionality

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -112,6 +112,11 @@ Initialize the Sentry React SDK in your `entry.client.tsx` file:
 +    }),
 +    // ___PRODUCT_OPTION_END___ user-feedback
 +  ],
++  // ___PRODUCT_OPTION_START___ logs
++
++  // Enable logs to be sent to Sentry
++  _experiments: { enableLogs: true },
++  // ___PRODUCT_OPTION_END___ logs
 +  // ___PRODUCT_OPTION_START___ performance
 +
 +  tracesSampleRate: 1.0, //  Capture 100% of the transactions
@@ -232,6 +237,11 @@ Sentry.init({
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+  // ___PRODUCT_OPTION_START___ logs
+
+  // Enable logs to be sent to Sentry
+  _experiments: { enableLogs: true },
+  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ profiling
   
   integrations: [nodeProfilingIntegration()],


### PR DESCRIPTION
The "Logs (Beta)" option on the React Router documentation page did not update the displayed code snippet. This was due to the absence of corresponding `OnboardingOption` blocks for logs configuration within `docs/platforms/javascript/guides/react-router/index.mdx`.

To resolve this:
*   The `_experiments: { enableLogs: true }` configuration was added.
*   This configuration was inserted into the `Sentry.init` call within the client-side setup, specifically under the `entry.client.tsx` section.
*   The same configuration was also added to the `Sentry.init` call within the server-side setup, under the `instrument.server.mjs` section.

These additions ensure that when "Logs (Beta)" is selected, the relevant code snippet for enabling logs is displayed in both client and server initialization examples, aligning with the expected behavior of the `OnboardingOptionButtons` component.