### PR TITLE
fix(native): update `sentry_value_t` example with 64-bit integer types

### DIFF
--- a/platform-includes/capture-message/native.mdx
+++ b/platform-includes/capture-message/native.mdx
@@ -21,6 +21,7 @@ To create and capture a manual event, follow these steps:
 3. Send the event to Sentry by invoking `sentry_capture_event`.
 
 In a more complex example, it looks like this:
+
 ```c
 sentry_value_t event = sentry_value_new_event();
 sentry_value_set_by_key(event, "message", sentry_value_new_string("Hello!"));

--- a/platform-includes/capture-message/native.mdx
+++ b/platform-includes/capture-message/native.mdx
@@ -20,15 +20,7 @@ To create and capture a manual event, follow these steps:
 2. Add custom attributes to the event, like a `message` or an `exception`.
 3. Send the event to Sentry by invoking `sentry_capture_event`.
 
-The custom attribute data must be of type `sentry_value_t`, which can store:
-* 32-bit signed integers,
-* 64-bit signed and unsigned integers,
-* double-precision floating-points,
-* null-terminated strings, as well as
-* lists and string-keyed maps containing `sentry_value_t` entries
-
 In a more complex example, it looks like this:
-
 ```c
 sentry_value_t event = sentry_value_new_event();
 sentry_value_set_by_key(event, "message", sentry_value_new_string("Hello!"));
@@ -36,15 +28,9 @@ sentry_value_set_by_key(event, "message", sentry_value_new_string("Hello!"));
 sentry_value_t screen = sentry_value_new_object();
 sentry_value_set_by_key(screen, "width", sentry_value_new_int32(1920));
 sentry_value_set_by_key(screen, "height", sentry_value_new_int32(1080));
-sentry_value_set_by_key(screen, "refresh_rate", sentry_value_new_double(29.97));
-
-sentry_value_t processed_files = sentry_value_new_list();
-sentry_value_append(processed_files, sentry_value_new_uint64(1073741824ULL));
-sentry_value_append(processed_files, sentry_value_new_uint64(2147483648ULL));
 
 sentry_value_t contexts = sentry_value_new_object();
 sentry_value_set_by_key(contexts, "screen_size", screen);
-sentry_value_set_by_key(contexts, "processed_files", processed_files);
 
 sentry_value_set_by_key(event, "contexts", contexts);
 sentry_capture_event(event);

--- a/platform-includes/capture-message/native.mdx
+++ b/platform-includes/capture-message/native.mdx
@@ -20,6 +20,13 @@ To create and capture a manual event, follow these steps:
 2. Add custom attributes to the event, like a `message` or an `exception`.
 3. Send the event to Sentry by invoking `sentry_capture_event`.
 
+The custom attribute data must be of type `sentry_value_t`, which can store:
+* 32-bit signed integers,
+* 64-bit signed and unsigned integers,
+* double-precision floating-points,
+* null-terminated strings, as well as
+* lists and string-keyed maps containing `sentry_value_t` entries
+
 In a more complex example, it looks like this:
 
 ```c
@@ -29,9 +36,15 @@ sentry_value_set_by_key(event, "message", sentry_value_new_string("Hello!"));
 sentry_value_t screen = sentry_value_new_object();
 sentry_value_set_by_key(screen, "width", sentry_value_new_int32(1920));
 sentry_value_set_by_key(screen, "height", sentry_value_new_int32(1080));
+sentry_value_set_by_key(screen, "refresh_rate", sentry_value_new_double(29.97));
+
+sentry_value_t processed_files = sentry_value_new_list();
+sentry_value_append(processed_files, sentry_value_new_uint64(1073741824ULL));
+sentry_value_append(processed_files, sentry_value_new_uint64(2147483648ULL));
 
 sentry_value_t contexts = sentry_value_new_object();
 sentry_value_set_by_key(contexts, "screen_size", screen);
+sentry_value_set_by_key(contexts, "processed_files", processed_files);
 
 sentry_value_set_by_key(event, "contexts", contexts);
 sentry_capture_event(event);

--- a/platform-includes/enriching-events/set-context/native.mdx
+++ b/platform-includes/enriching-events/set-context/native.mdx
@@ -4,6 +4,14 @@
 sentry_value_t character = sentry_value_new_object();
 sentry_value_set_by_key(character, "name", sentry_value_new_string("Mighty Fighter"));
 sentry_value_set_by_key(character, "age", sentry_value_new_int32(19));
-sentry_value_set_by_key(character, "attack_type", sentry_value_new_string("melee"));
+sentry_value_set_by_key(character, "height", sentry_value_new_double(184.6));
+sentry_value_set_by_key(character, "is_alive", sentry_value_new_bool(true));
+sentry_value_set_by_key(character, "exp", sentry_value_new_uint64(6442450941));
+
+sentry_value_t inventory = sentry_value_new_list();
+sentry_value_append(inventory, sentry_value_new_string("sword"));
+sentry_value_append(inventory, sentry_value_new_string("shield"));
+sentry_value_set_by_key(character, "inventory", inventory);
+
 sentry_set_context("character", character);
 ```

--- a/platform-includes/performance/improving-data/native.mdx
+++ b/platform-includes/performance/improving-data/native.mdx
@@ -2,7 +2,8 @@
 You can add Data Attributes to both Spans and Transactions. This data is visible in the trace explorer in Sentry.
 The data must be of type `sentry_value_t`, which can store:
 * 32-bit signed integers,
-* 64-bit signed and unsigned integers,
+* 64-bit signed integers,
+* 64-bit unsigned integers (due to a current limitation in processing, these will be converted to strings before sending),
 * double-precision floating-points,
 * null-terminated strings, as well as
 * lists and string-keyed maps containing `sentry_value_t` entries

--- a/platform-includes/performance/improving-data/native.mdx
+++ b/platform-includes/performance/improving-data/native.mdx
@@ -2,9 +2,16 @@
 You can add Data Attributes to both Spans and Transactions. This data is visible in the trace explorer in Sentry.
 The data must be of type `sentry_value_t`, which can store:
 * 32-bit signed integers,
+* 64-bit signed and unsigned integers,
 * double-precision floating-points,
 * null-terminated strings, as well as
 * lists and string-keyed maps containing `sentry_value_t` entries
+
+<Alert level="warning">
+
+Currently, 64-bit unsigned integers are sent as strings, since they can't be processed as numerical values yet.
+
+</Alert>
 
 ### Adding Data Attributes to Transactions
 
@@ -21,25 +28,33 @@ sentry_transaction_set_data(tx, "my-data-attribute-1",
 sentry_transaction_set_data(tx, "my-data-attribute-2",
     sentry_value_new_int32(42));
 sentry_transaction_set_data(tx, "my-data-attribute-3",
-    sentry_value_new_double(3.14));
+    sentry_value_new_int64(-9223372036854775808));
 sentry_transaction_set_data(tx, "my-data-attribute-4",
+    sentry_value_new_uint64(18446744073709551615));
+sentry_transaction_set_data(tx, "my-data-attribute-5",
+    sentry_value_new_double(3.14));
+sentry_transaction_set_data(tx, "my-data-attribute-6",
     sentry_value_new_bool(true));
 
 sentry_value_t value_list = sentry_value_new_list();
 sentry_value_append(value_list, sentry_value_new_string("value1"));
 sentry_value_append(value_list, sentry_value_new_int32(42));
+sentry_value_append(value_list, sentry_value_new_int64(-5123456789));
+sentry_value_append(value_list, sentry_value_new_uint64(18446744073709551615));
 sentry_value_append(value_list, sentry_value_new_double(3.14));
 sentry_value_append(value_list, sentry_value_new_bool(true));
 
-sentry_transaction_set_data(tx, "my-data-attribute-5", value_list);
+sentry_transaction_set_data(tx, "my-data-attribute-7", value_list);
 
 sentry_value_t value_object = sentry_value_new_object();
 sentry_value_set_by_key(value_object, "key_1", sentry_value_new_string("value1"));
 sentry_value_set_by_key(value_object, "key_2", sentry_value_new_int32(42));
-sentry_value_set_by_key(value_object, "key_3", sentry_value_new_double(3.14));
-sentry_value_set_by_key(value_object, "key_4", sentry_value_new_bool(true));
+sentry_value_set_by_key(value_object, "key_3", sentry_value_new_int64(-5123456789));
+sentry_value_set_by_key(value_object, "key_4", sentry_value_new_uint64(18446744073709551615));
+sentry_value_set_by_key(value_object, "key_5", sentry_value_new_double(3.14));
+sentry_value_set_by_key(value_object, "key_6", sentry_value_new_bool(true));
 
-sentry_transaction_set_data(tx, "my-data-attribute-6", value_object);
+sentry_transaction_set_data(tx, "my-data-attribute-8", value_object);
 ```
 
 ### Adding Data Attributes to Spans
@@ -59,23 +74,31 @@ sentry_span_set_data(span, "my-data-attribute-1",
 sentry_span_set_data(span, "my-data-attribute-2",
     sentry_value_new_int32(42));
 sentry_span_set_data(span, "my-data-attribute-3",
-    sentry_value_new_double(3.14));
+    sentry_value_new_int64(-9223372036854775808));
 sentry_span_set_data(span, "my-data-attribute-4",
+    sentry_value_new_uint64(18446744073709551615));
+sentry_span_set_data(span, "my-data-attribute-5",
+    sentry_value_new_double(3.14));
+sentry_span_set_data(span, "my-data-attribute-6",
     sentry_value_new_bool(true));
 
 sentry_value_t value_list = sentry_value_new_list();
 sentry_value_append(value_list, sentry_value_new_string("value1"));
 sentry_value_append(value_list, sentry_value_new_int32(42));
+sentry_value_append(value_list, sentry_value_new_int64(-5123456789));
+sentry_value_append(value_list, sentry_value_new_uint64(18446744073709551615));
 sentry_value_append(value_list, sentry_value_new_double(3.14));
 sentry_value_append(value_list, sentry_value_new_bool(true));
 
-sentry_span_set_data(span, "my-data-attribute-5", value_list);
+sentry_span_set_data(span, "my-data-attribute-7", value_list);
 
 sentry_value_t value_object = sentry_value_new_object();
 sentry_value_set_by_key(value_object, "key_1", sentry_value_new_string("value1"));
 sentry_value_set_by_key(value_object, "key_2", sentry_value_new_int32(42));
-sentry_value_set_by_key(value_object, "key_3", sentry_value_new_double(3.14));
-sentry_value_set_by_key(value_object, "key_4", sentry_value_new_bool(true));
+sentry_value_set_by_key(value_object, "key_3", sentry_value_new_int64(-5123456789));
+sentry_value_set_by_key(value_object, "key_4", sentry_value_new_uint64(18446744073709551615));
+sentry_value_set_by_key(value_object, "key_5", sentry_value_new_double(3.14));
+sentry_value_set_by_key(value_object, "key_6", sentry_value_new_bool(true));
 
-sentry_span_set_data(span, "my-data-attribute-6", value_object);
+sentry_span_set_data(span, "my-data-attribute-8", value_object);
 ```

--- a/platform-includes/performance/improving-data/native.mdx
+++ b/platform-includes/performance/improving-data/native.mdx
@@ -7,12 +7,6 @@ The data must be of type `sentry_value_t`, which can store:
 * null-terminated strings, as well as
 * lists and string-keyed maps containing `sentry_value_t` entries
 
-<Alert level="warning">
-
-Currently, 64-bit unsigned integers are sent as strings, since they can't be processed as numerical values yet.
-
-</Alert>
-
 ### Adding Data Attributes to Transactions
 
 You can add data attributes to your transactions using the following API:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Related to the changes in https://github.com/getsentry/sentry-native/pull/1326 , we update our docs where they explicitly mention the available `sentry_value_t` types.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
