### PR TITLE
feat(python): Document default span attrs in aiohttp, update for 3.0

### DIFF
--- a/docs/platforms/python/integrations/aiohttp/index__v3.x.mdx
+++ b/docs/platforms/python/integrations/aiohttp/index__v3.x.mdx
@@ -18,16 +18,6 @@ pip install "sentry-sdk[aiohttp]"
 uv add "sentry-sdk[aiohttp]"
 ```
 
-
-If you're on Python 3.6, you also need the `aiocontextvars` package:
-
-```bash {tabTitle:pip}
-pip install "aiocontextvars"
-```
-```bash {tabTitle:uv}
-uv add "aiocontextvars"
-```
-
 ## Configure
 
 If you have the `aiohttp` package in your dependencies, the AIOHTTP integration will be enabled automatically when you initialize the Sentry SDK.


### PR DESCRIPTION
Document what span attributes will be attached to transactions by default by our builtin integrations. This PR updates AIOHTTP. Rest will follow.

I created a new 3.x page for this since it's new behavior in 3.0.

Direct link to preview: https://sentry-docs-git-ivana-pythonsampling-context-integrations.sentry.dev/platforms/python/integrations/aiohttp__v3.x#tracing

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
