### PR TITLE
fix: Fix breadcrumb + markdown button allignment

### DIFF
--- a/src/components/breadcrumbs/index.tsx
+++ b/src/components/breadcrumbs/index.tsx
@@ -24,7 +24,7 @@ export function Breadcrumbs({leafNode}: BreadcrumbsProps) {
   }
 
   return (
-    <ul className="list-none flex p-0 flex-wrap float-left" style={{margin: 0}}>
+    <ul className="not-prose list-none flex flex-wrap" style={{margin: 0}}>
       {breadcrumbs.map(b => {
         return (
           <li className={styles['breadcrumb-item']} key={b.to}>

--- a/src/components/copyMarkdownButton.tsx
+++ b/src/components/copyMarkdownButton.tsx
@@ -119,7 +119,7 @@ export function CopyMarkdownButton({pathname}: CopyMarkdownButtonProps) {
   };
 
   const buttonClass =
-    'inline-flex items-center h-full text-gray-700 dark:text-[var(--foreground)] bg-transparent border-none cursor-pointer transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-[var(--gray-a4)] active:bg-gray-100 dark:active:bg-[var(--gray-5)] focus:bg-gray-50 dark:focus:bg-[var(--gray-a4)] outline-none';
+    'inline-flex items-center text-nowrap h-full text-gray-700 dark:text-[var(--foreground)] bg-transparent border-none cursor-pointer transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-[var(--gray-a4)] active:bg-gray-100 dark:active:bg-[var(--gray-5)] focus:bg-gray-50 dark:focus:bg-[var(--gray-a4)] outline-none';
   const dropdownItemClass =
     'flex items-center gap-3 w-full p-2 px-3 text-left bg-transparent rounded-md transition-colors hover:bg-gray-100 dark:hover:bg-[var(--gray-a4)] font-sans text-gray-900 dark:text-[var(--foreground)]';
   const iconContainerClass =

--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -82,9 +82,9 @@ export function DocPage({
             <div className="mb-4">
               <Banner />
             </div>
-            <div className="overflow-hidden">
+            <div className="flex items-center">
               {leafNode && <Breadcrumbs leafNode={leafNode} />}{' '}
-              <div className="float-right mt-4 sm:mt-0 hidden sm:block">
+              <div className="ml-auto hidden sm:block">
                 <CopyMarkdownButton pathname={pathname} />
               </div>
             </div>


### PR DESCRIPTION
**Before**

<img width="760" height="82" alt="Firefox 2025-08-26 01 48 44" src="https://github.com/user-attachments/assets/c79a78a7-9de8-4b91-8f9c-bc070298e638" />


**After**

<img width="759" height="99" alt="Screenshot 2025-08-26 at 01 48 10" src="https://github.com/user-attachments/assets/59589e87-dbec-4603-bbb1-e7d59121c114" />
