### PR TITLE
feat(python): Add `enable_logs`, `before_send_log` to 3.x migration guide

### DIFF
--- a/docs/platforms/python/migration/2.x-to-3.x.mdx
+++ b/docs/platforms/python/migration/2.x-to-3.x.mdx
@@ -57,6 +57,23 @@ The `profiles_sample_rate` and `profiler_mode` options previously nested under `
   )
 ```
 
+The `enable_logs` and `before_send_log` options previously nested under `_experiments` have been removed. They're replaced by top-level options of the same name:
+
+```python diff
+
+  def my_before_send_log(log, hint):
+      ...
+
+  sentry_sdk.init(
+-     _experiments={
+-         "enable_logs": True,
+-         "before_send_log": my_before_send_log,
+-     },
++     enable_logs=True,
++     before_send_log=my_before_send_log,
+  )
+```
+
 ## API Changes
 
 `add_attachment()` is now a part of the top-level level API and should be imported and used directly from `sentry_sdk`.


### PR DESCRIPTION
We'll be changing this in 3.0, adding to migration guide.

**Direct link to preview:** https://sentry-docs-git-ivana-pythonlogs-options-migration-guide.sentry.dev/platforms/python/migration/2.x-to-3.x#configuration

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
