### PR TITLE
Create wrangler sourcemaps guide for Cloudflare

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
@@ -169,7 +169,7 @@ If your source maps aren't working as expected:
 
 If you encounter build errors when adding source map flags:
 
-1. Make sure you're using a recent version of Wrangler
+1. Make sure you're using Wrangler `3.x` or above
 2. Verify that your project structure supports the `--outdir` flag
 3. Consider switching to Vite for a more robust build pipeline
 

--- a/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
@@ -23,14 +23,6 @@ The easiest way to configure source map uploading with Wrangler is by using the 
 
 <Include name="sourcemaps-wizard-instructions.mdx" />
 
-The wizard will guide you through the following steps:
-
-- Logging into Sentry and selecting a project
-- Installing the necessary Sentry packages
-- Modifying your deploy command to access source maps and inject the `SENTRY_RELEASE` environment variable
-- Creating a source map upload script
-- Configuring your CI to upload source maps
-
 If you'd rather configure source maps manually, follow the steps below.
 
 ## Manual Setup

--- a/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
@@ -115,15 +115,23 @@ This ensures that source maps are uploaded to Sentry immediately after a success
 
 Make sure your Sentry SDK configuration includes the release information:
 
-```javascript
+```typescript {filename:index.ts}
 import * as Sentry from "@sentry/cloudflare";
 
-Sentry.init({
-  dsn: "YOUR_DSN_HERE",
-  // The release name should match what's used during source map upload
-  release: env.SENTRY_RELEASE,
-  // other options...
-});
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: "YOUR_DSN_HERE",
+    // The release name should match what's used during source map upload
+    release: env.SENTRY_RELEASE,
+    // other options...
+  }),
+  {
+    async fetch(request, env, ctx) {
+      // Your worker logic here
+      return new Response("Hello World!");
+    },
+  } satisfies ExportedHandler<Env>
+);
 ```
 
 ### 7. Deploy Your Application

--- a/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
@@ -1,0 +1,173 @@
+---
+title: Wrangler
+description: "Upload your source maps using Wrangler and Sentry CLI."
+sidebar_order: 10
+supported:
+  - javascript.cloudflare
+---
+
+In this guide, you'll learn how to successfully upload source maps for Cloudflare Workers using Wrangler and our `sentry-cli` tool.
+
+<Include name="debug-id-requirement.mdx" />
+
+<Alert level="info">
+
+This guide is specifically for Cloudflare Workers using Wrangler. For other build tools like Vite with Cloudflare, use the corresponding Vite guide instead.
+
+We recommend using Vite to build your worker for an easier and more reliable setup. Learn more about [Cloudflare's Vite setup](https://developers.cloudflare.com/workers/vite-plugin/get-started/).
+
+</Alert>
+
+## Automatic Setup
+
+The easiest way to configure source map uploading with Wrangler is by using the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx" />
+
+The wizard will guide you through the following steps:
+
+- Logging into Sentry and selecting a project
+- Installing the necessary Sentry packages
+- Modifying your deploy command to access source maps and inject the `SENTRY_RELEASE` environment variable
+- Creating a source map upload script
+- Configuring your CI to upload source maps
+
+If you'd rather configure source maps manually, follow the steps below.
+
+## Manual Setup
+
+### 1. Install Sentry CLI
+
+First, install Sentry CLI as a dev dependency:
+
+```bash {tabTitle:npm}
+npm install --save-dev @sentry/cli
+```
+
+```bash {tabTitle:yarn}
+yarn add --dev @sentry/cli
+```
+
+```bash {tabTitle:pnpm}
+pnpm add --save-dev @sentry/cli
+```
+
+### 2. Configure Sentry CLI
+
+You can find installation instructions for Sentry CLI here: [https://docs.sentry.io/cli/installation/](https://docs.sentry.io/cli/installation/)
+
+For more info on `sentry-cli` configuration visit the [Sentry CLI configuration docs](/cli/configuration/).
+
+Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
+
+```bash {filename:.env.local}
+SENTRY_ORG=example-org
+SENTRY_PROJECT=example-project
+SENTRY_AUTH_TOKEN=sntrys_YOUR_TOKEN_HERE
+```
+
+### 3. Modify Your Deploy Command
+
+Update your Wrangler deploy command in `package.json` to include the necessary flags for source map generation and upload:
+
+```json {filename:package.json}
+{
+  "scripts": {
+    "deploy": "wrangler deploy --outdir dist --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version)"
+  }
+}
+```
+
+The key flags are:
+- `--outdir dist`: Specifies the output directory where source maps will be generated
+- `--upload-source-maps`: Forces Wrangler to generate source maps
+- `--var SENTRY_RELEASE:$(sentry-cli releases propose-version)`: Injects the release version as an environment variable
+
+### 4. Create a Source Map Upload Script
+
+Add a script to upload source maps to Sentry in your `package.json`:
+
+```json {filename:package.json}
+{
+  "scripts": {
+    "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=your-org --project=your-project && sentry-cli sourcemaps upload --org=your-org --project=your-project --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist"
+  }
+}
+```
+
+Replace `your-org` and `your-project` with your actual Sentry organization and project slugs.
+
+### 5. Add a Post-Deploy Hook
+
+Create a post-deploy script that automatically uploads source maps after deployment:
+
+```json {filename:package.json}
+{
+  "scripts": {
+    "deploy": "wrangler deploy --outdir dist --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version)",
+    "postdeploy": "npm run sentry:sourcemaps"
+  }
+}
+```
+
+This ensures that source maps are uploaded to Sentry immediately after a successful deployment.
+
+### 6. Configure Your Sentry SDK
+
+Make sure your Sentry SDK configuration includes the release information:
+
+```javascript
+import * as Sentry from '@sentry/cloudflare';
+
+Sentry.init({
+  dsn: 'YOUR_DSN_HERE',
+  // The release name should match what's used during source map upload
+  release: env.SENTRY_RELEASE,
+  // other options...
+});
+```
+
+### 7. Deploy Your Application
+
+Run your deploy command:
+
+```bash
+npm run deploy
+```
+
+This will:
+1. Build your worker with source maps enabled
+2. Deploy to Cloudflare with the release version injected
+3. Automatically upload source maps to Sentry via the post-deploy hook
+
+### 8. Verify Source Maps Upload
+
+You can verify that your source maps were uploaded successfully by:
+
+1. Going to **Project Settings > Source Maps** in Sentry
+2. Checking for your release in the "Artifact Bundles" tab
+3. Confirming that source maps are working by triggering an error and checking that the stack trace shows your original source code
+
+## Troubleshooting
+
+### Source Maps Not Working
+
+If your source maps aren't working as expected:
+
+1. Verify that the `SENTRY_RELEASE` environment variable is being set correctly in your worker
+2. Check that the release name in your Sentry SDK configuration matches the one used during upload
+3. Ensure that source maps are being generated in the specified `--outdir`
+
+### Build Errors
+
+If you encounter build errors when adding source map flags:
+
+1. Make sure you're using a recent version of Wrangler
+2. Verify that your project structure supports the `--outdir` flag
+3. Consider switching to Vite for a more robust build pipeline
+
+## Additional Resources
+
+- [Cloudflare Wrangler Documentation](https://developers.cloudflare.com/workers/wrangler/)
+- [Cloudflare Vite Plugin](https://developers.cloudflare.com/workers/vite-plugin/get-started/)
+- [Using sentry-cli to Upload Source Maps](/cli/releases/#sentry-cli-sourcemaps)

--- a/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
@@ -1,12 +1,11 @@
 ---
 title: Wrangler
-description: "Upload your source maps using Wrangler and Sentry CLI."
+description: "Upload your Cloudflare Workers source maps using Wrangler and Sentry CLI."
 sidebar_order: 10
 supported:
   - javascript.cloudflare
 ---
 
-In this guide, you'll learn how to successfully upload source maps for Cloudflare Workers using Wrangler and our `sentry-cli` tool.
 
 <Include name="debug-id-requirement.mdx" />
 
@@ -64,9 +63,9 @@ SENTRY_PROJECT=example-project
 SENTRY_AUTH_TOKEN=sntrys_YOUR_TOKEN_HERE
 ```
 
-### 3. Modify Your Deploy Command
+### 3. Modify Your Deploy Script
 
-Update your Wrangler deploy command in `package.json` to include the necessary flags for source map generation and upload:
+Update your Wrangler deploy script in `package.json` to include the necessary flags for source map generation and upload:
 
 ```json {filename:package.json}
 {

--- a/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx
@@ -54,8 +54,6 @@ pnpm add --save-dev @sentry/cli
 
 ### 2. Configure Sentry CLI
 
-You can find installation instructions for Sentry CLI here: [https://docs.sentry.io/cli/installation/](https://docs.sentry.io/cli/installation/)
-
 For more info on `sentry-cli` configuration visit the [Sentry CLI configuration docs](/cli/configuration/).
 
 Make sure `sentry-cli` is configured for your project. For that you can use environment variables:
@@ -79,6 +77,7 @@ Update your Wrangler deploy command in `package.json` to include the necessary f
 ```
 
 The key flags are:
+
 - `--outdir dist`: Specifies the output directory where source maps will be generated
 - `--upload-source-maps`: Forces Wrangler to generate source maps
 - `--var SENTRY_RELEASE:$(sentry-cli releases propose-version)`: Injects the release version as an environment variable
@@ -117,10 +116,10 @@ This ensures that source maps are uploaded to Sentry immediately after a success
 Make sure your Sentry SDK configuration includes the release information:
 
 ```javascript
-import * as Sentry from '@sentry/cloudflare';
+import * as Sentry from "@sentry/cloudflare";
 
 Sentry.init({
-  dsn: 'YOUR_DSN_HERE',
+  dsn: "YOUR_DSN_HERE",
   // The release name should match what's used during source map upload
   release: env.SENTRY_RELEASE,
   // other options...
@@ -136,6 +135,7 @@ npm run deploy
 ```
 
 This will:
+
 1. Build your worker with source maps enabled
 2. Deploy to Cloudflare with the release version injected
 3. Automatically upload source maps to Sentry via the post-deploy hook

--- a/platform-includes/sourcemaps/overview/javascript.cloudflare.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.cloudflare.mdx
@@ -22,10 +22,12 @@ If you want to configure source maps to upload manually, follow the guide for yo
 - <PlatformLink to="/sourcemaps/uploading/typescript/">
     TypeScript (tsc)
   </PlatformLink>
+
   <Alert>
     If you're using one of webpack, Vite, Rollup, or Esbuild, use the
     corresponding Sentry plugin instead (see section "Sentry Bundler Support").
   </Alert>
+
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
 - <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
 - [GitHub Actions](/product/releases/setup/release-automation/github-actions/)

--- a/platform-includes/sourcemaps/overview/javascript.cloudflare.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.cloudflare.mdx
@@ -24,8 +24,8 @@ If you want to configure source maps to upload manually, follow the guide for yo
   </PlatformLink>
 
   <Alert>
-    If you're using one of webpack, Vite, Rollup, or Esbuild, use the
-    corresponding Sentry plugin instead (see section "Sentry Bundler Support").
+    If you're using a bundler like Webpack, Vite, Rollup, or Esbuild, use the
+    corresponding Sentry plugin instead. For details, see the "Sentry Bundler Support" section.
   </Alert>
 
 - <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>

--- a/platform-includes/sourcemaps/overview/javascript.cloudflare.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.cloudflare.mdx
@@ -1,0 +1,35 @@
+## Uploading Source Maps
+
+The easiest way to configure uploading source maps is by using the Sentry Wizard:
+
+<Include name="sourcemaps-wizard-instructions.mdx" />
+
+If you want to configure source maps to upload manually, follow the guide for your bundler or build tool below.
+
+## Sentry Bundler Support
+
+- <PlatformLink to="/sourcemaps/uploading/webpack/">webpack</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/rollup/">Rollup</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/vite/">Vite</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/esbuild/">esbuild</PlatformLink>
+
+### Cloudflare-Specific Tools
+
+- <PlatformLink to="/sourcemaps/uploading/wrangler/">Wrangler</PlatformLink>
+
+### Guides for Source Maps
+
+- <PlatformLink to="/sourcemaps/uploading/typescript/">
+    TypeScript (tsc)
+  </PlatformLink>
+  <Alert>
+    If you're using one of webpack, Vite, Rollup, or Esbuild, use the
+    corresponding Sentry plugin instead (see section "Sentry Bundler Support").
+  </Alert>
+- <PlatformLink to="/sourcemaps/uploading/uglifyjs/">UglifyJS</PlatformLink>
+- <PlatformLink to="/sourcemaps/uploading/systemjs/">SystemJS</PlatformLink>
+- [GitHub Actions](/product/releases/setup/release-automation/github-actions/)
+
+## Other Tools
+
+If you're not using one of these tools, we assume you already know how to generate source maps with your toolchain and we recommend you upload them using <PlatformLink to="/sourcemaps/uploading/cli/">Sentry CLI</PlatformLink>.

--- a/platform-includes/sourcemaps/upload/primer/javascript.cloudflare.mdx
+++ b/platform-includes/sourcemaps/upload/primer/javascript.cloudflare.mdx
@@ -1,0 +1,12 @@
+We provide guides on uploading source maps to Sentry for the most popular JavaScript build tools and Cloudflare-specific tools.
+Pick one from the list below to learn more.
+
+<Alert>
+
+If you can't find the tool of your choice in the list below, we recommend you choose the "Sentry CLI" guide.
+
+</Alert>
+
+<Include name="sourcemaps/overview/javascript.cloudflare.mdx" />
+
+<PageGrid />


### PR DESCRIPTION
Documents the changes from https://github.com/getsentry/sentry-wizard/pull/999

ref https://github.com/getsentry/sentry-javascript/issues/14841

A new sourcemaps guide for Wrangler was added to the Cloudflare documentation.

*   A new guide, `docs/platforms/javascript/common/sourcemaps/uploading/wrangler.mdx`, was created.
    *   It details both automatic setup via the Sentry Wizard and manual configuration.
    *   Manual steps include installing `@sentry/cli`, configuring `sentry-cli`, and modifying the `package.json` scripts.
    *   The `deploy` script is updated to include `--outdir`, `--upload-source-maps`, and `--var SENTRY_RELEASE:$(sentry-cli releases propose-version)`.
    *   A `sentry:sourcemaps` script is added to create releases and upload sourcemaps.
    *   A `postdeploy` script is introduced to automatically run the `sentry:sourcemaps` command after deployment.
    *   Instructions for configuring the Sentry SDK with `release: env.SENTRY_RELEASE` are provided.
    *   The guide is marked as `supported: [javascript.cloudflare]` to ensure platform-specific visibility.
*   `platform-includes/sourcemaps/overview/javascript.cloudflare.mdx` was updated to include a "Cloudflare-Specific Tools" section, linking to the new Wrangler guide.
*   `platform-includes/sourcemaps/upload/primer/javascript.cloudflare.mdx` was modified to include the updated Cloudflare overview.

These changes ensure that Wrangler users have a dedicated guide for sourcemap uploads, integrated seamlessly into the Cloudflare platform documentation.