### PR TITLE
feat: Add span status docs

### DIFF
--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -729,6 +729,13 @@ These utilities can be used for more advanced tracing use cases.
 </SdkApi>
 
 <SdkApi
+  name="setHttpStatus"
+  signature="function setHttpStatus(span: Span, httpStatus: number): void"
+>
+  Set the status of a span based on the given http status code.
+</SdkApi>
+
+<SdkApi
   name="getActiveSpan"
   signature="function getActiveSpan(): Span | undefined"
 >

--- a/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
@@ -212,3 +212,17 @@ Prior to v8.39.0, you had to use `span.updateName('New Name')`, which had some l
 Using `Sentry.updateSpanName()` ensures that the name is updated correctly and no longer overwritten in these cases.
 
 If you use `@sentry/browser`, `@sentry/react`, and so on in browser environments, `span.updateName()` and `Sentry.updateSpanName()` will function identically, so you can use either one of them.
+
+### Updating the Span Status
+
+By default, spans will have an `unknown` status. You can manually update the status of a span to indicate whether it succeeded or failed:
+
+```javascript
+// Status codes:
+// 0: unknown
+// 1: ok
+// 2: error
+span.setStatus({ status: 2 });
+```
+
+Alternatively, you can also use the <PlatformLink to='/apis/#setHttpStatus'>`Sentry.setHttpStatus()`</PlatformLink> utility function to set a more specific error status.


### PR DESCRIPTION
This adds missing docs about setting span status in JS SDKs.