### PR TITLE
ref(docs): update instances of yarn to pnpm in environment setup docs

### DIFF
--- a/develop-docs/development-infrastructure/environment/index.mdx
+++ b/develop-docs/development-infrastructure/environment/index.mdx
@@ -65,12 +65,12 @@ First we will use [mkcert](https://github.com/FiloSottile/mkcert) to create and 
 brew install mkcert
 brew install nss # if you use Firefox
 brew install caddy
-yarn mkcert-localhost
+pnpm mkcert-localhost
 ```
 
 Then we will run the reverse proxy as needed:
 ```shell
-yarn https-proxy
+pnpm https-proxy
 ```
 
 After the server is running we can visit the dev server using `https` at port `:8003` instead of over `http` at `:8000`.


### PR DESCRIPTION
Was using these docs and noticed the outdated usages of `yarn`. Updated to use the working `pnpm` usages