### PR TITLE
feat(python): Replace experimental logs options with regular ones

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -245,7 +245,18 @@ The callback typically gets a second argument (called a "hint") which contains t
 
 </SdkOption>
 
+<SdkOption name="before_send_log" type='Optional[Callable[Log, Hint] -> Optional[Log]]' defaultValue='None'>
+
+A function that will be called for each log. It can be used to modify the log
+before it's sent to Sentry or to filter specific logs out altogether (if it returns
+`None`).
+
+New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
+
+</SdkOption>
+
 <PlatformContent includePath="/performance/traces-sampler-config-option" />
+
 
 ## Transport Options
 
@@ -422,16 +433,6 @@ Enables Sentry structured logs, allowing you to use the `sentry_sdk.logger` APIs
 to send logs to Sentry. This option being `True` is also the prerequisite for
 automatic capturing of logs from the standard library `logging` module or other
 logging integrations.
-
-New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
-
-</SdkOption>
-
-<SdkOption name="before_send_log" type='Optional[Callable[Log, Hint] -> Optional[Log]]' defaultValue='None'>
-
-A function that will be called for each log. It can be used to modify the log
-before it's sent to Sentry or to filter specific logs out altogether (if it returns
-`None`).
 
 New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
 

--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -176,7 +176,7 @@ Please note that the Sentry server [limits HTTP request body size](https://devel
 
 The number of characters after which the values containing text in the event payload will be truncated.
 
-In SDK versions prior to 2.34.0, the default was 1024.
+In SDK versions prior to `2.34.0`, the default was `1024`.
 
 </SdkOption>
 
@@ -410,5 +410,29 @@ In `trace` mode, the profiler starts and stops automatically based on active spa
 <SdkOption name="profile_session_sample_rate" type='float' defaultValue='None'>
 
 A number between `0` and `1`, controlling the percentage chance a given session will be profiled. The sampling decision is evaluated only once at SDK initialization.
+
+</SdkOption>
+
+
+## Logs Options
+
+<SdkOption name="enable_logs" type='bool' defaultValue='False'>
+
+Enables Sentry structured logs, allowing you to use the `sentry_sdk.logger` APIs
+to send logs to Sentry. This option being `True` is also the prerequisite for
+automatic capturing of logs from the standard library `logging` module or other
+logging integrations.
+
+New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
+
+</SdkOption>
+
+<SdkOption name="before_send_log" type='Optional[Callable[Log, Hint] -> Optional[Log]]' defaultValue='None'>
+
+A function that will be called for each log. It can be used to modify the log
+before it's sent to Sentry or to filter specific logs out altogether (if it returns
+`None`).
+
+New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
 
 </SdkOption>

--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -430,9 +430,7 @@ A number between `0` and `1`, controlling the percentage chance a given session 
 <SdkOption name="enable_logs" type='bool' defaultValue='False'>
 
 Enables Sentry structured logs, allowing you to use the `sentry_sdk.logger` APIs
-to send logs to Sentry. This option being `True` is also the prerequisite for
-automatic capturing of logs from the standard library `logging` module or other
-logging integrations.
+to send logs to Sentry. This option must be set to `True` to automatically capture logs from Python’s built-in logging module or other supported logging integrations.
 
 New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
 

--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -43,8 +43,6 @@ uv add "sentry-sdk"
 
 Configuration should happen as **early as possible** in your application's lifecycle.
 
-
-
 ```python
 import sentry_sdk
 
@@ -69,7 +67,7 @@ sentry_sdk.init(
     # ___PRODUCT_OPTION_START___ logs
 
     # Enable logs to be sent to Sentry
-    _experiments={"enable_logs": True},
+    enable_logs=True,
     # ___PRODUCT_OPTION_END___ logs
 )
 ```

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -54,7 +54,7 @@ main()
 - `"An exception happened"` will send the current exception from `sys.exc_info()` with the stack trace and everything to the Sentry Python SDK. If there's no exception, the current stack will be attached.
 - The debug message `"I am ignored"` will not surface anywhere. To capture it, you need to lower `level` to `DEBUG` (See below).
 
-Log records can additionally also be captured as [Sentry logs](/platforms/python/logs/) as long as the `enable_logs` experimental option is `True`.
+Log records can additionally also be captured as [Sentry logs](/platforms/python/logs/) as long as the `enable_logs` option is `True`.
 
 ```python
 import logging
@@ -62,9 +62,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     # ...
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 logging.info("I will be sent to Sentry logs")
@@ -102,12 +100,12 @@ You can pass the following keyword arguments to `LoggingIntegration()`:
 
 - `event_level` (default `ERROR`): The Sentry Python SDK will report log records with a level higher than or equal to `event_level` as events as long as the logger itself is set to output records of those log levels (see note below). If a value of `None` occurs, the SDK won't send log records as events.
 
-- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/) as long as the `enable_logs` experimental option is `True`.
+- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/) as long as the `enable_logs` option is `True`.
 
   ```python
   sentry_sdk.init(
       # ...
-      _experiments={"enable_logs": True},
+      enable_logs=True,
   )
   ```
 

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -68,7 +68,7 @@ logger.exception("An exception happened")
 - `"An exception happened"` will send the current exception from `sys.exc_info()` with the stack trace to Sentry. If there's no exception, the current stack will be attached.
 - The debug message `"I am ignored"` will not be captured by Sentry. To capture it, set `level` to `DEBUG` or lower in `LoguruIntegration`.
 
-Loguru log records can additionally also be captured as [Sentry logs](/platforms/python/logs/) as long as the `enable_logs` experimental option is `True`.
+Loguru log records can additionally also be captured as [Sentry logs](/platforms/python/logs/) as long as the `enable_logs` option is `True`.
 
 ```python
 import sentry_sdk
@@ -76,9 +76,7 @@ from loguru import logger
 
 sentry_sdk.init(
     # ...
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 logger.info("I will be sent to Sentry logs")
@@ -152,12 +150,12 @@ sentry_sdk.init(
 
   The Sentry Python SDK will capture log records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/). If set to `None`, the SDK won't send records as logs.
 
-  To capture Loguru log records as Sentry logs, you must enable the experimental `enable_logs` option when initializing the SDK (regardless of the `sentry_logs_level` setting).
+  To capture Loguru log records as Sentry logs, you must enable the `enable_logs` option when initializing the SDK (regardless of the `sentry_logs_level` setting).
 
   ```python
   sentry_sdk.init(
       # ...
-      _experiments={"enable_logs": True},
+      enable_logs=True,
   )
   ```
 

--- a/platform-includes/getting-started-config/python.mdx
+++ b/platform-includes/getting-started-config/python.mdx
@@ -30,9 +30,7 @@ sentry_sdk.init(
     # ___PRODUCT_OPTION_START___ logs
 
     # Enable logs to be sent to Sentry
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
     # ___PRODUCT_OPTION_END___ logs
 )
 ```

--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -8,9 +8,7 @@ import logging
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 # Your existing logging setup
@@ -31,9 +29,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True
-    },
+    enable_logs=True,
     integrations=[
         # Only send WARNING (and higher) logs to Sentry logs,
         # even if the logger is set to a lower level.
@@ -62,9 +58,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True
-    },
+    enable_logs=True,
     integrations=[
         LoggingIntegration(sentry_logs_level=None),  # Do not monkeypatch the sentry handler
     ],
@@ -84,9 +78,7 @@ from loguru import logger
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 loguru.debug("In this example, debug events will not be sent to Sentry logs.")
@@ -102,9 +94,7 @@ from sentry_sdk.integrations.loguru import LoggingLevels, LoguruIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True
-    },
+    enable_logs=True,
     integrations=[
         # Only send WARNING (and higher) logs to Sentry logs
         LoguruIntegration(sentry_logs_level=LoggingLevels.WARNING.value),
@@ -125,10 +115,8 @@ from sentry_sdk.integrations.loguru import LoguruIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        # In general, we want to capture logs as Sentry logs...
-        "enable_logs": True,
-    },
+    # In general, we want to capture logs as Sentry logs...
+    enable_logs=True,
     integrations=[
         # ...just not from Loguru
         LoguruIntegration(sentry_logs_level=None),

--- a/platform-includes/logs/options/python.mdx
+++ b/platform-includes/logs/options/python.mdx
@@ -1,6 +1,6 @@
 #### before_send_log
 
-To filter logs, or update them before they are sent to Sentry, you can use the `_experiments["before_send_log"]` option.
+To filter logs, or update them before they are sent to Sentry, you can use the `before_send_log` option.
 
 ```python
 import sentry_sdk
@@ -15,10 +15,8 @@ def before_log(log: Log, _hint: Hint) -> Optional[Log]:
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-        "before_send_log": before_log,
-    },
+    enable_logs=True,
+    before_send_log=before_log,
 )
 ```
 

--- a/platform-includes/logs/setup/python.mdx
+++ b/platform-includes/logs/setup/python.mdx
@@ -1,10 +1,8 @@
-To enable logging, you need to initialize the SDK with the `_experiments["enable_logs"]` option set to `True`.
+To enable logging, you need to initialize the SDK with the `enable_logs` option set to `True`.
 
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 ```


### PR DESCRIPTION
We'll be promoting the `enable_logs` and `before_send_log` options to regular SDK options. (We'll still keep the experimental counterparts until 3.0.)

Preparing this; merging will need to wait until the change has been released.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
