### PR TITLE
fix(agents-insights): deprecate llm monitoring docs

### DIFF
--- a/develop-docs/sdk/telemetry/traces/modules/llm-monitoring.mdx
+++ b/develop-docs/sdk/telemetry/traces/modules/llm-monitoring.mdx
@@ -1,6 +1,13 @@
 ---
 title: LLM Monitoring
+sidebar_hidden: true
 ---
+
+<Alert level="warning" title="Deprecated">
+
+This documentation is deprecated. Please use the [AI Agents Module](/sdk/telemetry/traces/modules/ai-agents) instead for AI/LLM monitoring and instrumentation.
+
+</Alert>
 
 Sentry auto-generates LLM Monitoring data for common providers in Python, but you may need to manually annotate spans for other frameworks.
 
@@ -9,18 +16,16 @@ Sentry auto-generates LLM Monitoring data for common providers in Python, but yo
 ### Span Operations
 
 | Span OP                 | Description                                                                          |
-|:------------------------|:-------------------------------------------------------------------------------------|
+| :---------------------- | :----------------------------------------------------------------------------------- |
 | `ai.pipeline.*`         | The top-level span which corresponds to one or more AI operations & helper functions |
 | `ai.run.*`              | A unit of work - a tool call, LLM execution, or helper method.                       |
 | `ai.chat_completions.*` | A LLM chat operation                                                                 |
 | `ai.embeddings.*`       | An LLM embedding creation operation                                                  |
 
-
-
 ### Span Data
 
 | Attribute                   | Type    | Description                                           | Examples                                 | Notes                                    |
-|-----------------------------|---------|-------------------------------------------------------|------------------------------------------|------------------------------------------|
+| --------------------------- | ------- | ----------------------------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | `ai.input_messages`         | string  | The input messages sent to the model                  | `[{"role": "user", "message": "hello"}]` |                                          |
 | `ai.completion_tоkens.used` | int     | The number of tokens used to respond to the message   | `10`                                     | required for cost calculation            |
 | `ai.prompt_tоkens.used`     | int     | The number of tokens used to process just the prompt  | `20`                                     | required for cost calculation            |

--- a/docs/platforms/javascript/common/tracing/span-metrics/examples.mdx
+++ b/docs/platforms/javascript/common/tracing/span-metrics/examples.mdx
@@ -120,7 +120,7 @@ The frontend span initiates the trace and handles the file upload process. It pr
 Sentry.startSpan(
   {
     name: "LLM Client Interaction",
-    op: "ai.client",
+    op: "gen_ai.generate_text",
     attributes: {
       // Initial metrics available at request time
       "input.char_count": 280,
@@ -173,7 +173,7 @@ Sentry.startSpan(
 Sentry.startSpan(
   {
     name: "LLM API Processing",
-    op: "ai.server",
+    op: "gen_ai.generate_text",
     attributes: {
       // Model configuration - known at start
       "llm.model": "claude-3-5-sonnet-20241022",

--- a/docs/platforms/python/tracing/span-metrics/examples.mdx
+++ b/docs/platforms/python/tracing/span-metrics/examples.mdx
@@ -143,7 +143,7 @@ from flask import jsonify
 
 @app.route("/ask", methods=["POST"])
 def handle_llm_request():
-    with sentry_sdk.start_span(op="llm", name="Generate Text") as span:
+    with sentry_sdk.start_span(op="gen_ai.generate_text", name="Generate Text") as span:
         start_time = time.time() * 1000  # Convert to milliseconds
         
         # Begin streaming response from LLM API
@@ -198,7 +198,7 @@ import openai
 
 def process_llm_request(request_data):
     with sentry_sdk.start_span(
-        op="llm",
+        op="gen_ai.generate_text",
         name="Generate Text"
     ) as span:
         start_time = int(time.time() * 1000)  # Current time in milliseconds


### PR DESCRIPTION
closes [TET-759: Deprecate old dev docs](https://linear.app/getsentry/issue/TET-759/deprecate-old-dev-docs)