### PR TITLE
ref(feedback): rm escape chars from last onSubmitSucces update

### DIFF
--- a/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/javascript/common/user-feedback/configuration/index.mdx
@@ -246,7 +246,7 @@ Sentry.init({
 });
 ```
 
-You can link directly to a saved feedback item by implementing the `onSubmitSuccess` callback. The URL you need to construct is `https://\$\{orgSlug}.sentry.io/issues/feedback/?projectSlug=\$\{projectSlug}&eventId=\$\{eventId}`.
+You can link directly to a saved feedback item by implementing the `onSubmitSuccess` callback. The URL you need to construct is `https://{orgSlug}.sentry.io/issues/feedback/?projectSlug={projectSlug}&eventId={eventId}`.
 
 *Note:* In v9 and below of the SDK, the signature of `onSubmitSuccess` was `(data: FeedbackFormData) => {}`.
 


### PR DESCRIPTION
Fix https://github.com/getsentry/sentry-docs/pull/14310/files#r2198457651

This isn't a template string, just md