### PR TITLE
ref(relay): Bump supported windows server version to 2022

### DIFF
--- a/docs/product/relay/operating-guidelines.mdx
+++ b/docs/product/relay/operating-guidelines.mdx
@@ -40,7 +40,7 @@ Every release of Relay also provides a set of binaries that are built for the Op
 | Ubuntu x64       | 20.04                     |
 | Ubuntu ARM       | 22.04                     |
 | macOS            | macOS Sonoma (version 14) |
-| Windows          | Windows Server 2019       |
+| Windows          | Windows Server 2022       |
 
 We will support Ubuntu binaries 2 years after the official LTS support has ended to allow customers with extended
 support to continue using Relay.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Tested version in CI is now 2022, due to the deprecation of 2019 runners.
https://github.com/getsentry/relay/pull/4945

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

