### PR TITLE
Fix rendering error on sourcemaps guide list

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.mdx
@@ -34,14 +34,15 @@ If you used Create React App to set up your React application see our <PlatformL
 ### Guides for Source Maps
 
 - <PlatformLink to="/sourcemaps/uploading/typescript/">TypeScript (tsc)</PlatformLink>
-- <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
-- <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
-- [GitHub Actions](/product/releases/setup/release-automation/github-actions/)
 
 <Alert>
   If you're using one of webpack, Vite, Rollup, or Esbuild, use the
   corresponding Sentry plugin instead (see section "Sentry Bundler Support").
 </Alert>
+
+- <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
+- [GitHub Actions](/product/releases/setup/release-automation/github-actions/)
 
 ## Other Tools
 

--- a/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.mdx
@@ -33,17 +33,15 @@ If you used Create React App to set up your React application see our <PlatformL
 
 ### Guides for Source Maps
 
-- <PlatformLink to="/sourcemaps/uploading/typescript/">
-    {" "}
-    TypeScript (tsc){" "}
-  </PlatformLink>
-  <Alert>
-    If you're using one of webpack, Vite, Rollup, or Esbuild, use the
-    corresponding Sentry plugin instead (see section "Sentry Bundler Support").
-  </Alert>
+- <PlatformLink to="/sourcemaps/uploading/typescript/">TypeScript (tsc)</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
 - [GitHub Actions](/product/releases/setup/release-automation/github-actions/)
+
+<Alert>
+  If you're using one of webpack, Vite, Rollup, or Esbuild, use the
+  corresponding Sentry plugin instead (see section "Sentry Bundler Support").
+</Alert>
 
 ## Other Tools
 


### PR DESCRIPTION
Fixes an issue where the list element had an unnecessary new line https://docs.sentry.io/platforms/javascript/guides/node/sourcemaps/

<img width="756" alt="image" src="https://github.com/user-attachments/assets/975ed378-f947-4dc5-bf52-97b9e2eca741" />