### PR TITLE
ref(spans): Expand `ignoreSpans` type and implementation specification

### DIFF
--- a/develop-docs/sdk/telemetry/spans/filtering.mdx
+++ b/develop-docs/sdk/telemetry/spans/filtering.mdx
@@ -19,16 +19,48 @@ Any APIs exposed to the user to filter spans MUST adhere to the following design
 
 ## Filter with `ignoreSpans`
 
-The `ignoreSpans` option accepts a glob pattern or string.
+The `ignoreSpans` option MUST accept a string, RegExp or glob pattern (whichever of the two the platform supports). Furthermore, it SHOULD accept an Object with the patterns matching at least one of or both, the span name and op. 
+
+```ts
+type IgnoreSpanPattern = string | RegExp | GlobPattern;
+
+type IgnoreSpanFilter = {
+  name: IgnoreSpanPattern;
+  op?: IgnoreSpanPattern;
+} | {
+  name?: IgnoreSpanPattern;
+  op: IgnoreSpanPattern;
+}
+
+type IgnoreSpans = Array<IgnoreSpanPattern | IgnoreSpanFilter>
+```
+(Note: `GlobPattern` is used as an illustrative type. It is not a valid TypeScript type.)
+
+Example:
 
 ```js
 Sentry.init({
   ignoreSpans: [
     'GET /about',
     'events.signal *',
+    /api\/\d+/,
+    {
+      op: 'fs.read',
+    },
+    {
+      name: 'health',
+      op: 'http.client',
+    }
   ]
 })
 ```
+(Note: The glob pattern serves an illustrative purpose. It is not supported in JavaScript.)
+
+### Implementation Requirements
+
+The `ignoreSpans` patterns MUST be applied to all spans, including the root or segment span.
+- If a pattern matches the root span, the span and all its children MUST be ignored.
+- If a pattern matches a child span, the span MUST be ignored but any potential child spans MUST be attempted to be reparented to the parent span of the ignored span.
 
 ## Filter with `integrations`
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
