### PR TITLE
docs(playstation): Add playstation endpoint info to the docs

### DIFF
--- a/develop-docs/sdk/overview.mdx
+++ b/develop-docs/sdk/overview.mdx
@@ -122,6 +122,7 @@ Sentry provides the following endpoints:
 - [`/minidump/`](https://docs.sentry.io/platforms/native/minidump/) for multipart requests containing Minidumps.
 - [`/unreal/`](https://docs.sentry.io/platforms/unreal/configuration/setup-crashreporter/) for Unreal
   Engine 4 crash reports.
+- [`/playstation/`](https://docs.sentry.io/platforms/playstation/) for PlayStation crash reports.
 - [`/security/`](https://docs.sentry.io/error-reporting/security-policy-reporting/) for Browser
   CSP reports, usually configured in a browser instead of an SDK.
 

--- a/develop-docs/sdk/overview.mdx
+++ b/develop-docs/sdk/overview.mdx
@@ -123,6 +123,9 @@ Sentry provides the following endpoints:
 - [`/unreal/`](https://docs.sentry.io/platforms/unreal/configuration/setup-crashreporter/) for Unreal
   Engine 4 crash reports.
 - [`/playstation/`](https://docs.sentry.io/platforms/playstation/) for PlayStation crash reports.
+  <Alert title="Note" level="info">
+  The PlayStation endpoint has limited access and requires allowlisting. Support involves components that are part of a partnership with Sony which cannot be made public or redistributed. This endpoint is only available in SaaS.
+  </Alert>
 - [`/security/`](https://docs.sentry.io/error-reporting/security-policy-reporting/) for Browser
   CSP reports, usually configured in a browser instead of an SDK.
 


### PR DESCRIPTION
This was missing before in our develop docs, now with the help of Cursor has been added with the note that it has restricted access