### PR TITLE
feat(deprecate)add-warning

### DIFF
--- a/docs/product/releases/setup/release-automation/github-deployment-gates/index.mdx
+++ b/docs/product/releases/setup/release-automation/github-deployment-gates/index.mdx
@@ -3,12 +3,18 @@ title: GitHub Deployment Gates
 description: "Learn how Sentry can act as an arbiter in promoting or rejecting canary releases in your deployment pipelines."
 ---
 
-<Alert level="warning">
+<Alert level="warning" title="Deprecation Warning">
 
-If you make changes to your organization slug, you'll need to update your configuration for this integration. Learn more in our [troubleshooting guide](/organization/integrations/troubleshooting).
+This integration is deprecated and will be removed in the future for existing organizations as well.
 
 </Alert>
 
 The [Sentry GitHub Deployment Gates](https://github.com/apps/sentry-deployment-gate) allows Sentry to interact with GitHub releases via deployment protection rules. After sending Sentry release information, you can watch a release for errors and reject a canary release before it is fully deployed.
 
 For more details about Sentry Deployment Gate, see the [GitHub Application](https://github.com/apps/sentry-deployment-gate).
+
+<Alert level="warning">
+
+If you make changes to your organization slug, you'll need to update your configuration for this integration. Learn more in our [troubleshooting guide](/organization/integrations/troubleshooting).
+
+</Alert>


### PR DESCRIPTION
We want to deprecate the [GitHub deployment gates](https://docs.sentry.io/product/releases/setup/release-automation/github-deployment-gates/) integration, and would eventually like to remove it altogther. Until then we should inform users and prepare them for the removal.