### PR TITLE
docs(replay): Let Replay troubleshooting items be expandable, and deep-linkable

### DIFF
--- a/docs/platforms/apple/guides/ios/session-replay/troubleshooting.mdx
+++ b/docs/platforms/apple/guides/ios/session-replay/troubleshooting.mdx
@@ -5,7 +5,7 @@ notSupported:
 description: "Troubleshoot and resolve common issues with the iOS Session Replay."
 ---
 
-## Session Replay is not recording with custom window setup
+<Expandable title="Session Replay is not recording with custom window setup" permalink>
 
 If you have a custom window setup (e.g., multiple instances of `UIWindow`), you need to ensure that the Sentry SDK is able to find the correct window.
 
@@ -69,3 +69,5 @@ final class SceneDelegate: NSObject, UIWindowSceneDelegate {
     }
 }
 ```
+
+</Expandable>


### PR DESCRIPTION


<img width="763" height="373" alt="SCR-20250825-lvfg" src="https://github.com/user-attachments/assets/4ff5c2aa-6909-47c4-8556-2cee204cb0d1" />
