### PR TITLE
Modified grouping behavior clarification

### DIFF
--- a/docs/concepts/data-management/event-grouping/index.mdx
+++ b/docs/concepts/data-management/event-grouping/index.mdx
@@ -10,7 +10,7 @@ By default, Sentry will run one of our built-in grouping algorithms to generate 
 
 ## Default Error Grouping Algorithms
 
-Each time default error grouping behavior is modified, Sentry releases it as a new version, which is applied at all new events going forward. As a result, modifications to the default behavior do not affect the grouping of existing issues.
+Each time default error grouping behavior is modified, Sentry releases it as a new version, which is only applied to new events going forward. As a result, modifications to the default behavior do not affect the grouping of existing issues.
 
 When you create a Sentry project, the most recent version of the error grouping algorithm is automatically selected. This ensures that grouping behavior is consistent within a project.
 

--- a/docs/concepts/data-management/event-grouping/index.mdx
+++ b/docs/concepts/data-management/event-grouping/index.mdx
@@ -10,11 +10,9 @@ By default, Sentry will run one of our built-in grouping algorithms to generate 
 
 ## Default Error Grouping Algorithms
 
-Each time default error grouping behavior is modified, Sentry releases it as a new version. As a result, modifications to the default behavior do not affect the grouping of existing issues.
+Each time default error grouping behavior is modified, Sentry releases it as a new version, which is applied at all new events going forward. As a result, modifications to the default behavior do not affect the grouping of existing issues.
 
 When you create a Sentry project, the most recent version of the error grouping algorithm is automatically selected. This ensures that grouping behavior is consistent within a project.
-
-To upgrade an existing project to a new error grouping algorithm version, navigate to **Settings > Projects > [project] > Issue Grouping > Upgrade Grouping**. After upgrading to a new error grouping algorithm, you will very likely see new groups being created.
 
 All versions consider the `fingerprint` first, the `stack trace` next, then the `exception`, and then finally the `message`.
 


### PR DESCRIPTION
The "Update Grouping" option does not exist anymore, as the latest grouping algorithm is automatically applied. I have edited the docs to reflect this information.