### PR TITLE
feat: Add naming requirements to the environment doc

### DIFF
--- a/docs/concepts/key-terms/environments/index.mdx
+++ b/docs/concepts/key-terms/environments/index.mdx
@@ -16,7 +16,17 @@ Environments are unique to each organization. Environment settings, however, are
 
 ## Creating Environments
 
-Sentry automatically creates environments when it receives an [event](/api/events/) with the environment tag. Environments are case-sensitive. You can also create an environment when you first `init` your SDK, [as documented for each SDK](/platform-redirect/?next=/configuration/environments/).
+Sentry automatically creates environments when it receives an [event](/api/events/) with the environment tag. You can also create an environment when you first `init` your SDK, [as documented for each SDK](/platform-redirect/?next=/configuration/environments/).
+
+### Environment Naming Requirements
+
+When creating environments, be aware of the following requirements:
+
+- Environment names are **case-sensitive**
+- Names cannot contain **newlines, spaces, or forward slashes**
+- Names cannot be the string **"None"**
+- Names cannot exceed **64 characters**
+- You **cannot delete** environments, but you can [hide them](#hidden-environments)
 
 ## Filtering Environments
 


### PR DESCRIPTION
Currently, some platforms include this information in their docs while others don't, making it difficult to provide a platform specific link in our app. Given that we already have a dedicated document covering environments and that this document can be used by any platform, we can just add a section describing the naming requirements. 

**Preview**
<img width="864" height="404" alt="image" src="https://github.com/user-attachments/assets/53109055-663e-48ab-943b-6c38ca1f9c90" />


Contributes to https://linear.app/getsentry/issue/TET-975/link-releaseandenv-processing-errors-to-docs