### PR TITLE
:wrench: chore(integrations): clarify service account usage for gitlab and azure

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -10,13 +10,16 @@ Azure DevOps was formerly known as Visual Studio Team Services (VSTS).
 
 <Alert title="Note">
   <p>
-  We recommend using a dedicated service account when installing this integration rather than a personal user account.
+  We recommend creating a dedicated service account on Azure DevOps when installing this integration rather than using a personal user account.
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration.
+  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the Azure DevOps user who created the tokens.
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.
+  </p>
+  <p>
+  After creating the Azure DevOps service account, you will need to sign into Sentry with an user account that has owner, manager, or admin permissions to install the integration.
   </p>
 </Alert>
 

--- a/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/gitlab/index.mdx
@@ -6,19 +6,22 @@ description: "Learn more about Sentry’s GitLab integration and how it helps yo
 
 ## Install
 
-<Alert>
-
 <p>
 Sentry owner, manager, or admin permissions and GitLab owner or maintainer permissions are required to install this integration.
 </p>
+
+<Alert title="Note">
   <p>
-  We recommend using a dedicated service account when installing this integration rather than a personal user account.
+  We recommend creating a dedicated service account on GitLab when installing this integration rather than using a personal user account. The service account should have owner or maintainer permissions in GitLab.
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the user who installed the integration.
+  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the GitLab user who created the tokens.
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.
+  </p>
+  <p>
+  After creating the GitLab service account, you will need to sign into Sentry with an user account that has owner, manager, or admin permissions to install the integration.
   </p>
 </Alert>
 


### PR DESCRIPTION
we got a ticket or two with questions about our service account recommendation for installing these integrations, so lets make it a bit more clear