### PR TITLE
Docs: Remove include.user from RequestData integration

### DIFF
--- a/includes/platforms/configuration/integrations/requestdata.mdx
+++ b/includes/platforms/configuration/integrations/requestdata.mdx
@@ -20,11 +20,6 @@ Controls what types of data are added to the event:
   ip: boolean  // default: false,
   query_string: boolean  // default: true,
   url: boolean  // default: true,
-  user: boolean | {
-    id: boolean  // default: true,
-    username: boolean  // default: true,
-    email: boolean  // default: true,
-  },
 }
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

In 9.x, [`RequestDataIncludeOptions`](https://github.com/getsentry/sentry-javascript/blob/c37d4e5a7546be97afa92ae5d7950cc7b6542cdd/packages/core/src/integrations/requestdata.ts#L8-L15) no longer has `user`. Presumably because of this change from the migration guide:

> The `requestDataIntegration` will no longer automatically set the user from `request.user` when `express` is used. Starting in v9, you'll need to manually call `Sentry.setUser()` e.g. in a middleware to set the user on Sentry events.

However the option is still listed here: https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/integrations/requestdata/

This PR updates the docs to match the new types.

## IS YOUR CHANGE URGENT?  

- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.