### PR TITLE
fixes hot reload for Shannon and hopefully others

### DIFF
--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -702,11 +702,14 @@ const fileBySlugCache = new Map<string, Promise<SlugFile>>();
  * This is useful for performance when rendering the same file multiple times.
  */
 export function getFileBySlugWithCache(slug: string): Promise<SlugFile> {
+  if (process.env.NODE_ENV === 'development') {
+    // Bypass the cache in development to ensure hot reload works for MDX files
+    return getFileBySlug(slug);
+  }
   let cached = fileBySlugCache.get(slug);
   if (!cached) {
     cached = getFileBySlug(slug);
     fileBySlugCache.set(slug, cached);
   }
-
   return cached;
 }


### PR DESCRIPTION
## DESCRIBE YOUR PR
**Problem:**
- Problem: MDX files in /docs directory required server restart to see changes
- Root Cause: The getFileBySlugWithCache function was caching MDX files even in development
- Solution: Added development mode check to bypass cache when NODE_ENV === 'development'
- Impact: Hot reload now works for .mdx files while preserving production performance

**Solution**
- Bypass MDX cache in development mode to allow hot reload
- Maintains caching behavior in production for performance
- Resolves issue where MDX changes required server restart

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)