### PR TITLE
docs(feedback): Update docs for onSubmitSuccess to include eventID 

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -239,12 +239,16 @@ Sentry.init({
     Sentry.feedbackIntegration({
       onFormOpen: () => {},
       onFormClose: () => {},
-      onSubmitSuccess: (data: FeedbackFormData) => {},
+      onSubmitSuccess: (data: FeedbackFormData, eventID: string) => {},
       onSubmitError: (error: Error) => {},
     }),
   ],
 });
 ```
+
+You can link directly to a saved feedback item by implementing the `onSubmitSuccess` callback. The url you need to construct is `https://\$\{orgSlug}.sentry.io/issues/feedback/?projectSlug=\$\{projectSlug}&eventId=\$\{eventId}`.
+
+*Note:* In v9 and below of the SDK the signature of `onSubmitSuccess` was `(data: FeedbackFormData) => {}`.
 
 ### Bring Your Own Button
 

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -248,7 +248,7 @@ Sentry.init({
 
 You can link directly to a saved feedback item by implementing the `onSubmitSuccess` callback. The URL you need to construct is `https://\$\{orgSlug}.sentry.io/issues/feedback/?projectSlug=\$\{projectSlug}&eventId=\$\{eventId}`.
 
-*Note:* In v9 and below of the SDK the signature of `onSubmitSuccess` was `(data: FeedbackFormData) => {}`.
+*Note:* In v9 and below of the SDK, the signature of `onSubmitSuccess` was `(data: FeedbackFormData) => {}`.
 
 ### Bring Your Own Button
 

--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -246,7 +246,7 @@ Sentry.init({
 });
 ```
 
-You can link directly to a saved feedback item by implementing the `onSubmitSuccess` callback. The url you need to construct is `https://\$\{orgSlug}.sentry.io/issues/feedback/?projectSlug=\$\{projectSlug}&eventId=\$\{eventId}`.
+You can link directly to a saved feedback item by implementing the `onSubmitSuccess` callback. The URL you need to construct is `https://\$\{orgSlug}.sentry.io/issues/feedback/?projectSlug=\$\{projectSlug}&eventId=\$\{eventId}`.
 
 *Note:* In v9 and below of the SDK the signature of `onSubmitSuccess` was `(data: FeedbackFormData) => {}`.
 


### PR DESCRIPTION
Also added a note for how to use `eventID` to link back to sentry.io

<img width="815" alt="SCR-20250709-ntqc" src="https://github.com/user-attachments/assets/55bfa501-416d-4a52-a5fc-1baa655bbf2c" />


Related to https://github.com/getsentry/sentry-javascript/pull/16835
Related to https://github.com/getsentry/sentry-javascript/issues/16836