### PR TITLE
docs(astro): Specify where to put the script tags

### DIFF
--- a/platform-includes/capture-error/javascript.astro.mdx
+++ b/platform-includes/capture-error/javascript.astro.mdx
@@ -1,11 +1,14 @@
 You can pass an `Error` object to `captureException()` to have it captured as an event. It's also possible to pass non-`Error` objects and strings, but be aware that the resulting events in Sentry may be missing a stack trace.
 
-```javascript
-import * as Sentry from "@sentry/astro";
+```javascript {filename:Component.astro}
+<!-- Make sure this script tag is placed at the top inside the <body> tag (for example, inside a Layout slot) -->
+<script>
+  import * as Sentry from "@sentry/astro";
 
-try {
-  aFunctionThatMightFail();
-} catch (err) {
-  Sentry.captureException(err);
-}
+  try {
+    aFunctionThatMightFail();
+  } catch (err) {
+    Sentry.captureException(err);
+  }
+</script>
 ```

--- a/platform-includes/enriching-events/import/javascript.astro.mdx
+++ b/platform-includes/enriching-events/import/javascript.astro.mdx
@@ -1,3 +1,6 @@
-```javascript
-import * as Sentry from "@sentry/astro";
+```javascript {filename:Component.astro}
+<!-- Make sure this script tag is placed at the top inside the <body> tag (for example, inside a Layout slot) -->
+<script>
+  import * as Sentry from "@sentry/astro";
+</script>
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds more context around where to put the JS code inside an Astro component. When the script is placed outside a `body` element, Sentry is not yet initialized.

Came up in this PR: https://github.com/getsentry/sentry-javascript/issues/16316

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

