### PR TITLE
fix(flags): add missing provider line to openfeature python code example

### DIFF
--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -47,6 +47,7 @@ The integration is tested by evaluating a feature flag using your OpenFeature SD
 from openfeature import api
 import sentry_sdk
 
+api.set_provider(MyProviderOfChoice(...))
 client = api.get_client()
 client.get_boolean_value("hello", default_value=False)
 


### PR DESCRIPTION
Openfeature needs a provider to evaluate flags.