### PR TITLE
chore: Updated known limitation in Unity with Cysharp

### DIFF
--- a/docs/platforms/unity/troubleshooting/known-limitations.mdx
+++ b/docs/platforms/unity/troubleshooting/known-limitations.mdx
@@ -43,7 +43,11 @@ This is also why you might end up with very high line numbers (in the several th
 
 ## Cysharp
 
-Currently, the SDK fails to provide line numbers and source context in combination with Cysharp. For context, the SDK relies on Unity's IL2CPP backend to provide it with instruction addresses for Sentry generate line numbers in events. When using Cysharp, those instruction addresses default back to `0x0` once the stacktrace goes into the library. There is no known workaround for this.
+**Note: This issue is obsolete and resolved for Unity 2021+ with UniTask 2.5.10+**
+
+In older versions, the SDK failed to provide line numbers and source context in combination with Cysharp. The SDK relies on Unity's IL2CPP backend to provide instruction addresses for Sentry to generate line numbers in events. When using Cysharp, those instruction addresses would default back to `0x0` once the stacktrace goes into the library.
+
+This issue has been resolved in newer versions. If you're experiencing this problem, updating to Unity 2021 or later with UniTask 2.5.10 or later should resolve it.
 
 ## WebGL Support
 

--- a/docs/platforms/unity/troubleshooting/known-limitations.mdx
+++ b/docs/platforms/unity/troubleshooting/known-limitations.mdx
@@ -45,7 +45,7 @@ This is also why you might end up with very high line numbers (in the several th
 
 **Note: This issue is obsolete and resolved for Unity 2021+ with UniTask 2.5.10+**
 
-In older versions, the SDK failed to provide line numbers and source context in combination with Cysharp. The SDK relies on Unity's IL2CPP backend to provide instruction addresses for Sentry to generate line numbers in events. When using Cysharp, those instruction addresses would default back to `0x0` once the stacktrace goes into the library.
+In older versions, the SDK failed to provide line numbers and source context in combination with Cysharp. This is because the SDK depends on Unity’s IL2CPP backend to supply instruction addresses, which Sentry uses to generate line numbers in events. However, when the stack trace entered the Cysharp library, those instruction addresses defaulted to 0x0, preventing line numbers from being reported.
 
 This issue has been resolved in newer versions. If you're experiencing this problem, updating to Unity 2021 or later with UniTask 2.5.10 or later should resolve it.
 


### PR DESCRIPTION
Dropping this screenshot here for proof:

<img width="806" height="817" alt="Screenshot 2025-08-14 at 15 02 03" src="https://github.com/user-attachments/assets/08f0a618-913d-4cf2-bb46-cf5c0fa70c75" />
