### PR TITLE
Simplify Crons rate limits documentation

### DIFF
--- a/includes/crons-rate-limits.mdx
+++ b/includes/crons-rate-limits.mdx
@@ -1,5 +1,11 @@
 ## Rate Limits
 
-Crons imposes a rate limit on check-ins to prevent abuse and resource overuse. Specifically, you can only send a maximum of **6 check-ins per minute per existing monitor environment**. This limit is enforced on a per-project basis, meaning that the rate limit applies collectively to all monitor environments within a given project. You can check if any of your check-ins are being dropped in the [Usage Stats](/product/stats/#usage-stats) page.
+To prevent abuse and resource overuse, Crons limits check-ins to **6 per minute for each monitor environment**.
 
-To avoid dropped check-ins, it is crucial to manage and distribute your check-ins efficiently within the rate limits. This will help maintain accurate monitoring and ensure that all critical check-ins are captured and processed.
+For example, if you have a monitor called "database-backup" with two environments:
+
+- `database-backup` in environment `production` can send up to 6 check-ins per minute
+- `database-backup` in environment `staging` can also send up to 6 check-ins per minute
+- Combined, they can send up to 12 check-ins per minute
+
+You can verify if any check-ins are being dropped by visiting the [Usage Stats](/product/stats/#usage-stats) page. To avoid dropped check-ins, ensure your monitors don't exceed the rate limit.


### PR DESCRIPTION
This PR simplifies the Crons rate limits documentation to make it clearer and less confusing for users.

## Changes:
- Removed confusing "per-project basis" language that was causing confusion
- Added a concrete example using a "database-backup" monitor with production and staging environments
- Clearly shows that each monitor-environment combination gets its own 6 check-in per minute limit
- Made the explanation more concise and actionable

## Example Added:
The new documentation includes an example showing:
- `database-backup` in `production`: 6 check-ins/minute
- `database-backup` in `staging`: 6 check-ins/minute  
- Combined total: 12 check-ins/minute

This should help users quickly understand how the rate limiting works in practice.