### PR TITLE
Add a new version of the sampling page for Python SDK 3.0

### DIFF
--- a/docs/platforms/python/configuration/sampling.mdx
+++ b/docs/platforms/python/configuration/sampling.mdx
@@ -125,7 +125,12 @@ If you're using a <PlatformIdentifier name="traces-sample-rate" /> rather than a
 
 If you know at transaction creation time whether or not you want the transaction sent to Sentry, you also have the option of passing a sampling decision directly to the transaction constructor (note, not in the <PlatformIdentifier name="custom-sampling-context" /> object). If you do that, the transaction won't be subject to the <PlatformIdentifier name="traces-sample-rate" />, nor will <PlatformIdentifier name="traces-sampler" /> be run, so you can count on the decision that's passed not to be overwritten.
 
-<PlatformContent includePath="performance/force-sampling-decision" />
+```python
+sentry_sdk.start_transaction(
+    name="GET /search",
+    sampled=True
+)
+```
 
 ## Precedence
 

--- a/docs/platforms/python/configuration/sampling__v3.x.mdx
+++ b/docs/platforms/python/configuration/sampling__v3.x.mdx
@@ -75,35 +75,15 @@ By default, none of these options are set, meaning no transactions will be sent 
 
 ### Default Sampling Context Data
 
-The information contained in the <PlatformIdentifier name="sampling-context" /> object passed to the <PlatformIdentifier name="traces-sampler" /> when a transaction is created varies by platform and integration.
+The information contained in the <PlatformIdentifier name="sampling-context" /> object passed to the <PlatformIdentifier name="traces-sampler" /> when a transaction is created varies by integration.
 
 <PlatformContent includePath="performance/default-sampling-context" />
 
 ### Custom Sampling Context Data
 
-When using custom instrumentation to create a transaction, you can add data to the <PlatformIdentifier name="sampling-context" /> by passing it as an optional second argument to <PlatformIdentifier name="start-transaction" />. This is useful if there's data to which you want the sampler to have access but which you don't want to attach to the transaction as `tags` or `data`, such as information that's sensitive or that’s too large to send with the transaction. For example:
+When using custom instrumentation to create a transaction, you can add data to the <PlatformIdentifier name="sampling-context" /> by providing additional `attributes` to <PlatformIdentifier name="start-span" />. All span attributes provided at span start are accessible via the <PlatformIdentifier name="sampling-context" /> and will also ultimately be sent to Sentry. If you want to exclude an attribute, you can filter it out in a <PlatformLink to="/configuration/filtering">`before_send`</PlatformLink>.
 
-```python
-sentry_sdk.start_transaction(
-    # kwargs passed to Transaction constructor - will be recorded on transaction
-    name="GET /search",
-    op="search",
-    data={
-        "query_params": {
-            "animal": "dog",
-            "type": "very good"
-        }
-    },
-    # `custom_sampling_context` - won't be recorded
-    custom_sampling_context={
-        # PII
-        "user_id": "12312012",
-        # too big to send
-        "search_results": { ... }
-    }
-)
-```
-
+<PlatformContent includePath="performance/custom-sampling-context" />
 
 ## Inheritance
 

--- a/docs/platforms/python/configuration/sampling__v3.x.mdx
+++ b/docs/platforms/python/configuration/sampling__v3.x.mdx
@@ -99,23 +99,23 @@ In some SDKs, for convenience, the <PlatformIdentifier name="traces-sampler" /> 
 
 </PlatformContent>
 
-If you're using a <PlatformIdentifier name="traces-sample-rate" /> rather than a <PlatformIdentifier name="traces-sampler" />, the decision will always be inherited.
+If you're using a <PlatformIdentifier name="traces-sample-rate" /> rather than a <PlatformIdentifier name="traces-sampler" />, the decision will always be inherited. The provided <PlatformIdentifier name="traces-sample-rate" /> will only be used to generate a sample rate if there is sampling decision coming in from upstream.
 
 ## Forcing a Sampling Decision
 
-If you know at transaction creation time whether or not you want the transaction sent to Sentry, you also have the option of passing a sampling decision directly to the transaction constructor (note, not in the <PlatformIdentifier name="custom-sampling-context" /> object). If you do that, the transaction won't be subject to the <PlatformIdentifier name="traces-sample-rate" />, nor will <PlatformIdentifier name="traces-sampler" /> be run, so you can count on the decision that's passed not to be overwritten.
+If you know at span creation time whether or not you want the root span (transaction) sent to Sentry, you also have the option of passing a sampling decision directly in the `start_span` API. If you do that, the root span won't be subject to the <PlatformIdentifier name="traces-sample-rate" />, nor will <PlatformIdentifier name="traces-sampler" /> be run, so you can count on the decision that's passed not to be overwritten.
 
 <PlatformContent includePath="performance/force-sampling-decision" />
 
 ## Precedence
 
-There are multiple ways for a transaction to end up with a sampling decision.
+There are multiple ways for a root span (transaction) to end up with a sampling decision.
 
 - Random sampling according to a static sample rate set in <PlatformIdentifier name="traces-sample-rate" />
 - Random sampling according to a sample function rate returned by <PlatformIdentifier name="traces-sampler" />
 - Absolute decision (100% chance or 0% chance) returned by <PlatformIdentifier name="traces-sampler" />
 - If the transaction has a parent, inheriting its parent's sampling decision
-- Absolute decision passed to <PlatformIdentifier name="start-transaction" />
+- Absolute decision passed to <PlatformIdentifier name="start-span" />
 
 When there's the potential for more than one of these to come into play, the following precedence rules apply:
 

--- a/platform-includes/performance/custom-sampling-context/python.mdx
+++ b/platform-includes/performance/custom-sampling-context/python.mdx
@@ -1,20 +1,20 @@
 ```python
-sentry_sdk.start_transaction(
-    # kwargs passed to Transaction constructor - will be recorded on transaction
+sentry_sdk.start_span(
     name="GET /search",
     op="search",
     data={
-      "query_params": {
-        "animal": "dog",
-        "type": "very good"
-      }
+        "query_params": {
+            "animal": "dog",
+            "type": "very good"
+        }
     },
-    # `custom_sampling_context` - won't be recorded
-    custom_sampling_context={
-        # PII
+    # Attributes defined at root span start will be accessible in traces_sampler
+    # and they will be sent to Sentry unless filtered out manually.
+    # Note that these can only be primitive types or a list of a single primitive
+    # type.
+    attributes={
         "user_id": "12312012",
-        # too big to send
-        "search_results": { ... }
+        "foo": "bar",
     }
-);
+)
 ```

--- a/platform-includes/performance/force-sampling-decision/python.mdx
+++ b/platform-includes/performance/force-sampling-decision/python.mdx
@@ -1,6 +1,8 @@
 ```python
-sentry_sdk.start_transaction(
-  name="GET /search",
-  sampled=True
-);
+sentry_sdk.start_span(
+    name="GET /search",
+    # Sample this span. Note that the `sampled` parameter is only taken into
+    # account for root-level spans (transactions).
+    sampled=True,
+)
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
We've made some changes to sampling in the upcoming 3.0 version of the Python SDK. Creating a new 3.x version of the page.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
