### PR TITLE
feat(replay): Add troubleshooting item for cross origin frames

### DIFF
--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -131,6 +131,23 @@ To hide this content, block the iframe, as described in our Session Replay <Plat
 
 </Expandable>
 
+<Expandable title="I'm getting the error: Blocked a frame with origin '...' from accessing a frame with origin '...'. Protocols, domains, and ports must match." permalink>
+
+The replay SDK attempted to access a cross-origin frame but was not allowed to. You will need to block the iframe in order to stop the errors:
+
+```javascript
+Sentry.init({
+  dsn: "...",
+  replaysSessionSampleRate: 1,
+  integrations: [
+    Sentry.replayIntegration({
+      block: ["iframe"],
+    }),
+  ],
+})
+```
+</Expandable>
+
 <Expandable title="Replay on my browser extension doesn't work" permalink>
 
 This is not a supported use-case. The replay package is built to work on a website and not as an externally-loaded script via browser extension or other mechanism. In fact, Sentry's Session Replay product can help developers find out when a third-party Chrome extension causes otherwise hard to debug or reproduce issues with their website.


### PR DESCRIPTION
This adds a new troubleshooting item to address the replay SDK causing cross-origin frame errors.
