### PR TITLE
remove 20h mention

### DIFF
--- a/docs/organization/authentication/sso/index.mdx
+++ b/docs/organization/authentication/sso/index.mdx
@@ -24,7 +24,7 @@ Every member who creates a new account via SSO will be given global organization
 
 Our SSO implementation prioritizes security. We aggressively monitor linked accounts and will disable them if there's any reasonable sign that the account’s access may have been revoked. Generally this will be transparent to you, but if the provider is functioning in an unexpected way you may experience more frequent re-authorization requests.
 
-Sessions last for [Django's default session length](https://docs.djangoproject.com/en/1.11/topics/http/sessions/#using-cookie-based-sessions), which is two weeks. For individual organizations with single sign-on, we expire organization access after one day (20 hours).
+Sessions last for [Django's default session length](https://docs.djangoproject.com/en/1.11/topics/http/sessions/#using-cookie-based-sessions), which is two weeks.
 
 ## Providers
 


### PR DESCRIPTION
SSO session expiry length was changed from 20h to 7 days in 2023
https://github.com/getsentry/sentry/pull/48596
https://github.com/getsentry/sentry/pull/48596/commits/3af2fd95261750863108ef4ca509752e6cfc7f7e