### PR TITLE
Corrects loguru logger usage ---

### DIFF
--- a/platform-includes/logs/integrations/python.mdx
+++ b/platform-includes/logs/integrations/python.mdx
@@ -80,8 +80,8 @@ sentry_sdk.init(
     enable_logs=True,
 )
 
-loguru.debug("In this example, debug events will not be sent to Sentry logs.")
-loguru.info("On the other hand, info events will be sent to Sentry logs.")
+logger.debug("In this example, debug events will not be sent to Sentry logs.")
+logger.info("On the other hand, info events will be sent to Sentry logs.")
 ```
 
 By default, the Loguru integration sends `INFO`-level and higher logs to Sentry logs as long as `enable_logs` is `True`. A different threshold can be set via the `LoguruIntegration`'s `sentry_logs_level` parameter.
@@ -122,5 +122,5 @@ sentry_sdk.init(
     ]
 )
 
-loguru.error("This won't be sent to Sentry logs.")
+logger.error("This won't be sent to Sentry logs.")
 ```


### PR DESCRIPTION
The loguru code examples were using `loguru.error()`, `loguru.info()` and `loguru.debug()` after importing the logger as `logger`. This commit updates the examples to consistently use, `logger.error()`, `logger.info()` and `logger.debug()`, aligning with the import statement and improving code clarity for users.

- [x] Not urgent, can wait up to 1 week+