### PR TITLE
fix(ui): Filter versioned files from navigation tree.

### DIFF
--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -246,7 +246,8 @@ const filterVisibleSiblings = (s: DocNode) =>
   (s.frontmatter.sidebar_title || s.frontmatter.title) &&
   !s.frontmatter.sidebar_hidden &&
   !s.frontmatter.draft &&
-  s.path;
+  s.path &&
+  !isVersioned(s.path);
 
 function nodeToPlatform(n: DocNode): Platform {
   const platformData = platformsData()[n.slug];


### PR DESCRIPTION
## DESCRIBE YOUR PR
Currently, the python page for [shutdown and draining](https://docs.sentry.io/platforms/python/configuration/draining/) navigates to a different version of itself upon clicking "Next". I added a check to filter out versioned pages in filterVisibleSiblings.
Issue: https://github.com/getsentry/sentry-docs/issues/14272
Fixes GH-14272
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
