### PR TITLE
EnableInExpoDevelopment looks like it disable sentry on non dev envs

### DIFF
--- a/docs/platforms/react-native/migration/sentry-expo.mdx
+++ b/docs/platforms/react-native/migration/sentry-expo.mdx
@@ -74,14 +74,14 @@ Replace `sentry-expo` export `Native` with `@sentry/react-native`:
 
 The `enableInExpoDevelopment` option is no longer supported. If you were using it, remove it and replace it with a `__DEV__` check, or leave the SDK enabled in development.
 
-```javascript {tabTitle:Disabled in Development} diff
+```javascript {tabTitle:Disabled in development} diff
 Sentry.init({
 -  enableInExpoDevelopment: false,
 +  enabled: !__DEV__,
 });
 ```
 
-```javascript {tabTitle:Enabled in Development} diff
+```javascript {tabTitle:Enabled in development} diff
 Sentry.init({
 -  enableInExpoDevelopment: true,
 +  enabled: true,

--- a/docs/platforms/react-native/migration/sentry-expo.mdx
+++ b/docs/platforms/react-native/migration/sentry-expo.mdx
@@ -74,14 +74,14 @@ Replace `sentry-expo` export `Native` with `@sentry/react-native`:
 
 The `enableInExpoDevelopment` option is no longer supported. If you were using it, remove it and replace it with a `__DEV__` check, or leave the SDK enabled in development.
 
-```javascript {tabTitle:JavaScript} diff
+```javascript {tabTitle:Disabled in Development} diff
 Sentry.init({
 -  enableInExpoDevelopment: false,
 +  enabled: !__DEV__,
 });
 ```
 
-```javascript {tabTitle:JavaScript} diff
+```javascript {tabTitle:Enabled in Development} diff
 Sentry.init({
 -  enableInExpoDevelopment: true,
 +  enabled: true,

--- a/docs/platforms/react-native/migration/sentry-expo.mdx
+++ b/docs/platforms/react-native/migration/sentry-expo.mdx
@@ -76,8 +76,15 @@ The `enableInExpoDevelopment` option is no longer supported. If you were using i
 
 ```javascript {tabTitle:JavaScript} diff
 Sentry.init({
+-  enableInExpoDevelopment: false,
++  enabled: !__DEV__,
+});
+```
+
+```javascript {tabTitle:JavaScript} diff
+Sentry.init({
 -  enableInExpoDevelopment: true,
-+  enabled: __DEV__,
++  enabled: true,
 });
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

EnableInExpoDevelopment looks like it disable sentry on non dev envs.

`__DEV__` is under prod = false which would mean Sentry = disabled or?

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
