### PR TITLE
Godot: Document `disabled-in-editor-play` option

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -92,7 +92,7 @@ If `true`, the SDK will not initialize in the Godot editor.
 
 <ConfigKey name="disabled-in-editor-play">
 
-If `true`, the SDK will not initialize when the project is run from within the Godot editor. This differs from `disabled_in_editor` which prevents initialization when working in the editor itself.
+If `true`, the SDK will not initialize when you play/run your project from within the Godot editor (using the play button or F5). This is different from `disabled_in_editor` which disables the SDK while you're editing your project in the Godot editor interface itself.
 
 </ConfigKey>
 

--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -84,15 +84,9 @@ If `false`, the SDK will not initialize. This is useful for temporarily disablin
 
 </ConfigKey>
 
-<ConfigKey name="disabled-in-editor">
-
-If `true`, the SDK will not initialize in the Godot editor.
-
-</ConfigKey>
-
 <ConfigKey name="disabled-in-editor-play">
 
-If `true`, the SDK will not initialize when you play/run your project from within the Godot editor (using the play button or F5). This is different from `disabled_in_editor` which disables the SDK while you're editing your project in the Godot editor interface itself.
+If `true`, the SDK will not initialize when you play/run your project from within the Godot editor (using the play button or F5).
 
 </ConfigKey>
 

--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -90,6 +90,12 @@ If `true`, the SDK will not initialize in the Godot editor.
 
 </ConfigKey>
 
+<ConfigKey name="disabled-in-editor-play">
+
+If `true`, the SDK will not initialize when the project is run from within the Godot editor. This differs from `disabled_in_editor` which prevents initialization when working in the editor itself.
+
+</ConfigKey>
+
 <ConfigKey name="attach-log">
 
 If enabled, the SDK will attach the Godot log file to the event.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add documentation for `disabled_in_editor_play` option added in:

- getsentry/sentry-godot/pull/262 

Remove option according to changes:
- getsentry/sentry-godot/pull/277

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
