### PR TITLE
Fix(dotnet) Add Null safety to doc

### DIFF
--- a/platform-includes/distributed-tracing/custom-instrumentation/dotnet.mdx
+++ b/platform-includes/distributed-tracing/custom-instrumentation/dotnet.mdx
@@ -33,12 +33,12 @@ consumer.Received += (model, ea) =>
         var sentryTraceHeader = string.Empty;
         var sentryBaggageHeader = string.Empty;
 
-        if (headers.TryGetValue("sentry-trace", out var traceHeader))
+        if (headers.TryGetValue("sentry-trace", out var traceHeader) && traceHeader != null)
         {
             sentryTraceHeader = Encoding.UTF8.GetString((byte[])traceHeader);
         }
 
-        if (headers.TryGetValue("baggage", out var baggageHeader))
+        if (headers.TryGetValue("baggage", out var baggageHeader) && baggageHeader != null)
         {
             sentryBaggageHeader = Encoding.UTF8.GetString((byte[])baggageHeader);
         }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

Fix `Value cannot be null. (Parameter 'bytes')` when users copy/paste this code into their servers.

This happens because on the same doc, it shows those values can be null
```
properties.Headers.Add("sentry-trace", SentrySdk.GetTraceHeader()?.ToString());
properties.Headers.Add("baggage", SentrySdk.GetBaggage()?.ToString());
```

So we add some null checks before retrieving the trace or baggage and everyone gets happy!.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
