### PR TITLE
docs(nuxt): Add low version notice to all start guides

### DIFF
--- a/platform-includes/getting-started-prerequisites/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-prerequisites/javascript.nuxt.mdx
@@ -5,3 +5,31 @@ You need:
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - Your application up and running
 - Nuxt version `3.7.0` or above (`3.14.0`+ recommended)
+
+<Expandable title="Are you using Nuxt version < 3.14.0?">
+  Add the following overrides:
+
+  ```json {tabTitle:npm} {filename:package.json}
+  "overrides": {
+    "ofetch": "^1.4.0",
+    "@vercel/nft": "^0.27.4"
+  }
+  ```
+
+  ```json {tabTitle:yarn} {filename:package.json}
+  "resolutions": {
+    "ofetch": "^1.4.0",
+    "@vercel/nft": "^0.27.4"
+  }
+  ```
+
+  ```json {tabTitle:pnpm} {filename:package.json}
+  "pnpm": {
+    "overrides": {
+      "ofetch": "^1.4.0",
+      "@vercel/nft": "^0.27.4"
+    }
+  }
+  ```
+
+</Expandable>


### PR DESCRIPTION
## DESCRIBE YOUR PR

The expandable "Are you using Nuxt version < 3.14.0?" was only visible on the "Manual Setup" docs. It's now added to the prerequisite section to be included in all start guides.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!


