### PR TITLE
ref(flags): add list of openfeature providers and generic webhook secret length

### DIFF
--- a/docs/organization/integrations/feature-flag/generic/index.mdx
+++ b/docs/organization/integrations/feature-flag/generic/index.mdx
@@ -32,7 +32,7 @@ Enabling Change Tracking is a four step process. To get started, visit the [feat
 2. **Save the webhook URL**.
     - Copy the provided Sentry webhook URL and save it for step 4.
 3. **Set the Signing Secret**.
-    - In your feature flagging system's UI, find the "Signing Secret".
+    - In your feature flagging system's UI, find or create a "Signing Secret" for this webhook. If you are writing your own webhook, secrets should be 10-64 characters long (we recommend at least 32).
     - Copy the signing secret and paste it into the input box next to "Secret" in Sentry settings.
     - Save the secret by clicking "Add Provider" in Sentry settings.
 4. **Write your own webhook**.

--- a/docs/organization/integrations/feature-flag/generic/index.mdx
+++ b/docs/organization/integrations/feature-flag/generic/index.mdx
@@ -32,7 +32,7 @@ Enabling Change Tracking is a four step process. To get started, visit the [feat
 2. **Save the webhook URL**.
     - Copy the provided Sentry webhook URL and save it for step 4.
 3. **Set the Signing Secret**.
-    - In your feature flagging system's UI, find or create a "Signing Secret" for this webhook. If you are writing your own webhook, secrets should be 10-64 characters long (we recommend at least 32).
+    - In your feature flagging system's UI, find or create a "Signing Secret" for this webhook. If you are writing your own webhook, secrets must be 10-64 characters long (we recommend at least 32).
     - Copy the signing secret and paste it into the input box next to "Secret" in Sentry settings.
     - Save the secret by clicking "Add Provider" in Sentry settings.
 4. **Write your own webhook**.

--- a/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openfeature.mdx
@@ -31,7 +31,9 @@ This integration only works inside a browser environment. It is only available f
 
 </Alert>
 
-The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.** This integration is available in
+The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. This SDK is supported by a broad range of feature flagging providers. For the full list, visit [OpenFeature's ecosystem page](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5BallTechnologies%5D%5B0%5D=JavaScript).
+
+The flag evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.** This integration is available in
 Sentry SDK **versions 8.43.0 or higher.**
 
 _Import name: `Sentry.openFeatureIntegration` and `Sentry.OpenFeatureIntegrationHook`_

--- a/docs/platforms/javascript/common/feature-flags/index.mdx
+++ b/docs/platforms/javascript/common/feature-flags/index.mdx
@@ -35,7 +35,7 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 If you use a third-party SDK to evaluate feature flags, you can enable a Sentry SDK integration to track those evaluations. Integrations are provider specific. Documentation for supported SDKs is listed below.
 
 - [LaunchDarkly](/platforms/javascript/configuration/integrations/launchdarkly/)
-- [OpenFeature](/platforms/javascript/configuration/integrations/openfeature/)
+- [OpenFeature](/platforms/javascript/configuration/integrations/openfeature/) (multiple providers supported)
 - [Statsig](/platforms/javascript/configuration/integrations/statsig/)
 - [Unleash](/platforms/javascript/configuration/integrations/unleash/)
 

--- a/docs/platforms/python/feature-flags/index.mdx
+++ b/docs/platforms/python/feature-flags/index.mdx
@@ -16,7 +16,7 @@ description: With Feature Flags, Sentry tracks feature flag evaluations in your 
 If you use a third-party SDK to evaluate feature flags, you can enable a Sentry SDK integration to track those evaluations. Integrations are provider specific. Documentation for supported SDKs is listed below.
 
 - [LaunchDarkly](/platforms/python/integrations/launchdarkly/)
-- [OpenFeature](/platforms/python/integrations/openfeature/)
+- [OpenFeature](/platforms/python/integrations/openfeature/) (multiple providers supported)
 - [Statsig](/platforms/python/integrations/statsig/)
 - [Unleash](/platforms/python/integrations/unleash/)
 

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -5,7 +5,9 @@ description: "Learn how to use Sentry with OpenFeature."
 
 <PlatformContent includePath="feature-flags/prerelease-alert" />
 
-The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. These evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.**
+The [OpenFeature](https://openfeature.dev/) integration tracks feature flag evaluations produced by the OpenFeature SDK. This SDK is supported by a broad range of feature flagging providers. For the full list, visit [OpenFeature's ecosystem page](https://openfeature.dev/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5BallTechnologies%5D%5B0%5D=Python).
+
+The flag evaluations are held in memory and are sent to Sentry on error and transaction events. **At the moment, we only support boolean flag evaluations.**
 
 ## Install
 


### PR DESCRIPTION
Makes some quality improvements to our Openfeature eval tracking and Generic change tracking pages. The secret length restrictions were added in https://github.com/getsentry/sentry/pull/94721