### PR TITLE
Update next.js title to Gavin

### DIFF
--- a/app/[[...path]]/layout.tsx
+++ b/app/[[...path]]/layout.tsx
@@ -5,7 +5,7 @@ import type {Metadata} from 'next';
 import {HotReload} from 'sentry-docs/components/hotReload';
 
 export const metadata: Metadata = {
-  title: {template: '%s | Sentry Documentation', default: 'Home'},
+  title: {template: '%s | Gavin', default: 'Gavin'},
 };
 
 export default function DocsLayout({children}: {children: React.ReactNode}) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const rubik = Rubik({
 });
 
 export const metadata: Metadata = {
-  title: 'Home',
+  title: 'Gavin',
   icons: {
     icon:
       process.env.NODE_ENV === 'production' ? '/favicon.ico' : '/favicon_localhost.png',


### PR DESCRIPTION
<pr_request_template><!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The Next.js application title has been updated to "Gavin" as per user request. This change was applied to both the root layout (`app/layout.tsx`) and the nested layout (`app/[[...path]]/layout.tsx`).

Specifically:
- In `app/layout.tsx`, the `title` metadata was changed from 'Home' to 'Gavin'.
- In `app/[[...path]]/layout.tsx`, the `title` metadata's `template` was changed from '%s | Sentry Documentation' to '%s | Gavin', and its `default` value was changed from 'Home' to 'Gavin'.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-0ba733b5-f731-4b0a-a7eb-66ca3d815a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ba733b5-f731-4b0a-a7eb-66ca3d815a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>