### PR TITLE
Update identifying users documentation

### DIFF
--- a/docs/platforms/javascript/common/session-replay/configuration.mdx
+++ b/docs/platforms/javascript/common/session-replay/configuration.mdx
@@ -107,7 +107,7 @@ replayIntegration({
 
 ## Identifying Users
 
-You can use the Sentry SDK to link a user to a session. Read more about it in our <PlatformLink to="/enriching-events/identify-user">Identify Users</PlatformLink> docs.
+You can add user information to events to help you identify the user that is experiencing an issue. See [setUser](https://docs.sentry.io/platforms/javascript/guides/nextjs/apis/#setUser) to learn how to to set the user on Sentry events.
 
 ```javascript
 Sentry.setUser({ email: "jane.doe@example.com" });


### PR DESCRIPTION
DESCRIBE YOUR PR
Updates the "Identifying Users" section in the Session Replay configuration to clarify how to associate user information with events and link directly to the `setUser` API documentation.

IS YOUR CHANGE URGENT

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week 

SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
