### PR TITLE
fix(Ruby): Remove duplicated onboarding options

### DIFF
--- a/docs/platforms/ruby/common/index.mdx
+++ b/docs/platforms/ruby/common/index.mdx
@@ -11,10 +11,6 @@ In addition to capturing errors, you can monitor interactions between multiple s
 
 Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
-<OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
-/>
-
 ## Install
 
 <PlatformContent includePath="getting-started-install" />


### PR DESCRIPTION
The on-boarding options are currently rendered twice on https://docs.sentry.io/platforms/ruby/.

<img width="1174" height="656" alt="image" src="https://github.com/user-attachments/assets/4a29bc75-2c71-4a41-9dbb-831396b8bc8b" />
