### PR TITLE
:wrench: chore: mention that tasks must be added to TASKWORKER_IMPORTS

### DIFF
--- a/develop-docs/backend/application-domains/asynchronous-workers.mdx
+++ b/develop-docs/backend/application-domains/asynchronous-workers.mdx
@@ -68,13 +68,15 @@ There are a few important points:
   large messages, large queues and more (de)serialising overheads so
   should be avoided.
 
-- The tasks' module _must_ be added to `CELERY_IMPORTS`.
+- The tasks' module _must_ be added to `CELERY_IMPORTS` _and_ `TASKWORKER_IMPORTS`.
 
-  Celery workers must find the task by name, they can only do so if
+  Celery (and Taskbroker) workers must find the task by name, they can only do so if
   the worker has imported the module with the decorated task function
   because this is what registers the task by name.  Thus every module
-  containing a task must be added to the `CELERY_IMPORTS` setting in
+  containing a task must be added to the `CELERY_IMPORTS` and `TASKWORKER_IMPORTS` settings in
   `src/sentry/conf/server.py`.
+  
+  We have a separate setting for the Taskbroker workers until we fully deprecate the Celery workers.
 
 ## Running a Worker
 


### PR DESCRIPTION
note to make sure we added a tasks's module to `TASKWORKER_IMPORTS` as well.