### PR TITLE
docs(js): Add docs for `strictTraceContinuation` and `orgId`

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -379,6 +379,31 @@ If you want to disable trace propagation, you can set this option to `[]`.
 
 </SdkOption>
 
+
+<PlatformCategorySection supported={["server", "serverless"]}>
+  <SdkOption name="strictTraceContinuation" type='boolean' defaultValue='false'>
+
+    If set to `true`, the SDK will only continue a trace if the organization ID of the incoming trace found in the
+    `baggage` header matches the organization ID of the current Sentry client.
+
+    The client's organization ID is extracted from the DSN or can be set with the `orgId` option.
+
+    If the organization IDs do not match, the SDK will start a new trace instead of continuing the incoming one.
+    This is useful to prevent traces of unknown third-party services from being continued in your application.
+
+  </SdkOption>
+
+  <SdkOption name="orgId" type='`${number}` | number'>
+
+    The organization ID for your Sentry project.
+
+    The SDK will try to extract the organization ID from the DSN. If it cannot be found, or if you need to override it,
+    you can provide the ID with this option. The organization ID is used for trace propagation and for features like `strictTraceContinuation`.
+
+  </SdkOption>
+
+</PlatformCategorySection>
+
 <PlatformCategorySection supported={['browser']}>
 
 <SdkOption name="beforeSendTransaction" type='(event: TransactionEvent, hint: EventHint) => TransactionEvent | null'>

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -18,6 +18,21 @@ sidebar_order: 1
 
 </SdkOption>
 
+<PlatformCategorySection supported={["server", "serverless"]}>
+  <SdkOption name="orgId" type='`${number}` | number'>
+
+    The organization ID for your Sentry project.
+
+    The SDK will try to extract the organization ID from the DSN. If it cannot be found, or if you need to override it,
+    you can provide the ID with this option. The organization ID is used for trace propagation and features like `strictTraceContinuation`.
+
+    <Alert level="info">
+      The organization ID is used for features like <PlatformLink to="/configuration/options#strictTraceContinuation">strict trace continuation</PlatformLink>.
+    </Alert>
+
+  </SdkOption>
+</PlatformCategorySection>
+
 <SdkOption name="debug" type='boolean' defaultValue='false'>
 
 Turns debug mode on or off. If debug is enabled SDK will attempt to print out useful debugging information about what the SDK is doing.
@@ -386,22 +401,12 @@ If you want to disable trace propagation, you can set this option to `[]`.
     If set to `true`, the SDK will only continue a trace if the organization ID of the incoming trace found in the
     `baggage` header matches the organization ID of the current Sentry client.
 
-    The client's organization ID is extracted from the DSN or can be set with the `orgId` option.
+    The client's organization ID is extracted from the DSN or can be set with the <PlatformLink to={'/configuration/options#orgId'}>`orgId` option</PlatformLink>.
 
     If the organization IDs do not match, the SDK will start a new trace instead of continuing the incoming one.
     This is useful to prevent traces of unknown third-party services from being continued in your application.
 
   </SdkOption>
-
-  <SdkOption name="orgId" type='`${number}` | number'>
-
-    The organization ID for your Sentry project.
-
-    The SDK will try to extract the organization ID from the DSN. If it cannot be found, or if you need to override it,
-    you can provide the ID with this option. The organization ID is used for trace propagation and for features like `strictTraceContinuation`.
-
-  </SdkOption>
-
 </PlatformCategorySection>
 
 <PlatformCategorySection supported={['browser']}>

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -71,6 +71,37 @@ This configuration lets your app track user actions across:
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
 
+### Strict Trace Continuation
+
+When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
+By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+as it can lead to unwanted traces, increased billing, and skewed performance data.
+
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
+It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+This is useful if your application is a public API or receives requests from services outside your organization.
+
+```javascript {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  // Ensure that only traces from your own organization are continued
+  strictTraceContinuation: true,
+});
+```
+
+The SDK automatically parses the organization ID from your DSN. If you use a DSN format that doesn't include the organization ID (number followed by the letter `"o"`), or if you need to override it, you can provide it manually using the `orgId` option:
+
+```javascript {6}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  strictTraceContinuation: true,
+  // Manually provide your organization ID (overrides organization ID parsed from DSN)
+  orgId: 12345,
+});
+```
+
 ### Disabling Distributed Tracing
 
 If you want to disable distributed tracing and ensure no Sentry trace headers are sent, you can configure your SDK like this:

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -76,11 +76,11 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 _Available since SDK version 10_
 
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
-By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+By default, the SDK will continue the trace from these incoming headers. However, this behavior can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.
 
-To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
-It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information and only continues the trace if it belongs to the same Sentry organization.
+Otherwise, it starts a new trace.
 This is useful if your application is a public API or receives requests from services outside your organization.
 
 ```javascript {5}

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nextjs.mdx
@@ -73,6 +73,8 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 
 ### Strict Trace Continuation
 
+_Available since SDK version 10_
+
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
 By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -10,7 +10,7 @@ Sentry.init({
 
 <Alert>
 
-Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports.
 
 For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
@@ -61,6 +61,37 @@ This configuration lets your app track user actions across:
 * Any local API endpoints in your app
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
+
+### Strict Trace Continuation
+
+When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
+By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+as it can lead to unwanted traces, increased billing, and skewed performance data.
+
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
+It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+This is useful if your application is a public API or receives requests from services outside your organization.
+
+```javascript {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  // Ensure that only traces from your own organization are continued
+  strictTraceContinuation: true,
+});
+```
+
+The SDK automatically parses the organization ID from your DSN. If you use a DSN format that doesn't include the organization ID (number followed by the letter `"o"`), or if you need to override it, you can provide it manually using the `orgId` option:
+
+```javascript {6}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  strictTraceContinuation: true,
+  // Manually provide your organization ID (overrides organization ID parsed from DSN)
+  orgId: 12345,
+});
+```
 
 ### Disabling Distributed Tracing
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -67,11 +67,11 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 _Available since SDK version 10_
 
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
-By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+By default, the SDK will continue the trace from these incoming headers. However, this behavior can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.
 
-To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
-It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information and only continues the trace if it belongs to the same Sentry organization.
+Otherwise, it starts a new trace.
 This is useful if your application is a public API or receives requests from services outside your organization.
 
 ```javascript {5}

--- a/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.node.mdx
@@ -64,6 +64,8 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 
 ### Strict Trace Continuation
 
+_Available since SDK version 10_
+
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
 By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -66,11 +66,11 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 _Available since SDK version 10_
 
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
-By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+By default, the SDK will continue the trace from these incoming headers. However, this behavior can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.
 
-To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
-It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information and only continues the trace if it belongs to the same Sentry organization.
+Otherwise, it starts a new trace.
 This is useful if your application is a public API or receives requests from services outside your organization.
 
 ```javascript {5}

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -63,6 +63,8 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 
 ### Strict Trace Continuation
 
+_Available since SDK version 10_
+
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
 By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.nuxt.mdx
@@ -1,10 +1,10 @@
-If you're using the current version of our Nuxt SDK, distributed tracing will work out of the box for the client and server runtimes. 
+If you're using the current version of our Nuxt SDK, distributed tracing will work out of the box for the client and server runtimes.
 
 To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues, you should define `tracePropagationTargets` for client-side.
 
 <Alert>
 
-Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports.
 
 For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
@@ -60,3 +60,34 @@ This configuration lets your app track user actions across:
 * Any local API endpoints in your app
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
+
+### Strict Trace Continuation
+
+When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
+By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+as it can lead to unwanted traces, increased billing, and skewed performance data.
+
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
+It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+This is useful if your application is a public API or receives requests from services outside your organization.
+
+```javascript {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  // Ensure that only traces from your own organization are continued
+  strictTraceContinuation: true,
+});
+```
+
+The SDK automatically parses the organization ID from your DSN. If you use a DSN format that doesn't include the organization ID (number followed by the letter `"o"`), or if you need to override it, you can provide it manually using the `orgId` option:
+
+```javascript {6}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  strictTraceContinuation: true,
+  // Manually provide your organization ID (overrides organization ID parsed from DSN)
+  orgId: 12345,
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -105,11 +105,11 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 _Available since SDK version 10_
 
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
-By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+By default, the SDK will continue the trace from these incoming headers. However, this behavior can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.
 
-To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
-It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information and only continues the trace if it belongs to the same Sentry organization.
+Otherwise, it starts a new trace.
 This is useful if your application is a public API or receives requests from services outside your organization.
 
 ```javascript {5}

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -35,7 +35,7 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 <Alert>
 
-Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports.
 
 For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
@@ -99,6 +99,37 @@ This configuration lets your app track user actions across:
 * Any local API endpoints in your app
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
+
+### Strict Trace Continuation
+
+When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
+By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+as it can lead to unwanted traces, increased billing, and skewed performance data.
+
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
+It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+This is useful if your application is a public API or receives requests from services outside your organization.
+
+```javascript {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  // Ensure that only traces from your own organization are continued
+  strictTraceContinuation: true,
+});
+```
+
+The SDK automatically parses the organization ID from your DSN. If you use a DSN format that doesn't include the organization ID (number followed by the letter `"o"`), or if you need to override it, you can provide it manually using the `orgId` option:
+
+```javascript {6}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  strictTraceContinuation: true,
+  // Manually provide your organization ID (overrides organization ID parsed from DSN)
+  orgId: 12345,
+});
+```
 
 ### Disabling Distributed Tracing
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.remix.mdx
@@ -102,6 +102,8 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 
 ### Strict Trace Continuation
 
+_Available since SDK version 10_
+
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
 By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -29,7 +29,7 @@ To get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/W
 
 <Alert>
 
-Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports.
 
 For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
@@ -93,3 +93,34 @@ This configuration lets your app track user actions across:
 * Any local API endpoints in your app
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
+
+### Strict Trace Continuation
+
+When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
+By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+as it can lead to unwanted traces, increased billing, and skewed performance data.
+
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
+It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+This is useful if your application is a public API or receives requests from services outside your organization.
+
+```javascript {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  // Ensure that only traces from your own organization are continued
+  strictTraceContinuation: true,
+});
+```
+
+The SDK automatically parses the organization ID from your DSN. If you use a DSN format that doesn't include the organization ID (number followed by the letter `"o"`), or if you need to override it, you can provide it manually using the `orgId` option:
+
+```javascript {6}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  strictTraceContinuation: true,
+  // Manually provide your organization ID (overrides organization ID parsed from DSN)
+  orgId: 12345,
+});
+```

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -99,11 +99,11 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 _Available since SDK version 10_
 
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
-By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+By default, the SDK will continue the trace from these incoming headers. However, this behavior can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.
 
-To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
-It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information and only continues the trace if it belongs to the same Sentry organization.
+Otherwise, it starts a new trace.
 This is useful if your application is a public API or receives requests from services outside your organization.
 
 ```javascript {5}

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -96,6 +96,8 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 
 ### Strict Trace Continuation
 
+_Available since SDK version 10_
+
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
 By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -1,10 +1,10 @@
-If you're using the current version of our SvelteKit SDK, distributed tracing will work out of the box for the client and server runtimes. 
+If you're using the current version of our SvelteKit SDK, distributed tracing will work out of the box for the client and server runtimes.
 
 When you are interacting with other external API systems, you might have to define `tracePropagationTargets` to get around possible [Browser CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues.
 
 <Alert>
 
-Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports. 
+Note: port numbers are relevant for trace propagation and the origin. You may need to configure the `tracePropagationTargets` to ensure that traces are propagated across your services if they run on different ports.
 
 For example, if you have a Node.js backend running locally on port 3000, that destination (`http://localhost:3000`) should be added to the `tracePropagationTargets` array on your frontend to ensure that CORS doesn't restrict the propagation of traces.
 
@@ -70,6 +70,37 @@ This configuration lets your app track user actions across:
 * Any local API endpoints in your app
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
+
+### Strict Trace Continuation
+
+When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
+By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+as it can lead to unwanted traces, increased billing, and skewed performance data.
+
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
+It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+This is useful if your application is a public API or receives requests from services outside your organization.
+
+```javascript {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  // Ensure that only traces from your own organization are continued
+  strictTraceContinuation: true,
+});
+```
+
+The SDK automatically parses the organization ID from your DSN. If you use a DSN format that doesn't include the organization ID (number followed by the letter `"o"`), or if you need to override it, you can provide it manually using the `orgId` option:
+
+```javascript {6}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  strictTraceContinuation: true,
+  // Manually provide your organization ID (overrides organization ID parsed from DSN)
+  orgId: 12345,
+});
+```
 
 ### Disabling Distributed Tracing
 

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -76,11 +76,11 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 _Available since SDK version 10_
 
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
-By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
+By default, the SDK will continue the trace from these incoming headers. However, this behavior can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.
 
-To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information.
-It only continues the trace if it belongs to the same Sentry organization. Otherwise, it starts a new trace.
+To prevent this, you can enable `strictTraceContinuation`. When this option is set to `true`, the SDK checks the incoming request for Sentry trace information and only continues the trace if it belongs to the same Sentry organization.
+Otherwise, it starts a new trace.
 This is useful if your application is a public API or receives requests from services outside your organization.
 
 ```javascript {5}

--- a/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.sveltekit.mdx
@@ -73,6 +73,8 @@ If your app crashes while a user is uploading a photo, you can trace exactly whe
 
 ### Strict Trace Continuation
 
+_Available since SDK version 10_
+
 When your application receives requests, they might include `sentry-trace` and `baggage` headers from an upstream service that is also using Sentry.
 By default, the SDK will continue the trace from the incoming headers. This can be undesirable if the requests are from a third-party service,
 as it can lead to unwanted traces, increased billing, and skewed performance data.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Docs for `strictTraceContinuation` and `orgId` ([related PR](https://github.com/getsentry/sentry-javascript/pull/16313)). 

I'm not 100% sure where I should put the `orgId` as it does not 100% fit into the "Tracing Options" section but it's currently only used for tracing.

closes https://github.com/getsentry/sentry-javascript/issues/16308

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

