### PR TITLE
fix(otlp): OTLP docs small improvements

### DIFF
--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -39,10 +39,6 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-<Alert>
-If you are already using an OpenTelemetry SDK to send traces alongside a Sentry SDK to send errors, you'll need to follow the instructions in the <PlatformLink to="/opentelemetry/custom-setup/">Custom Setup documentation</PlatformLink> to adjust your SDK configuration.
-</Alert>
-
 You can find the values of Sentry's OTLP endpoint and public key in your Sentry project settings.
 
 1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -5,7 +5,7 @@ description: "Learn how to send OpenTelemetry trace data directly to Sentry from
 keywords: ["otlp", "otel", "opentelemetry"]
 ---
 
-<Include name="feature-available-for-user-group-limited-avail.mdx" />
+<Include name="feature-available-alpha-otlp.mdx" />
 
 Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces directly via the  [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/). If you have an existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly. Sentry's OTLP ingestion endpoint is currently in development, and has a few known limitations:
 

--- a/includes/feature-available-alpha-otlp.mdx
+++ b/includes/feature-available-alpha-otlp.mdx
@@ -1,0 +1,5 @@
+<Alert>
+
+This feature is in beta and is only available if your organization is participating in its limited release. Please reach out to [feedback-tracing@sentry.io](mailto:feedback-tracing@sentry.io) if you want access. Features in beta are still in-progress and may have bugs. We recognize the irony.
+
+</Alert>


### PR DESCRIPTION
- **Add enrollment information** so people know who to contact to try OTLP
- **Remove platform link**, since it was broken for almost everyone: it's platform content that only exists in JavaScript, so linking there from a general concepts document didn't work well
