### PR TITLE
feat(Unity ): Added `APK+OBB` initialization to troubleshooting

### DIFF
--- a/docs/platforms/unity/troubleshooting/index.mdx
+++ b/docs/platforms/unity/troubleshooting/index.mdx
@@ -35,6 +35,34 @@ This happens if you've copied some of the SDK files directly to the Assets folde
 
 ## Runtime issues
 
+### Android: Initialization fails - APK+OBB
+
+When exporting your Unity project as APK+OBB, the `ScriptableSentryOptions` configuration file stored in `/Resources/Sentry` may end up in the OBB file instead of the main APK. This can cause initialization issues if the OBB file is not available when the SDK attempts to auto-initialize.
+
+**Workaround (requires Unity SDK version `4.0.0 or later`):**
+
+Instead of relying on the ScriptableObject configuration and auto-initialization, you can manually initialize the SDK from your code:
+
+```csharp
+using Sentry;
+
+public class GameInitializer : MonoBehaviour
+{
+    private void Start()
+    {
+        SentrySdk.Init(options =>
+        {
+            options.Dsn = "YOUR_DSN_HERE";
+            options.Debug = true;
+            // Add other configuration options as needed
+        });
+    }
+}
+```
+
+Since this way the options are embedded in code, the reliance on the `/Resources` being available at the time of initialization falls away.
+Prior to version `4.0.0`, native support is limited when programmatically initializing the SDK.
+
 ### Library not loaded: @rpath/Sentry.framework/Sentry
 
 If you encounter the following error:


### PR DESCRIPTION
With the Unity SDK version `4.0.0 and newer` there is a proper workaround to this problem.