### PR TITLE
fix: MCP dashboard URL 

### DIFF
--- a/docs/product/insights/ai/mcp/dashboard.mdx
+++ b/docs/product/insights/ai/mcp/dashboard.mdx
@@ -6,7 +6,7 @@ description: "Learn how to use Sentry's MCP Dashboard."
 
 <Include name="feature-limited-on-team-retention.mdx" />
 
-Once you've [configured the Sentry SDK](/product/insights/ai/mcp/getting-started/) for your MCP project, you'll start receiving data in the Sentry [MCP Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/mcp/) dashboard.
+Once you've [configured the Sentry SDK](/product/insights/ai/mcp/getting-started/) for your MCP project, you'll start receiving data in the Sentry [MCP Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/mcp/) dashboard.
 
 The main dashboard provides a comprehensive view of all your MCP server activities, performance metrics, and recent tool executions.
 


### PR DESCRIPTION
Dashboard URL missing /ai/ route; throwing permission error as a result. 