### PR TITLE
Fix(hono): custom hono tracing instrumentation code

### DIFF
--- a/platform-includes/performance/configure-sample-rate/javascript.hono.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.hono.mdx
@@ -1,0 +1,17 @@
+```javascript
+import * as Sentry from "@sentry/node"
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+
+  // Enhanced tracing options
+  environment: process.env.NODE_ENV || 'development',
+  
+  // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
+  tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+});
+```


### PR DESCRIPTION
Hono tracing page pointed to our browser sdk and also to our `browserTracingIntegration`, proof:

![Screenshot 2025-06-20 at 17 42 39](https://github.com/user-attachments/assets/53c31101-beeb-4794-9c8e-483b08120a0c)

Now it point's to our node sdk: 
![Screenshot 2025-06-20 at 17 45 28](https://github.com/user-attachments/assets/74a47027-82d6-4be1-8c85-83b3a44a6f4e)
