### PR TITLE
fix(ai): min SDK version

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -28,7 +28,7 @@ supported:
 
 <Alert>
 
-This integration only works in the Node.js, Cloudflare Workers, Vercel Edge Functions and Bun runtimes. Requires SDK version `9.33.0` or higher.
+This integration only works in the Node.js, Cloudflare Workers, Vercel Edge Functions and Bun runtimes. Requires SDK version ``10.6.0` or higher.
 
 </Alert>
 


### PR DESCRIPTION
bumps minimum sentry SDK version for Vercel AI instrumentation