### PR TITLE
feat(python): Document default span attrs in ASGI, update for 3.0

### DIFF
--- a/docs/platforms/python/integrations/asgi/index__v3.x.mdx
+++ b/docs/platforms/python/integrations/asgi/index__v3.x.mdx
@@ -113,18 +113,18 @@ Additionally, a transaction will show up in the "Performance" section on [sentry
 
 A set of predefined span attributes will be attached to ASGI transactions by default. These can also be used for sampling since they will also be accessible via the `sampling_context` dictionary in the [`traces_sampler`](/platforms/python/configuration/options/#traces_sampler).
 
-    | Span Attribute                  | Description                  |
-    | ------------------------------- | ---------------------------- |
-    | `network.protocol.name`         | `type` on ASGI scope         |
-    | `url.scheme`                    | `scheme` on ASGI scope       |
-    | `url.path`                      | `path` on ASGI scope         |
-    | `url.query`                     | `query` on ASGI scope        |
-    | `network.protocol.version`      | `http_version` on ASGI scope |
-    | `http.request.method`           | `method` on ASGI scope       |
-    | `server.address`, `server.port` | `server` on ASGI scope       |
-    | `client.address`, `client.port` | `client` on ASGI scope       |
-    | `url.full`                      | full URL                     |
-    | `http.request.header.{header}`  | `headers` on ASGI scope      |
+    | Span Attribute                  | Description                                              |
+    | ------------------------------- | -------------------------------------------------------- |
+    | `network.protocol.name`         | `type` on ASGI scope                                     |
+    | `url.scheme`                    | `scheme` on ASGI scope                                   |
+    | `url.path`                      | `path` on ASGI scope                                     |
+    | `url.query`                     | `query` on ASGI scope                                    |
+    | `network.protocol.version`      | `http_version` on ASGI scope                             |
+    | `http.request.method`           | `method` on ASGI scope                                   |
+    | `server.address`, `server.port` | `server` on ASGI scope                                   |
+    | `client.address`, `client.port` | `client` on ASGI scope                                   |
+    | `url.full`                      | full URL, reconstructed from individual ASGI scope parts |
+    | `http.request.header.{header}`  | `headers` on ASGI scope                                  |
 
 These attributes will also be sent to Sentry. If you don't want that, you can filter them out using a custom [`before_send`](/platforms/python/configuration/options/#before_send) function.
 


### PR DESCRIPTION
Document what span attributes will be attached to transactions by default by our builtin integrations. This PR updates ASGI. Rest will follow.

I created a new 3.x page for this since it's new behavior in 3.0.

Direct link to preview: https://sentry-docs-git-ivana-pythondefault-attrs-asgi.sentry.dev/platforms/python/integrations/asgi__v3.x#default-span-attributes

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
