### PR TITLE
fix(go): Add missing tracing config option

### DIFF
--- a/docs/platforms/go/common/index.mdx
+++ b/docs/platforms/go/common/index.mdx
@@ -16,14 +16,6 @@ In addition to capturing errors, you can monitor interactions between multiple s
 
 Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-    'logs',
-  ]}
-/>
-
 ## Install
 
 <PlatformContent includePath="getting-started-install" />

--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -25,9 +25,10 @@ func main() {
 		// Adds request headers and IP for users,
         // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
         SendDefaultPII: true,
+        // ___PRODUCT_OPTION_START___ performance
+        EnableTracing: true,
+        // ___PRODUCT_OPTION_END___ performance
         // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
         EnableLogs: true,
         // ___PRODUCT_OPTION_END___ logs
 	})


### PR DESCRIPTION
### Description

Fixed onboarding buttons. For some reason the tracing option was removed.

