### PR TITLE
docs(logs): fix hyphenation

### DIFF
--- a/docs/platforms/android/logs/index.mdx
+++ b/docs/platforms/android/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/dart/common/logs/index.mdx
+++ b/docs/platforms/dart/common/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/dart/guides/flutter/logs/index.mdx
+++ b/docs/platforms/dart/guides/flutter/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/go/common/logs/index.mdx
+++ b/docs/platforms/go/common/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5600
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/java/common/logs/index.mdx
+++ b/docs/platforms/java/common/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/javascript/common/logs/index.mdx
+++ b/docs/platforms/javascript/common/logs/index.mdx
@@ -12,7 +12,7 @@ notSupported:
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/php/common/logs/index.mdx
+++ b/docs/platforms/php/common/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5600
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 <Alert title="Looking for Symfony?">
 

--- a/docs/platforms/php/guides/laravel/logs/index.mdx
+++ b/docs/platforms/php/guides/laravel/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5600
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your Laravel applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your Laravel applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/python/logs/index.mdx
+++ b/docs/platforms/python/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/react-native/logs/index.mdx
+++ b/docs/platforms/react-native/logs/index.mdx
@@ -9,7 +9,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/ruby/logs/index.mdx
+++ b/docs/platforms/ruby/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5755
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/platforms/rust/common/logs/index.mdx
+++ b/docs/platforms/rust/common/logs/index.mdx
@@ -7,7 +7,7 @@ sidebar_order: 5600
 
 <Include name="feature-stage-beta-logs.mdx" />
 
-With Sentry Structured Logs, you can send text based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
+With Sentry Structured Logs, you can send text-based log information from your applications to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual attributes.
 
 ## Requirements
 

--- a/docs/product/explore/logs/index.mdx
+++ b/docs/product/explore/logs/index.mdx
@@ -8,7 +8,7 @@ description: "Structured logs allow you to send, view and query logs and paramet
 
 ## Overview
 
-With Structured Logs, users can send text based log information from their applications, whether frontend or backend, to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual parameters.
+With Structured Logs, users can send text-based log information from their applications, whether frontend or backend, to Sentry. Once in Sentry, these logs can be viewed alongside relevant errors, searched by text-string, or searched using their individual parameters.
 
 <Arcade src="https://demo.arcade.software/PalOCHofpcO3DqvA4Rzr?embed" />
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
In #14583, @coolguyzone noticed a missing hyphen: see https://github.com/getsentry/sentry-docs/pull/14583#discussion_r2271395947.
This PR is applying the fix for the other platforms as well.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
