### PR TITLE
feat(js): Update docs for vercelAiIntegration

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -9,6 +9,7 @@ supported:
   - javascript.express
   - javascript.fastify
   - javascript.gcp-functions
+  - javascript.cloudflare
   - javascript.hapi
   - javascript.hono
   - javascript.koa
@@ -27,26 +28,42 @@ supported:
 
 <Alert>
 
-This integration only works in the Node.js and Bun runtimes. Requires SDK version `9.30.0` or higher.
+This integration only works in the Node.js, Cloudflare Workers, Vercel Edge Functions and Bun runtimes. Requires SDK version `9.30.0` or higher.
 
 </Alert>
 
 _Import name: `Sentry.vercelAIIntegration`_
 
-The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry). Get started with the following snippet:
+The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
+
+<PlatformSection notSupported={["javascript.cloudflare", "javascript.nextjs"]}>
+  It is enabled by default and will automatically capture spans for all `ai`
+  function calls.
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+This integration is not enabled by default. You need to manually enable it by passing `Sentry.vercelAIIntegration()` to `Sentry.init`:
 
 ```javascript
 Sentry.init({
-  tracesSampleRate: 1.0,
-  integrations: [
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
-  ],
+  integrations: [Sentry.vercelAIIntegration()],
 });
 ```
 
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+This integration is enabled by default in the Node runtime, but not in the Edge runtime. You need to manually enable it by passing `Sentry.vercelAIIntegration()` to `Sentry.init` in your `sentry.edge.config.js` file:
+
+```javascript {filename: 'sentry.edge.config.(js|ts)'}
+Sentry.init({
+  integrations: [Sentry.vercelAIIntegration()],
+});
+```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.nextjs']}>
 To correctly capture spans, pass the `experimental_telemetry` object with `isEnabled: true` to every `generateText`, `generateObject`, and `streamText` function call. For more details, see the [AI SDK Telemetry Metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
 
 ```javascript
@@ -58,6 +75,9 @@ const result = await generateText({
 });
 ```
 
+</PlatformSection>
+
+<PlatformSection notSupported={['javascript.cloudflare']}>
 ## Options
 
 ### `force`
@@ -76,6 +96,12 @@ Sentry.init({
 });
 ```
 
+<PlatformSection supported={["javascript.nextjs"]}>
+  This option is not available in the Edge runtime. There, the integration is
+  forced when it is enabled.
+</PlatformSection>
+
+<PlatformSection notSupported={['javascript.nextjs']}>
 ### `recordInputs`
 
 Requires SDK version `9.27.0` or higher.
@@ -107,6 +133,10 @@ Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ recordOutputs: true })],
 });
 ```
+
+</PlatformSection>
+
+</PlatformSection>
 
 ## Identifying functions
 

--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -22,7 +22,7 @@ Depending on whether an integration enhances the functionality of a particular r
 ### Browser Integrations
 
 |                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
-|-------------------------------------------------------|:----------------:|:----------:|:-----------:|:----------:|:----------------------:|
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
 | [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
@@ -72,6 +72,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
@@ -17,6 +17,7 @@
 | [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
 | [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`amqplibIntegration`](./amqplib)                         |                  |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.bun.mdx
+++ b/platform-includes/configuration/integrations/javascript.bun.mdx
@@ -29,6 +29,7 @@
 | [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
 | [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.connect.mdx
+++ b/platform-includes/configuration/integrations/javascript.connect.mdx
@@ -30,6 +30,7 @@
 | [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)             |        ✓         |     ✓      |             |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.fastify.mdx
+++ b/platform-includes/configuration/integrations/javascript.fastify.mdx
@@ -30,6 +30,7 @@
 | [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/integrations/javascript.gcp-functions.mdx
@@ -17,6 +17,7 @@
 | [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
 | [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`amqplibIntegration`](./amqplib)                         |                  |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.hapi.mdx
+++ b/platform-includes/configuration/integrations/javascript.hapi.mdx
@@ -30,6 +30,7 @@
 | [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nestjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nestjs.mdx
@@ -30,6 +30,7 @@
 | [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`captureConsoleIntegration`](./captureconsole)           |                  |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -22,7 +22,7 @@ Depending on whether an integration enhances the functionality of a particular r
 ### Browser Integrations
 
 |                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
-|-------------------------------------------------------|:----------------:|:----------:|:-----------:|:----------:|:----------------------:|
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
 | [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
@@ -85,9 +85,11 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |           ✓            |
 
 ### Edge Integrations
 
 |                                               | **Auto Enabled** | **Errors** | **Tracing** | **Additional Context** |
 | --------------------------------------------- | :--------------: | :--------: | :---------: | :--------------------: |
 | [`winterCGFetchIntegration`](./wintercgfetch) |        ✓         |            |      ✓      |           ✓            |
+| [`vercelAiIntegration`](./vercelai)           |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.node.mdx
+++ b/platform-includes/configuration/integrations/javascript.node.mdx
@@ -36,6 +36,7 @@
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
 | [`redisIntegration`](./redis)                             |        ✓         |            |      ✓      |                        |
 | [`requestDataIntegration`](./requestdata)                 |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
 | [`supabaseIntegration`](./supabase)                       |                  |     ✓      |      ✓      |                        |
 | [`tediousIntegration`](./tedious)                         |        ✓         |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -71,6 +71,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -71,6 +71,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -71,6 +71,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -21,7 +21,7 @@ Depending on whether an integration enhances the functionality of a particular r
 ### Browser Integrations
 
 |                                                       | **Auto Enabled** | **Errors** | **Tracing** | **Replay** | **Additional Context** |
-|-------------------------------------------------------|:----------------:|:----------:|:-----------:|:----------:|:----------------------:|
+| ----------------------------------------------------- | :--------------: | :--------: | :---------: | :--------: | :--------------------: |
 | [`breadcrumbsIntegration`](./breadcrumbs)             |        ✓         |            |             |            |           ✓            |
 | [`browserApiErrorsIntegration`](./browserapierrors)   |        ✓         |     ✓      |             |            |                        |
 | [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
@@ -70,6 +70,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`childProcessIntegration`](./childProcess)               |        ✓         |            |             |           ✓            |
 | [`dataloaderIntegration`](./dataloader)                   |        ✓         |            |      ✓      |                        |
 | [`prismaIntegration`](./prisma)                           |        ✓         |            |      ✓      |                        |
+| [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |                        |
 | [`anrIntegration`](./anr)                                 |                  |     ✓      |             |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)           |                  |            |             |           ✓            |
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |


### PR DESCRIPTION
This updates the integration docs for vercelAiIntegration:

1. Adds proper docs for next.js, cloudflare - this is waiting on the next release!
2. Ensure it is added on overview pages as well. 