### PR TITLE
Document undocumented php prefix option

### DIFF
--- a/docs/platforms/php/common/configuration/options.mdx
+++ b/docs/platforms/php/common/configuration/options.mdx
@@ -93,6 +93,24 @@ This option can be overridden using `in_app_include`.
 
 </SdkOption>
 
+<SdkOption name="prefixes" type='string[]' defaultValue='[]'>
+
+A list of prefixes that should be stripped from the filenames of captured stacktraces to make them relative. This helps in normalizing file paths across different environments.
+
+For example, if your code is deployed in different locations across environments (e.g., `/var/www/app` in production and `/home/user/projects/app` in development), you can use this option to strip these prefixes and make the paths consistent.
+
+```php
+\Sentry\init([
+    'dsn' => '___DSN___',
+    'prefixes' => [
+        '/var/www/',
+        '/home/user/projects/',
+    ],
+]);
+```
+
+</SdkOption>
+
 <SdkOption name="max_request_body_size"type='string' defaultValue='medium'>
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:


### PR DESCRIPTION
## DESCRIBE YOUR PR
This PR adds documentation for the `prefixes` option in the PHP SDK configuration. This option allows users to strip specified prefixes from filenames in stacktraces, helping to normalize file paths across different environments.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
<a href="https://cursor.com/background-agent?bcId=bc-016859c4-0c54-4223-8d7a-544a757983fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-016859c4-0c54-4223-8d7a-544a757983fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

