### PR TITLE
Fixing session replay responsiveness in code blocks

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/index.mdx
@@ -69,6 +69,7 @@ Sentry.init({
     Sentry.browserTracingIntegration(),
     // ___PRODUCT_OPTION_END___ performance
     // ___PRODUCT_OPTION_START___ session-replay
+    // Replay may only be enabled for the client-side
     Sentry.replayIntegration(),
     // ___PRODUCT_OPTION_END___ session-replay
     // ___PRODUCT_OPTION_START___ user-feedback
@@ -93,8 +94,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ session-replay
-
-  // Capture Replay for 10% of all sessions,
+  // Capture Replay for 10% of all 
   // plus for 100% of sessions with an error
   // Learn more at
   // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration

--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -129,6 +129,7 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   integrations: [
     // ___PRODUCT_OPTION_START___ session-replay
+    // Replay may only be enabled for the client-side
     Sentry.replayIntegration(),
     // ___PRODUCT_OPTION_END___ session-replay
     // ___PRODUCT_OPTION_START___ user-feedback

--- a/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -127,10 +127,10 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ session-replay
-  // Replay may only be enabled for the client-side
   integrations: [
+    // ___PRODUCT_OPTION_START___ session-replay
     Sentry.replayIntegration(),
+    // ___PRODUCT_OPTION_END___ session-replay
     // ___PRODUCT_OPTION_START___ user-feedback
     Sentry.feedbackIntegration({
       // Additional SDK configuration goes in here, for example:
@@ -138,6 +138,7 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
+  // ___PRODUCT_OPTION_START___ session-replay
 
   // Capture Replay for 10% of all sessions,
   // plus for 100% of sessions with an error
@@ -145,7 +146,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
-
   // ___PRODUCT_OPTION_END___ session-replay
   // ___PRODUCT_OPTION_START___ logs
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Session replay code was showing up in the code blocks whether or not `session replay` was selected as a feature to install. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)