### PR TITLE
ref: Make note about supported versions more generic

### DIFF
--- a/includes/python-use-older-sdk-for-legacy-support.mdx
+++ b/includes/python-use-older-sdk-for-legacy-support.mdx
@@ -1,5 +1,5 @@
 <Alert>
 
-The versions above apply for Sentry Python SDK version `2.0+`, which drops support for some legacy Python and framework versions. If you're looking to use Sentry with older Python or framework versions, consider using an SDK version from the `1.x` major line of releases.
+The versions above apply for the current major version of the Python SDK. If you're looking to use Sentry with older Python or framework versions, consider using an older major version of the SDK.
 
 </Alert>


### PR DESCRIPTION
We have an info note on some Python integration pages that suggests switching to an older SDK major if a framework/Python version is not supported on the current one. Currently it mentions specific SDK versions. Make it more generic so that it doesn't get out of date if we release a new major.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
