### PR TITLE
feat(python): Remove experimental logging options

### DIFF
--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -12,20 +12,19 @@ categories:
 
 ## Prerequisites
 
-* You need a Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
-* Read one of our dedicated guides if you use any of the <PlatformLink to="/integrations/#web-frameworks">frameworks</PlatformLink> we support
+- You need a Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Read one of our dedicated guides if you use any of the <PlatformLink to="/integrations/#web-frameworks">frameworks</PlatformLink> we support
 
 ## Features
 
-<p className="mb-5">Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.</p>
+<p className="mb-5">
+  Select which Sentry features you'd like to install in addition to Error
+  Monitoring to get the corresponding installation and configuration
+  instructions below.
+</p>
 
 <OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-    'profiling',
-    'logs',
-  ]}
+  options={["error-monitoring", "performance", "profiling", "logs"]}
 />
 
 ## Install
@@ -35,6 +34,7 @@ Install the Sentry SDK using [`pip`](https://pip.pypa.io/en/stable/):
 ```bash {tabTitle:pip}
 pip install "sentry-sdk"
 ```
+
 ```bash {tabTitle:uv}
 uv add "sentry-sdk"
 ```
@@ -42,8 +42,6 @@ uv add "sentry-sdk"
 ## Configure
 
 Configuration should happen as **early as possible** in your application's lifecycle.
-
-
 
 ```python
 import sentry_sdk
@@ -69,7 +67,7 @@ sentry_sdk.init(
     # ___PRODUCT_OPTION_START___ logs
 
     # Enable logs to be sent to Sentry
-    _experiments={"enable_logs": True},
+    enable_logs=True,
     # ___PRODUCT_OPTION_END___ logs
 )
 ```

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -12,6 +12,7 @@ Install `sentry-sdk` from PyPI:
 ```bash {tabTitle:pip}
 pip install "sentry-sdk"
 ```
+
 ```bash {tabTitle:uv}
 uv add "sentry-sdk"
 ```
@@ -19,7 +20,6 @@ uv add "sentry-sdk"
 ## Configure
 
 The logging integrations is a default integration so it will be enabled automatically when you initialize the Sentry SDK.
-
 
 ```python
 import sentry_sdk
@@ -62,9 +62,7 @@ import sentry_sdk
 
 sentry_sdk.init(
     # ...
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 logging.info("I will be sent to Sentry logs")
@@ -107,7 +105,7 @@ You can pass the following keyword arguments to `LoggingIntegration()`:
   ```python
   sentry_sdk.init(
       # ...
-      _experiments={"enable_logs": True},
+      enable_logs=True,
   )
   ```
 

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -14,6 +14,7 @@ Install `sentry-sdk` from PyPI with the `loguru` extra.
 ```bash {tabTitle:pip}
 pip install "sentry-sdk[loguru]"
 ```
+
 ```bash {tabTitle:uv}
 uv add "sentry-sdk[loguru]"
 ```
@@ -21,7 +22,6 @@ uv add "sentry-sdk[loguru]"
 ## Configure
 
 If you have the `loguru` package in your dependencies, the Loguru integration will be enabled automatically when you initialize the Sentry SDK.
-
 
 ```python
 import sentry_sdk
@@ -157,12 +157,11 @@ sentry_sdk.init(
   ```python
   sentry_sdk.init(
       # ...
-      _experiments={"enable_logs": True},
+      enable_logs=True,
   )
   ```
 
   Default: `INFO`
-
 
 ## Supported Versions
 

--- a/platform-includes/getting-started-config/python.mdx
+++ b/platform-includes/getting-started-config/python.mdx
@@ -1,11 +1,7 @@
 <OnboardingOptionButtons
-  options={[
-    'error-monitoring',
-    'performance',
-    'profiling',
-    'logs',
-  ]}
+  options={["error-monitoring", "performance", "profiling", "logs"]}
 />
+
 ```python
 import sentry_sdk
 
@@ -30,9 +26,7 @@ sentry_sdk.init(
     # ___PRODUCT_OPTION_START___ logs
 
     # Enable logs to be sent to Sentry
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
     # ___PRODUCT_OPTION_END___ logs
 )
 ```

--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -8,9 +8,7 @@ import logging
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 # Your existing logging setup
@@ -31,9 +29,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True
-    },
+    enable_logs=True,
     integrations=[
         # Only send WARNING (and higher) logs to Sentry logs,
         # even if the logger is set to a lower level.
@@ -52,7 +48,6 @@ my_logger.setLevel(logging.ERROR)
 my_logger.warning('Now, this log message will not be sent to Sentry logs, since the logger is set to ERROR.')
 ```
 
-
 The logging integration automatically monkeypatches a handler into all loggers except for the root logger. If you'd like to manually configure the handler, you can do that like so:
 
 ```python
@@ -62,9 +57,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True
-    },
+    enable_logs=True,
     integrations=[
         LoggingIntegration(sentry_logs_level=None),  # Do not monkeypatch the sentry handler
     ],
@@ -84,9 +77,7 @@ from loguru import logger
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 
 loguru.debug("In this example, debug events will not be sent to Sentry logs.")
@@ -102,9 +93,7 @@ from sentry_sdk.integrations.loguru import LoggingLevels, LoguruIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True
-    },
+    enable_logs=True,
     integrations=[
         # Only send WARNING (and higher) logs to Sentry logs
         LoguruIntegration(sentry_logs_level=LoggingLevels.WARNING.value),
@@ -125,10 +114,8 @@ from sentry_sdk.integrations.loguru import LoguruIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        # In general, we want to capture logs as Sentry logs...
-        "enable_logs": True,
-    },
+    # In general, we want to capture logs as Sentry logs...
+    enable_logs=True,
     integrations=[
         # ...just not from Loguru
         LoguruIntegration(sentry_logs_level=None),

--- a/platform-includes/logs/options/python.mdx
+++ b/platform-includes/logs/options/python.mdx
@@ -1,6 +1,6 @@
 #### before_send_log
 
-To filter logs, or update them before they are sent to Sentry, you can use the `_experiments["before_send_log"]` option.
+To filter logs, or update them before they are sent to Sentry, you can use the `before_send_log` option.
 
 ```python
 import sentry_sdk
@@ -15,10 +15,8 @@ def before_log(log: Log, _hint: Hint) -> Optional[Log]:
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-        "before_send_log": before_log,
-    },
+    enable_logs=True,
+    before_send_log=before_log,
 )
 ```
 

--- a/platform-includes/logs/requirements/python.mdx
+++ b/platform-includes/logs/requirements/python.mdx
@@ -1,8 +1,9 @@
-Logs for Python are supported in Sentry Python SDK version `2.28.0` and above.
+Logs for Python are supported in Sentry Python SDK version `2.35.0` and above.
 
 ```bash {tabTitle:pip}
 pip install "sentry-sdk"
 ```
+
 ```bash {tabTitle:uv}
 uv add "sentry-sdk"
 ```

--- a/platform-includes/logs/setup/python.mdx
+++ b/platform-includes/logs/setup/python.mdx
@@ -3,8 +3,6 @@ To enable logging, you need to initialize the SDK with the `_experiments["enable
 ```python
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
-    _experiments={
-        "enable_logs": True,
-    },
+    enable_logs=True,
 )
 ```


### PR DESCRIPTION
documents logging changes made in https://github.com/getsentry/sentry-python/releases/tag/2.35.0, so also bumps the min required sdk version.