### PR TITLE
fix(detectors): Update Consecutive HTTP page 

### DIFF
--- a/docs/product/issues/issue-details/performance-issues/consecutive-http/index.mdx
+++ b/docs/product/issues/issue-details/performance-issues/consecutive-http/index.mdx
@@ -19,7 +19,7 @@ The detector for this performance issue looks for a set of sequential, non-overl
 Once this sequence is found, the following must hold true for each HTTP span:
 
 - The HTTP method must be a GET, POST, DELETE, PUT, or PATCH
-- The HTTP URL must not contain `\_next/static/` , `\_next/data/` , or `aiplatform.googleapis.com`
+- The HTTP URL must not contain `\_next/static/` , `\_next/data/` , or `googleapis.com`
 
 Once these spans are found, the following must also hold true:
 


### PR DESCRIPTION
updates the consecutive http detector page to better reflect what the detector does 