### PR TITLE
docs(mcp): use VersionRequirement component

### DIFF
--- a/docs/product/insights/ai/mcp/getting-started.mdx
+++ b/docs/product/insights/ai/mcp/getting-started.mdx
@@ -4,15 +4,14 @@ sidebar_order: 0
 description: "Learn how to set up Sentry MCP Monitoring"
 ---
 
-<Alert>
-
-MCP observability is supported on Sentry **SDK versions above `9.46.0`**. If you're on an older version and want to use MCP monitoring, we recommend upgrading your SDK that version or above.
-
-</Alert>
-
 Sentry MCP Observability helps you track and debug Model Context Protocol (MCP) implementations using our supported SDKs and integrations. Monitor your complete MCP workflows from client connections to server responses, including tool executions, resource access, and protocol communications.
 
 To start sending MCP data to Sentry, make sure you've created a Sentry project for your MCP-enabled repository and follow the guide below:
+
+## Requirements
+
+<VersionRequirement product="MCP Observability" sdk="Node SDK" minVersion="9.46.0" />
+
 
 ## Supported SDKs
 


### PR DESCRIPTION
Using the new `VersionRequirement` component for MCP.
<img width="939" height="806" alt="Screenshot 2025-08-13 at 14 37 40" src="https://github.com/user-attachments/assets/f1277a1b-4208-436f-a2ea-faa4b47b2f57" />
