### PR TITLE
Updating Console Access Pricing In Docs

### DIFF
--- a/docs/platforms/playstation/index.mdx
+++ b/docs/platforms/playstation/index.mdx
@@ -13,9 +13,9 @@ categories:
 You can also use Sentry's [Unity](/platforms/unity/game-consoles/) and [Unreal Engine SDKs](/platforms/unreal/game-consoles/) with PlayStation.
 
 <Alert>
-
 PlayStation support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
 
+Access to Sentry's error and crash reporting for consoles is a paid feature. We will review the pricing and details with you during the verification process.
 </Alert>
 ----
 

--- a/docs/platforms/unity/game-consoles/index.mdx
+++ b/docs/platforms/unity/game-consoles/index.mdx
@@ -7,6 +7,9 @@ sidebar_order: 7
 Sentry supports [PlayStation](https://docs.sentry.io/platforms/playstation/), [Xbox](https://docs.sentry.io/platforms/xbox/) and [Nintendo Switch](https://docs.sentry.io/platforms/nintendo-switch/) via the Unity SDK.  Once you submit the middleware verification process, we'll reach out and send you an invite to our private GitHub repositories with console specific code.
 This allows your configuration and custom data set via C# to show up in C# exceptions as well as crash dumps on these console platforms.
 
+<Alert>
+Access to Sentry's error and crash reporting for consoles is a paid feature. We will review the pricing and details with you during the verification process.
+</Alert>
 
 ## Nintendo Switch
 

--- a/docs/platforms/unreal/game-consoles/index.mdx
+++ b/docs/platforms/unreal/game-consoles/index.mdx
@@ -8,7 +8,7 @@ Sentry supports [PlayStation](https://docs.sentry.io/platforms/playstation/), [X
 This allows your configuration and custom data set via C++ or Blueprints to show up in non-fatal events as well as crash dumps on these console platforms.
 
 <Alert>
-Access to Sentry's error and crash reporting for consoles is available at a separate cost. We will review the pricing and details with you during the verification process.
+Access to Sentry's error and crash reporting for consoles is a paid feature. We will review the pricing and details with you during the verification process.
 </Alert>
 
 

--- a/docs/platforms/unreal/game-consoles/index.mdx
+++ b/docs/platforms/unreal/game-consoles/index.mdx
@@ -7,6 +7,10 @@ sidebar_order: 7
 Sentry supports [PlayStation](https://docs.sentry.io/platforms/playstation/), [Xbox](https://docs.sentry.io/platforms/xbox/) and [Nintendo Switch](https://docs.sentry.io/platforms/nintendo-switch/) via the Unreal Engine SDK extensions. Once you submit the middleware verification process, we'll reach out and send you an invite to our private GitHub repositories with console specific code.
 This allows your configuration and custom data set via C++ or Blueprints to show up in non-fatal events as well as crash dumps on these console platforms.
 
+<Alert>
+Access to Sentry's error and crash reporting for consoles is available at a separate cost. We will review the pricing and details with you during the verification process.
+</Alert>
+
 
 ## PlayStation
 

--- a/docs/platforms/xbox/index.mdx
+++ b/docs/platforms/xbox/index.mdx
@@ -12,6 +12,10 @@ categories:
 
 You can also use Sentry's [Unity](/platforms/unity/game-consoles/) and [Unreal Engine SDKs](/platforms/unreal/game-consoles/) with Xbox.
 
+<Alert>
+Access to Sentry's error and crash reporting for consoles is a paid feature. We will review the pricing and details with you during the verification process.
+</Alert>
+
 ----
 
 "Microsoft", "Xbox" are trademarks of the Microsoft group of companies.


### PR DESCRIPTION
## DESCRIBE YOUR PR
We need to update the docs for Unreal, Unity, PlayStation, Xbox, and Nintendo Switch to include details about the pricing for console access. 
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
