### PR TITLE
Add `new_trace` to Python migration guide

### DIFF
--- a/docs/platforms/python/migration/2.x-to-3.x.mdx
+++ b/docs/platforms/python/migration/2.x-to-3.x.mdx
@@ -90,7 +90,7 @@ with sentry_sdk.start_span(name="parent"):
             # The first span started in this context manager will become
             # a new transaction (root span) with its own trace
             with sentry_sdk.start_span(name="new-parent"):
-                with sentry_sdk.start_span("name="child-of-new-parent"):
+                with sentry_sdk.start_span(name="child-of-new-parent"):
                     ...
 ```
 

--- a/docs/platforms/python/migration/2.x-to-3.x.mdx
+++ b/docs/platforms/python/migration/2.x-to-3.x.mdx
@@ -86,7 +86,7 @@ If you start a span, it will automatically become the child of the currently act
 ```python
 with sentry_sdk.start_span(name="parent"):
     with sentry_sdk.start_span(name="child-of-parent"):    
-        with new_trace():
+        with sentry_sdk.new_trace():
             # The first span started in this context manager will become
             # a new transaction (root span) with its own trace
             with sentry_sdk.start_span(name="new-parent"):

--- a/docs/platforms/python/migration/2.x-to-3.x.mdx
+++ b/docs/platforms/python/migration/2.x-to-3.x.mdx
@@ -71,7 +71,7 @@ The `profiles_sample_rate` and `profiler_mode` options previously nested under `
 
 Using `sentry_sdk.add_attachment()` directly also makes sure the attachment is added to the correct scope internally.
 
-### Custom Tracing API
+### Tracing
 
 Tracing in the Sentry Python SDK `3.x` is powered by [OpenTelemetry](https://opentelemetry.io/) in the background, which also means we're moving away from the Sentry-specific concept of transactions and towards a span-only future. `sentry_sdk.start_transaction()` is now deprecated in favor of `sentry_sdk.start_span()`.
 
@@ -79,6 +79,19 @@ Tracing in the Sentry Python SDK `3.x` is powered by [OpenTelemetry](https://ope
 - with sentry_sdk.start_transaction():
 + with sentry_sdk.start_span():
       ...
+```
+
+If you start a span, it will automatically become the child of the currently active span. If you want to create a span that should instead start its own trace, use the `new_trace()` context manager.
+
+```python
+with sentry_sdk.start_span(name="parent"):
+    with sentry_sdk.start_span(name="child-of-parent"):    
+        with new_trace():
+            # The first span started in this context manager will become
+            # a new transaction (root span) with its own trace
+            with sentry_sdk.start_span(name="new-parent"):
+                with sentry_sdk.start_span("name="child-of-new-parent"):
+                    ...
 ```
 
 Any spans without a parent span will become transactions by default. If you want to avoid promoting a span without a parent to a transaction, you can pass the `only_if_parent=True` keyword argument to `sentry_sdk.start_span()`.


### PR DESCRIPTION
We're [adding new API](https://github.com/getsentry/sentry-python/pull/4642) in 3.x, documenting it in the migration guide.

**Direct link to preview:** https://sentry-docs-git-ivana-pythonnew-trace.sentry.dev/platforms/python/migration/2.x-to-3.x#tracing

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
