### PR TITLE
feat(develop): Update Response Context

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -793,7 +793,7 @@ Page context contains information about the page that the event occurred on.
 
 ## Response Context
 
-Response context contains information about the HTTP response related to the event.
+Response context contains information about the HTTP response associated with the event.
 
 This is mostly set on transactions in a web server environment where one transaction represents a HTTP request/response cycle.
 

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -801,13 +801,13 @@ This is mostly set on transactions in a web server environment where one transac
 
 : _Optional_. The cookie values. Can be passed, unparsed, as a string, as a dictionary, or as a list of tuples.
 
-- Example: `["PHPSESSID=12345; csrftoken=1234567"]`
+- Example: `{ "PHPSESSID": "12345", "csrftoken": "1234567" }`
 
 `headers`
 
 : _Optional_. A dictionary of submitted headers. If a header appears multiple times it, needs to be merged according to the HTTP standard for header merging. Sentry treats header names as case-insensitive.
 
-- Example: `[["Content-Type", "text/plain"]]`
+- Example: `{ "Content-Type": "text/plain" }`
 
 `status_code`
 

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -805,7 +805,7 @@ This is mostly set on transactions in a web server environment where one transac
 
 `headers`
 
-: _Optional_. A dictionary of submitted headers. If a header appears multiple times it, needs to be merged according to the HTTP standard for header merging. Header names are treated case-insensitively by Sentry.
+: _Optional_. A dictionary of submitted headers. If a header appears multiple times it, needs to be merged according to the HTTP standard for header merging. Sentry treats header names as case-insensitive.
 
 - Example: `[["Content-Type", "text/plain"]]`
 

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -793,11 +793,21 @@ Page context contains information about the page that the event occurred on.
 
 ## Response Context
 
-Response context contains information about the HTTP response associated with the event.
-
-The only and required field is `status_code`.
+Response context contains information about the HTTP response related to the event.
 
 This is mostly set on transactions in a web server environment where one transaction represents a HTTP request/response cycle.
+
+`cookies`
+
+: _Optional_. The cookie values. Can be given unparsed as string, as dictionary, or as a list of tuples.
+
+- Example: `["PHPSESSID=12345; csrftoken=1234567"]`
+
+`headers`
+
+: _Optional_. A dictionary of submitted headers. If a header appears multiple times it, needs to be merged according to the HTTP standard for header merging. Header names are treated case-insensitively by Sentry.
+
+- Example: `[["Content-Type", "text/plain"]]`
 
 `status_code`
 
@@ -805,13 +815,34 @@ This is mostly set on transactions in a web server environment where one transac
 
 - Example: `200`
 
+`body_size`
+
+: _Optional_. HTTP response body size in bytes.
+
+- Example: `1000`
+
+`data`
+
+: _Optional_. Response data in any format that makes sense. SDKs should discard large and binary bodies by default. Can be given as a string or structural data of any format.
+
+- Example: `"Invalid request"`
+
 **Example Response Context**
 
 ```json
 {
   "contexts": {
     "response": {
-      "status_code": 404
+      "cookies": {
+        "PHPSESSID": "12345",
+        "csrftoken": "1234567"
+      },
+      "headers": {
+        "Content-Type": "text/plain"
+      },
+      "status_code": 500,
+      "body_size": 1000,
+      "data": "Invalid request"
     }
   }
 }

--- a/develop-docs/sdk/data-model/event-payloads/contexts.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/contexts.mdx
@@ -799,7 +799,7 @@ This is mostly set on transactions in a web server environment where one transac
 
 `cookies`
 
-: _Optional_. The cookie values. Can be given unparsed as string, as dictionary, or as a list of tuples.
+: _Optional_. The cookie values. Can be passed, unparsed, as a string, as a dictionary, or as a list of tuples.
 
 - Example: `["PHPSESSID=12345; csrftoken=1234567"]`
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Document the Response Context for events, including all fields, according to the implementation in [Relay](https://github.com/getsentry/relay/blob/1bdc463896fb6f1425fac10915fa49799ecc5d85/relay-event-schema/src/protocol/contexts/response.rs#L11). Note that we don't include `inferred_content_type` because that's always overridden by Relay anyways.
