### PR TITLE
fix(platform): Filter versioned integrations in platform selector

### DIFF
--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -393,15 +393,17 @@ const extractIntegrations = (p: DocNode): PlatformIntegration[] => {
   }
   const integrations = nodeForPath(p, 'integrations');
   return (
-    integrations?.children.map(integ => {
-      return {
-        key: integ.slug,
-        name: integ.frontmatter.title,
-        icon: p.slug + '.' + integ.slug,
-        url: ['', 'platforms', p.slug, 'integrations', integ.slug].join('/'),
-        platform: p.slug,
-        type: 'integration',
-      };
-    }) ?? []
+    integrations?.children
+      .filter(({path}) => !isVersioned(path))
+      .map(integ => {
+        return {
+          key: integ.slug,
+          name: integ.frontmatter.title,
+          icon: p.slug + '.' + integ.slug,
+          url: ['', 'platforms', p.slug, 'integrations', integ.slug].join('/'),
+          platform: p.slug,
+          type: 'integration',
+        };
+      }) ?? []
   );
 };


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/ENG-4597/integration-dropdown-shows-duplicate-entries-for-versioned-index-page