### PR TITLE
Fix reference to non-existent tanstackstart-router

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -133,7 +133,7 @@ Wrap TanStack Start's `createRootRoute` function using `wrapCreateRootRouteWithS
 ```tsx {filename:src/routes/__root.tsx} {3,6}
 import type { ReactNode } from "react";
 import { createRootRoute } from "@tanstack/react-router";
-import { wrapCreateRootRouteWithSentry } from "@sentry/tanstackstart-router";
+import { wrapCreateRootRouteWithSentry } from "@sentry/tanstackstart-react";
 
 // (Wrap `createRootRoute`, not its return value!)
 export const Route = wrapCreateRootRouteWithSentry(createRootRoute)({


### PR DESCRIPTION
## DESCRIBE YOUR PR

The docs reference @sentry/tanstackstart-router which does not exist. The function is exported by @sentry/tanstackstart-react though

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
