### PR TITLE
docs(replay): Bring replay nav item to all apple platforms

### DIFF
--- a/docs/platforms/apple/common/session-replay/customredact.mdx
+++ b/docs/platforms/apple/common/session-replay/customredact.mdx
@@ -1,8 +1,12 @@
 ---
 title: Using Custom Masking for Session Replay
 sidebar_order: 5501
-notSupported:
 description: "Learn how to mask parts of your app's data in Session Replay."
+notSupported:
+  - apple.macos
+  - apple.watchos
+  - apple.tvos
+  - apple.visionos
 ---
 
 <Alert>

--- a/docs/platforms/apple/common/session-replay/index.mdx
+++ b/docs/platforms/apple/common/session-replay/index.mdx
@@ -2,9 +2,27 @@
 title: Set Up Session Replay
 sidebar_title: Session Replay
 sidebar_order: 5500
-notSupported:
 description: "Learn how to enable Session Replay in your mobile app."
+notSupported:
 ---
+
+<PlatformSection notSupported={["apple.ios"]}>
+
+## FAQ
+
+Q: **Does Session Replay work with SwiftUI?**
+
+A: Yes. It works with both UIKit and SwiftUI.
+
+Q: **Does Session Replay work on macOS, watchOS, tvOS and visionOS?**
+
+A: We don't actively prevent you from using Session Replay on these platforms, but we only officially support it on iOS. As a consequence, we can't make guarantees about its functionality and performance on other platforms.
+
+# Session Replay for Mobile Apps
+
+</PlatformSection>
+
+<PlatformSection notSupported={["apple.macos", "apple.tvos", "apple.watchos", "apple.visionos"]}>
 
 <Alert level="warning">
 
@@ -105,24 +123,4 @@ Errors that happen while a replay is running will be linked to the replay, makin
 - The replay was deleted by a member of your org.
 - There were network errors and the replay wasn't saved.
 
-## FAQ
-
-Q: **Does Session Replay work with SwiftUI?**
-
-A: Yes. It works with both UIKit and SwiftUI.
-
-Q: **Why are parts of my replay not masked?**
-
-A: Text views, input views, images, video players and webviews are all masked by default. Images with bundled assets aren't masked because the likelihood of these assets containing PII is low. If you encounter a view that should be masked by default, consider opening a [GitHub issue](https://github.com/getsentry/sentry-cocoa/issues).
-
-Q: **What's the lowest version of iOS supported?**
-
-A: Session Replay recording happens even on the lowest version supported by the Sentry SDK, which is aligend with appstore support.
-
-Q: **Why is my issue missing a replay?**
-
-A: An issue may be missing a replay because the user's device was [offline](/product/explore/session-replay/mobile#frequently-asked-questions) while `sessionSampleRate` was specified, your project/organization was rate-limited, or (in rare cases) the device failed to capture the replay video.
-
-Q: **Does Session Replay work on macOS, watchOS, tvOS and visionOS?**
-
-A: We don't actively prevent you from using Session Replay on these platforms, but we only officially support it on iOS. As a consequence, we can't make guarantees about its functionality and performance on other platforms.
+</PlatformSection>

--- a/docs/platforms/apple/common/session-replay/performance-overhead.mdx
+++ b/docs/platforms/apple/common/session-replay/performance-overhead.mdx
@@ -1,8 +1,12 @@
 ---
 title: Performance Overhead
 sidebar_order: 5502
-notSupported:
 description: "Learn about how enabling Session Replay impacts the performance of your application."
+notSupported:
+  - apple.macos
+  - apple.watchos
+  - apple.tvos
+  - apple.visionos
 ---
 
 If you're considering enabling Session Replay, it's important to first understand the potential performance impact to your app. While accurate metrics require realistic testing where you apply typical access patterns and correlate the results with your business metrics, to provide a baseline, we measured the overhead using the open-source [Pocket Casts](https://github.com/Automattic/pocket-casts-ios) app.

--- a/docs/platforms/apple/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/apple/common/session-replay/troubleshooting.mdx
@@ -1,9 +1,31 @@
 ---
 title: Troubleshooting
 sidebar_order: 5503
-notSupported:
 description: "Troubleshoot and resolve common issues with the iOS Session Replay."
+notSupported:
+  - apple.macos
+  - apple.watchos
+  - apple.tvos
+  - apple.visionos
 ---
+
+<Expandable title="Why are parts of my replay not masked?" permalink>
+
+Text views, input views, images, video players and webviews are all masked by default. Images with bundled assets aren't masked because the likelihood of these assets containing PII is low. If you encounter a view that should be masked by default, consider opening a [GitHub issue](https://github.com/getsentry/sentry-cocoa/issues).
+
+</Expandable>
+
+<Expandable title="What's the lowest version of iOS supported?" permalink>
+
+Session Replay recording happens even on the lowest version supported by the Sentry SDK, which is aligend with appstore support.
+
+</Expandable>
+
+<Expandable title="Why is my issue missing a replay?" permalink>
+
+An issue may be missing a replay because the user's device was [offline](/product/explore/session-replay/mobile#frequently-asked-questions) while `sessionSampleRate` was specified, your project/organization was rate-limited, or (in rare cases) the device failed to capture the replay video.
+
+</Expandable>
 
 <Expandable title="Session Replay is not recording with custom window setup" permalink>
 


### PR DESCRIPTION
This puts all the Session Replay pages into the Apple platform section, not just iOS. 

`/platforms/apple/` Nav
| Before | After |
| --- | --- |
<img width="285" height="779" alt="SCR-20250825-mjyo" src="https://github.com/user-attachments/assets/ca7e07bd-b28f-4600-bc60-c9a0fa5a8875" /> | <img width="299" height="819" alt="SCR-20250825-mkbs" src="https://github.com/user-attachments/assets/1e0821bc-e69c-434b-be9d-a7c30f7ea1e6" />

But since most of the Apple platforms are not specifically supported I put the two "Does Session Replay work with *" faq questions at the top of the index page whenever you're not looking specifically at iOS docs. 
Only the main Apple and iOS show the sub-pages in the nav bar, the other platform specific sections only show the FAQ stuff and no sub-pages.

| Apple Overall | iOS Specific | The others |
| --- | --- | --- |
| <img width="1304" height="856" alt="SCR-20250825-mird" src="https://github.com/user-attachments/assets/6d498fac-8dc6-4525-ad37-87da1cd99f8b" /> | <img width="1293" height="837" alt="SCR-20250825-misb" src="https://github.com/user-attachments/assets/e6b5afe1-8de0-4bb7-9a72-3c7d3efab65a" /> | <img width="1131" height="797" alt="SCR-20250825-mlcq" src="https://github.com/user-attachments/assets/e3c839de-7a5b-4988-a3f6-b265226cbce6" />
