### PR TITLE
fix(js): Fix references of `registerWorker` to `registerWebWorker`

### DIFF
--- a/docs/platforms/javascript/common/best-practices/web-workers.mdx
+++ b/docs/platforms/javascript/common/best-practices/web-workers.mdx
@@ -56,7 +56,7 @@ Then, establish communication between the worker and the SDK:
 import * as Sentry from "@sentry/browser";
 
 // Call this before posting any message
-Sentry.registerWorker({ self })
+Sentry.registerWebWorker({ self })
 
 // Errors from `onmessage` callback of `worker.js`
 // will be captured automatically.
@@ -101,7 +101,7 @@ webWorkerIntegration.addWorker(worker3);
 
 <Alert level="warning" title="Keep in Mind">
 
-- Every worker must call `Sentry.registerWorker({ self })` to register itself with the SDK.
+- Every worker must call `Sentry.registerWebWorker({ self })` to register itself with the SDK.
 - Do not call `Sentry.webWorkerIntegration()` multiple times! This will lead to unexpected behavior.
 
 </Alert>
@@ -135,7 +135,7 @@ Other times, if the worker is just part of your application, you likely want to 
 <Alert level="warning" title="Keep in Mind">
 
 If you initialize the SDK in the worker, don't use the `Sentry.webWorkerIntegration` to register the worker.
-Likewise, don't use the `Sentry.registerWorker` in the worker. Both methods are only supposed to be used when relying on the SDK [from the main thread](#recommended-setup).
+Likewise, don't use the `Sentry.registerWebWorker` in the worker. Both methods are only supposed to be used when relying on the SDK [from the main thread](#recommended-setup).
 
 </Alert>
 

--- a/docs/platforms/javascript/common/configuration/integrations/webworker.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/webworker.mdx
@@ -21,14 +21,14 @@ notSupported:
 
 _Import name: `Sentry.webWorkerIntegration`_
 
-This integration, together with `Sentry.registerWorker()`, establishes communication between the browser's main thread and one or more [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
+This integration, together with `Sentry.registerWebWorker()`, establishes communication between the browser's main thread and one or more [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
 It listens to worker messages from the passed workers and forwards them to the main thread. 
 
 Read our <PlatformLink to="/best-practices/web-workers/">Web Worker Guide</PlatformLink> for more information. 
 
 <Expandable title="What does this integration do?">
 
-This integration listens to a message sent from the worker when it calls `Sentry.registerWorker({ self })`.
+This integration listens to a message sent from the worker when it calls `Sentry.registerWebWorker({ self })`.
 The purpose is to sync source map information (debugIds) between the main thread and the worker so that worker
 errors caught by the main thread SDK are properly mapped to the worker's source code.
 
@@ -41,7 +41,7 @@ errors caught by the main thread SDK are properly mapped to the worker's source 
 
 _Type: `Worker | Array<Worker>`_
 
-The web worker(s) to listen to. Every worker must call `Sentry.registerWorker({ self })` to register itself with the SDK.
+The web worker(s) to listen to. Every worker must call `Sentry.registerWebWorker({ self })` to register itself with the SDK.
 
 ## Methods
 
@@ -49,4 +49,4 @@ The web worker(s) to listen to. Every worker must call `Sentry.registerWorker({ 
 
 Adds a worker to the integration, after the integraion was already initialized and added to the SDK.
 This is useful if you have workers that are initialized at later point in your application's lifecycle.
-Note that every worker must call `Sentry.registerWorker({ self })` to register itself with the SDK.
+Note that every worker must call `Sentry.registerWebWorker({ self })` to register itself with the SDK.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

I incorrectly referred to `Sentry.registerWebWorker` by `Sentry.registerWorker` when reworking our web worker docs in #14395. 

Closes https://github.com/getsentry/sentry-javascript/issues/17443

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
