### PR TITLE
feat(otlp): Add basic OTLP beta documentation

### DIFF
--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -38,6 +38,10 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
+<Alert>
+If you are already using an OpenTelemetry SDK to send traces alongside a Sentry SDK to send errors, you'll need to follow the instructions in the <PlatformLink to="/opentelemetry/custom-setup/">Custom Setup documentation</PlatformLink> to adjust your SDK configuration.
+</Alert>
+
 You can find the values of Sentry's OTLP endpoint and public key in your Sentry project settings.
 
 1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -7,7 +7,11 @@ keywords: ["otlp", "otel", "opentelemetry"]
 
 <Include name="feature-available-for-user-group-limited-avail.mdx" />
 
-Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have an existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly.
+Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have an existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly. Sentry's OTLP ingestion endpoint is currently in development, and has a few known limitations:
+
+- Span events are not supported. All span events are dropped during ingestion.
+- Span links are partially supported. We ingest and display span links, but they cannot be searched, filtered, or aggregated. Links are are shown in the [Trace View](https://docs.sentry.io/concepts/key-terms/tracing/trace-view/).
+- Array attributes are partially supported. We ingest and display array attributes, but they cannot be searched, filtered, or aggregated. Array attributes are shown in the [Trace View](https://docs.sentry.io/concepts/key-terms/tracing/trace-view/).
 
 The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
 

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -9,14 +9,14 @@ keywords: ["otlp", "otel", "opentelemetry"]
 
 Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly.
 
-The easiest way to configure an OpenTelemetry Exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers.
+The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
 
 ```bash {filename: .env}
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="___OTLP_TRACES_URL___""
 export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-sentry-auth=sentry sentry_key=___PUBLIC_KEY___"
 ```
 
-If you don't want to use environment variables, you can configure the OpenTelemetry Exporter directly in your application code.
+Alternatively, you can configure the OpenTelemetry Exporter directly in your application code.
 
 ```typescript {filename: app.ts}
 import { NodeSDK } from "@opentelemetry/sdk-node";

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -1,0 +1,41 @@
+---
+title: OTLP
+sidebar_order: 400
+description: "Learn how to send OpenTelemetry trace data directly to Sentry from OpenTelemetry SDKs."
+keywords: ["otlp", "otel", "opentelemetry"]
+---
+
+<Include name="feature-available-for-user-group-limited-avail.mdx" />
+
+Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly.
+
+The easiest way to configure an OpenTelemetry Exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers.
+
+```bash {filename: .env}
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="___OTLP_TRACES_URL___""
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-sentry-auth=sentry sentry_key=___PUBLIC_KEY___"
+```
+
+If you don't want to use environment variables, you can configure the OpenTelemetry Exporter directly in your application code.
+
+```typescript {filename: app.ts}
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter({
+    url: "___OTLP_TRACES_URL___",
+    headers: {
+      "x-sentry-auth": "sentry sentry_key=___PUBLIC_KEY___",
+    },
+  }),
+});
+
+sdk.start();
+```
+
+You can find the values of Sentry's OTLP endpoint and public key in your Sentry project settings.
+
+1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.
+2. Select a project from the list.
+3. Go to the "Client Keys (DSN)" sub-page for this project under the "SDK Setup" heading.

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: OTLP
+title: OpenTelemetry Protocol (OTLP)
 sidebar_order: 400
 description: "Learn how to send OpenTelemetry trace data directly to Sentry from OpenTelemetry SDKs."
 keywords: ["otlp", "otel", "opentelemetry"]

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -7,7 +7,7 @@ keywords: ["otlp", "otel", "opentelemetry"]
 
 <Include name="feature-available-for-user-group-limited-avail.mdx" />
 
-Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly.
+Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have an existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly.
 
 The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
 

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -12,6 +12,7 @@ Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via 
 - Span events are not supported. All span events are dropped during ingestion.
 - Span links are partially supported. We ingest and display span links, but they cannot be searched, filtered, or aggregated. Links are are shown in the [Trace View](https://docs.sentry.io/concepts/key-terms/tracing/trace-view/).
 - Array attributes are partially supported. We ingest and display array attributes, but they cannot be searched, filtered, or aggregated. Array attributes are shown in the [Trace View](https://docs.sentry.io/concepts/key-terms/tracing/trace-view/).
+- Sentry does not support ingesting OTLP metrics or OTLP logs.
 
 The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
 

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -16,7 +16,7 @@ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="___OTLP_TRACES_URL___""
 export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-sentry-auth=sentry sentry_key=___PUBLIC_KEY___"
 ```
 
-Alternatively, you can configure the OpenTelemetry Exporter directly in your application code.
+Alternatively, you can configure the OpenTelemetry Exporter directly in your application code. Here is an example with the OpenTelemetry Node SDK:
 
 ```typescript {filename: app.ts}
 import { NodeSDK } from "@opentelemetry/sdk-node";

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -14,6 +14,7 @@ type ProjectCodeKeywords = {
   ORG_ID: number;
   ORG_INGEST_DOMAIN: string;
   ORG_SLUG: string;
+  OTLP_TRACES_URL: string;
   PROJECT_ID: number;
   PROJECT_SLUG: string;
   PUBLIC_DSN: string;
@@ -86,6 +87,7 @@ export const DEFAULTS: CodeKeywords = {
       MINIDUMP_URL:
         'https://o0.ingest.sentry.io/api/0/minidump/?sentry_key=examplePublicKey',
       UNREAL_URL: 'https://o0.ingest.sentry.io/api/0/unreal/examplePublicKey/',
+      OTLP_TRACES_URL: 'https://o0.ingest.sentry.io/api/0/otlp/v1/traces',
       title: `example-org / example-project`,
     },
   ],
@@ -135,6 +137,10 @@ const formatMinidumpURL = ({scheme, host, pathname, publicKey}: Dsn) => {
 
 const formatUnrealEngineURL = ({scheme, host, pathname, publicKey}: Dsn) => {
   return `${scheme}${host}/api${pathname}/unreal/${publicKey}/`;
+};
+
+const formatOtlpTracesUrl = ({scheme, host, pathname}: Dsn) => {
+  return `${scheme}${host}/api${pathname}/otlp/v1/traces`;
 };
 
 const formatApiUrl = ({scheme, host}: Dsn) => {
@@ -229,6 +235,7 @@ export async function fetchCodeKeywords(): Promise<CodeKeywords> {
           parsedDsn.host ?? `o${project.organizationId}.ingest.sentry.io`,
         MINIDUMP_URL: formatMinidumpURL(parsedDsn),
         UNREAL_URL: formatUnrealEngineURL(parsedDsn),
+        OTLP_TRACES_URL: formatOtlpTracesUrl(parsedDsn),
         title: `${project.organizationSlug} / ${project.projectSlug}`,
       };
     }),


### PR DESCRIPTION
## DESCRIBE YOUR PR

Sentry is working on OTLP ingestion! This'll allow customers to configure their OpenTelemetry SDKs to send traces directly to Sentry. This is a major departure from our current OTLP support, which mostly requires users to configure their SDKs in special ways.

We are gearing up for a Limited Availability Beta with a few select customers. While we expect to hold their hand for a lot of it, it's still a good idea to have some public documentation they can refer to.

I'm looking for feedback from the Docs team on where to best place this kind of generic documentation (I took a shot!) and from the SDKs team for how to make this document play nice with existing SDK documentation about OpenTelemetry.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
