### PR TITLE
ref(python): Update wording regarding async init

### DIFF
--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -43,8 +43,6 @@ uv add "sentry-sdk"
 
 Configuration should happen as **early as possible** in your application's lifecycle.
 
-
-
 ```python
 import sentry_sdk
 
@@ -74,7 +72,7 @@ sentry_sdk.init(
 )
 ```
 
-However, in async applications, you need to call `sentry_sdk.init()` inside an `async` function to ensure async code is instrumented properly. We recommend calling `sentry_sdk.init()` at the beginning of the first `async` function you call, as demonstrated in the example below.
+In async programs, it's recommended to call `sentry_sdk.init()` inside an `async` function to ensure async code is instrumented properly. If possible, we recommend calling `sentry_sdk.init()` at the beginning of the first `async` function you call.
 
 ```python
 import asyncio


### PR DESCRIPTION
`init()`-ing in an async function is not always possible (e.g. in an async web framework like FastAPI) and also not always necessary.

**Direct link to preview:** https://sentry-docs-git-ivana-pythonasync-init.sentry.dev/platforms/python/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
