### PR TITLE
feat(go): refactor initial guide pages

### DIFF
--- a/docs/platforms/go/common/index.mdx
+++ b/docs/platforms/go/common/index.mdx
@@ -10,20 +10,6 @@ Check out the other SDKs we support in the left-hand dropdown.
 
 * If you don't have an account and Sentry project established already, please head over to [Sentry](https://sentry.io/signup/), and then return to this page.
 
-## Features
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-    'logs',
-  ]}
-/>
-
 ## Install
 
 <PlatformContent includePath="getting-started-install" />

--- a/docs/platforms/go/guides/echo/index.mdx
+++ b/docs/platforms/go/guides/echo/index.mdx
@@ -7,78 +7,24 @@ For a quick reference, there is a [complete example](https://github.com/getsentr
 
 [Go Dev-style API documentation](https://pkg.go.dev/github.com/getsentry/sentry-go/echo) is also available.
 
-## Features
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance'
-  ]}
-/>
-
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/echo
 ```
 
 <Break />
 
-
-```go
-import (
-	"fmt"
-	"net/http"
-
-	"github.com/getsentry/sentry-go"
-	sentryecho "github.com/getsentry/sentry-go/echo"
-	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for tracing.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-	// Adds request headers and IP for users,
-	// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-	SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-// Then create your app
-app := echo.New()
-
-app.Use(middleware.Logger())
-app.Use(middleware.Recover())
-
-// Once it's done, you can attach the handler as one of your middleware
-app.Use(sentryecho.New(sentryecho.Options{}))
-
-// Set up routes
-app.GET("/", func(ctx echo.Context) error {
-	return ctx.String(http.StatusOK, "Hello, World!")
-})
-
-// And run it
-app.Logger.Fatal(app.Start(":3000"))
-```
-
 ## Configure
 
-`sentryecho` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently it respects 3 options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentryecho` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
@@ -90,6 +36,41 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+app := echo.New()
+app.Use(sentryecho.New(sentryecho.Options{
+    // you can modify these options
+    Repanic:         true,
+    WaitForDelivery: false,
+    Timeout:         5 * time.Second,
+}))
+```
+
+## Verify
+
+```go
+app := echo.New()
+app.Use(middleware.Logger())
+app.Use(middleware.Recover())
+
+// Attach the sentryecho handler as one of your middlewares
+app.Use(sentryecho.New(sentryecho.Options{
+// specify options here...
+}))
+
+// Set up routes
+app.GET("/", func(ctx echo.Context) error {
+    // capturing an error intentionally to simulate usage
+    sentry.CaptureMessage("It works!")
+
+	return ctx.String(http.StatusOK, "Hello, World!")
+})
+
+app.Logger.Fatal(app.Start(":3000"))
 ```
 
 ## Usage

--- a/docs/platforms/go/guides/fasthttp/index.mdx
+++ b/docs/platforms/go/guides/fasthttp/index.mdx
@@ -7,75 +7,24 @@ For a quick reference, there is a [complete example](https://github.com/getsentr
 
 [Go Dev-style API documentation](https://pkg.go.dev/github.com/getsentry/sentry-go/fasthttp) is also available.
 
-## Features
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance'
-  ]}
-/>
-
-```shell
+```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/fasthttp
 ```
 
 <Break />
 
-
-```go
-import (
-	"fmt"
-	"net/http"
-
-	"github.com/getsentry/sentry-go"
-	sentryfasthttp "github.com/getsentry/sentry-go/fasthttp"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	EnableTracing: true,
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for tracing.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-	// Adds request headers and IP for users,
-	// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-	SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-// Create an instance of sentryfasthttp
-sentryHandler := sentryfasthttp.New(sentryfasthttp.Options{})
-
-// After creating the instance, you can attach the handler as one of your middleware
-fastHTTPHandler := sentryHandler.Handle(func(ctx *fasthttp.RequestCtx) {
-	panic("y tho")
-})
-
-fmt.Println("Listening and serving HTTP on :3000")
-
-// And run it
-if err := fasthttp.ListenAndServe(":3000", fastHTTPHandler); err != nil {
-	panic(err)
-}
-```
-
 ## Configure
 
-`sentryfasthttp` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently, it respects three options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentryfasthttp` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Repanic configures whether Sentry should repanic after recovery, in most cases, it defaults to false,
@@ -87,6 +36,41 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+// Create an instance of sentryfasthttp
+sentryHandler := sentryfasthttp.New(sentryfasthttp.Options{
+    Repanic:         false,
+    WaitForDelivery: true,
+    Timeout:         5 * time.Second,
+})
+```
+
+## Verify
+
+```go
+// Create an instance of sentryfasthttp
+sentryHandler := sentryfasthttp.New(sentryfasthttp.Options{
+// specify options here...
+})
+
+// After creating the instance, you can attach the handler as one of your middleware
+fastHTTPHandler := sentryHandler.Handle(func(ctx *fasthttp.RequestCtx) {
+	// capturing an error intentionally to simulate usage
+	sentry.CaptureMessage("It works!")
+	
+	ctx.SetStatusCode(fasthttp.StatusOK)
+})
+
+fmt.Println("Listening and serving HTTP on :3000")
+
+// And run it
+if err := fasthttp.ListenAndServe(":3000", fastHTTPHandler); err != nil {
+	panic(err)
+}
 ```
 
 ## Usage

--- a/docs/platforms/go/guides/fiber/index.mdx
+++ b/docs/platforms/go/guides/fiber/index.mdx
@@ -3,95 +3,28 @@ title: Fiber
 description: "Learn how to add Sentry instrumentation to programs using the Fiber package."
 ---
 
-The Sentry Go SDK repository has a [complete
-example](https://github.com/getsentry/sentry-go/tree/master/_examples/fiber)
-of how to set up Sentry for a Fiber app.
+For a quick reference, there is a [complete example](https://github.com/getsentry/sentry-go/tree/master/_examples/fiber) at the Go SDk source code repository.
 
-For additional reference, see the [`sentryfiber` API
-documentation](https://godoc.org/github.com/getsentry/sentry-go/fiber).
+[Go Dev-style API documentation](https://godoc.org/github.com/getsentry/sentry-go/fiber) is also available.
 
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-  ]}
-/>
-
-```shell
+```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/fiber
 ```
 
 <Break />
 
-```go
-import (
-	"fmt"
-	"net/http"
-
-	"github.com/getsentry/sentry-go"
-	sentryfiber "github.com/getsentry/sentry-go/fiber"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	EnableTracing: true,
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for performance monitoring.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-	// Adds request headers and IP for users,
-	// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-	SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-    // Later in the code
-	sentryHandler := sentryfiber.New(sentryfiber.Options{
-		Repanic:         true,
-		WaitForDelivery: true,
-	})
-
-	enhanceSentryEvent := func(ctx *fiber.Ctx) error {
-		if hub := sentryfiber.GetHubFromContext(ctx); hub != nil {
-			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
-		}
-		return ctx.Next()
-	}
-
-	app := fiber.New()
-
-	app.Use(sentryHandler)
-
-	app.All("/foo", enhanceSentryEvent, func(c *fiber.Ctx) error {
-		panic("y tho")
-	})
-
-	app.All("/", func(ctx *fiber.Ctx) error {
-		if hub := sentryfiber.GetHubFromContext(ctx); hub != nil {
-			hub.WithScope(func(scope *sentry.Scope) {
-				scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
-				hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
-			})
-		}
-		return ctx.SendStatus(fiber.StatusOK)
-	})
-
-	if err := app.Listen(":3000"); err != nil {
-		panic(err)
-	}
-```
-
 ## Configure
 
-`sentryfiber` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently, it respects three options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentryfiber` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Repanic configures whether Sentry should repanic after recovery, in most cases it should be set to true,
@@ -103,6 +36,41 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+sentryHandler := sentryfiber.New(sentryfiber.Options{
+    // you can modify these options
+    Repanic:         true,
+    WaitForDelivery: false,
+    Timeout:         5 * time.Second,
+})
+
+app := fiber.New()
+app.Use(sentryHandler)
+```
+
+## Verify
+
+```go
+app := fiber.New()
+
+app.Use(sentryfiber.New(sentryfiber.Options{
+// specify options here...
+}))
+
+app.All("/", func(ctx *fiber.Ctx) error {
+	// capturing an error intentionally to simulate usage
+	sentry.CaptureMessage("It works!")
+	
+	return ctx.SendStatus(fiber.StatusOK)
+})
+
+if err := app.Listen(":3000"); err != nil {
+	panic(err)
+}
 ```
 
 ## Usage
@@ -152,8 +120,6 @@ fmt.Println("Listening and serving HTTP on :3000")
 ```
 
 ### Accessing Context in `BeforeSend` callback
-
-<SignInNote />
 
 ```go
 sentry.Init(sentry.ClientOptions{

--- a/docs/platforms/go/guides/gin/index.mdx
+++ b/docs/platforms/go/guides/gin/index.mdx
@@ -7,75 +7,24 @@ For a quick reference, there is a [complete example](https://github.com/getsentr
 
 [Go Dev-style API documentation](https://pkg.go.dev/github.com/getsentry/sentry-go/gin) is also available.
 
-## Features
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-  ]}
-/>
-
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/gin
 ```
 
 <Break />
 
-
-```go
-import (
-	"fmt"
-	"net/http"
-
-	sentry "github.com/getsentry/sentry-go"
-	sentrygin "github.com/getsentry/sentry-go/gin"
-	"github.com/gin-gonic/gin"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	EnableTracing: true,
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for tracing.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-	// Adds request headers and IP for users,
-	// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-	SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-// Then create your app
-app := gin.Default()
-
-// Once it's done, you can attach the handler as one of your middleware
-app.Use(sentrygin.New(sentrygin.Options{}))
-
-// Set up routes
-app.GET("/", func(ctx *gin.Context) {
-	ctx.String(http.StatusOK, "Hello world!")
-})
-
-// And run it
-app.Run(":3000")
-```
-
 ## Configure
 
-`sentrygin` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently it respects 3 options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentrygin` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Whether Sentry should repanic after recovery, in most cases it should be set to true,
@@ -87,6 +36,40 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+app := gin.Default()
+app.Use(sentrygin.New(sentrygin.Options{
+    // you can modify these options
+    Repanic:         true,
+    WaitForDelivery: false,
+    Timeout:         5 * time.Second,
+}))
+```
+
+## Verify
+
+```go
+app := gin.Default()
+
+// you can attach the handler as one of your middleware
+app.Use(sentrygin.New(sentrygin.Options{
+// specify options here...
+}))
+
+// Set up routes
+app.GET("/", func(ctx *gin.Context) {
+	// capturing an error intentionally to simulate usage
+	sentry.CaptureMessage("It works!")
+	
+	ctx.String(http.StatusOK, "Hello world!")
+})
+
+// And run it
+app.Run(":3000")
 ```
 
 ## Usage

--- a/docs/platforms/go/guides/http/index.mdx
+++ b/docs/platforms/go/guides/http/index.mdx
@@ -28,55 +28,15 @@ go get github.com/getsentry/sentry-go/http
 
 <Break />
 
-
-```go
-import (
-	"fmt"
-	"net/http"
-
-	"github.com/getsentry/sentry-go"
-	sentryhttp "github.com/getsentry/sentry-go/http"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	EnableTracing: true,
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for tracing.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-  // Adds request headers and IP for users,
-  // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-  SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-// Create an instance of sentryhttp
-sentryHandler := sentryhttp.New(sentryhttp.Options{})
-
-// Once it's done, you can set up routes and attach the handler as one of your middleware
-http.Handle("/", sentryHandler.Handle(&handler{}))
-http.HandleFunc("/foo", sentryHandler.HandleFunc(func(rw http.ResponseWriter, r *http.Request) {
-	panic("y tho")
-}))
-
-fmt.Println("Listening and serving HTTP on :3000")
-
-// And run it
-if err := http.ListenAndServe(":3000", nil); err != nil {
-	panic(err)
-}
-```
-
 ## Configure
 
-`sentryhttp` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently it respects 3 options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentryhttp` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Whether Sentry should repanic after recovery, in most cases it should be set to true,
@@ -87,6 +47,45 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+// Create an instance of sentryhttp
+sentryHandler := sentryhttp.New(sentryhttp.Options{
+    Repanic:         true,
+    WaitForDelivery: false,
+    Timeout:         5 * time.Second,
+})
+```
+
+## Verify
+
+```go
+type handler struct{}
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	// capturing an error intentionally to simulate usage
+	sentry.CaptureMessage("It works!")
+	
+	rw.WriteHeader(http.StatusOK)
+}
+
+// Create an instance of sentryhttp
+sentryHandler := sentryhttp.New(sentryhttp.Options{
+// specify options here...
+})
+
+// Once it's done, you can set up routes and attach the handler as one of your middleware
+http.Handle("/", sentryHandler.Handle(&handler{}))
+
+fmt.Println("Listening and serving HTTP on :3000")
+
+// And run it
+if err := http.ListenAndServe(":3000", nil); err != nil {
+	panic(err)
+}
 ```
 
 ## Usage

--- a/docs/platforms/go/guides/iris/index.mdx
+++ b/docs/platforms/go/guides/iris/index.mdx
@@ -7,74 +7,24 @@ For a quick reference, there is a [complete example](https://github.com/getsentr
 
 [Go Dev-style API documentation](https://pkg.go.dev/github.com/getsentry/sentry-go/iris) is also available.
 
-## Features
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-  ]}
-/>
-
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/iris
 ```
 
 <Break />
 
-
-```go
-import (
-	"fmt"
-
-	"github.com/getsentry/sentry-go"
-	sentryiris "github.com/getsentry/sentry-go/iris"
-	"github.com/kataras/iris/v12"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	EnableTracing: true,
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for tracing.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-	// Adds request headers and IP for users,
-	// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-	SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-// Then create your app
-app := iris.Default()
-
-// Once it's done, you can attach the handler as one of your middleware
-app.Use(sentryiris.New(sentryiris.Options{}))
-
-// Set up routes
-app.Get("/", func(ctx iris.Context) {
-	ctx.Writef("Hello world!")
-})
-
-// And run it
-app.Run(iris.Addr(":3000"))
-```
-
 ## Configure
 
-`sentryiris` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently it respects 3 options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentryiris` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Whether Sentry should repanic after recovery, in most cases it should be set to true,
@@ -86,6 +36,41 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+app := iris.Default()
+app.Use(sentryiris.New(sentryiris.Options{
+    // modify your own config options
+    Repanic:         true,
+    WaitForDelivery: false,
+    Timeout:         5 * time.Second,
+}))
+```
+
+## Verify
+
+```go
+// Create your app
+app := iris.Default()
+
+// Once it's done, you can attach the handler as one of your middleware
+app.Use(sentryiris.New(sentryiris.Options{
+// specify options here...
+}))
+
+// Set up routes
+app.Get("/", func(ctx iris.Context) {
+	// capturing an error intentionally to simulate usage
+	sentry.CaptureMessage("It works!")
+	
+	ctx.Writef("Hello world!")
+})
+
+// And run it
+app.Run(iris.Addr(":3000"))
 ```
 
 ## Usage

--- a/docs/platforms/go/guides/logrus/index.mdx
+++ b/docs/platforms/go/guides/logrus/index.mdx
@@ -14,12 +14,86 @@ Logrus structured logging is supported in Sentry Go SDK version `0.34.0` and abo
 ## Install
 
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/logrus
 ```
 
 <Break />
 
-<SignInNote />
+## Configure
+
+### Initialize the Sentry SDK
+
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentrylogrus` provides two types of hooks to configure the integration with Sentry. Both hooks accept these options:
+- **Levels**: A slice of `logrus.Level` specifying which log levels to capture
+- **ClientOptions**: Standard `sentry.ClientOptions` for configuration
+
+#### LogHook
+
+Use `sentrylogrus.NewLogHook()` to send structured logs to Sentry. This hook captures log entries and sends them to Sentry's structured logging system.
+
+```go
+logHook, err := sentrylogrus.NewLogHook(
+    []logrus.Level{logrus.InfoLevel, logrus.WarnLevel},
+    sentry.ClientOptions{
+        Dsn: "___PUBLIC_DSN___",
+        EnableLogs: true, // Required for log entries
+    })
+```
+
+#### EventHook
+
+Use `sentrylogrus.NewEventHook()` to send log entries as Sentry events. This is useful for error tracking and alerting.
+
+```go
+eventHook, err := sentrylogrus.NewEventHook(
+    []logrus.Level{logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel},
+    sentry.ClientOptions{
+        Dsn: "___PUBLIC_DSN___",
+        Debug: true,
+        AttachStacktrace: true,
+    })
+```
+
+<Alert>
+    When using both hooks, ensure you flush both of them before the application exits and register exit handlers for fatal logs to avoid losing pending events.
+</Alert>
+
+## Verify
+
+```go
+// Initialize Logrus
+logger := logrus.New()
+logger.Level = logrus.DebugLevel
+logger.Out = os.Stderr
+
+// Create event hook for errors
+eventHook, err := sentrylogrus.NewEventHook([]logrus.Level{
+	logrus.ErrorLevel,
+	logrus.FatalLevel,
+	logrus.PanicLevel,
+}, sentry.ClientOptions{
+	Dsn: "___PUBLIC_DSN___",
+	AttachStacktrace: true,
+})
+if err != nil {
+	panic(err)
+}
+defer eventHook.Flush(5 * time.Second)
+logger.AddHook(eventHook)
+
+// Test logging - this will be sent to Sentry as an event
+logger.Error("This error will be sent to Sentry!")
+
+// Example of logging with attributes
+logger.WithField("user", "test-user").Error("An error occurred")
+```
+
+## Usage
 
 To integrate Sentry with Logrus, you can set up both log hooks and event hooks to capture different types of data at various log levels.
 
@@ -109,67 +183,6 @@ func main() {
     // Example of logging with attributes
 	logger.WithField("user", "test-user").Error("An error occurred")
 }
-```
-
-## Configure
-
-`sentrylogrus` provides two types of hooks to configure the integration with Sentry. Both hooks accept these options:
-- **Levels**: A slice of `logrus.Level` specifying which log levels to capture
-- **ClientOptions**: Standard `sentry.ClientOptions` for configuration
-
-### LogHook
-
-Use `sentrylogrus.NewLogHook()` to send structured logs to Sentry. This hook captures log entries and sends them to Sentry's structured logging system.
-
-```go
-logHook, err := sentrylogrus.NewLogHook(
-    []logrus.Level{logrus.InfoLevel, logrus.WarnLevel},
-    sentry.ClientOptions{
-        Dsn: "___PUBLIC_DSN___",
-        EnableLogs: true, // Required for log entries
-    })
-```
-
-### EventHook
-
-Use `sentrylogrus.NewEventHook()` to send log entries as Sentry events. This is useful for error tracking and alerting.
-
-```go
-eventHook, err := sentrylogrus.NewEventHook(
-    []logrus.Level{logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel},
-    sentry.ClientOptions{
-        Dsn: "___PUBLIC_DSN___",
-        Debug: true,
-        AttachStacktrace: true,
-    })
-```
-
-<Alert>
-    When using both hooks, ensure you flush both of them before the application exits and register exit handlers for fatal logs to avoid losing pending events.
-</Alert>
-
-## Correlating Logs with Traces
-
-To correlate logs with transactions, you need to pass a `context.Context` that contains transaction information to your logger calls. The `sentryhttp` middleware automatically adds transaction information to the request's context.
-Here's an example of how to use `WithContext` in an HTTP handler to ensure logs are associated with the correct trace.
-
-```go
-// Assume logger is initialized and Sentry hooks are added as shown above.
-// var logger *logrus.Logger
-
-func myAsyncHandler(w http.ResponseWriter, r *http.Request) {
-	// The sentryhttp middleware adds a Hub with transaction information to the request context.
-	ctx := r.Context()
-	// By using WithContext, the log entry will be associated with the transaction from the request.
-    logger.WithContext(ctx).Info("Log inside handler")
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, "Handler finished, async task running in background.")
-}
-
-// In your main function, or wherever you set up your routes:
-// Wrap your handler with sentryhttp to automatically start transactions for requests.
-sentryHandler := sentryhttp.New(sentryhttp.Options{})
-http.Handle("/async", sentryHandler.Handle(http.HandlerFunc(myAsyncHandler)))
 ```
 
 ## Logs

--- a/docs/platforms/go/guides/negroni/index.mdx
+++ b/docs/platforms/go/guides/negroni/index.mdx
@@ -7,79 +7,24 @@ For a quick reference, there is a [complete example](https://github.com/getsentr
 
 [Go Dev-style API documentation](https://pkg.go.dev/github.com/getsentry/sentry-go/negroni) is also available.
 
-## Features
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
-
 ## Install
 
-<OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-  ]}
-/>
-
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/negroni
 ```
 
 <Break />
 
-
-```go
-import (
-	"fmt"
-	"net/http"
-
-	"github.com/getsentry/sentry-go"
-	sentrynegroni "github.com/getsentry/sentry-go/negroni"
-	"github.com/urfave/negroni"
-)
-
-// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
-if err := sentry.Init(sentry.ClientOptions{
-	Dsn: "___PUBLIC_DSN___",
-	// ___PRODUCT_OPTION_START___ performance
-	EnableTracing: true,
-	// Set TracesSampleRate to 1.0 to capture 100%
-	// of transactions for tracing.
-	// We recommend adjusting this value in production,
-	TracesSampleRate: 1.0,
-	// ___PRODUCT_OPTION_END___ performance
-	// Adds request headers and IP for users,
-	// visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-	SendDefaultPII: true,
-}); err != nil {
-	fmt.Printf("Sentry initialization failed: %v\n", err)
-}
-
-// Then create your app
-app := negroni.Classic()
-
-// Once it's done, you can attach the handler as one of your middleware
-app.Use(sentrynegroni.New(sentrynegroni.Options{}))
-
-// Set up routes
-mux := http.NewServeMux()
-
-mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello world!")
-})
-
-app.UseHandler(mux)
-
-// And run it
-http.ListenAndServe(":3000", app)
-```
-
 ## Configure
 
-`sentrynegroni` accepts a struct of `Options` that allows you to configure how the handler will behave.
+### Initialize the Sentry SDK
 
-Currently it respects 3 options:
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+`sentrynegroni` accepts a struct of `Options` that allows you to configure how the handler will behave.
 
 ```go
 // Whether Sentry should repanic after recovery, in most cases it should be set to true,
@@ -91,6 +36,44 @@ Repanic bool
 WaitForDelivery bool
 // Timeout for the event delivery requests.
 Timeout time.Duration
+```
+
+<Break />
+
+```go
+app := negroni.Classic()
+
+app.Use(sentrynegroni.New(sentrynegroni.Options{
+    // modify your own config options
+    Repanic:         true,
+    WaitForDelivery: false,
+    Timeout:         5 * time.Second,
+}))
+```
+
+## Verify
+
+```go
+app := negroni.Classic()
+
+app.Use(sentrynegroni.New(sentrynegroni.Options{
+// specify options here...
+}))
+
+// Set up routes
+mux := http.NewServeMux()
+
+mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+	// capturing an error intentionally to simulate usage
+	sentry.CaptureMessage("It works!")
+	
+	fmt.Fprintf(rw, "Hello world!")
+})
+
+app.UseHandler(mux)
+
+// And run it
+http.ListenAndServe(":3000", app)
 ```
 
 ## Usage

--- a/docs/platforms/go/guides/slog/index.mdx
+++ b/docs/platforms/go/guides/slog/index.mdx
@@ -14,12 +14,73 @@ Slog structured logging is supported in Sentry Go SDK version `0.34.0` and above
 ## Install
 
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/slog
 ```
 
 <Break />
 
-<SignInNote />
+## Configure
+
+### Initialize the Sentry SDK
+
+<PlatformContent includePath="getting-started-config" />
+
+### Slog Integration
+
+`sentryslog` provides options to configure the integration with Sentry. It accepts a struct of `sentryslog.Options` that allows you to configure how the handler will behave. The options are:
+
+```go
+// EventLevel specifies the exact log levels to capture and send to Sentry as Events.
+// Only logs at these specific levels will be processed as events.
+// Defaults to []slog.Level{slog.LevelError, LevelFatal}.
+EventLevel slog.Leveler
+// LogLevel specifies the exact log levels to capture and send to Sentry as Log entries
+// Only logs at these specific levels will be processed as log entries.
+// Defaults to []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError, LevelFatal}.
+LogLevel slog.Leveler
+// Hub specifies the Sentry Hub to use for capturing events.
+// If not provided, the current Hub is used by default.
+Hub *sentry.Hub
+// Converter is an optional function that customizes how log records
+// are converted into Sentry events. By default, the DefaultConverter is used.
+Converter Converter
+// AttrFromContext is an optional slice of functions that extract attributes
+// from the context. These functions can add additional metadata to the log entry.
+AttrFromContext []func(ctx context.Context) []slog.Attr
+// AddSource is an optional flag that, when set to true, includes the source
+// information (such as file and line number) in the Sentry event.
+// This can be useful for debugging purposes.
+AddSource bool
+// ReplaceAttr is an optional function that allows for the modification or
+// replacement of attributes in the log record. This can be used to filter
+// or transform attributes before they are sent to Sentry.
+ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+```
+
+## Verify
+
+```go
+// Configure `slog` to use Sentry as a handler
+ctx := context.Background()
+handler := sentryslog.Option{
+	EventLevel: []slog.Level{slog.LevelError}, // Only Error level will be sent as events
+	LogLevel:   []slog.Level{slog.LevelWarn, slog.LevelInfo},         // Only Warn and Info levels will be sent as logs
+}.NewSentryHandler(ctx)
+logger := slog.New(handler)
+
+// Test logging - this will be sent to Sentry as an event
+logger.Error("This error will be sent to Sentry!")
+
+// Example of logging with attributes
+logger.With("user", "test-user").Error("An error occurred")
+```
+
+## Usage
+
+### Sending Logs vs Events
+
+Sentry allows you to send logs either as log entries or as events. The minimum log level defaults to `slog.LevelDebug` and logs will be sent if the `EnableLogs` option is set. The minimum event level defaults to `slog.LevelError`.
 
 To integrate Sentry with slog, you need to set up a Sentry handler and configure the Sentry client.
 
@@ -73,44 +134,6 @@ func main() {
 		ErrorContext(ctx, "a message")
 }
 ```
-
-## Configure
-
-`sentryslog` provides options to configure the integration with Sentry. It accepts a struct of `sentryslog.Options` that allows you to configure how the handler will behave. The options are:
-
-```go
-// EventLevel specifies the exact log levels to capture and send to Sentry as Events.
-// Only logs at these specific levels will be processed as events.
-// Defaults to []slog.Level{slog.LevelError, LevelFatal}.
-EventLevel slog.Leveler
-// LogLevel specifies the exact log levels to capture and send to Sentry as Log entries
-// Only logs at these specific levels will be processed as log entries.
-// Defaults to []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError, LevelFatal}.
-LogLevel slog.Leveler
-// Hub specifies the Sentry Hub to use for capturing events.
-// If not provided, the current Hub is used by default.
-Hub *sentry.Hub
-// Converter is an optional function that customizes how log records
-// are converted into Sentry events. By default, the DefaultConverter is used.
-Converter Converter
-// AttrFromContext is an optional slice of functions that extract attributes
-// from the context. These functions can add additional metadata to the log entry.
-AttrFromContext []func(ctx context.Context) []slog.Attr
-// AddSource is an optional flag that, when set to true, includes the source
-// information (such as file and line number) in the Sentry event.
-// This can be useful for debugging purposes.
-AddSource bool
-// ReplaceAttr is an optional function that allows for the modification or
-// replacement of attributes in the log record. This can be used to filter
-// or transform attributes before they are sent to Sentry.
-ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
-```
-
-## Usage
-
-### Sending Logs vs Events
-
-Sentry allows you to send logs either as log entries or as events. The minimum log level defaults to `slog.LevelDebug` and logs will be sent if the `EnableLogs` option is set. The minimum event level defaults to `slog.LevelError`.
 
 ### Example: Sending Logs as Events
 

--- a/docs/platforms/go/guides/zerolog/index.mdx
+++ b/docs/platforms/go/guides/zerolog/index.mdx
@@ -10,15 +10,73 @@ For a complete example, visit the [Go SDK source code repository](https://github
 ## Install
 
 ```bash
+go get github.com/getsentry/sentry-go
 go get github.com/getsentry/sentry-go/zerolog
 ```
 
 <Break />
 
-<SignInNote />
+## Configure
+
+### Initialize the Sentry SDK
+
+<PlatformContent includePath="getting-started-config" />
+
+### Options
+
+sentryzerolog provides options to configure the integration with Sentry. It expects a `sentryzerolog.Config` that has `sentry.ClientOptions` and `sentryzerolog.Options`.
+The sentryzerolog.Options struct has the following fields:
+
+```go
+// Levels specifies the log levels that will trigger event sending to Sentry.
+// Only log messages at these levels will be sent. By default, the levels are
+// Error, Fatal, and Panic.
+Levels []zerolog.Level
+
+// WithBreadcrumbs, when enabled, adds log entries as breadcrumbs in Sentry.
+// Breadcrumbs provide a trail of events leading up to an error, which can
+// be invaluable for understanding the context of issues.
+WithBreadcrumbs bool
+
+// FlushTimeout sets the maximum duration allowed for flushing events to Sentry.
+// This is the time limit within which all pending events must be sent to Sentry
+// before the application exits. A typical use is ensuring all logs are sent before
+// application shutdown. The default timeout is usually 3 seconds.
+FlushTimeout time.Duration
+```
+
+## Verify
+
+```go
+// Configure Zerolog to use Sentry as a writer
+sentryWriter, err := sentryzerolog.New(sentryzerolog.Config{
+	ClientOptions: sentry.ClientOptions{
+		Dsn: "___PUBLIC_DSN___",
+	},
+	Options: sentryzerolog.Options{
+		Levels:          []zerolog.Level{zerolog.ErrorLevel, zerolog.FatalLevel, zerolog.PanicLevel},
+		WithBreadcrumbs: true,
+		FlushTimeout:    3 * time.Second,
+	},
+})
+if err != nil {
+	log.Fatal().Err(err).Msg("failed to create sentry writer")
+}
+defer sentryWriter.Close()
+
+// Use Sentry writer in Zerolog
+log.Logger = log.Output(zerolog.MultiLevelWriter(zerolog.ConsoleWriter{Out: os.Stderr}, sentryWriter))
+
+// Test logging - this will be sent to Sentry as an event
+log.Error().Msg("This error will be sent to Sentry!")
+
+// Example of logging with error context
+log.Error().Err(errors.New("test error")).Msg("An error occurred")
+```
+
+## Usage
 
 To integrate Sentry with Zerolog, you need to set up a custom writer that sends logs to Sentry based on the configured levels.
-
 
 ```go
 import (
@@ -81,32 +139,8 @@ func main() {
 }
 ```
 
-## Configure
 
-sentryzerolog provides options to configure the integration with Sentry. It expects a `sentryzerolog.Config` that has `sentry.ClientOptions` and `sentryzerolog.Options`. The `sentry.ClientOptions` are used to initialize the Sentry client, and the `sentryzerolog.Options` are used to configure the Zerolog integration.
-
-The sentryzerolog.Options struct has the following fields:
-
-
-```go
-// Levels specifies the log levels that will trigger event sending to Sentry.
-// Only log messages at these levels will be sent. By default, the levels are
-// Error, Fatal, and Panic.
-Levels []zerolog.Level
-
-// WithBreadcrumbs, when enabled, adds log entries as breadcrumbs in Sentry.
-// Breadcrumbs provide a trail of events leading up to an error, which can
-// be invaluable for understanding the context of issues.
-WithBreadcrumbs bool
-
-// FlushTimeout sets the maximum duration allowed for flushing events to Sentry.
-// This is the time limit within which all pending events must be sent to Sentry
-// before the application exits. A typical use is ensuring all logs are sent before
-// application shutdown. The default timeout is usually 3 seconds.
-FlushTimeout time.Duration
-```
-
-- Using `hubProvider` for Scoped Sentry Hubs
+### Using `hubProvider` for Scoped Sentry Hubs
 
 The hubProvider allows you to configure the Sentry hook to use a custom Sentry hub. This can be particularly useful when you want to scope logs to specific goroutines or operations, enabling more precise grouping and context in Sentry.
 
@@ -121,7 +155,6 @@ sentryHook.SetHubProvider(func() *sentry.Hub {
 
 This ensures that logs from specific contexts or threads use the appropriate Sentry hub and scope.
 
-## Usage
 
 Use Zerolog as you normally would, and it will automatically send logs at or above the specified levels to Sentry.
 

--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -1,41 +1,34 @@
 <OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-    'logs',
-  ]}
+    options={[
+        'error-monitoring',
+        'performance',
+        'logs',
+    ]}
 />
 
 ```go
-package main
-
-import (
-	"log"
-	"time"
-
-	"github.com/getsentry/sentry-go"
-)
-
-func main() {
-	err := sentry.Init(sentry.ClientOptions{
-		Dsn: "___PUBLIC_DSN___",
-		// Enable printing of SDK debug messages.
-		// Useful when getting started or trying to figure something out.
-		Debug: true,
-		// Adds request headers and IP for users,
-        // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
-        SendDefaultPII: true,
-        // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
-        EnableLogs: true,
-        // ___PRODUCT_OPTION_END___ logs
-	})
-	if err != nil {
-		log.Fatalf("sentry.Init: %s", err)
-	}
-	// Flush buffered events before the program terminates.
-	// Set the timeout to the maximum duration the program can afford to wait.
-	defer sentry.Flush(2 * time.Second)
+err := sentry.Init(sentry.ClientOptions{
+    Dsn: "___PUBLIC_DSN___",
+    // Enable printing of SDK debug messages.
+    // Useful when getting started or trying to figure something out.
+    Debug: true,
+    // Adds request headers and IP for users,
+    // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
+    SendDefaultPII: true,
+    // ___PRODUCT_OPTION_START___ performance
+    EnableTracing: true,
+    // Set TracesSampleRate to 1.0 to capture 100%
+    // of transactions for tracing.
+    TracesSampleRate: 1.0,
+    // ___PRODUCT_OPTION_END___ performance
+    // ___PRODUCT_OPTION_START___ logs
+    EnableLogs: true,
+    // ___PRODUCT_OPTION_END___ logs
+})
+if err != nil {
+    log.Fatalf("sentry.Init: %s", err)
 }
+// Flush buffered events before the program terminates.
+// Set the timeout to the maximum duration the program can afford to wait.
+defer sentry.Flush(2 * time.Second)
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Part of a refactoring initiative for the Go SDK docs pages. This PR mostly aims for consistency among all it's guides index pages. Things changed:
- Every page uses the `getting-started-config` to avoid snippets not correctly including all available onboarding options.
- Make snippets pastable (thus removing main function and whole package declarations).
- Divide parts of the snippets to different sections (Install, Configure, Options, Verify). Aim for pages to follow this format if possible.
