### PR TITLE
allow specifying docs pages as full width if their content requires it

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -47,7 +47,12 @@ export const dynamic = 'force-static';
 const mdxComponentsWithWrapper = mdxComponents(
   {Include, PlatformContent},
   ({children, frontMatter, nextPage, previousPage}) => (
-    <DocPage frontMatter={frontMatter} nextPage={nextPage} previousPage={previousPage}>
+    <DocPage 
+      frontMatter={frontMatter} 
+      nextPage={nextPage} 
+      previousPage={previousPage}
+      fullWidth={frontMatter.fullWidth}
+    >
       {children}
     </DocPage>
   )

--- a/docs/platforms/apple/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/configuration/index.mdx
@@ -2,6 +2,7 @@
 title: Configure User Feedback
 sidebar_order: 6900
 description: "Learn about general User Feedback configuration fields."
+fullWidth: true
 ---
 
 <PlatformSection notSupported={["apple.macos", "apple.tvos", "apple.watchos", "apple.visionos"]}>

--- a/src/types/frontmatter.ts
+++ b/src/types/frontmatter.ts
@@ -89,4 +89,8 @@ export interface FrontMatter {
    * @example ['v7.119.0', 'next']
    */
   versions?: string[];
+  /**
+   * Set this to true to take all the available width for the page content.
+   */
+  fullWidth?: boolean;
 }

--- a/src/types/frontmatter.ts
+++ b/src/types/frontmatter.ts
@@ -24,6 +24,10 @@ export interface FrontMatter {
    */
   draft?: boolean;
   /**
+   * Set this to true to take all the available width for the page content.
+   */
+  fullWidth?: boolean;
+  /**
    * A list of keywords for indexing with search.
    */
   keywords?: string[];
@@ -89,8 +93,4 @@ export interface FrontMatter {
    * @example ['v7.119.0', 'next']
    */
   versions?: string[];
-  /**
-   * Set this to true to take all the available width for the page content.
-   */
-  fullWidth?: boolean;
 }


### PR DESCRIPTION
This is one option for fixing the table formatting issue in https://github.com/getsentry/sentry-docs/pull/14227