### PR TITLE
fix(compose-multiplatform): remove unnecessary header

### DIFF
--- a/docs/platforms/kotlin/guides/compose-multiplatform/index.mdx
+++ b/docs/platforms/kotlin/guides/compose-multiplatform/index.mdx
@@ -8,8 +8,6 @@ categories:
 sidebar_order: 15
 ---
 
-# Compose Multiplatform
-
 <Alert level="warning" title="Experimental Support">
 While Sentry's Kotlin Multiplatform SDK works in Compose Multiplatform (CMP) projects, it isn't natively supported or fully tested for CMP. Some features may behave unexpectedly or provide incomplete data. Use with caution in production environments and report any issues you encounter.
 </Alert>


### PR DESCRIPTION
`# Compose Multiplatform` is unnecessary since the page already displays a header by default