### PR TITLE
Increase self-hosted requirements to 32GB memory

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -31,10 +31,10 @@ We require at least **Docker 19.03.6** and **Docker Compose 2.32.2**. It is reco
 
 These are the minimum requirements:
 - 4 CPU Cores
-- 16 GB RAM
+- 16GB memory + 16GB swap
 - 20 GB Free Disk Space
 
-We also recommend using a swapfile whenever applicable.
+We recommend using 32GB memory, but it works with 16GB memory + 16GB swap as well. You will not notice a downside if your 16GB swap is on a high speed disk.
 
 Depending on your traffic volume, you may want to increase your system specification to handle increased load. Although most of the times, this is not the case for self-hosted Sentry, since no matter how small or big the traffic is, you will most likely hover around the same used resources.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Sentry self-hosted uses more than 28GB memory at the minimum right now, this PR increases memory requirements to 32GB memory, also mentioning 16GB memory + 16GB swap is fine.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.):
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

cc @aldy505 

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
