### PR TITLE
fix: clarify monitor quota docs more

### DIFF
--- a/docs/pricing/quotas/manage-cron-monitors.mdx
+++ b/docs/pricing/quotas/manage-cron-monitors.mdx
@@ -5,7 +5,7 @@ sidebar_order: 70
 description: Learn how to manage the number of cron and uptime monitors you pay for and adjust your pay-as-you-go budget.
 ---
 
-All Sentry plans include **one cron monitor**. To activate additional monitors, you need to add a [**pay-as-you-go (PAYG)**](/pricing/#pricing-how-it-works) budget.
+All Sentry plans include **one cron monitor** and **one uptime monitor**. To activate additional monitors, you need to add a [**pay-as-you-go (PAYG)**](/pricing/#pricing-how-it-works) budget.
 
 <Alert>
 
@@ -35,7 +35,7 @@ When you add a new monitor or reactivate a previously deactivated one, Sentry wi
 
 1. **Check for Reusable Quota**
 
-   - Sentry first checks if there's any **reusable quota** from monitors deactivated or deleted within the **same billing period**.
+   - Sentry first checks if there's any **reusable quota** from monitors of the same type deactivated or deleted within the **same billing period**.
    - If available, the monitor is activated using this quota **at no additional cost**.
 
 2. **Use PAYG Budget or Reserved Quota**
@@ -62,7 +62,7 @@ At the start of each new billing period:
 
 ## Deactivating or Deleting Monitors
 
-You can manually deactivate or delete cron monitors at any time from the **Alerts** page, you can use the **Alert Type:** dropdown to filter for **Cron** or **Uptime** monitors.
+You can manually deactivate or delete monitors at any time from the **Alerts** page, you can use the **Alert Type:** dropdown to filter for **Cron** or **Uptime** monitors.
 
 **Effects of Deactivation or Deletion:**
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Updates the cron and uptime monitor quota management docs to be more accurate (some sections only mentioned crons; added part to clarify you can only reuse a monitor for the same type you're trying to activate for).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
