### PR TITLE
chore(nel): Enable 1% NEL success

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "NEL",
-          "value": "{\"report_to\":\"nel\",\"max_age\":3600,\"success_fraction\":0.0,\"failure_fraction\":1.0}"
+          "value": "{\"report_to\":\"nel\",\"max_age\":3600,\"success_fraction\":0.01,\"failure_fraction\":1.0}"
         },
         {
           "key": "Report-To",


### PR DESCRIPTION
Now that we are [internally dogfooding these as logs](https://sentry.sentry.io/explore/logs/?project=4507503193292800) we can enable success.