### PR TITLE
correcting region storage for symbol and source map metadata

### DIFF
--- a/docs/organization/data-storage-location/index.mdx
+++ b/docs/organization/data-storage-location/index.mdx
@@ -30,6 +30,7 @@ Here’s a list of the types of data that will be stored in whichever data stora
 - Profiles
 - Release health
 - Releases, debug symbols, and source maps
+- Debug symbol metadata and source map metadata
 - Session replays
 - Backups for these resources
 
@@ -48,7 +49,6 @@ Here’s a list of the types of data that may be stored in the US.
 - Project metadata
 - DSN keys
 - Detailed usage data
-- Debug symbol metadata and source map metadata
 - Sentry applications
 - SSO, SAML, and SCIM metadata
 


### PR DESCRIPTION
Correcting references to metadata storage location to reflect that source map and symbol data is stored regionally. 
