### PR TITLE
fix: Order versioned docs select items by recency

### DIFF
--- a/src/components/versionSelector/index.tsx
+++ b/src/components/versionSelector/index.tsx
@@ -35,7 +35,7 @@ function sortVersions(versions: string[]) {
 }
 
 export function VersionSelector({versions, sdk}: {sdk: string; versions: string[]}) {
-  const availableVersions = ['latest', ...sortVersions(versions)];
+  const availableVersions = ['latest', ...sortVersions([...versions])];
   const router = useRouter();
   const pathname = usePathname();
 

--- a/src/components/versionSelector/index.tsx
+++ b/src/components/versionSelector/index.tsx
@@ -12,21 +12,26 @@ import styles from './style.module.scss';
 import {VersionBanner} from '../versionBanner';
 
 function sortVersions(versions: string[]) {
-  return versions
-    .sort((a, b) => {
-      const aSegments = parseInt(a.split('.')[0], 10);
-      const bSegments = parseInt(b.split('.')[0], 10);
+  return versions.sort((a, b) => {
+    const aMajor = parseInt(a.split('.')[0], 10);
+    const bMajor = parseInt(b.split('.')[0], 10);
 
-      if (isNaN(aSegments) || isNaN(bSegments)) {
-        return a.localeCompare(b);
-      }
+    if (isNaN(aMajor) || isNaN(bMajor)) {
+      return a.localeCompare(b);
+    }
 
-      if (aSegments < bSegments) {
-        return -1;
-      }
+    if (aMajor < bMajor) {
       return 1;
-    })
-    .reverse();
+    }
+
+    if (aMajor === bMajor) {
+      // yes, this is flawed. But for now there's no case where we need to order
+      // by minor or patch so I wanna avoid pulling in semver as a dependency
+      return a.localeCompare(b);
+    }
+
+    return -1;
+  });
 }
 
 export function VersionSelector({versions, sdk}: {sdk: string; versions: string[]}) {

--- a/src/components/versionSelector/index.tsx
+++ b/src/components/versionSelector/index.tsx
@@ -11,8 +11,26 @@ import styles from './style.module.scss';
 
 import {VersionBanner} from '../versionBanner';
 
+function sortVersions(versions: string[]) {
+  return versions
+    .sort((a, b) => {
+      const aSegments = parseInt(a.split('.')[0], 10);
+      const bSegments = parseInt(b.split('.')[0], 10);
+
+      if (isNaN(aSegments) || isNaN(bSegments)) {
+        return a.localeCompare(b);
+      }
+
+      if (aSegments < bSegments) {
+        return -1;
+      }
+      return 1;
+    })
+    .reverse();
+}
+
 export function VersionSelector({versions, sdk}: {sdk: string; versions: string[]}) {
-  const availableVersions = ['latest', ...versions];
+  const availableVersions = ['latest', ...sortVersions(versions)];
   const router = useRouter();
   const pathname = usePathname();
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

This PR makes a change to the order in which we show the version select items if a docs page has multiple versions: Instead of sorting the version designator alphabetically, this PR attempts to sort them by recent to oldest. For now, this only looks at the major number, since the version designator can be arbitrary and we can't assume proper semver (see example).If we can't extract a proper major version, we continue to sort alphabetically.

Before:
<img width="287" height="237" alt="image" src="https://github.com/user-attachments/assets/d0e39874-3548-4b82-b940-9b4ebdad9a44" />

After:
<img width="291" height="240" alt="image" src="https://github.com/user-attachments/assets/e4f005ad-0f97-4107-8f0c-982f81c8af0e" />

(the 10x version in this screenshot serves an illustrative purpose. I'm not shipping that anytime soon :D)
 
(This PR is brought to you by a sidequest while working on updating sveltekit docs and encountering weird ordering. Happy to close/adjust as reviewers see fit :) )

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: Some time week ending Sept 5th
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)