### PR TITLE
Add Android troubleshooting entry for ad blockers

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -249,9 +249,9 @@ Switches out the transport used to send events. How this works depends on the SD
 
 </ConfigKey>
 
-<ConfigKey name="http-proxy">
+<ConfigKey name="proxy">
 
-When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https-proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `http_proxy` environment variable will be picked up.
+When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests.
 
 </ConfigKey>
 

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -177,12 +177,14 @@ internally. As a result, this option won't work out of the box on devices with a
 android.bundle.enableUncompressedNativeLibs=false
 ```
 
-## Ad Blockers and Network Issues
+## The SDK is not sending data
 
-If Sentry events are not being sent from your Android app, ad blockers or network restrictions might be preventing the SDK from reaching Sentry's servers. To work around this issue, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server.
+If you set up the Sentry SDK and it's not sending any data to Sentry:
 
-Then you can set the [proxy option](/platforms/android/configuration/options/#proxy) in your SDK configuration.
-
+- Check that you have configured a DSN and that you are passing it to the `dsn` option in `SentryAndroid.init()`.
+- An ad-blocker or network restrictions might be preventing the SDK from reaching Sentry's servers. To work around this issue, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server. Then you can add the [proxy option](/platforms/android/configuration/options/#proxy) in your SDK configuration.
+- Set `debug: true` in the `SentryAndroid.init()` or the manifest options and observe your Logcat output when you start your application. The SDK may tell you why it is not sending any data.
+- Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Subscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may have ran out of quota.
 
 ## Sentry Android Gradle Plugin Build Issues
 

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -177,6 +177,13 @@ internally. As a result, this option won't work out of the box on devices with a
 android.bundle.enableUncompressedNativeLibs=false
 ```
 
+## Ad Blockers and Network Issues
+
+If Sentry events are not being sent from your Android app, ad blockers or network restrictions might be preventing the SDK from reaching Sentry's servers. To work around this issue, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server.
+
+Then you can set the [proxy option](/platforms/android/configuration/options/#proxy) in your SDK configuration.
+
+
 ## Sentry Android Gradle Plugin Build Issues
 
 ### Proguard Mapping Upload Issues

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -181,9 +181,9 @@ android.bundle.enableUncompressedNativeLibs=false
 
 If you set up the Sentry SDK and it's not sending any data to Sentry:
 
-- Check that you have configured a DSN and that you are passing it to the `dsn` option in `SentryAndroid.init()`.
+- Check that you have configured a DSN and that you are passing it to the `dsn` option in `SentryAndroid.init()` or `AndroidManifest`.
 - When a crash happens or the app closes, the system allows only a short time to handle it before terminating the process. The SDK might not have enough time to send the event, spans, profile, or replay data. In these cases, simply relaunching the app should allow the SDK to send the remaining data.
-- An ad-blocker or network restrictions might be preventing the SDK from reaching Sentry's servers. As a workaround, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server. Then you can add the [proxy option](/platforms/android/configuration/options/#proxy) to your SDK configuration.
+- An ad-blocker (e.g. [DuckDuckGo's App Tracking Protection](https://duckduckgo.com/duckduckgo-help-pages/p-app-tracking-protection/what-is-app-tracking-protection)) or network restrictions might be preventing the SDK from reaching Sentry's servers. As a workaround, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server. Then you can add the [proxy option](/platforms/android/configuration/options/#proxy) to your SDK configuration.
 - Set `debug: true` in the `SentryAndroid.init()` or the manifest options and observe your Logcat output when you start your application. The SDK may tell you why it is not sending any data.
 - Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Subscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may be out of quota.
 

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -177,15 +177,15 @@ internally. As a result, this option won't work out of the box on devices with a
 android.bundle.enableUncompressedNativeLibs=false
 ```
 
-## The SDK is not sending data
+## The SDK Is Not Sending Data
 
 If you set up the Sentry SDK and it's not sending any data to Sentry:
 
 - Check that you have configured a DSN and that you are passing it to the `dsn` option in `SentryAndroid.init()`.
-- When a crash occurs or the app is closed, the system gives only some time to handle it before terminating the app process. The SDK may not have enough time to send the event or the related spans, profile and replay. Relaunching the app should be enough to send the data in such cases.
-- An ad-blocker or network restrictions might be preventing the SDK from reaching Sentry's servers. To work around this issue, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server. Then you can add the [proxy option](/platforms/android/configuration/options/#proxy) in your SDK configuration.
+- When a crash happens or the app closes, the system allows only a short time to handle it before terminating the process. The SDK might not have enough time to send the event, spans, profile, or replay data. In these cases, simply relaunching the app should allow the SDK to send the remaining data.
+- An ad-blocker or network restrictions might be preventing the SDK from reaching Sentry's servers. As a workaround, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server. Then you can add the [proxy option](/platforms/android/configuration/options/#proxy) to your SDK configuration.
 - Set `debug: true` in the `SentryAndroid.init()` or the manifest options and observe your Logcat output when you start your application. The SDK may tell you why it is not sending any data.
-- Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Subscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may have ran out of quota.
+- Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Subscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may be out of quota.
 
 ## Sentry Android Gradle Plugin Build Issues
 

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -182,6 +182,7 @@ android.bundle.enableUncompressedNativeLibs=false
 If you set up the Sentry SDK and it's not sending any data to Sentry:
 
 - Check that you have configured a DSN and that you are passing it to the `dsn` option in `SentryAndroid.init()`.
+- When a crash occurs or the app is closed, the system gives only some time to handle it before terminating the app process. The SDK may not have enough time to send the event or the related spans, profile and replay. Relaunching the app should be enough to send the data in such cases.
 - An ad-blocker or network restrictions might be preventing the SDK from reaching Sentry's servers. To work around this issue, you can use [tunneling](/platforms/javascript/troubleshooting/#using-the-tunnel-option) to proxy Sentry events through your own server. Then you can add the [proxy option](/platforms/android/configuration/options/#proxy) in your SDK configuration.
 - Set `debug: true` in the `SentryAndroid.init()` or the manifest options and observe your Logcat output when you start your application. The SDK may tell you why it is not sending any data.
 - Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Subscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may have ran out of quota.

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -16,7 +16,7 @@ If you set up the Sentry SDK and it's not sending any data to Sentry:
 
 - Check that you have disabled any ad-blockers.
 - Set `debug: true` in the `Sentry.init()` options and observe your console output when you start your application. The SDK may tell you why it is not sending any data.
-- Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Suscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may have ran out of quota.
+- Check the [Stats](https://sentry.io/orgredirect/organizations/:orgslug/stats/) and [Subscription](https://sentry.io/orgredirect/organizations/:orgslug/settings/billing/overview/) pages in Sentry. You may have ran out of quota.
 
 <PlatformSection supported={["javascript.nextjs"]}>
   - Check that you didn't set `sideEffects: false` in your `package.json`.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Added Android troubleshooting entry for ad blockers
Updated proxy option
Closes https://github.com/getsentry/sentry-android-gradle-plugin/issues/658

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
