### PR TITLE
chore(issues): Update capture_message for Python

### DIFF
--- a/docs/platforms/python/usage/index.mdx
+++ b/docs/platforms/python/usage/index.mdx
@@ -27,8 +27,8 @@ While capturing an event, you can also record the breadcrumbs that lead up to th
 
 ## Capturing Messages
 
-Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically, our SDKs don't automatically capture messages, but you can capture them manually.
+While uncommon, you can also manually capture a plain message without an exception.
 
-Messages show up as issues on your issue stream, with the message as the issue name.
+Messages show up as issues on your issue stream, with the message as the issue name so avoid serializing payloads or embedding unique values in the message text, instead attach additional information via tags and context.
 
 <PlatformContent includePath="capture-message" />

--- a/platform-includes/capture-message/python.mdx
+++ b/platform-includes/capture-message/python.mdx
@@ -1,5 +1,5 @@
 ```python
 import sentry_sdk
 
-sentry_sdk.capture_message('Something went wrong')
+sentry_sdk.capture_message('Something went wrong', tags={'component': 'worker', 'region': 'us-west-2'})
 ```


### PR DESCRIPTION
Using capture_message with a high-cardinality message is one of the best ways to defeat our grouping algorithms and give yourself a _very_ noisy issue stream.

Starting with Python for now so we can easily iterate on messaging here but we will want to apply similar changes to all platforms in the future.