### PR TITLE
docs(react-native): Update the docs in accordance to how the current structure of an Expo project looks like

### DIFF
--- a/docs/platforms/react-native/manual-setup/expo.mdx
+++ b/docs/platforms/react-native/manual-setup/expo.mdx
@@ -67,7 +67,7 @@ pnpm add @sentry/react-native
 Import the `@sentry/react-native` package and call `init` with your DSN:
 
 ```javascript {tabTitle:App.js or app/_layout.js}
-import { Text, View } from "react-native";
+import { Stack } from "expo-router";
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
@@ -89,15 +89,11 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ profiling
 });
 
-function App() {
-  return (
-    <View>
-      <Text>Expo Example!</Text>
-    </View>
-  );
+function RootLayout() {
+  return <Stack />;
 }
 
-export default Sentry.wrap(App);
+export default Sentry.wrap(RootLayout);
 ```
 
 ### Wrap Your App
@@ -105,7 +101,7 @@ export default Sentry.wrap(App);
 Wrap the root component of your application with `Sentry.wrap`:
 
 ```javascript {tabTitle:App.js or app/_layout.js}
-export default Sentry.wrap(App);
+export default Sentry.wrap(RootLayout);
 ```
 
 ### Add the Sentry Expo Plugin


### PR DESCRIPTION
A relatively minor change: the current version of docs for Expo seems a bit outdated in a sense that it asks you to make a change to the project that doesn't match the actual project that's being generated by Expo.
This PR fixes that and makes it a bit easier for newcomers to understand what changes need to be made.