### PR TITLE
:wrench: chore(gitlab): update codeowners syntax  link

### DIFF
--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -77,7 +77,7 @@ This feature supports GitHub and GitLab CODEOWNERS file syntax with the followin
 - Escaping a pattern starting with `#` using `\` so it is treated as a pattern and not a comment
 - Using `!` to negate a pattern
 - Using `[ ]` to define a character range
-- [GitLab Premium syntax](https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections)
+- [GitLab Premium syntax](https://docs.gitlab.com/user/project/codeowners/reference/)
 - [GitHub CODEOWNERS syntax exceptions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
 
 <Alert>

--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -77,7 +77,7 @@ This feature supports GitHub and GitLab CODEOWNERS file syntax with the followin
 - Escaping a pattern starting with `#` using `\` so it is treated as a pattern and not a comment
 - Using `!` to negate a pattern
 - Using `[ ]` to define a character range
-- [GitLab Premium syntax](https://docs.gitlab.com/user/project/codeowners/reference/)
+- [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference/)
 - [GitHub CODEOWNERS syntax exceptions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
 
 <Alert>


### PR DESCRIPTION
the existing link is a dead link

closes ECO-724