### PR TITLE
feat: Update min js sdk version for logging and update console logging snippet

### DIFF
--- a/includes/logs/javascript-console-logging-integration.mdx
+++ b/includes/logs/javascript-console-logging-integration.mdx
@@ -6,8 +6,8 @@ You can also configure the SDK to send logs via the JavaScript console object, u
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 ```

--- a/platform-includes/llm-rules-logs/javascript.nextjs.mdx
+++ b/platform-includes/llm-rules-logs/javascript.nextjs.mdx
@@ -32,8 +32,8 @@ Sentry.init({
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 ```

--- a/platform-includes/llm-rules-logs/javascript.node.mdx
+++ b/platform-includes/llm-rules-logs/javascript.node.mdx
@@ -32,8 +32,8 @@ Sentry.init({
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
   integrations: [
-    // send console.log, console.error, and console.warn calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "error", "warn"] }),
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });
 ```

--- a/platform-includes/logs/requirements/javascript.mdx
+++ b/platform-includes/logs/requirements/javascript.mdx
@@ -1,4 +1,4 @@
-Logs for JavaScript are supported in Sentry JavaScript SDK version `9.17.0` and above.
+Logs for JavaScript are supported in Sentry JavaScript SDK version `9.41.0` and above.
 
 <PlatformSection supported={["javascript"]}>
 


### PR DESCRIPTION
In `9.41.0` of the JS SDK, we dropped the experimental `enableLogs` option. Given we document snippets without the experimental option everywhere, let's bump the min version in the docs: https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#9410

This is the version we will lock in for GA.

While I was here, I also cleaned up the `consoleLoggingIntegration` so that we follow the order log < warn < error.