### PR TITLE
options(android): Add attach threads option to docs

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -88,6 +88,16 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </ConfigKey>
 
+<ConfigKey name="attach-threads">
+
+When enabled, information about all threads is attached to events, not just the crashing thread. This provides a more complete picture of the application state at the time of an error, including stack traces from all running threads.
+
+This option is turned off by default.
+
+Note that enabling this option may increase the payload size of events sent to Sentry.
+
+</ConfigKey>
+
 <ConfigKey name="send-default-pii">
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.

--- a/docs/platforms/java/common/configuration/options.mdx
+++ b/docs/platforms/java/common/configuration/options.mdx
@@ -88,6 +88,16 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </ConfigKey>
 
+<ConfigKey name="attach-threads">
+
+When enabled, information about all threads is attached to events, not just the crashing thread. This provides a more complete picture of the application state at the time of an error, including stack traces from all running threads.
+
+This option is turned off by default.
+
+Note that enabling this option may increase the payload size of events sent to Sentry.
+
+</ConfigKey>
+
 <ConfigKey name="send-default-pii">
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adds documentation for the `attach-threads` option to the Android and Java configuration options. This change addresses a customer's question about viewing all thread stacks and documents the previously undocumented `isAttachThreads`/`setAttachThreads` option.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+
