### PR TITLE
fix(examples): Python SDK Metric Span tracing examples set data indiv…

### DIFF
--- a/docs/platforms/python/tracing/span-metrics/index.mdx
+++ b/docs/platforms/python/tracing/span-metrics/index.mdx
@@ -25,13 +25,9 @@ if span:
     # Add individual metrics
     span.set_data("database.rows_affected", 42)
     span.set_data("cache.hit_rate", 0.85)
-
-    # Add multiple metrics at once
-    span.set_data({
-        "memory.heap_used": 1024000,
-        "queue.length": 15,
-        "processing.duration_ms": 127
-    })
+    span.set_data("memory.heap_used", 1024000)
+    span.set_data("queue.length", 15)
+    span.set_data("processing.duration_ms", 127s)
 ```
 
 ### Best Practices for Span Data
@@ -52,13 +48,11 @@ with sentry_sdk.start_span(
     name="Database Query Metrics"
 ) as span:
     # Set metrics after creating the span
-    span.set_data({
-        "db.query_type": "SELECT",
-        "db.table": "users",
-        "db.execution_time_ms": 45,
-        "db.rows_returned": 100,
-        "db.connection_pool_size": 5
-    })
+    span.set_data("db.query_type", "SELECT")
+    span.set_data("db.table", "users")
+    span.set_data("db.execution_time_ms", 45)
+    span.set_data("db.rows_returned", 100)
+    span.set_data("db.connection_pool_size", 5)
     # Your database operation here
     pass
 ```

--- a/docs/platforms/python/tracing/span-metrics/index.mdx
+++ b/docs/platforms/python/tracing/span-metrics/index.mdx
@@ -27,7 +27,7 @@ if span:
     span.set_data("cache.hit_rate", 0.85)
     span.set_data("memory.heap_used", 1024000)
     span.set_data("queue.length", 15)
-    span.set_data("processing.duration_ms", 127s)
+    span.set_data("processing.duration_ms", 127)
 ```
 
 ### Best Practices for Span Data


### PR DESCRIPTION
Examples for metric spans in the Python SDK set data for spans using a dictionary, which does not work when tested locally. Change this to set the span_data indivually instead.

Fixes GH-14359


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
