### PR TITLE
docs(nuxt): Remove Log-in notice from router page

### DIFF
--- a/docs/platforms/javascript/guides/nuxt/features/vue-router.mdx
+++ b/docs/platforms/javascript/guides/nuxt/features/vue-router.mdx
@@ -3,7 +3,6 @@ title: Vue Router
 description: "Learn about Sentry's Vue Routing integration."
 ---
 
-Nuxt uses the `vue-router` under the hood, and our Nuxt SDK instruments your routing automatically, to parameterize transactions according to your routes.
+Nuxt uses the `vue-router` under the hood, and the Sentry Nuxt SDK automatically instruments it to create parameterized transaction names for your page loads and navigations. For example, a navigation to `/users/123` will be captured as a transaction named `/users/:id`.
 
-<SignInNote />
-
+This feature is enabled by default and requires no additional configuration.


### PR DESCRIPTION

## DESCRIBE YOUR PR
Removing the Log-in notice from the router page as it is not needed here and is misleading. I also rewrote the text a bit to include an example.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

