### PR TITLE
Update debug symbols and stubbed targets on home page

### DIFF
--- a/docs/platforms/kotlin/guides/compose-multiplatform/index.mdx
+++ b/docs/platforms/kotlin/guides/compose-multiplatform/index.mdx
@@ -46,4 +46,12 @@ This snippet includes an intentional error, so you can test that everything is w
 
 Error stack traces in your app might appear unreadable or obfuscated, making it hard to debug issues. To make stack traces clear and human-readable in Sentry, you need to upload your app's debug symbols.
 
-For step-by-step instructions, see the [Debug Symbols guide](/platforms/kotlin/guides/kotlin-multiplatform/debug-symbols/).
+### Android
+
+For Android applications, you need to manually upload ProGuard mapping files using the sentry-cli. Follow the [ProGuard Mapping Upload guide](https://docs.sentry.io/cli/dif/#proguard-mapping-upload) for detailed instructions.
+
+### iOS
+
+For iOS applications, follow the [Uploading Debug Symbols guide](/platforms/apple/guides/ios/dsym) to set up debug symbols upload.
+
+<PlatformContent includePath="stubbed-platforms-kmp" />

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/features/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/features/index.mdx
@@ -29,3 +29,5 @@ The table below lists supported platforms and their corresponding presets.
 | macOS           | <ul><li>`macosArm64`</li><li>`macosX64`</li></ul>                                                            |
 | watchOS         | <ul><li>`watchosArm32`</li><li>`watchosArm64`</li><li>`watchosX64`</li><li>`watchosSimulatorArm64`</li></ul> |
 | tvOS            | <ul><li>`tvosArm64`</li><li>`tvosX64`</li><li>`tvosSimulatorArm64`</li></ul>                                 |
+
+<PlatformContent includePath="stubbed-platforms-kmp" />

--- a/platform-includes/stubbed-platforms-kmp/kotlin.compose-multiplatform.mdx
+++ b/platform-includes/stubbed-platforms-kmp/kotlin.compose-multiplatform.mdx
@@ -1,0 +1,11 @@
+## Stubbed Platforms (No-Op Implementations)
+
+You can add these targets to your Kotlin Multiplatform project just like the supported ones.  
+They compile and satisfy the API surface, but **do nothing at runtime**.
+
+| Target Platform | Target preset                                     |
+|:---------------:|---------------------------------------------------|
+| JS              | <ul><li>`js`</li></ul>                            |
+| Wasm JS         | <ul><li>`wasmJs`</li></ul>                        |
+| Linux           | <ul><li>`linuxx64`</li><li>`linuxarm64`</li></ul> |
+| Windows         | <ul><li>`mingwx64`</li></ul>                      |

--- a/platform-includes/stubbed-platforms-kmp/kotlin.kotlin-multiplatform.mdx
+++ b/platform-includes/stubbed-platforms-kmp/kotlin.kotlin-multiplatform.mdx
@@ -1,0 +1,11 @@
+## Stubbed Platforms (No-Op Implementations)
+
+You can add these targets to your Kotlin Multiplatform project just like the supported ones.  
+They compile and satisfy the API surface, but **do nothing at runtime**.
+
+| Target Platform | Target preset                                     |
+|:---------------:|---------------------------------------------------|
+| JS              | <ul><li>`js`</li></ul>                            |
+| Wasm JS         | <ul><li>`wasmJs`</li></ul>                        |
+| Linux           | <ul><li>`linuxx64`</li><li>`linuxarm64`</li></ul> |
+| Windows         | <ul><li>`mingwx64`</li></ul>                      |


### PR DESCRIPTION
```
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This PR updates the Sentry Compose Multiplatform home page by:
- Replacing the generic debug symbols link with platform-specific instructions for Android (sentry-cli ProGuard upload) and iOS (existing dSYM guide).
- Adding a new section about "Stubbed Platforms (No-Op Implementations)" at the bottom, explaining that these targets compile but do nothing at runtime.
- The "Stubbed Platforms" content is now shared and reused on the Kotlin Multiplatform features page as well, using `PlatformContent` includes for consistency.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-794633c0-3e12-4cab-bd92-8e465aafe4a3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-794633c0-3e12-4cab-bd92-8e465aafe4a3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)