### PR TITLE
docs(android): Extend NDK troubleshooting docs for debug images

### DIFF
--- a/docs/platforms/android/configuration/using-ndk.mdx
+++ b/docs/platforms/android/configuration/using-ndk.mdx
@@ -115,6 +115,26 @@ configurations.configureEach {
 Unsymbolicated stack traces may be caused by module-caching on the SDK side. Be sure to clear any existing module cache if your modules are loaded dynamically:
 
 ```cpp
-// load a new module
+// 1. Load a new module
+load_my_module();
+
+// 2. Clear the module cache
 sentry_clear_modulecache();
+```
+
+```kotlin
+// 1. Manually initialize the SDK, 
+// in order to keep a reference to the SDK options
+var optionsRef: SentryAndroidOptions? = null
+SentryAndroid.init(this) { options ->
+    options.dsn = "___PUBLIC_DSN___"
+    // ...
+    optionsRef = options
+}
+
+// 2. Load a new module
+System.loadLibrary("<library>")
+
+// 3. Clear the cache
+optionsRef?.debugImagesLoader?.clearDebugImages()
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR
Extends NDK troubleshooting docs for debug images and how to invalidate the cache.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
