### PR TITLE
Update documentation phrase to keep secret

### DIFF
--- a/platform-includes/sourcemaps/upload/primer/javascript.sveltekit.mdx
+++ b/platform-includes/sourcemaps/upload/primer/javascript.sveltekit.mdx
@@ -12,7 +12,7 @@ You can set all values as environment variables, for example, in a `.env` file:
 <OrgAuthTokenNote />
 
 ```bash {filename: .env}
-# DO NOT commit this file to your repo. The auth token is a secret.
+# Keep this secret - do not commit this file to your repo. The auth token is a secret.
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 SENTRY_ORG=___ORG_SLUG___
 SENTRY_PROJECT=___PROJECT_SLUG___

--- a/src/components/codeKeywords/orgAuthTokenCreator.tsx
+++ b/src/components/codeKeywords/orgAuthTokenCreator.tsx
@@ -168,7 +168,7 @@ export function OrgAuthTokenCreator() {
       <KeywordDropdown
         ref={setReferenceEl}
         role="button"
-        title="Click to generate token (DO NOT commit)"
+        title="Click to generate token (keep this secret)"
         tabIndex={0}
         onClick={() => {
           handlePress();
@@ -192,7 +192,7 @@ export function OrgAuthTokenCreator() {
               onAnimationStart={() => setIsAnimating(true)}
               onAnimationComplete={() => setIsAnimating(false)}
             >
-              Click to generate token (DO NOT commit)
+              Click to generate token (keep this secret)
             </Keyword>
           </AnimatePresence>
         </span>


### PR DESCRIPTION
## DESCRIBE YOUR PR
This PR updates instances of "DO NOT commit" to "keep this secret" across the documentation. The change aims to improve clarity and user-friendliness of security warnings, specifically for authentication tokens, based on feedback received in Slack.

The update affects:
*   The interactive token generator component (`src/components/codeKeywords/orgAuthTokenCreator.tsx`), changing both its tooltip and display text.
*   A comment in `platform-includes/sourcemaps/upload/primer/javascript.sveltekit.mdx` for consistency.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/C010884QHLG/p1756278357449279?thread_ts=1756278357.449279&cid=C010884QHLG)

<a href="https://cursor.com/background-agent?bcId=bc-621ce82b-afed-40b9-8f27-c21b112c109f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-621ce82b-afed-40b9-8f27-c21b112c109f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

