### PR TITLE
docs(apple): Add troubleshooting issue in 8.54.0

### DIFF
--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -209,3 +209,19 @@ You can fix this by not subclassing the affected classes. Strictly speaking, thi
 Cocoa SDK versions [8.51.1](https://github.com/getsentry/sentry-cocoa/releases/tag/8.51.1) and [8.52.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.52.0) have a bug that causes unsymbolicated stacktraces for non-fatal events, such as`captureError`, `captureMessage` or `captureException`. All or most stacktrace frames are then marked as `redacted` by Sentry. This bug doesn't impact fatal events or crashes.
 
 Please update the Cocoa SDK to version [8.52.1](https://github.com/getsentry/sentry-cocoa/releases/tag/8.52.1) or above or stay on version [8.51.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.51.0) or below to fix this problem.
+
+## SentrySDK API members not available after updating to 8.54.0
+
+After updating to Cocoa SDK version [8.54.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.54.0), you might encounter build errors indicating that `SentrySDK` has no member `capture` or other API methods that were previously available, such as:
+
+```
+'SentrySDK' has no member 'capture'
+```
+
+To resolve this problem try the following:
+
+1. Clean your build by going to **Product > Clean Build Folder** in Xcode
+2. Remove derived data by going to **Xcode > Settings > Locations > Derived Data** and clicking the arrow next to the path, then delete the folder for your project
+3. Reset your package cache if using Swift Package Manager by going to **File > Packages > Reset Package Caches**
+4. Restart Xcode
+5. Rebuild your project


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Addresses sentry-cocoa issue getsentry/sentry-cocoa#5769 where users report that SentrySDK API members like 'capture' are not available after updating to version 8.54.0. Provides step-by-step resolution instructions including cleaning build folder, removing derived data, resetting package cache, and restarting Xcode.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
