### PR TITLE
Remove SSL root change announcement

### DIFF
--- a/docs/security-legal-pii/security/ssl.mdx
+++ b/docs/security-legal-pii/security/ssl.mdx
@@ -44,20 +44,8 @@ This suite of protocols and ciphers represents Sentry's official support; howeve
 
 ## Certificate Pinning
 
-<Alert title="Note" level="warning">
-
-Starting on 2025-07-17, the following domains with certificates previously issued by DigiCert will be transitioned to being issued by Let's Encrypt:
-
-- `sentry.io`
-- `de.sentry.io`
-- `us.sentry.io`
-- `*.ingest.sentry.io`
-- `*.ingest.us.sentry.io`
-- `*.ingest.de.sentry.io`
-
-</Alert>
-
 At the moment, all Sentry TLS certificates use either Digicert or Let's Encrypt as certificate authorities. If this list of roots needs to be changed, we will publish an announcement on [status.sentry.io](https://status.sentry.io/).
+
 
 Here are corresponding root CA certificates if you would like to pin them in your applications:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Remove the announcement for change of root as we have since returned to Digicert, which was our previous state anyway.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)