### PR TITLE
feat(python): Document default span attrs in WSGI, update for 3.0

### DIFF
--- a/docs/platforms/python/integrations/wsgi/index__v3.x.mdx
+++ b/docs/platforms/python/integrations/wsgi/index__v3.x.mdx
@@ -1,0 +1,120 @@
+---
+title: WSGI
+description: "Learn about the WSGI integration and how it adds support for WSGI applications."
+---
+
+If you use a WSGI framework not directly supported by the SDK, or you wrote a raw WSGI app, you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.
+
+<Alert>
+
+Please check our list of [supported integrations](/platforms/python/integrations/) as there might already be a specific integration (like [Django](/platforms/python/integrations/django/) or [Flask](/platforms/python/integrations/flask/)) that is easier to use and captures more useful information than our generic WSGI middleware. If that's the case, you should use the specific integration instead of this middleware.
+</Alert>
+
+## Install
+
+```bash {tabTitle:pip}
+pip install "sentry-sdk"
+```
+```bash {tabTitle:uv}
+uv add "sentry-sdk"
+```
+
+## Configure
+
+In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](/product/explore/profiling/).
+
+Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
+
+<OnboardingOptionButtons
+  options={[
+    'error-monitoring',
+    'performance',
+    'profiling',
+  ]}
+/>
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+
+from my_wsgi_app import app
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Add data like request headers and IP for users, if applicable;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # ___PRODUCT_OPTION_START___ performance
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # ___PRODUCT_OPTION_END___ performance
+    # ___PRODUCT_OPTION_START___ profiling
+    # To collect profiles for all profile sessions,
+    # set `profile_session_sample_rate` to 1.0.
+    profile_session_sample_rate=1.0,
+    # Profiles will be automatically collected while
+    # there is an active span.
+    profile_lifecycle="trace",
+    # ___PRODUCT_OPTION_END___ profiling
+)
+
+app = SentryWsgiMiddleware(app)
+```
+
+## Verify
+
+This minimal WSGI application will create a transaction and send it to Sentry. The error will also be sent to Sentry and associated with the transaction:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+
+sentry_sdk.init(...)  # same as above
+
+def app(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    response_body = 'Hello World'
+    1 / 0  # this raises an error
+    return [response_body.encode()]
+
+app = SentryWsgiMiddleware(app)
+
+# Run the application in a mini WSGI server.
+from wsgiref.simple_server import make_server
+make_server('', 8000, app).serve_forever()
+```
+
+## Behavior
+
+<Include name="python-uwsgi-warning.mdx" />
+
+- Request data is attached to all events: **HTTP method, URL, headers**. Sentry excludes raw bodies and multipart file uploads. Sentry also excludes personally identifiable information (such as user IDs, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+
+Each request has a separate scope. Changes to the scope within a view, for example setting a tag, will only apply to events sent as part of the request being handled.
+
+- The WSGI middleware does not behave like a regular integration. It is not initialized through an extra parameter to `init` and is not attached to a client. When capturing or supplementing events, it just uses the currently active scopes.
+
+### Default Span Attributes
+
+A set of predefined span attributes will be attached to WSGI transactions by default. These can also be used for sampling since they will also be accessible via the `sampling_context` dictionary in the [`traces_sampler`](/platforms/python/configuration/options/#traces_sampler).
+
+    | Span Attribute                                    | Description                         |
+    | ------------------------------------------------- | ----------------------------------- |
+    | `url.path`                                        | `PATH_INFO` from WSGI environ       |       
+    | `url.query`                                       | `QUERY_STRING` from WSGI environ    |
+    | `http.request.method`                             | `REQUEST_METHOD` from WSGI environ  |
+    | `server.address`                                  | `SERVER_NAME` from WSGI environ     |
+    | `server.port`                                     | `SERVER_PORT` from WSGI environ     |
+    | `server.protocol.name`, `server.protocol.version` | `SERVER_PROTOCOL` from WSGI environ |
+    | `url.scheme`                                      | `wsgi.url_scheme` from WSGI environ |                                    |
+    | `url.full`                                        | full URL                            |
+    | `http.request.header.{header}`                    | `HTTP_*` from WSGI environ          |
+
+These attributes will also be sent to Sentry. If you don't want that, you can filter them out using a custom [`before_send`](/platforms/python/configuration/options/#before_send) function.
+
+## Supported Versions
+
+- Python: 3.7+
+
+<Include name="python-use-older-sdk-for-legacy-support.mdx" />


### PR DESCRIPTION
Document what span attributes will be attached to transactions by default by our builtin integrations. This PR updates WSGI. Rest will follow.

I created a new 3.x page for this since it's new behavior in 3.0.

Direct link to preview: <TODO>

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
