### PR TITLE
fix(python): Update default of `max_value_length`

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -172,14 +172,11 @@ Please note that the Sentry server [limits HTTP request body size](https://devel
 
 </SdkOption>
 
-<SdkOption name="max_value_length" type='int' defaultValue='1024'>
+<SdkOption name="max_value_length" type='int' defaultValue='100 000'>
 
 The number of characters after which the values containing text in the event payload will be truncated.
 
-<Alert level='warning'>
-  If the value you set for this is exceptionally large, the event may exceed 1
-  MiB and will be dropped by Sentry.
-</Alert>
+In SDK versions prior to 2.34.0, the default was 1024.
 
 </SdkOption>
 


### PR DESCRIPTION
We raised the default in https://github.com/getsentry/sentry-python/releases/tag/2.34.0, updating here.

**Direct link to preview:** https://sentry-docs-git-ivana-pythonupdate-max-value-length.sentry.dev/platforms/python/configuration/options/#max_value_length

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: ASAP (SDK with this is already out)
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
