### PR TITLE
docs(js): Mark `@sentry/react-router` as beta

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -11,7 +11,7 @@ categories:
 
 <Alert title='SDK Limitations' level='warning'>
 
-  This SDK is considered **experimental and in an alpha state**. It may experience breaking changes. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/) if you have any feedback or concerns.
+  This SDK is considered **experimental and in a beta state**. It may experience breaking changes. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/) if you have any feedback or concerns.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -9,10 +9,11 @@ categories:
   - server-node
 ---
 
-<Alert title='SDK Limitations' level='warning'>
-
-  This SDK is considered **experimental and in a beta state**. It may experience breaking changes. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/) if you have any feedback or concerns.
-
+<Alert level="warning">
+  This SDK is currently in **beta**. Beta features are still in progress and may
+  have bugs. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if
+  you have any feedback or concerns.
 </Alert>
 
 <Alert title='Looking for library mode?' level='info'>

--- a/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
@@ -5,7 +5,7 @@ sidebar_order: 10
 ---
 
 <Alert level="info" title="Looking for framework mode?">
-  React Router v7 (framework mode) is currently in experimental Beta, check out
+  React Router v7 (framework mode) is currently in Beta, check out
   the docs [here](/platforms/javascript/guides/react-router/).
 </Alert>
 Apply the following setup steps based on your routing method and create a

--- a/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
@@ -5,7 +5,7 @@ sidebar_order: 10
 ---
 
 <Alert level="info" title="Looking for framework mode?">
-  React Router v7 (framework mode) is currently in experimental Alpha, check out
+  React Router v7 (framework mode) is currently in experimental Beta, check out
   the docs [here](/platforms/javascript/guides/react-router/).
 </Alert>
 Apply the following setup steps based on your routing method and create a


### PR DESCRIPTION
Documentation for the React Router framework SDK was updated to reflect its transition from an alpha to a beta state.

closes https://github.com/getsentry/sentry-javascript/issues/16689