### PR TITLE
Update time-to-display.mdx to remove the indication that TTID/TTFD doesn't work with the new architecture

### DIFF
--- a/docs/platforms/react-native/tracing/instrumentation/time-to-display.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/time-to-display.mdx
@@ -83,7 +83,7 @@ function MyComponent() {
 
 ## Troubleshooting
 
-- Time To Display is not available on Web and React Native New Architecture yet.
+- Time To Display is not available on Web yet.
 
 - Time To Display supports Expo applications, but doesn't work for Expo Go. Build the native projects to test this feature.
 


### PR DESCRIPTION
Time To Initial Display / Time To Full Display works with the new architecture after certain changes done in the past: https://github.com/getsentry/sentry-react-native/pull/5081
It still needs to be re-implemented as a turbo module, and that will be handled later but at least it can be used now.