### PR TITLE
docs(ai): Update AI agent integrations list

### DIFF
--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -12,7 +12,12 @@ As a prerequisite to setting up AI Agent Monitoring with Python, you'll need to 
 
 The Python SDK supports automatic instrumentation for some AI libraries. We recommend adding their integrations to your Sentry configuration to automatically capture spans for AI agents.
 
-- <PlatformLink to="/integrations/openai-agents/">OpenAI Agents</PlatformLink>
+- <PlatformLink to="/integrations/anthropic/">Anthropic</PlatformLink>
+- <PlatformLink to="/integrations/openai/">OpenAI</PlatformLink>
+- <PlatformLink to="/integrations/openai-agents/">
+    OpenAI Agents SDK
+  </PlatformLink>
+- <PlatformLink to="/integrations/langchain/">LangChain</PlatformLink>
 
 ## Manual Instrumentation
 


### PR DESCRIPTION
Added links for Anthropic, OpenAI, OpenAI Agents SDK, and LangChain to the Python SDK documentation for AI Agent Monitoring
