### PR TITLE
Remove localvariables integration for unsupported SDKs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
@@ -22,7 +22,6 @@ supported:
   - javascript.react-router
   - javascript.astro
   - javascript.bun
-  - javascript.cloudflare
   - javascript.deno
   - javascript.tanstackstart-react
 ---

--- a/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/localvariables.mdx
@@ -21,8 +21,6 @@ supported:
   - javascript.remix
   - javascript.react-router
   - javascript.astro
-  - javascript.bun
-  - javascript.deno
   - javascript.tanstackstart-react
 ---
 


### PR DESCRIPTION
The `supported` list in `docs/platforms/javascript/common/configuration/integrations/localvariables.mdx` was modified.

*   `javascript.cloudflare` was removed from the `supported` list.
*   `javascript.bun` was removed from the `supported` list.
*   `javascript.deno` was removed from the `supported` list.