### PR TITLE
Update Unreal Engine SDK installation methods page

### DIFF
--- a/docs/platforms/unreal/install/index.mdx
+++ b/docs/platforms/unreal/install/index.mdx
@@ -15,24 +15,19 @@ While you can use any of the three methods to install Sentry, each has its own l
 
 The table below highlights some key differences between different versions of the SDK:
 
-| Feature                    | __GitHub Releases__* | Fab                 | Build Yourself |
-|----------------------------|----------------------|---------------------|----------------|
-| Supported engine versions  | 4.27 and newer       | 5.1 and newer       | 4.27 and newer |
-| Supported UE project types | C++ only             | Blueprint and C++   | C++ only       |
-| Backend (Windows)          | Crashpad             | Breakpad            | Crashpad       |
-| `on_crash` hook (Windows)  | Supported            | Not supported       | Supported      |
-| Sentry CLI **              | Included             | Manual download     | Included       |
-| Fast-fail crash capturing  | Supported            | Not supported       | Supported      |
+| Feature                      | __GitHub Releases__* | Fab                  | Build Yourself |
+|------------------------------|----------------------|----------------------|----------------|
+| Supported engine versions    | 4.27 and newer       | 5.4 and newer        | 4.27 and newer |
+| Supported UE project types   | C++ only             | Blueprint and C++    | C++ only       |
+| Cross-compiling for Linux ** | Supported            | Manual configuration | Supported      |
 
 Legend:
 `*`: Recommended version of the SDK
-`**`: Sentry CLI is a standalone tool that the plugin uses under the hood to automatically upload debug information files upon game build completion.
+`**`: To support cross-compilation for Linux on Windows, the Fab version of the SDK includes an editor utility that pre-builds the binaries required by UAT.
 
 ## Installing from GitHub Releases (Recommended)
 
-The [GitHub Releases page](https://github.com/getsentry/sentry-unreal/releases) provides two plugin packages: `github` and `marketplace`. The key difference between the two is the crash capturing backend, which is used under the hood on Windows.
-
-We recommend using the `github` version, because it uses `Crashpad`, an out-of-proc handler that sends the crash report right away. The `marketplace` version relies on `Breakpad`, an in-proc handler which requires the UE application or game to be relaunched before any crash reports can be sent to Sentry.
+The [GitHub Releases page](https://github.com/getsentry/sentry-unreal/releases) provides plugin packages for all supported engine versions.
 
 To install the SDK, download the most up-to-date sources from the [Releases page](https://github.com/getsentry/sentry-unreal/releases) and add them to your project's `Plugins` directory. On the next project launch, UE will prompt you to build the Sentry and SentryEditor modules.
 
@@ -44,7 +39,7 @@ Currently, this method is available only for C++ UE projects. Blueprint projects
 
 <Alert>
 
-To avoid warnings during the build for licensee versions of Unreal Engine, the `EngineVersion` key is not set in the `Sentry.uplugin` for the `github` package.
+To avoid warnings during the build for licensee versions of Unreal Engine remove the `EngineVersion` key from the `Sentry.uplugin` file.
 
 </Alert>
 


### PR DESCRIPTION
This PR updates Unreal SDK installation methods page after the support of two separate package versions for GitHub and FAB was removed in https://github.com/getsentry/sentry-unreal/pull/1030.

Related to https://github.com/getsentry/team-gdx/issues/13