### PR TITLE
Update index.mdx

### DIFF
--- a/docs/pricing/index.mdx
+++ b/docs/pricing/index.mdx
@@ -89,7 +89,7 @@ Tracing is enabled by and will be billed for in spans.
 
 Profile Hours are determined by the length of the profile in milliseconds and are billed in hours. Partial hours are prorated and rounded down to the nearest cent. Profile Hours can only be purchased with your PAYG budget.
 <Alert>
-  [Transaction-Based profiling](/product/explore/profiling/transaction-vs-continuous-profiling/) is billed under Continuous Profile Hours, by extracting the duration from the samples that make up the profile.
+  [Transaction-Based profiling](/product/explore/profiling/transaction-vs-continuous-profiling/) is billed under either UI or Continuous Profile Hours, by extracting the duration from the samples that make up the profile.
 </Alert>
 **Continuous Profile Hours**
 


### PR DESCRIPTION
Clarification on how transaction-based profiles are billed. Transaction-based profiles will be automatically converted to either UI or Continuous profile hours after ingestion depending on the SDK used. This is also pointed out in our help desk article [here](https://sentry.zendesk.com/hc/en-us/articles/36061384317339-Why-do-I-suddenly-see-UI-Continuous-profiling-hours).