### PR TITLE
fix Hydrogen on CF docs link redirects

### DIFF
--- a/docs/platforms/javascript/guides/remix/frameworks/index.mdx
+++ b/docs/platforms/javascript/guides/remix/frameworks/index.mdx
@@ -6,4 +6,4 @@ description: "Learn how to set up the Remix SDK or Hydrogen with Cloudflare."
 You can use the Sentry Remix SDK to set up Sentry with frameworks like Shopify's Hydrogen. The following guides will help you get started with the Sentry Remix SDK on Cloudflare:
 
 - **[Remix on Cloudflare](/platforms/javascript/guides/cloudflare/frameworks/remix/)**
-- **[Hydrogen on Cloudflare](/platforms/javascript/guides/cloudflare/frameworks/hydrogen/)**
+- **[Hydrogen on Cloudflare](/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router/)**

--- a/redirects.js
+++ b/redirects.js
@@ -753,7 +753,7 @@ const userDocsRedirects = [
   },
   {
     source: '/platforms/javascript/guides/remix/frameworks/hydrogen/',
-    destination: '/platforms/javascript/guides/cloudflare/frameworks/hydrogen/',
+    destination: '/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router/',
   },
   {
     source: '/product/metrics/:path*',


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Closes https://github.com/getsentry/sentry-docs/issues/14607
Fixes redirect from https://github.com/getsentry/sentry-docs/pull/14645 to React Router docs
Fixes https://docs.sentry.io/platforms/javascript/guides/remix/frameworks/ hydrogen on cf link

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
