### PR TITLE
Clarify 64-bit unsigned integer behaviour in logs

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -89,7 +89,7 @@ It consists of the following fields:
 
 : **Object, optional**. A dictionary of key-value pairs of arbitrary data attached to the log. Attributes must also declare the type of the value. The following types are supported: `string`, `boolean`, `integer`, `double`. In the future arrays will be supported (`string[]`, `boolean[]`, `integer[]`, `double[]`).
 
-Integers should be a 64-bit signed integer, while doubles should be a 64-bit floating point number. For 64-bit unsigned integers, use the `string` type to avoid overflow issues. In the future we will support 64-bit unsigned integers.
+Integers should be a 64-bit signed integer, while doubles should be a 64-bit floating point number. For 64-bit unsigned integers, use the `string` type to avoid overflow issues. Make sure to always convert 64-bit unsigned integers to strings regardless of if they are in or out of the 64-bit signed range. In the future we will support sending 64-bit unsigned integers without converting them to strings.
 
 Example:
 


### PR DESCRIPTION
Quick note to make it clear that 64-bit unsigned integer should always be sent as a string