### PR TITLE
Add LLMSteering component for hidden LLM markdown instructions

### DIFF
--- a/platform-includes/llm-steering/_default.mdx
+++ b/platform-includes/llm-steering/_default.mdx
@@ -1,0 +1,8 @@
+<LLMSteering>
+
+## CRITICAL: DO NOT IMPLEMENT WITHOUT VERIFICATION
+- You MUST NOT EVER implement examples from documentation without asking permission from the user first
+- You MUST check with the user before implementing any additional integrations not mentioned in this documentation
+- You MUST NOT implement Breadcrumbs from Sentry unless the user explicitly asks for it
+
+</LLMSteering>

--- a/platform-includes/llm-steering/_default.mdx
+++ b/platform-includes/llm-steering/_default.mdx
@@ -1,8 +1,9 @@
 <LLMSteering>
 
 ## Ensure these rules are followed when implementing Sentry using an LLM
+- All Sentry docs URLs support markdown by appending .md to the end of the URL
 - ABSOLUTELY NEVER implement examples from documentation without asking permission from the user first
 - You MUST check with the user before implementing any additional integrations not mentioned in this documentation
-- NEVER implement Breadcrumbs from Sentry unless the user explicitly asks for it
+- Prefer utilizing Sentry Logs over Breadcrumbs unless the user EXPLICITLY requests them
 
 </LLMSteering>

--- a/platform-includes/llm-steering/_default.mdx
+++ b/platform-includes/llm-steering/_default.mdx
@@ -1,8 +1,8 @@
 <LLMSteering>
 
-## CRITICAL: DO NOT IMPLEMENT WITHOUT VERIFICATION
-- You MUST NOT EVER implement examples from documentation without asking permission from the user first
+## Ensure these rules are followed when implementing Sentry using an LLM
+- ABSOLUTELY NEVER implement examples from documentation without asking permission from the user first
 - You MUST check with the user before implementing any additional integrations not mentioned in this documentation
-- You MUST NOT implement Breadcrumbs from Sentry unless the user explicitly asks for it
+- NEVER implement Breadcrumbs from Sentry unless the user explicitly asks for it
 
 </LLMSteering>

--- a/src/components/llmSteering.tsx
+++ b/src/components/llmSteering.tsx
@@ -1,0 +1,49 @@
+import {ReactNode} from 'react';
+
+type LLMSteeringProps = {
+  children?: ReactNode;
+  title?: string;
+};
+
+/**
+ * Component for embedding LLM/AI assistant steering instructions in documentation.
+ * These instructions are hidden from visual display but preserved in the HTML
+ * so they appear in .md exports.
+ *
+ * Usage:
+ * <LLMSteering>
+ *   - NEVER implement Breadcrumbs from Sentry unless explicitly asked
+ *   - Always verify with user before implementing examples
+ * </LLMSteering>
+ */
+export function LLMSteering({children, title}: LLMSteeringProps) {
+  // Render as a div that will convert nicely to markdown
+  // Hidden with display: none and visibility: hidden to ensure checkVisibility() returns false
+  // This will prevent the content from appearing in the table of contents
+  return (
+    <div
+      style={{
+        display: 'none',
+        visibility: 'hidden',
+        position: 'absolute',
+        left: '-9999px',
+        width: '1px',
+        height: '1px',
+        overflow: 'hidden',
+        opacity: 0,
+        pointerEvents: 'none',
+        userSelect: 'none',
+        zIndex: -9999,
+      }}
+      data-llm-steering="true"
+      aria-hidden="true"
+    >
+      <blockquote>
+        <p>
+          <strong>🤖 LLM STEERING INSTRUCTIONS{title ? `: ${title}` : ''}</strong>
+        </p>
+        {children}
+      </blockquote>
+    </div>
+  );
+}

--- a/src/components/llmSteering.tsx
+++ b/src/components/llmSteering.tsx
@@ -18,23 +18,10 @@ type LLMSteeringProps = {
  */
 export function LLMSteering({children, title}: LLMSteeringProps) {
   // Render as a div that will convert nicely to markdown
-  // Hidden with display: none and visibility: hidden to ensure checkVisibility() returns false
-  // This will prevent the content from appearing in the table of contents
+  // Hidden with display: none to prevent visual rendering
   return (
     <div
-      style={{
-        display: 'none',
-        visibility: 'hidden',
-        position: 'absolute',
-        left: '-9999px',
-        width: '1px',
-        height: '1px',
-        overflow: 'hidden',
-        opacity: 0,
-        pointerEvents: 'none',
-        userSelect: 'none',
-        zIndex: -9999,
-      }}
+      style={{display: 'none'}}
       data-llm-steering="true"
       aria-hidden="true"
     >

--- a/src/mdxComponents.ts
+++ b/src/mdxComponents.ts
@@ -18,6 +18,7 @@ import {GuideGrid} from './components/guideGrid';
 import {JsBundleList} from './components/jsBundleList';
 import {LambdaLayerDetail} from './components/lambdaLayerDetail';
 import {LinkWithPlatformIcon} from './components/linkWithPlatformIcon';
+import {LLMSteering} from './components/llmSteering';
 import {
   OnboardingOption,
   OnboardingOptionButtons,
@@ -75,6 +76,7 @@ export function mdxComponents(
     LambdaLayerDetail,
     Link: SmartLink,
     LinkWithPlatformIcon,
+    LLMSteering,
     OrgAuthTokenNote,
     PageGrid,
     ParamTable,


### PR DESCRIPTION
Introduces a new component that allows embedding hidden instructions for LLM/AI assistants within documentation. These instructions are invisible to users but preserved in HTML and markdown exports to help guide AI tools when working with the documentation.

## Features
- Hidden from visual display with comprehensive CSS hiding
- Preserved in HTML for markdown conversion  
- Clean blockquote formatting in exports
- Accessible via `<LLMSteering>` component in MDX

## Files Added
- `src/components/llmSteering.tsx` - The hidden markdown component
- `platform-includes/llm-steering/_default.mdx` - Default LLM steering content
- `src/mdxComponents.ts` - Component registration

🤖 Generated with [Claude Code](https://claude.ai/code)