### PR TITLE
Update documentation for span.setStatus method

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx
@@ -108,7 +108,7 @@ function sentryInterceptor(methodDescriptor, nextCall) {
       if (span) {
         // Update status based on the gRPC result
         if (status.code !== grpc.status.OK) {
-          span.setStatus({ code: 'error' });
+          span.setStatus({ code: 2, message: 'error' });
           span.setAttribute('grpc.status_code', status.code);
           span.setAttribute('grpc.status_description', status.details);
         }


### PR DESCRIPTION
The documentation in `platform-includes/distributed-tracing/custom-instrumentation/javascript.mdx` was updated to correct the usage of `span.setStatus`.

*   Previously, `span.setStatus({ code: 'error' });` was used.
*   This has been changed to `span.setStatus({ code: 2, message: 'error' });`.

This modification aligns the documentation with the Sentry JavaScript SDK's `SpanStatus` interface, which expects a numerical `code` (following OpenTelemetry standards) rather than a string. The numerical code `2` signifies an 'error' status. This ensures that `span.setStatus` correctly updates the span's status, resolving issues where the status was not visually reflected due to incorrect API parameter types.