### PR TITLE
fix(python): Fix `new_scope` example

### DIFF
--- a/docs/platforms/python/enriching-events/scopes/index.mdx
+++ b/docs/platforms/python/enriching-events/scopes/index.mdx
@@ -27,17 +27,13 @@ However, if your use case requires direct access to the scope object, you can us
 
 <Alert>
 
-Avoid calling top-level APIs inside the  <PlatformIdentifier name="new-scope" /> context manager. The top-level API might interact with a different scope from what <PlatformIdentifier name="new-scope" /> yields, causing unintended results. While within the <PlatformIdentifier name="new-scope" /> context manager, please call methods directly on the scope that <PlatformIdentifier name="new-scope" /> yields!
+Avoid calling top-level APIs inside the <PlatformIdentifier name="new-scope" /> context manager. The top-level API might interact with a different scope from what <PlatformIdentifier name="new-scope" /> yields, causing unintended results. While within the <PlatformIdentifier name="new-scope" /> context manager, please call methods directly on the scope that <PlatformIdentifier name="new-scope" /> yields!
 
 </Alert>
 
-Using <PlatformIdentifier name="new-scope" /> allows you to attach additional information, such as adding custom tags or informing Sentry about the currently authenticated user.
+Using <PlatformIdentifier name="new-scope" /> allows you to attach additional information, such as adding custom tags.
 
 <PlatformContent includePath="enriching-events/scopes/configure-scope" />
-
-You can also apply this configuration when unsetting a user at logout:
-
-<PlatformContent includePath="enriching-events/unset-user" />
 
 To learn what useful information can be associated with scopes see
 [the context documentation](../context/).

--- a/platform-includes/enriching-events/scopes/configure-scope/python.mdx
+++ b/platform-includes/enriching-events/scopes/configure-scope/python.mdx
@@ -1,15 +1,21 @@
 ```python
 import sentry_sdk
 
-scope = sentry_sdk.get_current_scope()
-scope.set_tag("my-tag", "my value")
-scope.user = {"id": 42, "email": "john.doe@example.com"}
+sentry_sdk.init(...)
 
-# reset all scope data
-scope.clear()
+with sentry_sdk.new_scope() as scope:
+    scope.set_tag("inside-new-scope", "yes")
+    try:
+        raise RuntimeError("With new_scope")
+    except:
+        # This exception will have the tag set
+        sentry_sdk.capture_exception()
 
-# Or:
-
-sentry_sdk.set_tag("my-tag", "my value")
-sentry_sdk.set_user({"id": 42, "email": "john.doe@example.com"})
+# The scope is automatically cleared and the previous scope
+# is restored after the `with` block
+try:
+    raise RuntimeError("Outside of new_scope")
+except:
+    # This exception won't have the custom tag set
+    sentry_sdk.capture_exception()
 ```


### PR DESCRIPTION
The example for `new_scope` didn't actually use `new_scope`.

Direct link to preview: https://sentry-docs-git-ivana-pythonfix-new-scope-example.sentry.dev/platforms/python/enriching-events/scopes/#changing-the-scope

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
