### PR TITLE
ref(flags): mention spans/txn event support in JS integration docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/featureflags.mdx
@@ -37,7 +37,7 @@ If you are using an external feature flag provider, refer to the [supported list
 </Alert>
 
 The Feature Flags integration allows you to manually track feature flag evaluations through an API.
-These evaluations are held in memory and sent to Sentry when an error occurs.
+These evaluations are held in memory and sent to Sentry on error and transaction events.
 **At the moment, we only support boolean flag evaluations.** This integration is available in
 Sentry SDK **versions 8.43.0 or higher.**
 

--- a/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/launchdarkly.mdx
@@ -30,8 +30,7 @@ This integration only works inside a browser environment. It is only available f
 
 </Alert>
 
-The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag evaluations produced by the LaunchDarkly SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.** This integration is available in
-Sentry SDK **versions 8.43.0 or higher.**
+The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag evaluations produced by the LaunchDarkly SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.** This integration is available in Sentry SDK **versions 8.43.0 or higher.**
 
 _Import names: `Sentry.launchDarklyIntegration` and `Sentry.buildLaunchDarklyFlagUsedHandler`_
 

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -31,7 +31,7 @@ This integration only works inside a browser environment. It is only available f
 
 </Alert>
 
-The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations.** This integration is available in
+The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.** This integration is available in
 Sentry SDK **versions 8.43.0 or higher.**
 
 _Import name: `Sentry.openFeatureIntegration` and `Sentry.OpenFeatureIntegrationHook`_

--- a/docs/platforms/javascript/common/configuration/integrations/statsig.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/statsig.mdx
@@ -29,7 +29,7 @@ This integration only works inside a browser environment. It is only available f
 
 </Alert>
 
-The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluations produced by the Statsig JavaScript Client SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations from Statsig's `checkGate` method**. Learn more about [Statsig feature gates](https://docs.statsig.com/feature-flags/working-with/).
+The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluations produced by the Statsig JavaScript Client SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations from Statsig's `checkGate` method**. Learn more about [Statsig feature gates](https://docs.statsig.com/feature-flags/working-with/).
 
 This integration is available in Sentry SDK **versions 9.0.0 and higher**, or **versions 8.55.0 and higher for v8.**
 

--- a/docs/platforms/javascript/common/configuration/integrations/unleash.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/unleash.mdx
@@ -30,7 +30,7 @@ This integration only works inside a browser environment. It is only available f
 
 </Alert>
 
-The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory, and in the event an error occurs, sent to Sentry for review and analysis. **At the moment, we only support boolean flag evaluations from Unleash's isEnabled method.** This integration is available in Sentry SDK **versions 8.51.0 or higher.**
+The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations from Unleash's isEnabled method.** This integration is available in Sentry SDK **versions 8.51.0 or higher.**
 
 _Import names: `Sentry.unleashIntegration`_
 

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -21,11 +21,7 @@ If you use a third-party SDK to evaluate feature flags, you can enable a Sentry 
 - [Unleash](/platforms/python/integrations/unleash/)
 
 ### Generic API
-The generic API allows you to manually track feature flag evaluations. These
-evaluations are held in memory, and in the event an error occurs, sent to
-Sentry for review and analysis. Specifically, the generic integration enables
-users to integrate with proprietary (or otherwise unsupported) feature flagging
-solutions.  **At the moment, we only support boolean flag evaluations.**
+If you use an unsupported solution, you can use the generic API to manually track feature flag evaluations. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.**
 
 ```python
 import sentry_sdk

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to use Sentry with LaunchDarkly."
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag evaluations produced by the LaunchDarkly SDK. These evaluations are held in memory and are sent to Sentry on error and trace events. **At the moment, we only support boolean flag evaluations.**
+The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag evaluations produced by the LaunchDarkly SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.**
 
 ## Install
 

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to use Sentry with OpenFeature."
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory and are sent to Sentry on error and trace events. **At the moment, we only support boolean flag evaluations.**
+The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.**
 
 ## Install
 

--- a/docs/platforms/python/integrations/statsig/index.mdx
+++ b/docs/platforms/python/integrations/statsig/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to use Sentry with Statsig."
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluations produced by the Statsig Python Server SDK. These evaluations are held in memory and are sent to Sentry on error and trace events. **At the moment, we only support boolean flag evaluations from Statsig's `check_gate` function.** Learn more about [Statsig feature gates](https://docs.statsig.com/feature-flags/working-with/).
+The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluations produced by the Statsig Python Server SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations from Statsig's `check_gate` function.** Learn more about [Statsig feature gates](https://docs.statsig.com/feature-flags/working-with/).
 
 ## Install
 

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to use Sentry with Unleash."
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory and are sent to Sentry on error and trace events. **At the moment, we only support boolean flag evaluations from Unleash's is_enabled method.**
+The [Unleash](https://www.getunleash.io/) integration tracks feature flag evaluations produced by the Unleash SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations from Unleash's is_enabled method.**
 
 ## Install
 


### PR DESCRIPTION
Since JS [9.31.0](https://github.com/getsentry/sentry-javascript/releases/tag/9.31.0) our FF integrations capture flags on spans, which are sent in [transaction events](https://develop.sentry.dev/sdk/data-model/event-payloads/transaction/). This PR updates the JS integration docs to mention this, and renames "trace events" to "transaction events" in python