### PR TITLE
Fix Hydrogen 404s: Update link to correct page

### DIFF
--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -13,7 +13,7 @@ Use this guide for general instructions on using the Sentry SDK with Cloudflare.
 
 - **[Astro](frameworks/astro/)**
 - **[Hono](frameworks/hono/)**
-- **[Hydrogen](frameworks/hydrogen/)**
+- **[Hydrogen](frameworks/hydrogen-react-router/)**
 - **[Nuxt](frameworks/nuxt/)**
 - **[Remix](frameworks/remix/)**
 - **[SvelteKit](frameworks/sveltekit/)**

--- a/redirects.js
+++ b/redirects.js
@@ -741,6 +741,10 @@ const userDocsRedirects = [
     destination: '/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router/',
   },
   {
+    source: '/platforms/javascript/guides/cloudflare/frameworks/hydrogen/',
+    destination: '/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router/',
+  },
+  {
     source: '/product/metrics/:path*',
     destination: '/product/explore/metrics/:path*',
   },


### PR DESCRIPTION
## Summary
- Fixed broken Hydrogen link in Cloudflare index page that was causing 404s
- Updated link from `frameworks/hydrogen/` to `frameworks/hydrogen-react-router/`

## Context
The Cloudflare index page was linking to `frameworks/hydrogen/` which doesn't exist, causing users to hit 404 errors. The content was moved to separate pages for different Hydrogen versions:
- `hydrogen-react-router/` for newer Hydrogen versions (2025.5.0+) 
- `hydrogen-remix/` for legacy versions

This PR points to the current version (`hydrogen-react-router/`) to resolve the 404 issue.

## Test plan
- [x] Verified the target page exists at `frameworks/hydrogen-react-router/`
- [x] Checked that this resolves the 404 alerts for `/platforms/javascript/guides/cloudflare/frameworks/hydrogen/`

🤖 Generated with [Claude Code](https://claude.ai/code)