### PR TITLE
feat(platform): Add onRouterTransitionStart

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -38,3 +38,5 @@ if (process.env.NODE_ENV === 'development') {
     showClearEventsButton: true,
   });
 }
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
Adds the future-proof way of instrumenting client-side navigations by using `onRouterTransitionStart`