### PR TITLE
docs(js): Update react-router docs for import flags

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -373,6 +373,24 @@ Update the `start` and `dev` script to include the instrumentation file:
 }
 ```
 
+#### Alternative Setup for Hosting Platforms
+
+If you're deploying to platforms like **Vercel** or **Netlify** where setting the `NODE_OPTIONS` import flag is not possible, you can import the instrumentation file directly at the top of your `entry.server.tsx`:
+
+```tsx {diff} {filename: entry.server.tsx}
++import './instrument.server.mjs';
+ import * as Sentry from '@sentry/react-router';
+ import { createReadableStreamFromReadable } from '@react-router/node';
+ import { renderToPipeableStream } from 'react-dom/server';
+ // ... rest of your imports
+```
+
+<Alert title="Incomplete Auto-instrumentation" level="warning">
+
+  When importing the instrumentation file directly in `entry.server.tsx` instead of using the `--import` flag, some automatic instrumentation may be incomplete. This approach should only be used when the `NODE_OPTIONS` approach is not available on your hosting platform.
+
+</Alert>
+
 ## Source Maps Upload
 
 Update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it:


### PR DESCRIPTION
Documentation for React Router was updated to provide an alternative setup for environments where the `NODE_OPTIONS` `--import` flag is not supported.

*   A new subsection, "Alternative Setup for Hosting Platforms," was added under the "Update Scripts" section in `docs/platforms/javascript/guides/react-router/index.mdx`.
*   This section addresses platforms like Vercel and Netlify, where direct import of the instrumentation file is necessary.
*   Instructions were added to import `./instrument.server.mjs` at the top of `entry.server.tsx`.
*   A code example demonstrates this direct import.
*   A warning alert was included to clarify that this alternative method results in incomplete auto-instrumentation and should only be used when the `--import` flag is not an option.

ref https://github.com/getsentry/sentry-javascript/issues/15198