### PR TITLE
chore(derived_code_mappings): Remove call out

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -10,10 +10,10 @@ Azure DevOps was formerly known as Visual Studio Team Services (VSTS).
 
 <Alert title="Note">
   <p>
-  We recommend using a dedicated service account when installing this integration rather than a personal user account. 
+  We recommend using a dedicated service account when installing this integration rather than a personal user account.
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration. 
+  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration.
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.
@@ -103,12 +103,6 @@ Fixes MYAPP-317
 When Sentry sees this, we’ll automatically annotate the matching issue with reference to the commit, and later, when that commit is part of a release, we’ll mark the issue as resolved. The commit must be associated with a release. Otherwise, if the commit is squashed, Sentry won’t know when the commit has been released, and the issue may never be marked as a regression.
 
 ### Stack Trace Linking
-
-<Alert>
-
-This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
-
-</Alert>
 
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default branch).
 

--- a/docs/organization/integrations/source-code-mgmt/bitbucket/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/bitbucket/index.mdx
@@ -174,12 +174,6 @@ When Sentry sees this, we’ll automatically annotate the matching issue with re
 
 ### Stack Trace Linking
 
-<Alert>
-
-This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
-
-</Alert>
-
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default branch).
 
 1. Navigate to **Settings > Integrations > Bitbucket > Configurations**.

--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -12,7 +12,7 @@ There are two types of GitHub integrations, so make sure you're choosing the cor
   - `https://ghe.example.com/`
 
   For these accounts, follow the '[Installing GitHub Enterprise](#installing-github-enterprise)' instructions.
-  
+
 
 ### Check Your Domain
 
@@ -67,9 +67,9 @@ The following permissions are required for the GitHub integration to work correc
 | <span>Members<br/><em>_[Org-level]_</em></span>          | Read-only     | To map organization users to GitHub identities for improved issue attribution and collaboration.                                   |
 | Metadata           | Read-only     | To identify repository structure, names, default branches, and visibility.                                                        |
 | Pull Requests      | Read & Write  | To write comments on pull requests for (1) issues caused by the pull request and (2) to highlight existing issues in the code diff.|
-| Webhooks           | Read & Write  | To subscribe to real-time updates like push events, PRs, and issues.     
+| Webhooks           | Read & Write  | To subscribe to real-time updates like push events, PRs, and issues.
 
-Occasionally, Sentry will request additional permissions to your GitHub account as new features are introduced. Denying or ignoring the request to update will not affect your current Sentry usage, but may prevent access to future features. 
+Occasionally, Sentry will request additional permissions to your GitHub account as new features are introduced. Denying or ignoring the request to update will not affect your current Sentry usage, but may prevent access to future features.
 
 ## Installing GitHub Enterprise
 
@@ -328,7 +328,7 @@ By default, this feature is automatically enabled once your GitHub integration h
 
 <Alert>
 
-Sentry will automatically try to set up code mappings on C#, Go, JavaScript, Node.js, PHP, Python, and Ruby projects for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually. Support for other languages and other source code integrations is being worked on.
+Sentry will automatically try to set up code mappings on certain platforms for organizations with the GitHub integration installed ([more details](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/auto_source_code_config/constants.py)). If your project uses a different SDK, you can add code mappings manually.
 
 </Alert>
 

--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -328,7 +328,7 @@ By default, this feature is automatically enabled once your GitHub integration h
 
 <Alert>
 
-Sentry will automatically try to set up code mappings on certain platforms for organizations with the GitHub integration installed ([more details](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/auto_source_code_config/constants.py)). If your project uses a different SDK, you can add code mappings manually.
+Sentry will automatically try to set up code mappings on C#, Clojure, Go, Groovy, Java, JavaScript, PHP, Python, Ruby, and Scala for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually.
 
 </Alert>
 

--- a/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
@@ -12,10 +12,10 @@ description: "Learn more about Sentry’s GitLab integration and how it helps yo
 Sentry owner, manager, or admin permissions and GitLab owner or maintainer permissions are required to install this integration.
 </p>
   <p>
-  We recommend using a dedicated service account when installing this integration rather than a personal user account. 
+  We recommend using a dedicated service account when installing this integration rather than a personal user account.
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration. 
+  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration.
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.
@@ -117,12 +117,6 @@ A `<SHORT-ID>` may look something like 'BACKEND-C' in the image below.
 ![Issue detail highlighting suspect commits](./img/short-id.png)
 
 ### Stack Trace Linking
-
-<Alert>
-
-This feature is currently only supported for Ruby, Python, Php, Node, JavaScript, Go and Elixir.
-
-</Alert>
 
 Stack trace linking takes you from a file in your Sentry stack trace to that same file in your source code. If you have commit tracking set up in Sentry, we can take you to the exact version (using the commit associated with the event) of the source code when the error occurred. Otherwise we'll link you to the current state of the source code (using the default **branch**).
 


### PR DESCRIPTION
It's always been a source of confusion since it would not make any mention of the automatic code mapping derivation (only available for GitHub).

There are also some automatic commit fixes.