### PR TITLE
fix: message.receive.latency should be in ms not seconds

### DIFF
--- a/develop-docs/sdk/telemetry/traces/modules/queues.mdx
+++ b/develop-docs/sdk/telemetry/traces/modules/queues.mdx
@@ -33,7 +33,7 @@ The following data attributes are only to be set if exposed by the instrumented 
 | `messaging.message.retry.count ` | int | the retries/attempts processing a message |
 | `messaging.message.envelope.size` | int | the size of the message body and metadata in bytes |
 | `messaging.message.body.size` | int | the size of the message | body in bytes |
-| `messaging.message.receive.latency ` | float | time delta in seconds between a message being published and when it was received by a consumer (not including processing time on the consumer) |
+| `messaging.message.receive.latency ` | float | time delta in milliseconds between a message being published and when it was received by a consumer (not including processing time on the consumer) |
 
 ## Instrumentation
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Fix the docs, because they are wrong.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
