### PR TITLE
feat(python): Document default span attrs in Tornado, update for 3.0

### DIFF
--- a/docs/platforms/python/integrations/tornado/index__v3.x.mdx
+++ b/docs/platforms/python/integrations/tornado/index__v3.x.mdx
@@ -1,0 +1,85 @@
+---
+title: Tornado
+description: "Learn about using Sentry with Tornado."
+---
+
+The Tornado integration adds support for the [Tornado web framework](https://www.tornadoweb.org/).
+
+## Install
+
+Install `sentry-sdk` from PyPI with the `tornado` extra:
+
+```bash {tabTitle:pip}
+pip install "sentry-sdk[tornado]"
+```
+```bash {tabTitle:uv}
+uv add "sentry-sdk[tornado]"
+```
+
+## Configure
+
+If you have the `tornado` package in your dependencies, the Tornado integration will be enabled automatically when you initialize the Sentry SDK.
+
+<PlatformContent includePath="getting-started-config" />
+
+## Verify
+
+```python
+import asyncio
+import tornado
+
+sentry_sdk.init(...)  # same as above
+
+class MainHandler(tornado.web.RequestHandler):
+    def get(self):
+        1 / 0  # raises an error
+        self.write("Hello, world")
+
+def make_app():
+    return tornado.web.Application([
+        (r"/", MainHandler),
+    ])
+
+async def main():
+    app = make_app()
+    app.listen(8888)
+    await asyncio.Event().wait()
+
+asyncio.run(main())
+```
+
+When you point your browser to [http://localhost:8888/](http://localhost:8888/) a transaction in the Performance section of [sentry.io](https://sentry.io) will be created. Additionally, an error event will be sent to [sentry.io](https://sentry.io) and will be connected to the transaction.
+
+It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+
+## Behavior
+
+- The Tornado integration will be installed for all of your apps and handlers.
+- All exceptions leading to a Internal Server Error are reported.
+- Request data is attached to all events: **HTTP method, URL, headers, form data, JSON payloads**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+- Each request has a separate scope. Changes to the scope within a view, for example setting a tag, will only apply to events sent as part of the request being handled.
+- Logging with any logger will create breadcrumbs when the [Logging](/platforms/python/integrations/logging/) integration is enabled (done by default).
+
+### Tracing
+
+A set of predefined span attributes will be attached to Tornado transactions by default. These can also be used for sampling since they will also be accessible via the `sampling_context` dictionary in the [`traces_sampler`](/platforms/python/configuration/options/#traces_sampler).
+
+- `url.path`
+- `url.query`
+- `url.scheme`
+- `url.full`
+- `http.request.method`
+- `http.request.header.{header}`
+- `server.address`
+- `server.port`
+- `network.protocol.name`
+- `network.protocol.version`
+
+These attributes will also be sent to Sentry. If you don't want that, you can filter them out using a custom [`before_send`](/platforms/python/configuration/options/#before_send) function.
+
+## Supported Versions
+
+- Tornado: 6+
+- Python: 3.8+
+
+<Include name="python-use-older-sdk-for-legacy-support.mdx" />


### PR DESCRIPTION
Document what span attributes will be attached to transactions by default by our builtin integrations. This PR updates Tornado. Rest will follow.

I created a new 3.x page for this since it's new behavior in 3.0.

Direct link to preview: TODO

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
