### PR TITLE
docs(mcp): Update getting started guide to include SDK version requirement and terminology change

### DIFF
--- a/docs/product/insights/ai/mcp/getting-started.mdx
+++ b/docs/product/insights/ai/mcp/getting-started.mdx
@@ -4,7 +4,13 @@ sidebar_order: 0
 description: "Learn how to set up Sentry MCP Monitoring"
 ---
 
-Sentry MCP Monitoring helps you track and debug Model Context Protocol (MCP) implementations using our supported SDKs and integrations. Monitor your complete MCP workflows from client connections to server responses, including tool executions, resource access, and protocol communications.
+<Alert>
+
+MCP observability is supported on Sentry **SDK versions above `9.46.0`**. If you're on an older version and want to use MCP monitoring, we recommend upgrading your SDK that version or above.
+
+</Alert>
+
+Sentry MCP Observability helps you track and debug Model Context Protocol (MCP) implementations using our supported SDKs and integrations. Monitor your complete MCP workflows from client connections to server responses, including tool executions, resource access, and protocol communications.
 
 To start sending MCP data to Sentry, make sure you've created a Sentry project for your MCP-enabled repository and follow the guide below:
 
@@ -12,7 +18,7 @@ To start sending MCP data to Sentry, make sure you've created a Sentry project f
 
 ### JavaScript - MCP Server
 
-The Sentry JavaScript SDK supports MCP monitoring by wrapping the MCP Server from the [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) package. This wrapper automatically captures spans for your MCP server workflows including tool executions, resource access, and client connections.
+The Sentry JavaScript SDK supports MCP observability by wrapping the MCP Server from the [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) package. This wrapper automatically captures spans for your MCP server workflows including tool executions, resource access, and client connections.
 
 #### Quick Start with MCP Server
 


### PR DESCRIPTION
Final touches to our MCP Server instrumentation docs before the launch tomorrow (Thursday, August 14).

- put an alert to let users know the minimum version requirement to use our MCP Server instrumentation (inspo from [here](https://docs.sentry.io/platforms/javascript/guides/express/sourcemaps/uploading/esbuild/)).
- change wording a bit to talk about MCP Observability rather than MCP Monitoring.