### PR TITLE
Update sentry build options documentation

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
@@ -268,6 +268,30 @@ The route manifest is a build-time generated mapping of your Next.js App Router 
 
 </SdkOption>
 
+<SdkOption name="reactComponentAnnotation" type="object | undefined">
+
+Enables React component name tracking. When enabled, it annotates React components with data attributes that allow Sentry to track which components users interacted with in features like Session Replay and breadcrumbs.
+
+This option accepts an object with the following property:
+
+- `enabled` (boolean): Whether to enable React component annotation. Defaults to `false`.
+
+```javascript
+withSentryConfig(nextConfig, {
+  reactComponentAnnotation: {
+    enabled: true,
+  },
+});
+```
+
+When enabled, the Sentry Metro plugin applies `@sentry/babel-plugin-component-annotate`, which parses your application's JSX source code at build time and adds `data-sentry-component` and `data-sentry-source-file` attributes to your components. This helps identify exactly which React component was interacted with, removing ambiguity from generic element names.
+
+<Alert level="info">
+  This feature requires components to be in `.jsx` or `.tsx` file formats. Only components in your project (outside of `node_modules`) are annotated by default.
+</Alert>
+
+</SdkOption>
+
 <SdkOption
   name="unstable_sentryWebpackPluginOptions"
   type="SentryWebpackPluginOptions"


### PR DESCRIPTION
## DESCRIBE YOUR PR
This PR adds documentation for the `reactComponentAnnotation` option to the Next.js build configuration guide (`index.mdx`). This ensures the documentation accurately reflects the available `SentryBuildOptions` and provides clear guidance on enabling React component name tracking for features like Session Replay and breadcrumbs.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
<a href="https://cursor.com/background-agent?bcId=bc-1002a975-85b6-465c-9540-4cbbb378ad0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1002a975-85b6-465c-9540-4cbbb378ad0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

