### PR TITLE
feat(kmp): Add Sentry Cocoa compatibility version info

### DIFF
--- a/platform-includes/getting-started-install/kotlin.compose-multiplatform.mdx
+++ b/platform-includes/getting-started-install/kotlin.compose-multiplatform.mdx
@@ -14,6 +14,8 @@ The plugin does the following:
 
 <Alert>
 
-If you use Swift Package Manager instead of Cocoapods, you need to install the [sentry-cocoa dependency with Swift Package Manager](/platforms/apple/install/swift-package-manager/) in your Xcode project before executing the Gradle plugin. 
+If you use Swift Package Manager instead of Cocoapods, you need to install the [Sentry Cocoa dependency with Swift Package Manager](/platforms/apple/install/swift-package-manager/) in your Xcode project first before executing the Gradle plugin.
+
+Make sure that you install the Sentry Cocoa SDK version compatible with the corresponding Sentry Kotlin Multiplatform SDK version. You can find the compatible versions in the [Sentry Kotlin Multiplatform SDK README](https://github.com/getsentry/sentry-kotlin-multiplatform?tab=readme-ov-file#cocoa-sdk-version-compatibility-table).
 
 </Alert>

--- a/platform-includes/getting-started-install/kotlin.kotlin-multiplatform.mdx
+++ b/platform-includes/getting-started-install/kotlin.kotlin-multiplatform.mdx
@@ -12,9 +12,10 @@ The plugin does the following:
 - If you use the Kotlin Cocoapods plugin, it installs the Sentry Cocoa dependency.
 - If you use Swift Package Manager, it sets up linking to the Sentry Cocoa framework.
 
-
 <Alert>
 
-If you use Swift Package Manager instead of Cocoapods, you need to install the [sentry-cocoa dependency with Swift Package Manager](/platforms/apple/install/swift-package-manager/) in your Xcode project first before executing the Gradle plugin. 
+If you use Swift Package Manager instead of Cocoapods, you need to install the [Sentry Cocoa dependency with Swift Package Manager](/platforms/apple/install/swift-package-manager/) in your Xcode project first before executing the Gradle plugin.
+
+Make sure that you install the Sentry Cocoa SDK version compatible with the corresponding Sentry Kotlin Multiplatform SDK version. You can find the compatible versions in the [Sentry Kotlin Multiplatform SDK README](https://github.com/getsentry/sentry-kotlin-multiplatform?tab=readme-ov-file#cocoa-sdk-version-compatibility-table).
 
 </Alert>


### PR DESCRIPTION
Adds small info that the user has to install a compatible version of the Sentry Cocoa SDK for KMP