### PR TITLE
Unreal Engine: Update plugin docs

### DIFF
--- a/docs/platforms/unreal/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/unreal/enriching-events/breadcrumbs/index.mdx
@@ -22,7 +22,7 @@ Manually record a breadcrumb:
 ```cpp
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
-TMap<FString, FString> AdditionalData;
+TMap<FString, FSentryVariant> AdditionalData;
 AdditionalData.Add("SomeKey", "SomeValue");
 
 SentrySubsystem->AddBreadcrumb("Message", "Category", "Type", AdditionalData, ESentryLevel::Info);

--- a/docs/platforms/unreal/enriching-events/context/index.mdx
+++ b/docs/platforms/unreal/enriching-events/context/index.mdx
@@ -22,7 +22,7 @@ Then, use <PlatformIdentifier name="set-context" /> and give the context a uniqu
 ```cpp
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
-TMap<FString, FString> ContextData;
+TMap<FString, FSentryVariant> ContextData;
 AdditionalData.Add("Class", "Paladin");
 AdditionalData.Add("Role", "Taunt");
 

--- a/docs/platforms/unreal/enriching-events/scopes/index.mdx
+++ b/docs/platforms/unreal/enriching-events/scopes/index.mdx
@@ -61,9 +61,7 @@ To learn what useful information can be associated with scopes see
 
 ## Local Scopes
 
-We also support pushing and configuring a scope within a single call. This is typically
-called <PlatformIdentifier name="with-scope" />, <PlatformIdentifier name="push-scope" /> or implemented as a function parameter on the capture methods, depending on the SDK. It's very helpful if
-you only want to send data for one specific event.
+We also support pushing and configuring a scope within a single call. This is implemented as a delegate parameter on the capture methods. It's very helpful if you only want to send data for one specific event.
 
 ### Using Scope Callback Parameter
 
@@ -94,6 +92,12 @@ Before the callback is invoked the SDK creates a clone of the current scope, and
 made will stay isolated within the callback function. This allows you to
 more easily isolate pieces of context information to specific locations in your code or
 even call `clear` to briefly remove all context information.
+
+<Alert>
+
+On Windows and Linux, the scope object that is passed to the callback is empty and doesn't contain any of the current scope data.
+
+</Alert>
 
 <Alert title="Important">
 

--- a/platform-includes/enriching-events/attach-screenshots/unreal.mdx
+++ b/platform-includes/enriching-events/attach-screenshots/unreal.mdx
@@ -11,7 +11,7 @@ Settings->AttachScreenshot = true;
 
 <Alert>
 
-Currently, this feature is supported for Windows and Linux only.
+Currently, this feature is not supported on Android.
 
 </Alert>
 
@@ -20,7 +20,7 @@ Currently, this feature is supported for Windows and Linux only.
 Since the Unreal Engine SDK consists of multiple SDKs, the specific mechanism with which a screenshot is captured will vary depending on where the error originated.
 
 - On Windows/Linux, errors from within your game will be captured using the Unreal Engine API. This means that screenshots will only contain what's visible within your game. Any overlays on top of your game won't be visible.
-- On Apple/Android, screenshots will be captured using platform APIs. If you're using a native plugin to display an overlay and an error occurs, the SDK will try to capture a screenshot that contains the overlay.
+- On Mac/iOS, screenshots will be captured using platform APIs. If you're using a native plugin to display an overlay and an error occurs, the SDK will try to capture a screenshot that contains the overlay.
 
 <Alert>
 

--- a/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/unreal.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/breadcrumbs-example/unreal.mdx
@@ -1,7 +1,7 @@
 ```cpp
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
-TMap<FString, FString> AdditionalData;
+TMap<FString, FSentryVariant> AdditionalData;
 AdditionalData.Add("SomeKey", "SomeValue");
 
 SentrySubsystem->AddBreadcrumb("Message", "Category", "Type", AdditionalData, ESentryLevel::Info);

--- a/platform-includes/enriching-events/set-context/unreal.mdx
+++ b/platform-includes/enriching-events/set-context/unreal.mdx
@@ -1,7 +1,7 @@
 ```cpp
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
-TMap<FString, FString> ContextData;
+TMap<FString, FSentryVariant> ContextData;
 AdditionalData.Add("Class", "Paladin");
 AdditionalData.Add("Role", "Taunt");
 


### PR DESCRIPTION
Key Changes:

- Updated some C++ examples to use `FSentryVariant` type instead of string (https://github.com/getsentry/sentry-unreal/pull/971)
- Added notice about using local scopes on Windows/Linux (https://github.com/getsentry/sentry-unreal/pull/928)
- Fixed supported platforms for screenshot feature