### PR TITLE
fix(native): reference `@sentry/wasm` in the WASM guide

### DIFF
--- a/docs/platforms/native/guides/wasm/index.mdx
+++ b/docs/platforms/native/guides/wasm/index.mdx
@@ -47,42 +47,9 @@ then needs to be uploaded to Sentry. For more information, see [Debug Informatio
 
 ## Crash Reporting
 
-WebAssembly does not currently have a runtime that can produce stack traces. We
-do not yet provide a ready-to-use SDK, though we have a small integration for the
-Sentry JavaScript SDK to enhance error reports in the browser environment
-which include WASM frames, called [wasm-support.js](https://gist.github.com/mitsuhiko/c27fee8445d2a18a8c134e0169119058), which needs to be loaded _after_ the JavaScript SDK and before you start loading your WASM modules:
-
-```html {tabTitle: CDN}
-<script
-  src="https://browser.sentry-cdn.com/{{@inject packages.version('sentry.javascript.browser') }}/bundle.min.js"
-  integrity="sha384-{{@inject packages.checksum('sentry.javascript.browser', 'bundle.min.js', 'sha384-base64') }}"
-  crossorigin="anonymous"
-></script>
-<script src="wasm-support.js"></script>
-```
-
-If you then throw a JavaScript exception you can get the stack trace. If you want
-to capture an error from within your WebAssembly application you can export a
-utility function like this:
-
-```javascript
-function captureError() {
-  try {
-    throw new Error();
-  } catch (e) {
-    Sentry.captureException(e);
-  }
-}
-
-async function loadWasm(url) {
-  const importObj = {
-    env: {
-      capture_error: captureError,
-    },
-  };
-  return await WebAssembly.instantiateStreaming(fetch(url), importObj);
-}
-```
+If you want to have crash reporting in the browser, the recommended way with Sentry is to use
+the `@sentry/wasm` package and apply its `wasmIntegration` to your `@sentry/browser` configuration.
+This is [documented in detail](/platforms/javascript/guides/wasm/) in the JavaScript platform docs.
 
 ## Custom Crash Reports
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
The native guide for WebAssembly still explains that there is no official Sentry support for WASM crash reporting in the browser. This is no longer the case with the `@sentry/wasm` integration, and this PR updates the docs accordingly.

Fixes https://github.com/getsentry/sentry-javascript/issues/15420

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
