### PR TITLE
feat(python): Update troubleshooting page for 3.x

### DIFF
--- a/docs/platforms/python/troubleshooting__v3.x.mdx
+++ b/docs/platforms/python/troubleshooting__v3.x.mdx
@@ -42,46 +42,6 @@ Use the information in this page to help answer these questions:
   for a more complete example that involves forking the isolation scope.
 </Expandable>
 
-<Expandable title="Context Variables vs Thread Locals">
-
-  The Python SDK uses [thread locals](https://docs.python.org/3/library/threading.html#thread-local-data) to
-  keep contextual data where it belongs. There are a few situations where this
-  approach fails.
-
-  Read along if you cannot figure out why contextual data is leaking across HTTP
-  requests, or data is missing or popping up at the wrong place and time.
-
-#### Python 2: Thread Locals and gevent
-
-  If the SDK is installed on Python 2, there is not much else to use than the
-  aforementioned thread locals, so the SDK will use just that.
-
-  Code that uses async libraries such as **`twisted` is not supported** in the
-  sense that you will experience context data leaking across tasks/any logical
-  boundaries, at least out of the box.
-
-  Code that uses more "magical" async libraries such as **`gevent` or `eventlet`
-  will work just fine** provided those libraries are configured to monkeypatch
-  the stdlib. If you are only using those libraries in the context of running
-  `gunicorn` that is the case, for example.
-
-#### Python 3: Context Variables or Thread Locals
-
-  Python 3 introduced `asyncio`, which, just like Twisted, had the problem of not
-  having any concept of attaching contextual data to your control flow. That
-  means in Python 3.6 and lower, the SDK is not able to prevent leaks of
-  contextual data.
-
-  Python 3.7 rectified this problem with the `contextvars` stdlib module which is
-  basically thread locals that also work in asyncio-based code. The SDK will
-  attempt to use that module instead of thread locals if available.
-
-  **For Python 3.6 and older, install `aiocontextvars` from PyPI** which is a
-  fully-functional backport of `contextvars`. The SDK will check for this package
-  and use it instead of thread locals.
-
-</Expandable>
-
 <Expandable title="Context Variables vs gevent/eventlet">
   If you are using `gevent` (older than 20.5) or `eventlet` in your application and
   have configured it to monkeypatch the stdlib, the SDK will abstain from using


### PR DESCRIPTION
- updated example on Troubleshooting page
- created a new copy of the Troubleshooting page for the upcoming SDK 3.0 with the following changes:
  - remove the section on Context Variables vs Thread Locals since it's only relevant for Python older than 3.7 which is not supported in SDK 3.0

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
