### PR TITLE
docs(js): Clarify behavior of `timeoutWarningLimit` in AWS

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/configuration/lambda-wrapper.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/configuration/lambda-wrapper.mdx
@@ -20,7 +20,7 @@ exports.handler = Sentry.wrapHandler(yourHandler, {
 
 ## Timeout Warning
 
-Sentry reports timeout warnings when the Lambda function is within 500ms of its execution time. You can turn off timeout warnings by setting `captureTimeoutWarning` to `false` in the handler options.
+Sentry reports timeout warnings when the Lambda function is within 500ms of the configured Lambda timeout. You can turn off timeout warnings by setting `captureTimeoutWarning` to `false` in the handler options.
 
 ```javascript {filename:index.js} {2}
 exports.handler = Sentry.wrapHandler(yourHandler, {
@@ -28,11 +28,11 @@ exports.handler = Sentry.wrapHandler(yourHandler, {
 });
 ```
 
-To change the timeout warning limit, assign a numeric value (in ms) to `timeoutWarningLimit`:
+To change the timeout warning limit, assign a numeric value (in ms) to `timeoutWarningLimit`. This value specifies the time left before the warning is triggered.
 
 ```javascript {filename:index.js} {2}
 exports.handler = Sentry.wrapHandler(yourHandler, {
-  timeoutWarningLimit: 700,
+  timeoutWarningLimit: 700, // Warn when within 700ms of timeout
 });
 ```
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

resolves https://github.com/getsentry/sentry-javascript/issues/9810

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
