### PR TITLE
feat(android/java): document Ktor Client integration

### DIFF
--- a/docs/platforms/android/integrations/ktor-client/index.mdx
+++ b/docs/platforms/android/integrations/ktor-client/index.mdx
@@ -20,7 +20,8 @@ The Sentry Ktor Client integration supports Ktor Client version `3.x`.
 
 <Alert level="warning">
   If you're using Ktor Client with OKHttp as the engine, and you're already using the [Sentry OkHttp integration](/platforms/android/integrations/okhttp/),
-  either with manual or automatic installation (via the Sentry Android Gradle Plugin), you shouldn't use this integration, otherwise the SDK will produce duplicate data, instrumenting each HTTP request twice.
+  either with manual or automatic installation (via the Sentry Android Gradle Plugin), you should avoid using this integration, otherwise the SDK will produce duplicate data, instrumenting each HTTP request twice.
+  Use the [Sentry OkHttp integration](/platforms/android/integrations/okhttp/) instead, as it provides more detailed information about HTTP request.
 </Alert>
 
 ## Install

--- a/docs/platforms/java/common/tracing/instrumentation/ktor-client.mdx
+++ b/docs/platforms/java/common/tracing/instrumentation/ktor-client.mdx
@@ -15,7 +15,7 @@ To be able to capture transactions, you'll need to first <PlatformLink to="/trac
 
 </Alert>
 
-The `sentry-ktor-client` library provides [Ktor Client](https://ktor.io/) support for Sentry via the Sentry Ktor Client Plugin. The source can be found [on GitHub](https://github.com/getsentry/sentry-java/tree/main/sentry-ktor-client).
+The `sentry-ktor-client` library provides [Ktor Client](https://ktor.io/) support for Sentry via the Sentry Ktor Client Plugin.
 
 On this page, we get you up and running with Sentry's Ktor Client Integration.
 The integration supports:
@@ -27,7 +27,8 @@ The Sentry Ktor Client integration supports Ktor Client version `3.x`.
 
 <Alert level="warning">
   If you're using Ktor Client with OKHttp as the engine, and you're already using the [Sentry OkHttp integration](/platforms/java/tracing/instrumentation/okhttp/),
-  you shouldn't use this integration, otherwise the SDK will produce duplicate data, instrumenting each HTTP request twice.
+  you should avoid using this integration, otherwise the SDK will produce duplicate data, instrumenting each HTTP request twice.
+  Use the [Sentry OkHttp integration](/platforms/java/tracing/instrumentation/okhttp/) instead, as it provides more detailed information about HTTP request.
 </Alert>
 
 ## Install


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
- Docs for https://github.com/getsentry/sentry-java/pull/4527
- Mainly took the OkHttp docs and asked Cursor to adapt them to the new integration by using the code as context, with some manual changes.
- Also adds a docs page for it for Java. Changes wrt Android docs:
  - Don't mention SAGP
  - Use the JVM client engine instead of Android
  - `Sentry.init` instead of `SentryAndroid.init`