### PR TITLE
docs: Update uptime monitoring automatic detection disable instructions

### DIFF
--- a/docs/product/uptime-monitoring/automatic-detection.mdx
+++ b/docs/product/uptime-monitoring/automatic-detection.mdx
@@ -21,18 +21,6 @@ Once an automatically detected uptime alert has been created, you'll be able to 
 
 ## Disabling Automatic Detection
 
-If you prefer not to use automatically detected uptime alerts, you have two options for disabling them:
+If you prefer not to use automatically detected uptime alerts, you can delete them directly from your [Alerts page](https://sentry.io/orgredirect/organizations/:orgslug/alerts/rules).
 
-1. **Deleting Uptime Alerts:** You can directly delete existing automatically detected uptime alerts from your [Alerts page](https://sentry.io/orgredirect/organizations/:orgslug/alerts/rules). Once deleted, these alerts will not be re-created automatically in the future.
-2. **Blocking Sentry via `robots.txt`:** Another method to prevent automatic detection is by updating your hostname's robots.txt file to block Sentry’s uptime monitoring bot. To do this, add the following lines to your robots.txt file:
-
-```txt{tabTitle: Example}{filename: robots.txt}
-User-agent: SentryUptimeBot
-Disallow: *
-```
-
-<Alert level="warning">
-  **Note:** The `robots.txt` file only prevents Sentry from detecting URLs that
-  it encounters after its been implemented. Existing URLs that have already been
-  detected will continue to have uptime alerts unless they're manually deleted.
-</Alert>
+**Once deleted, these automatically detected uptime alerts will not be re-created in the future.**


### PR DESCRIPTION
This PR updates the uptime monitoring documentation to:

- Remove the unsupported robots.txt option for disabling automatic detection
- Emphasize that deleted uptime alerts won't be re-created automatically
- Simplify the disabling section for better clarity

The robots.txt feature is not currently supported, so the best way to disable automatic detection is to simply delete the uptime alert.