### PR TITLE
Unreal Engine: Remove deprecated marketplace plugin package mentions from the landing page

### DIFF
--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -41,7 +41,7 @@ The Unreal Engine (UE) SDK is officially supported for the three latest UE versi
 
 We recommend downloading the latest plugin sources from the [GitHub Releases page](https://github.com/getsentry/sentry-unreal/releases), but we also support [alternate installation methods](/platforms/unreal/install/).
 
-To integrate Sentry into your Unreal Engine project using the GitHub package, select the artifact that matches your Unreal Engine version and includes `github` in its name. Place the extracted files in your project's `Plugins` directory. On the next project launch, UE will prompt you to build the Sentry and SentryEditor modules.
+To integrate Sentry into your Unreal Engine project using the GitHub package, select the artifact that matches your Unreal Engine version. Place the extracted files in your project's `Plugins` directory. On the next project launch, UE will prompt you to build the Sentry and SentryEditor modules.
 
 <Alert>
 

--- a/platform-includes/getting-started-install/unreal.mdx
+++ b/platform-includes/getting-started-install/unreal.mdx
@@ -8,14 +8,6 @@ Currently, this method is available only for C++ UE projects. Blueprint projects
 
 </Alert>
 
-<Alert>
-
-The [Releases page](https://github.com/getsentry/sentry-unreal/releases) provides two plugin packages: `github` and `marketplace`. The key difference between the two is the crash capturing backend, which is used under the hood on Windows.
-
-We recommend using the `github` version which uses `Crashpad`, an out-of-proc handler that sends the crash report right away. The `marketplace` version relies on `Breakpad`, an in-proc handler which requires the UE application or game to be relaunched in order to send the crash reports to Sentry.
-
-</Alert>
-
 Alternatively, the Sentry SDK can be downloaded via the [standard installation process](https://docs.unrealengine.com/5.2/en-US/working-with-plugins-in-unreal-engine/#installingpluginsfromtheunrealenginemarketplace) from its [UE Marketplace](https://www.unrealengine.com/marketplace/en-US/product/sentry-01) page within the Epic Games Launcher.
 
 <Alert>


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-docs/pull/14481