### PR TITLE
Updating Prevent AI docs to add latest permissions UX

### DIFF
--- a/docs/product/ai-in-sentry/sentry-prevent-ai/index.mdx
+++ b/docs/product/ai-in-sentry/sentry-prevent-ai/index.mdx
@@ -16,6 +16,8 @@ To enable Sentry Prevent AI in your GitHub organization or on specific repositor
 
 If you're not an admin, copy the Sentry Prevent AI GitHub App Integration link and share it with your organization's admin or owner to install it.
 
+**Note:** Both `Show Generative AI Features` and `Enable PR Review and Test Generation` settings must be enabled in your [organization settings](https:sentry.io/settings/organization/) to run Sentry Prevent AI on your pull requests.
+
 ## Sentry Prevent AI Commands
 
 After installing the app, use these commands in your pull request comments:
@@ -30,22 +32,17 @@ Once you have added a comment, the assistant will reply, acknowledging the reque
 
 ## Frequently Asked Questions
 
-**What data does Sentry Prevent need access to for the AI system to function, and what information is sent to third-party AI providers?**
+- **What data does Sentry Prevent need access to for the AI system to function, and what information is sent to third-party AI providers?**
 
-Sentry Prevent requires access to your pull requests, including PR metadata, repository information, file names, directory structures, and code diffs. The file names, code diffs, and PR descriptions are sent to the AI provider for analysis.
+  Sentry Prevent requires access to your pull requests, including PR metadata, repository information, file names, directory structures, and code diffs. The file names, code diffs, and PR descriptions are sent to the AI provider for analysis.
 
-**Does Sentry Prevent run anywhere outside of GitHub, and does it run in the background?**
+- **Does Sentry Prevent run anywhere outside of GitHub, and does it run in the background?**
 
-Sentry Prevent AI only runs on GitHub, and only runs when triggered by a comment. 
+  Sentry Prevent AI only runs on GitHub, and only runs when triggered by a comment. 
 
-The [Show Generative AI Features toggle](https://sentry.io/orgredirect/organizations/:orgslug/settings/#hideAiFeatures) does not currently apply to Sentry Prevent AI. if you don't want Sentry Prevent AI used on your projects, you can uninstall the [Seer app](https://github.com/apps/seer-by-sentry) at any time.
+  You can learn more about AI privacy and security [here](/product/ai-in-sentry/ai-privacy-and-security/).
 
-You can learn more about AI privacy and security [here](/product/ai-in-sentry/ai-privacy-and-security/).
+- **Why aren't `@sentry` commands working?**
 
-## Feedback & Support
+  Sentry Prevent AI will respond with a message to enable the `Show Generative AI Features` and `Enable PR Review and Test Generation` settings in your [organization settings](https:sentry.io/settings/organization/), if you have not already enabled them. Once enabled, try `@sentry review` or `@sentry generate-test` again to run Prevent AI. 
 
-Have feedback? Drop us a line on GitHub Issues or contact Sentry support.
-
----
-
-For more information, see the [Sentry Prevent documentation](https://docs.sentry.io/).


### PR DESCRIPTION
## DESCRIBE YOUR PR
Sentry Prevent AI just updated their permissions, and docs need to reflect the same. The Gen AI toggle, plus a Prevent toggle are now a part of the on/off flow for prevent AI. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Today, the change is already merged. 
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
