### PR TITLE
fix: remove outdated list of acceptable platforms

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/index.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/index.mdx
@@ -81,27 +81,7 @@ used by the Sentry interface to customize various components in the interface.
 }
 ```
 
-Acceptable values are:
-
-- `as3`
-- `c`
-- `cfml`
-- `cocoa`
-- `csharp`
-- `elixir`
-- `haskell`
-- `go`
-- `groovy`
-- `java`
-- `javascript`
-- `native`
-- `node`
-- `objc`
-- `other`
-- `perl`
-- `php`
-- `python`
-- `ruby`
+For the full list of acceptable values, consult `platforms.tsx` in [sentry source](https://github.com/getsentry/sentry).
 
 ## Optional Attributes
 

--- a/develop-docs/sdk/data-model/event-payloads/index.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/index.mdx
@@ -81,7 +81,7 @@ used by the Sentry interface to customize various components in the interface.
 }
 ```
 
-For the full list of acceptable values, consult `platforms.tsx` in [sentry source](https://github.com/getsentry/sentry).
+For the full list of acceptable values, consult `platforms.tsx` in [sentry source](https://github.com/getsentry/sentry/blob/master/static/app/data/platforms.tsx).
 
 ## Optional Attributes
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The list of accepted values for platform is very outdated. We should just remove it from over here.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
