### PR TITLE
feat(sdk): enable logs in docs

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -7,6 +7,9 @@ Sentry.init({
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,
 
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
@@ -30,6 +33,7 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       linkPreviousTrace: 'session-storage',
     }),
+    Sentry.consoleLoggingIntegration(),
   ],
 });
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -5,9 +5,11 @@ export function register() {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       tracesSampleRate: 1,
+      enableLogs: true,
       debug: false,
       environment: process.env.NODE_ENV === 'development' ? 'development' : undefined,
       spotlight: process.env.NODE_ENV === 'development',
+      integrations: [Sentry.consoleLoggingIntegration()],
     });
   }
 
@@ -15,8 +17,10 @@ export function register() {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       tracesSampleRate: 1,
+      enableLogs: true,
       debug: false,
       environment: process.env.NODE_ENV === 'development' ? 'development' : undefined,
+      integrations: [Sentry.consoleLoggingIntegration()],
       // temporary change for investigating edge middleware tx names
       beforeSendTransaction(event) {
         if (


### PR DESCRIPTION
Realized we never dogfooded logs in docs, let's give it a try.