### PR TITLE
fix(typo): Update name of CompositeExperimentalMetricsBackend

### DIFF
--- a/develop-docs/backend/application-domains/metrics.mdx
+++ b/develop-docs/backend/application-domains/metrics.mdx
@@ -145,9 +145,9 @@ LOGGING['handlers']['console:metrics'] = {
 }
 ```
 
-## Composit Experimental Backend
+## Composite Experimental Backend
 
-The current implementation of the `MetricsBackend` is known as `CompositExperimentalMetricsBackend`. The `CompositeExperimentalMetricsBackend` reports all operations to both Datadog and Sentry. For this reason, you will be able to see your metrics on both platforms.
+The current implementation of the `MetricsBackend` is known as `CompositeExperimentalMetricsBackend`. The `CompositeExperimentalMetricsBackend` reports all operations to both Datadog and Sentry. For this reason, you will be able to see your metrics on both platforms.
 
 ```python
 SENTRY_METRICS_BACKEND = "sentry.metrics.composite_experimental.CompositeExperimentalMetricsBackend"


### PR DESCRIPTION
## DESCRIBE YOUR PR

The documentation incorrectly spells "CompositeExperimentalMetricsBackend," which is defined here with the proposed spelling: https://github.com/getsentry/sentry/blob/377e7d8bd378016ea1d22d6900cdced96740889b/src/sentry/metrics/composite_experimental.py#L11

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.