### PR TITLE
fix(js/browser): Amend user IP + `sendDefaultPii` change to v10 migration guide

### DIFF
--- a/docs/platforms/javascript/common/migration/v9-to-v10.mdx
+++ b/docs/platforms/javascript/common/migration/v9-to-v10.mdx
@@ -57,6 +57,29 @@ The removal entails **no breaking API changes**. However, in rare cases, you mig
 
 The `_experiments.autoFlushOnFeedback` option was removed and is now the default behavior.
 
+## Update: User IP Address collection gated by `sendDefaultPii`
+
+Version `10.4.0` introduced a change that should have ideally been introduced with `10.0.0` of the SDK.
+Originally destined for [version `9.0.0`](https://docs.sentry.io/platforms/javascript/migration/v8-to-v9/#behavior-changes), but having not the desired effect until v10,
+SDKs will now control IP address inference of user IP addresses depending on the value of the top level `sendDefaultPii` init option.
+
+- If `sendDefaultPii` is `true`, Sentry will infer the IP address of users' devices to events (errors, traces, replays, etc) in all browser-based SDKs.
+- If `sendDefaultPii` is `false` or not set, Sentry will not infer or collect IP address data.
+
+Given that this was already [advertised behaviour](https://docs.sentry.io/platforms/javascript/data-management/data-collected/#users-ip-address-and-location) since v9, 
+we classify the change [as a fix](https://github.com/getsentry/sentry-javascript/pull/17364), though we recognize the potential impact of it. 
+
+If you want to continue receiving user IP addresses, set `sendDefaultPii: true` in your `Sentry.init` config:
+
+```js
+Sentry.init({
+  // ...
+  sendDefaultPii: true,
+});
+```
+
+We apologize for any inconvenience caused.
+
 </PlatformCategorySection>
 
 ## Removed APIs


### PR DESCRIPTION
Mentions a fix to be introduced in [10.4.0](https://github.com/getsentry/sentry-javascript/pull/17364) in the migration guide given it has quite a lot of impact, albeit belated (should have been like this since v9). 

This change is now mentioned in:
- 10.4.0 changelog
- in-repo migration guide
- in-docs migration guide (this PR)