### PR TITLE
feat(apple): Add PDF viewer to list of masked session replay views

### DIFF
--- a/docs/platforms/apple/guides/ios/session-replay/index.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/index.mdx
@@ -71,7 +71,7 @@ Sampling begins as soon as a session starts. `sessionSampleRate` is evaluated fi
 
 ## Privacy
 
-The SDK is recording and aggressively masking all text, images, pdf viewer, and webviews by default. If your app has any sensitive data, you should only turn the default masking off after explicitly masking out the sensitive data, using the APIs described below.
+The SDK is recording and aggressively masking all text, images, PDF viewers, and webviews by default. If your app has any sensitive data, you should only turn the default masking off after explicitly masking out the sensitive data, using the APIs described below.
 If you want to manually mask parts of your app's data, read our guide on [custom masking](/platforms/apple/guides/ios/session-replay/customredact).
 
 <Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

https://github.com/getsentry/sentry-cocoa/pull/5766 adds `PDFView` from the `PDFKit` as a default masked view like web views.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
