### PR TITLE
Update javascript sourcemaps documentation

### DIFF
--- a/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
@@ -1,21 +1,17 @@
-Setting up source maps can be tricky, but it's worth it to get it right. To troubleshoot your source maps set up, you can either:
+Setting up source maps can be tricky, but it's worth it to get it right. To troubleshoot your source maps setup, you can use our built-in sourcemaps debugger modal directly in the Sentry product, or follow the manual steps listed below.
 
-1. Use our automated verification tool inside `sentry-cli`, or
-2. Follow the manual steps listed below
+## Use the Sourcemaps Debugger Modal
 
-## Use the Sentry CLI
+Sentry provides a built-in sourcemaps debugger modal that you can access directly from the **Issue Details** page. This tool helps you understand why your source maps might not be working correctly.
 
-To use the automated verification process, install and configure the Sentry [Command Line Interface](/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
+To use the debugger modal:
 
-For example, "Event ID: c2ad049f":
+1. Navigate to an issue in your Sentry project
+2. Click on the **Issue Details** page
+3. Look for the sourcemaps debugger option in the interface
+4. The debugger will analyze your source maps and provide detailed information about any issues
 
-![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)
-
-```shell
-sentry-cli sourcemaps explain c2ad049fd9e448ada7849df94575e019
-```
-
-The CLI output should give you useful information about what went wrong with your source maps setup.
+This is the recommended approach for troubleshooting source maps issues as it provides real-time analysis and doesn't require any CLI tools.
 
 <PlatformSection notSupported={["javascript.electron"]}>
 

--- a/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -269,30 +269,20 @@ Sentry.init({
 
 If you followed all of the steps above but still have issues setting up source maps using the legacy method this section will try to help troubleshoot your setup.
 
-To troubleshoot your source maps set up, you can either:
+To troubleshoot your source maps setup, you can use our built-in sourcemaps debugger modal directly in the Sentry product, or follow the manual steps listed below.
 
-1. Use our automated verification tool inside `sentry-cli`, or
-2. Follow the manual steps listed below
+### Use the Sourcemaps Debugger Modal
 
-### Use the Sentry CLI
+Sentry provides a built-in sourcemaps debugger modal that you can access directly from the **Issue Details** page. This tool helps you understand why your source maps might not be working correctly.
 
-To use the automated verification process, install and configure the Sentry [Command Line Interface](/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
+To use the debugger modal:
 
-<Alert title="Note" level="warning">
+1. Navigate to an issue in your Sentry project
+2. Click on the **Issue Details** page
+3. Look for the sourcemaps debugger option in the interface
+4. The debugger will analyze your source maps and provide detailed information about any issues
 
-The `sourcemaps explain` command requires an auth token with the following scopes: `project:admin`, `release:admin`, `event:read`, and `organization:read`. We recommend creating an [internal integration token](/organization/integrations/integration-platform/internal-integration/) over a personal token.
-
-</Alert>
-
-For example, "Event ID: c2ad049f":
-
-![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)
-
-```shell
-sentry-cli sourcemaps explain c2ad049fd9e448ada7849df94575e019
-```
-
-The CLI output should give you useful information about what went wrong with your source maps setup.
+This is the recommended approach for troubleshooting source maps issues as it provides real-time analysis and doesn't require any CLI tools.
 
 <PlatformSection notSupported={["javascript.electron"]}>
 

--- a/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -30,25 +30,20 @@ Dependency versions that require the legacy method of uploading source maps incl
 
 </Alert>
 
-Setting up source maps can be tricky, but it's worth it to get it right. To troubleshoot your source maps set up, you can either:
+Setting up source maps can be tricky, but it's worth it to get it right. To troubleshoot your source maps setup, you can use our built-in sourcemaps debugger modal directly in the Sentry product, or follow the manual steps listed below.
 
-1. Use our automated verification tool inside `sentry-cli`, or
-2. Follow the manual steps listed below
+## Use the Sourcemaps Debugger Modal
 
-## Use the CLI
+Sentry provides a built-in sourcemaps debugger modal that you can access directly from the **Issue Details** page. This tool helps you understand why your source maps might not be working correctly.
 
-To use the automated verification process, install and configure the Sentry [Command Line Interface](/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
+To use the debugger modal:
 
-For example, "Event ID: c2ad049f":
+1. Navigate to an issue in your Sentry project
+2. Click on the **Issue Details** page
+3. Look for the sourcemaps debugger option in the interface
+4. The debugger will analyze your source maps and provide detailed information about any issues
 
-![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)
-
-```shell
-sentry-cli sourcemaps explain c2ad049fd9e448ada7849df94575e019
-```
-
-The CLI output should give you useful information about what went wrong with your source maps setup.
-If it doesn't, let us know by filing an issue on our [Sentry CLI repo](https://github.com/getsentry/sentry-cli) so we can make it better.
+This is the recommended approach for troubleshooting source maps issues as it provides real-time analysis and doesn't require any CLI tools.
 
 ## Follow Manual Steps
 


### PR DESCRIPTION
<pr_request_template><!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This PR updates the JavaScript sourcemaps troubleshooting documentation to remove references to the deprecated `sentry-cli sourcemaps explain` command. Instead, it guides users to the new, in-product sourcemaps debugger modal for troubleshooting.

The changes affect:
*   `platform-includes/sourcemaps/troubleshooting/javascript.mdx`
*   `platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx`
*   `platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx`

Associated unused image files (`event_id.png`) have also been removed from these directories.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-a5e81657-bf58-4c7f-9e80-1281da5ab9a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5e81657-bf58-4c7f-9e80-1281da5ab9a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>