### PR TITLE
Remove setup variant for Java OpenTelemetry agentless setup

### DIFF
--- a/platform-includes/performance/opentelemetry-setup/without-java-agent/java.mdx
+++ b/platform-includes/performance/opentelemetry-setup/without-java-agent/java.mdx
@@ -1,12 +1,6 @@
 #### Initializing OpenTelemetry
 
-Our `sentry-opentelemetry-agentless` dependency also adds `opentelemetry-sdk-extension-autoconfigure` which takes care of configuring OpenTelemetry to work with Sentry. There's two ways to trigger it.
-
-1. Using a property on startup
-
-Add `-Dotel.java.global-autoconfigure.enabled=true` to the `java` command when starting your application.
-
-2. Using `AutoConfiguredOpenTelemetrySdk`
+Our `sentry-opentelemetry-agentless` dependency also adds `opentelemetry-sdk-extension-autoconfigure` which takes care of configuring OpenTelemetry to work with Sentry. You can configure it using `AutoConfiguredOpenTelemetrySdk`:
 
 ```java {tabTitle: Java}
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;


### PR DESCRIPTION
`-Dotel.java.global-autoconfigure.enabled=true` alone leads to lazy init of the OpenTelemetry SDK.
If Sentry API is used before any OpenTelemetry API then calls like `Sentry.captureMessage` etc. don't work.
We'd have to ensure eager init of the OpenTelemetry SDK in order to have Sentry initialized early like this:
```
import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;

class Main {
  static {
    AutoConfiguredOpenTelemetrySdk.initialize();
  }
}
```

Due to this requiring the `java` arg AND code, it's easier to just rely on the second method in docs that only need code changes.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
