### PR TITLE
docs(browser): Delete deprecated `profilesSampler`

### DIFF
--- a/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/_default.mdx
@@ -24,25 +24,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-const Sentry = require("@sentry/browser");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.angular.mdx
@@ -24,25 +24,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-import * as Sentry from "@sentry/angular";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.astro.mdx
@@ -23,25 +23,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-import * as Sentry from "@sentry/astro";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.electron.mdx
@@ -26,25 +26,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-const Sentry = require("@sentry/electron/renderer");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.nextjs.mdx
@@ -23,25 +23,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript {filename:instrumentation-client.js|ts}
-import * as Sentry from "@sentry/nextjs";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.nuxt.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.nuxt.mdx
@@ -23,25 +23,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript {filename:sentry.client.config.js|ts}
-import * as Sentry from "@sentry/nuxt";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.react.mdx
@@ -24,26 +24,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-import * as Sentry from "@sentry/react";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.remix.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.remix.mdx
@@ -24,25 +24,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript {filename:entry.client.tsx}
-import * as Sentry from "@sentry/remix";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.svelte.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.svelte.mdx
@@ -24,25 +24,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-import * as Sentry from "@sentry/svelte";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.sveltekit.mdx
@@ -23,25 +23,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript {filename:hooks.client.js}
-import * as Sentry from "@sentry/sveltekit";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```

--- a/platform-includes/profiling/automatic-instrumentation-setup/javascript.vue.mdx
+++ b/platform-includes/profiling/automatic-instrumentation-setup/javascript.vue.mdx
@@ -24,25 +24,3 @@ Sentry.init({
   profilesSampleRate: 1.0,
 });
 ```
-
-Alternatively, instead of a `profilesSampleRate` your can also provide a `profilesSampler` function:
-
-```javascript
-import * as Sentry from "@sentry/vue";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  integrations: [
-    // Add browser profiling integration to the list of integrations
-    Sentry.browserTracingIntegration(),
-    Sentry.browserProfilingIntegration(),
-  ],
-  tracesSampleRate: 1.0,
-
-  // This function will be called for every sampled span
-  // to determine if it should be profiled
-  profilesSampler: (samplingContext) => {
-    return 1.0;
-  },
-});
-```


### PR DESCRIPTION
## DESCRIBE YOUR PR


Removes all occurrences of `profilesSampler` in the JS browser SDKs as this API is not available and also deprecated, so we won't implement it.

- https://github.com/getsentry/sentry-javascript/issues/16773#issuecomment-3143858577
- https://github.com/getsentry/sentry-javascript/issues/17279

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

