### PR TITLE
feat(python): Document default span attrs in RQ, update for 3.0

### DIFF
--- a/docs/platforms/python/integrations/rq/index__v3.x.mdx
+++ b/docs/platforms/python/integrations/rq/index__v3.x.mdx
@@ -1,0 +1,220 @@
+---
+title: RQ (Redis Queue)
+description: "Learn about using Sentry with RQ."
+---
+
+The RQ integration adds support for the [RQ job queue system](https://python-rq.org/).
+
+## Install
+
+Install `sentry-sdk` from PyPI with the `rq` extra:
+
+```bash {tabTitle:pip}
+pip install "sentry-sdk[rq]"
+```
+```bash {tabTitle:uv}
+uv add "sentry-sdk[rq]"
+```
+
+## Configure
+
+If you have the `rq` package in your dependencies, the RQ integration will be enabled automatically when you initialize the Sentry SDK.
+
+Create a file called `mysettings.py` with the following content:
+
+
+In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also collect and analyze performance profiles from real users with [profiling](/product/explore/profiling/).
+
+Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
+
+<OnboardingOptionButtons
+  options={[
+    'error-monitoring',
+    'performance',
+    'profiling',
+  ]}
+/>
+
+```python {filename:mysettings.py}
+# mysettings.py
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Add data like request headers and IP for users, if applicable;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # ___PRODUCT_OPTION_START___ performance
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # ___PRODUCT_OPTION_END___ performance
+    # ___PRODUCT_OPTION_START___ profiling
+    # To collect profiles for all profile sessions,
+    # set `profile_session_sample_rate` to 1.0.
+    profile_session_sample_rate=1.0,
+    # Profiles will be automatically collected while
+    # there is an active span.
+    profile_lifecycle="trace",
+    # ___PRODUCT_OPTION_END___ profiling
+)
+```
+
+Start your worker with:
+
+```shell
+rq worker \
+    -c mysettings \  # module name of mysettings.py
+    --sentry-dsn="___PUBLIC_DSN___"  # only necessary for RQ < 1.0
+```
+
+The integration will automatically report errors from all RQ jobs.
+
+Generally, make sure that the **call to `init` is loaded on worker startup**, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.
+
+In addition, make sure that **`init` is called only once** in your app. For example, if you have a `Flask` app and a worker that depends on the app, we recommend only initializing Sentry once. Note that because the Flask integration is enabled automatically, you don't need to change the configuration shown above.
+
+
+```python {filename:app.py}
+# app.py
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Add data like request headers and IP for users, if applicable;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # ___PRODUCT_OPTION_START___ performance
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # ___PRODUCT_OPTION_END___ performance
+    # ___PRODUCT_OPTION_START___ profiling
+    # To collect profiles for all profile sessions,
+    # set `profile_session_sample_rate` to 1.0.
+    profile_session_sample_rate=1.0,
+    # Profiles will be automatically collected while
+    # there is an active span.
+    profile_lifecycle="trace",
+    # ___PRODUCT_OPTION_END___ profiling
+)
+```
+
+The worker configuration `mysettings.py` then becomes:
+
+```python {filename:mysettings.py}
+# mysettings.py
+# This import causes the Sentry SDK to be initialized
+import app
+```
+
+## Verify
+
+To verify, create a `main.py` script that enqueues a function in RQ, then start an RQ worker to run the function:
+
+### Job definition:
+
+```python {filename:jobs.py}
+# jobs.py
+def hello(name):
+    1 / 0  # raises an error
+    return f"Hello {name}!"
+```
+
+### Settings for worker
+
+```python {filename:mysettings.py}
+# mysettings.py
+import sentry_sdk
+
+# Sentry configuration for RQ worker processes
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Add data like request headers and IP for users, if applicable;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # ___PRODUCT_OPTION_START___ performance
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # ___PRODUCT_OPTION_END___ performance
+    # ___PRODUCT_OPTION_START___ profiling
+    # To collect profiles for all profile sessions,
+    # set `profile_session_sample_rate` to 1.0.
+    profile_session_sample_rate=1.0,
+    # Profiles will be automatically collected while
+    # there is an active span.
+    profile_lifecycle="trace",
+    # ___PRODUCT_OPTION_END___ profiling
+)
+```
+
+### Main Python Script
+
+```python {filename:main.py}
+# main.py
+from redis import Redis
+from rq import Queue
+
+from jobs import hello
+
+import sentry_sdk
+
+# Sentry configuration for main.py process
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Add data like request headers and IP for users, if applicable;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # ___PRODUCT_OPTION_START___ performance
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # ___PRODUCT_OPTION_END___ performance
+    # ___PRODUCT_OPTION_START___ profiling
+    # To collect profiles for all profile sessions,
+    # set `profile_session_sample_rate` to 1.0.
+    profile_session_sample_rate=1.0,
+    # Profiles will be automatically collected while
+    # there is an active span.
+    profile_lifecycle="trace",
+    # ___PRODUCT_OPTION_END___ profiling
+)
+
+q = Queue(connection=Redis())
+with sentry_sdk.start_transaction(name="testing_sentry"):
+    result = q.enqueue(hello, "World")
+```
+
+When you run `python main.py` a transaction named `testing_sentry` will be created in the Performance section of [sentry.io](https://sentry.io) and spans for the enqueueing will be created.
+
+If you run the RQ worker with `rq worker -c mysettings`, a transaction for the execution of `hello()` will be created. Additionally, an error event will be sent to [sentry.io](https://sentry.io) and will be connected to the transaction.
+
+It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+
+## The `--sentry-dsn` CLI option
+
+Passing `--sentry-dsn=""` to RQ forcibly disables [RQ's shortcut for using Sentry](https://python-rq.org/patterns/sentry/). For RQ versions before 1.0 this is necessary to avoid conflicts, because back then RQ would attempt to use the `raven` package instead of this SDK. Since RQ 1.0 it's possible to use this CLI option and the associated RQ settings for initializing the SDK.
+
+We still recommend against using those shortcuts because it would be harder to provide options to the SDK at a later point. See [the GitHub issue about RQ's Sentry integration](https://github.com/rq/rq/issues/1003) for discussion.
+
+## Default Span Attributes
+
+A set of predefined span attributes will be attached to RQ transactions by default. These can also be used for sampling since they will also be accessible via the `sampling_context` dictionary in the [`traces_sampler`](/platforms/python/configuration/options/#traces_sampler).
+
+    | Span Attribute               | Description                     |
+    | ---------------------------- | ------------------------------- |
+    | `rq.job.args.{index}`        | Positional job args, serialized |
+    | `rq.job.kwargs.{kwarg}`      | Keyword job args, serialized    |
+    | `rq.job.func`                | Job `func`, serialized          |
+    | `messaging.destination.name` | Queue name                      |
+    | `messaging.message.id`       | Job ID                          |
+
+These attributes will also be sent to Sentry. If you don't want that, you can filter them out using a custom [`before_send`](/platforms/python/configuration/options/#before_send) function.
+
+## Supported Versions
+
+- RQ: 0.6+
+- Python: 3.7+
+
+<Include name="python-use-older-sdk-for-legacy-support.mdx" />


### PR DESCRIPTION
Document what span attributes will be attached to transactions by default by our builtin integrations. This PR updates RQ. Rest will follow.

I created a new 3.x page for this since it's new behavior in 3.0.

Direct link to preview: https://sentry-docs-git-ivana-pythondefault-attrs-rq.sentry.dev/platforms/python/integrations/rq__v3.x#default-span-attributes

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
