### PR TITLE
feat(js): Add log options

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -436,7 +436,7 @@ Please note that the `span` you receive as an argument is a serialized object, n
 
 A list of strings or regex patterns matching span names that shouldn't be sent to Sentry. When using strings, partial matches will be filtered out, so if you need to filter by exact match, use regex patterns instead. You can also provide an object with a `name` and `op` property to match both the span name and the operation name. Note that at least `name` or `op` must be provided.
 
-If a root span matches any of the specified patterns, the entire local trace will be dropped. If a child span matches, its children will be reparented to the dropped span's parent span. 
+If a root span matches any of the specified patterns, the entire local trace will be dropped. If a child span matches, its children will be reparented to the dropped span's parent span.
 
 By default, no spans are ignored.
 
@@ -462,6 +462,20 @@ Note that this option is only available for browser SDKs.
 </PlatformCategorySection>
 
 <PlatformCategorySection supported={['browser']}>
+
+## Logs Options
+
+<SdkOption name="enableLogs" type='boolean' defaultValue='false'>
+
+Set this option to `true` to enable log capturing in Sentry. Only when this is enabled will the `logger` APIs actually send logs to Sentry.
+
+</SdkOption>
+
+<SdkOption name="beforeSendLog" type='(log: Log) => Log | null'>
+
+This function is called with a log object, and can return a modified log object, or `null` to skip sending this log to Sentry. This can be used, for instance, for manual PII stripping before sending, or to add custom attributes to all logs.
+
+</SdkOption>
 
 ## Session Replay Options
 


### PR DESCRIPTION
Adds the log options for JS.

In a follow up, we should also add the `logger` to the APIs page.