### PR TITLE
feat(python): Document default span attrs in Celery, update for 3.0

### DIFF
--- a/docs/platforms/python/integrations/celery/index__v3.x.mdx
+++ b/docs/platforms/python/integrations/celery/index__v3.x.mdx
@@ -21,9 +21,9 @@ uv add "sentry-sdk[celery]"
 If you have the `celery` package in your dependencies, the Celery integration will be enabled automatically when you initialize the Sentry SDK.
 
 <Alert>
-  Make sure that the call to `sentry_sdk.init()` is loaded on worker startup and
-  not only in the module where your tasks are defined. Otherwise, the
-  initialization may happen too late and events might not get reported.
+Make sure you call `sentry_sdk.init()` when the worker process starts, 
+  not just in the module that defines your tasks. Otherwise, the
+  initialization may happen too late, causing events to go unreported.
 </Alert>
 
 ### Set up Celery Without Django
@@ -184,7 +184,7 @@ You can pass the following keyword arguments to `CeleryIntegration()`:
 
   The default is `True`.
 
-  See [Distributed Traces](#distributed-traces) below to learn how to get more fine grained control over distributed tracing in Celery tasks.
+  See [Distributed Traces](#distributed-traces) below to learn how to get more fine-grained control over distributed tracing in Celery tasks.
 
 - `monitor_beat_tasks`:
 
@@ -208,7 +208,7 @@ You can pass the following keyword arguments to `CeleryIntegration()`:
 
 ### Distributed Traces
 
-Distributed tracing extends the trace from the code that's running your Celery task so that it includes the code that initiated the task.
+Distributed tracing connects the trace of your Celery task to the trace of the code that started the task, giving you a complete view of the entire workflow.
 
 You can disable this globally with the `propagate_traces` parameter, documented above. If you set `propagate_traces` to `False`, all Celery tasks will start their own trace.
 


### PR DESCRIPTION
Document what span attributes will be attached to transactions by default by our builtin integrations. This PR updates Celery. Rest will follow.

I created a new 3.x page for this since it's new behavior in 3.0.

Direct link to preview: https://sentry-docs-git-ivana-pythondefault-attributes-celery.sentry.dev/platforms/python/integrations/celery__v3.x#default-span-attributes

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
