### PR TITLE
docs(js): Fix Next.js client tracing config

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/index.mdx
@@ -71,9 +71,6 @@ Sentry.init({
   sendDefaultPii: true,
 
   integrations: [
-    // ___PRODUCT_OPTION_START___ performance
-    Sentry.browserTracingIntegration(),
-    // ___PRODUCT_OPTION_END___ performance
     // ___PRODUCT_OPTION_START___ session-replay
     // Replay may only be enabled for the client-side
     Sentry.replayIntegration(),
@@ -108,6 +105,10 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
 });
+
+// ___PRODUCT_OPTION_START___ performance
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+// ___PRODUCT_OPTION_END___ performance
 ```
 
 ### Server-Side Configuration


### PR DESCRIPTION
Just realized we're missing the router instrumentation here, also the browserTracingIntegration is added by default.