### PR TITLE
chore(dynamic-sampling): add hint about conditions in dynamic sampling rules

### DIFF
--- a/develop-docs/application-architecture/dynamic-sampling/architecture.mdx
+++ b/develop-docs/application-architecture/dynamic-sampling/architecture.mdx
@@ -52,6 +52,18 @@ An example of rule encoded in JSON is the following:
 }
 ```
 
+<Alert title="✨ Note">
+Dynamic sampling rules must always include a `condition` field, otherwise the entire dynamic sampling ruleset will be ignored by Relay. If you want a rule to match every event, set the condition as follows:
+```json
+{
+  "condition": {
+    "inner": [],
+    "op": "and"
+  }
+}
+```
+</Alert>
+
 #### Fetching the Sampling Configuration
 
 The sampling configuration is fetched by Relay from Sentry in a pull fashion. This is done by sending a request to the `/api/0/relays/projectconfigs/` endpoint periodically (defined [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/relay/project_configs.py#L34-L34)).


### PR DESCRIPTION
There is an implementation detail in dynamic sampling rules: a condition needs to be added, otherwise the ruleset is not considered valid. The documentation does not contain any reference to this, and it's frustrating to figure out the correct way of specifying a catch-all yourself, therefore I'm adding this here.