### PR TITLE
Add `LOG_CHANNEL` to Laravel example

### DIFF
--- a/docs/platforms/php/guides/laravel/usage/index.mdx
+++ b/docs/platforms/php/guides/laravel/usage/index.mdx
@@ -112,6 +112,7 @@ After you configured the Sentry log channel, you can configure your app to both 
 
 ```bash {filename:.env}
 # ...
+LOG_CHANNEL=stack
 LOG_STACK=single,sentry
 # ...
 ```

--- a/platform-includes/logs/setup/php.laravel.mdx
+++ b/platform-includes/logs/setup/php.laravel.mdx
@@ -16,6 +16,7 @@ After you configured the Sentry log channel, you can configure your app to both 
 
 ```bash {filename:.env}
 # ...
+LOG_CHANNEL=stack
 LOG_STACK=single,sentry_logs
 # ...
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

When a user is setting up their log stack in Laravel it isn't a given that the log driver is actually set to "stack" which it needs to be otherwise the existing instructions (setting `LOG_STACK `) has no effect. So add the additional env variable to indicate the `LOG_CHANNEL` should be set to "stack".

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)