### PR TITLE
docs(releases): De-duplicate release naming docs, and centralize in /product/releases/naming-releases/

### DIFF
--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -23,7 +23,7 @@ sentry-cli releases new "$VERSION"
 
 There are some release name restrictions and conventions to be aware of. [Learn more about Naming Releases](/product/releases/naming-releases/).
 
-Releases can also be auto created by different systems. For instance upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+Releases can also be auto-created by different systems -- for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
 
 
 ## Finalizing Releases

--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -21,9 +21,9 @@ Releases are created with the `sentry-cli releases new` command. It takes at the
 sentry-cli releases new "$VERSION"
 ```
 
-There are some release name restrictions and conventions to be aware of. [Learn more about Naming Releases](/product/releases/naming-releases/).
+There are some release name restrictions and conventions to be aware of. [Learn more about naming releases](/product/releases/naming-releases/).
 
-Releases can also be auto-created by different systems -- for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+Releases can also be auto-created by different systems—for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
 
 
 ## Finalizing Releases

--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -14,24 +14,17 @@ Because releases work on projects you will need to specify the organization and 
 
 ## Creating Releases
 
-Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. There are a few restrictions -- the release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(/), or back slashes(\\)
-- be (in their entirety) period (.), double period (..), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but for certain platforms, recommendations exist:
-
-- for mobile devices use `package-name@version-number` or `package-name@version-number+build-number`. **Do not** use `VERSION_NUMBER (BUILD_NUMBER)` as the parenthesis are used for display purposes (foo@1.0+2 becomes 1.0 (2)), so invoking them will cause an error.
-- if you use a DVCS we recommend using the identifying hash (eg: the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let sentry-cli automatically determine this hash for supported version control systems with `sentry-cli releases propose-version`.
-- if you tag releases we recommend using the release tag prefixed with a product or package name (for example, `my-project-name@2.3.12`).
+Releases are created with the `sentry-cli releases new` command. It takes at the very least a version identifier that uniquely identifies the releases. 
 
 ```bash
 #!/bin/sh
 sentry-cli releases new "$VERSION"
 ```
 
-Releases can also be auto created by different systems. For instance upon uploading a source map a release is automatically created. Likewise releases are created by some clients when an event for a release comes in.
+There are some release name restrictions and conventions to be aware of. [Learn more about Naming Releases](/product/releases/naming-releases/).
+
+Releases can also be auto created by different systems. For instance upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+
 
 ## Finalizing Releases
 

--- a/docs/platforms/android/configuration/releases.mdx
+++ b/docs/platforms/android/configuration/releases.mdx
@@ -13,40 +13,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 
 Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/apple/common/configuration/releases.mdx
+++ b/docs/platforms/apple/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/dart/common/configuration/releases.mdx
+++ b/docs/platforms/dart/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/dart/guides/flutter/configuration/releases.mdx
+++ b/docs/platforms/dart/guides/flutter/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/dotnet/common/configuration/releases.mdx
+++ b/docs/platforms/dotnet/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/elixir/configuration/releases.mdx
+++ b/docs/platforms/elixir/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/go/common/configuration/releases.mdx
+++ b/docs/platforms/go/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/godot/configuration/releases.mdx
+++ b/docs/platforms/godot/configuration/releases.mdx
@@ -17,40 +17,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/java/common/configuration/releases.mdx
+++ b/docs/platforms/java/common/configuration/releases.mdx
@@ -13,40 +13,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 
 Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/javascript/common/configuration/releases.mdx
+++ b/docs/platforms/javascript/common/configuration/releases.mdx
@@ -13,40 +13,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 
 Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/configuration/releases.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/configuration/releases.mdx
@@ -13,40 +13,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 
 Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/native/common/configuration/releases.mdx
+++ b/docs/platforms/native/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/php/common/configuration/releases.mdx
+++ b/docs/platforms/php/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/powershell/configuration/releases.mdx
+++ b/docs/platforms/powershell/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>`
-  - `build` is the number that identifies an iteration of your app
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/react-native/configuration/releases.mdx
+++ b/docs/platforms/react-native/configuration/releases.mdx
@@ -13,40 +13,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 
 Additionally, releases are used for applying [source maps](/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code.
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/ruby/common/configuration/releases.mdx
+++ b/docs/platforms/ruby/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/rust/common/configuration/releases.mdx
+++ b/docs/platforms/rust/common/configuration/releases.mdx
@@ -11,40 +11,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/unity/configuration/releases.mdx
+++ b/docs/platforms/unity/configuration/releases.mdx
@@ -17,40 +17,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/platforms/unreal/configuration/releases.mdx
+++ b/docs/platforms/unreal/configuration/releases.mdx
@@ -17,40 +17,7 @@ A release is a version of your code that is deployed to an <PlatformLink to="/co
 - Resolve issues by including the issue number in your commit message
 - Receive email notifications when your code gets deployed
 
-## Bind the Version
-
-Include a release ID (often called a "version") when you initialize the SDK.
-
-The release name cannot:
-
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
-- be (in their entirety) period (`.`), double period (`..`), or space ( )
-- exceed 200 characters
-
-The value can be arbitrary, but we recommend either of these naming strategies:
-
-- **Semantic Versioning**: `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
-  - `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
-  - `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
-  - `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
-- **Commit SHA**: If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems. Learn more in our [Sentry CLI](/cli/releases/#creating-releases) documentation.
-
-<Alert>
-
-Releases are global per organization; prefix them with something project-specific for easy differentiation.
-
-</Alert>
-
-The behavior of a few features depends on whether a project is using semantic or time-based versioning.
-
-- Regression detection
-- `release:latest`
-
-We automatically detect whether a project is using semantic or time-based versioning based on:
-
-- If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
-- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+<Include name="bind-release-version.mdx" />
 
 ## Setting a Release
 

--- a/docs/product/releases/naming-releases.mdx
+++ b/docs/product/releases/naming-releases.mdx
@@ -1,0 +1,48 @@
+---
+title: Naming Releases
+sidebar_order: 3
+description: "Learn about release naming conventions."
+---
+
+## Creating Releases
+
+Releases are created directly via [automatic release management](/product/releases/setup/release-automation/), the [Sentry CLI](/cli/releases/), or manually via the [Sentry API](/api/releases/create-a-new-release-for-an-organization/).
+
+Releases can also be auto created by different systems. For instance upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+
+## Release Names
+
+Release IDs, (often called a "version", or "name") are used to uniquely identify a release across the entire Sentry organization. A Release Name may be associated with builds, events, sessions, etc from multiple projects. 
+
+<Alert>
+
+Releases are global per organization; prefix them with something project-specific for easy differentiation.
+
+</Alert>
+
+The value can be arbitrary, but there are a few restrictions. In all cases, the release name cannot:
+- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
+- be (in their entirety) period (`.`), double period (`..`), or space ( )
+- exceed 200 characters
+
+While the value can be arbitrary, we do recommend these naming strategies:
+
+### Semantic Versioning
+Use the format `package@version` or `package@version+build` (for example, `my.project.name@2.3.12+1234`)
+- `package` is the unique identifier of the project/app (`CFBundleIdentifier` on iOS, `packageName` on Android)
+- `version` is the semver-like structure `<major>.<minor?>.<patch?>.<revision?>-<prerelease?>` (`CFBundleShortVersionString` on iOS, `versionName` on Android)
+- `build` is the number that identifies an iteration of your app (`CFBundleVersion` on iOS, `versionCode` on Android)
+**Do not** use `VERSION_NUMBER (BUILD_NUMBER)` as the parenthesis are used for display purposes (foo@1.0+2 becomes 1.0 (2)), so invoking them will cause an error.
+
+We automatically detect whether a project is using semantic or time-based versioning based on:
+
+- If ≤ 2 releases total: we look at most recent release.
+- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
+- If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
+
+### Commit SHA
+If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems; and pass it in at build time to your codebase so it can be used to tag events.
+
+## Related Features
+
+Regression Detection and `release:latest` sorting strategies will changed depending on whether a project is using semantic or SHA/time-based versioning. 

--- a/docs/product/releases/naming-releases.mdx
+++ b/docs/product/releases/naming-releases.mdx
@@ -8,11 +8,11 @@ description: "Learn about release naming conventions."
 
 Releases are created directly via [automatic release management](/product/releases/setup/release-automation/), the [Sentry CLI](/cli/releases/), or manually via the [Sentry API](/api/releases/create-a-new-release-for-an-organization/).
 
-Releases can also be auto created by different systems. For instance upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+Releases can also be auto-created by different systems -- for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
 
 ## Release Names
 
-Release IDs, (often called a "version", or "name") are used to uniquely identify a release across the entire Sentry organization. A Release Name may be associated with builds, events, sessions, etc from multiple projects. 
+Release IDs, (often called a "version" or "name") are used to uniquely identify a release across the entire Sentry organization. A release name may be associated with builds, events, sessions, etc. from multiple projects. 
 
 <Alert>
 
@@ -41,7 +41,7 @@ We automatically detect whether a project is using semantic or time-based versio
 - If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
 
 ### Commit SHA
-If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems; and pass it in at build time to your codebase so it can be used to tag events.
+If you use a version control system like Git, we recommend using the identifying hash (for example, the commit SHA, `da39a3ee5e6b4b0d3255bfef95601890afd80709`). You can let Sentry CLI automatically determine this hash for supported version control systems, and pass it in at build time to your codebase so it can be used to tag events.
 
 ## Related Features
 

--- a/docs/product/releases/naming-releases.mdx
+++ b/docs/product/releases/naming-releases.mdx
@@ -8,11 +8,11 @@ description: "Learn about release naming conventions."
 
 Releases are created directly via [automatic release management](/product/releases/setup/release-automation/), the [Sentry CLI](/cli/releases/), or manually via the [Sentry API](/api/releases/create-a-new-release-for-an-organization/).
 
-Releases can also be auto-created by different systems -- for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+Releases can also be auto-created by different systems—for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
 
 ## Release Names
 
-Release IDs, (often called a "version" or "name") are used to uniquely identify a release across the entire Sentry organization. A release name may be associated with builds, events, sessions, etc. from multiple projects. 
+Release IDs (often called a "version" or "name") are used to uniquely identify a release across the entire Sentry organization. A release name may be associated with builds, events, sessions, etc. from multiple projects. 
 
 <Alert>
 
@@ -21,7 +21,7 @@ Releases are global per organization; prefix them with something project-specifi
 </Alert>
 
 The value can be arbitrary, but there are a few restrictions. In all cases, the release name cannot:
-- contain newlines, tabulator characters, forward slashes(`/`) or back slashes(`\`)
+- contain newlines, tabulator characters, forward slashes (`/`) or back slashes (`\`)
 - be (in their entirety) period (`.`), double period (`..`), or space ( )
 - exceed 200 characters
 
@@ -37,7 +37,7 @@ Use the format `package@version` or `package@version+build` (for example, `my.pr
 We automatically detect whether a project is using semantic or time-based versioning based on:
 
 - If ≤ 2 releases total: we look at most recent release.
-- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
+- If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver (i.e., semantic versioning).
 - If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.
 
 ### Commit SHA

--- a/includes/bind-release-version.mdx
+++ b/includes/bind-release-version.mdx
@@ -1,0 +1,7 @@
+## Bind the Version
+
+Include a release ID (often called a "version") when you initialize the SDK.
+
+There are some release name restrictions and conventions to be aware of. [Learn more about Naming Releases](/product/releases/naming-releases/).
+
+Releases can also be auto created by different systems. For instance upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.

--- a/includes/bind-release-version.mdx
+++ b/includes/bind-release-version.mdx
@@ -2,6 +2,6 @@
 
 Include a release ID (often called a "version") when you initialize the SDK.
 
-There are some release name restrictions and conventions to be aware of. [Learn more about Naming Releases](/product/releases/naming-releases/).
+There are some release name restrictions and conventions to be aware of. [Learn more about naming releases](/product/releases/naming-releases/).
 
-Releases can also be auto-created by different systems -- for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+Releases can also be auto-created by different systems—for example, when uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.

--- a/includes/bind-release-version.mdx
+++ b/includes/bind-release-version.mdx
@@ -4,4 +4,4 @@ Include a release ID (often called a "version") when you initialize the SDK.
 
 There are some release name restrictions and conventions to be aware of. [Learn more about Naming Releases](/product/releases/naming-releases/).
 
-Releases can also be auto created by different systems. For instance upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.
+Releases can also be auto-created by different systems -- for instance, upon uploading a source map, or by some clients when an event that is tagged with a release is ingested. Therefore, it's important to set the release name when building and deploying your application. Learn more in our [Releases](/platform-redirect/?next=/configuration/releases/) documentation.


### PR DESCRIPTION
I noticed we had a lot of duplicate pages with the same docs related to release names. 

The goal of this PR is to:
1. Move Release Name related content out of platform docs, and into a central place. It's not platform specific knowledge really
2. De-duplicate whatever is left over in the platform docs, so it's easier to maintain links to the central docs going forward.

The new central page is available at: `/product/releases/naming-releases/`
- this content was taken from other places and re-worked a little.

Some existing pages are now more streamlined and will link to the new central location:
- `/cli/releases/`
- `/platforms/javascript/configuration/releases/` (19 platform pages with the exact same content)

| New page | CLI Releases | Platform pages |
| --- | --- | --- |
| <img width="1300" height="852" alt="SCR-20250827-nlxs" src="https://github.com/user-attachments/assets/4dee8d13-1a99-4e35-8925-d232c45f806f" /> | <img width="765" height="470" alt="SCR-20250827-nmcx" src="https://github.com/user-attachments/assets/8e525d12-e875-4ac8-aa4d-f0f551e10b4d" /> | <img width="777" height="382" alt="SCR-20250827-nmgx" src="https://github.com/user-attachments/assets/3836bc51-ad51-4fd4-833b-0ab63d01ca57" />

