### PR TITLE
feat(js): Document how to disable tracing

### DIFF
--- a/docs/platforms/javascript/common/configuration/tree-shaking.mdx
+++ b/docs/platforms/javascript/common/configuration/tree-shaking.mdx
@@ -120,7 +120,7 @@ Replacing this flag with `false` will tree shake any SDK code that's related to 
 
 <Alert>
   `__SENTRY_TRACING__` must not be replaced with `false` when you're using any
-  tracing-related SDK features (for example,`Sentry.startTransaction()`). This
+  tracing-related SDK features (for example,`Sentry.startSpan()`). This
   flag is intended to be used in combination with packages like `@sentry/next`
   or `@sentry/sveltekit`, which automatically include the tracing functionality.
 </Alert>

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -31,12 +31,12 @@ With [tracing](/product/insights/overview/), Sentry automatically tracks your so
 ## Configure
 
 <PlatformSection supported={["javascript"]}>
-  Enable tracing by configuring the sampling rate for transactions. Set the
-  sample rate for your transactions by either:
+  Enable tracing by configuring the sampling rate for traces. Set the sample
+  rate as follows:
 </PlatformSection>
 
 <PlatformSection notSupported={["javascript"]}>
-  Enable tracing by setting the sample rate for your transactions.
+  Enable tracing by setting the sample rate for your traces.
 </PlatformSection>
 
 <PlatformContent includePath="performance/configure-sample-rate" />
@@ -75,12 +75,35 @@ See <PlatformLink to="/tracing/instrumentation/automatic-instrumentation">Automa
 
 You can also manually start spans to instrument specific parts of your code. This is useful when you want to measure the performance of a specific operation or function.
 
-- <PlatformLink to="/apis/#tracing">Tracing APIs</PlatformLink>:
-  Find information about APIs for custom tracing instrumentation
+- <PlatformLink to="/apis/#tracing">Tracing APIs</PlatformLink>: Find
+  information about APIs for custom tracing instrumentation
 - <PlatformLink to="/tracing/instrumentation/">Instrumentation</PlatformLink>:
   Find information about manual instrumentation with the Sentry SDK
 - <PlatformLink to="/tracing/span-metrics/">Sending Span Metrics</PlatformLink>:
   Learn how to capture metrics on your spans
+
+## Disabling Tracing
+
+If you want to disable tracing, you _should not_ set `tracesSampleRate` at
+all. Setting it to `0` will not disable tracing, it will simply never send any
+traces to Sentry.
+
+<PlatformSection
+  supported={[
+    "javascript.nextjs",
+    "javascript.nuxt",
+    "javascript.sveltekit",
+    "javascript.astro",
+    "javascript.solidstart",
+  ]}
+>
+  In addition, you can configure `__SENTRY_TRACING__` to ensure the tracing code
+  is removed from your production build. This will result in{" "}
+  <PlatformLink to="/tracing/distributed-tracing/">trace propagation</PlatformLink>{" "}
+  being disabled as well. See{" "}
+  <PlatformLink to="/configuration/tree-shaking/">Tree Shaking</PlatformLink>{" "}
+  for more information.
+</PlatformSection>
 
 ## Next Steps
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-docs/issues/14267

This adds more explicit docs explaining how to disable tracing, as this sometimes is confusing for folks.