### PR TITLE
chore(native): add example of global fingerprint setting

### DIFF
--- a/platform-includes/set-fingerprint/basic/native.mdx
+++ b/platform-includes/set-fingerprint/basic/native.mdx
@@ -1,3 +1,15 @@
+You can set a fingerprint to be added to all future events and errors:
+```c
+#include <sentry.h>
+
+sentry_set_fingerprint("myFingerPrint", NULL); // overwrites existing fingerprints
+my_fingerprinted_function(); // events are grouped on "myFingerPrint"
+
+sentry_clear_fingerprint(); // clears all fingerprints
+```
+
+For manually captured events, fingerprints can be added to the `fingerprint` key of the event. This will be prioritized over the globally set fingerprint:
+
 ```cpp
 #include <sentry.h>
 

--- a/platform-includes/set-fingerprint/basic/native.mdx
+++ b/platform-includes/set-fingerprint/basic/native.mdx
@@ -1,4 +1,4 @@
-You can set a fingerprint to be added to all future events and errors:
+You can set a fingerprint to be added to **all future events and errors**:
 ```c
 #include <sentry.h>
 
@@ -8,7 +8,7 @@ my_fingerprinted_function(); // events are grouped on "myFingerPrint"
 sentry_clear_fingerprint(); // clears all fingerprints
 ```
 
-For manually captured events, fingerprints can be added to the `fingerprint` key of the event. This will be prioritized over the globally set fingerprint:
+For specific, manually captured events, fingerprints can be added to the `fingerprint` key of the event. This will be prioritized over the globally set fingerprint:
 
 ```cpp
 #include <sentry.h>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

### Link to updated example [vercel preview](https://sentry-docs-git-joshua-nativefingerprinting.sentry.dev/platforms/native/usage/sdk-fingerprinting/#basic-example)

## DESCRIBE YOUR PR
This came up in a Discord thread, and we didn't really have this documented anywhere.

For manual event captures, we already provide a simple `sentry_value_set_by_key(event, "fingerprint", fp);` example, but this does not help with fingerprinting crashes. Hence I added an example of using `sentry_set_fingerprint("myFingerPrint", NULL);` which sets the global fingerprint list to `["myFingerPrint"]`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
