### PR TITLE
feat(js): Add `propagateTraceparent` option documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -443,6 +443,27 @@ By default, no spans are ignored.
 
 </SdkOption>
 
+<PlatformCategorySection supported={['browser']}>
+
+<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false'>
+
+_Available since: `10.10.0`_
+
+If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/) to outgoing Http requests made via `fetch` or `XMLHttpRequest`.
+This header is attached in addition to the `sentry-trace` and `baggage` headers.
+Set this option to `true` if your backend services are instrumented with e.g. OpenTelemetry or other W3C Trace Context compatible libraries and you want to continue traces from the client.
+
+**Important:** Make sure that your backend services' CORS configuration allows the `traceparent` header.
+Otherwise, requests might be blocked.
+Use the [`tracePropagationTargets` option](#tracepropagationtargets) to control which requests the `traceparent` header is attached to.
+See <PlatformLink to="/tracing/distributed-tracing/dealing-with-cors-issues/">Dealing with CORS Issues</PlatformLink> for more information.
+
+Note that this option is only available for browser SDKs.
+
+</SdkOption>
+
+</PlatformCategorySection>
+
 ## Session Replay Options
 
 <SdkOption name="replaysSessionSampleRate" type='number' categorySupported={['browser']}>

--- a/docs/platforms/javascript/common/tracing/distributed-tracing/dealing-with-cors-issues/index.mdx
+++ b/docs/platforms/javascript/common/tracing/distributed-tracing/dealing-with-cors-issues/index.mdx
@@ -20,7 +20,7 @@ If your frontend and backend are hosted on different domains (for example, your 
 
 ## Understanding Trace Propagation
 
-Sentry doesn't attach the `sentry-trace` and `baggage` headers to every outgoing request. Instead, it only attaches these headers to requests whose URLs match the patterns specified in the `tracePropagationTargets` configuration option.
+Sentry doesn't attach the `sentry-trace` and `baggage` (and optionally `traceparent`) headers to every outgoing request. Instead, it only attaches these headers to requests whose URLs match the patterns specified in the `tracePropagationTargets` configuration option.
 
 By default, `tracePropagationTargets` is set to `['localhost', /^\//]`, which means trace headers are only attached to:
 - Requests containing `localhost` in their URL (e.g., `http://localhost:3000/api`)
@@ -54,6 +54,14 @@ Access-Control-Allow-Headers: sentry-trace, baggage
 ```
 
 Your server's exact configuration will depend on your setup, but the important part is allowing both the `sentry-trace` and `baggage` headers.
+
+### W3C traceparent header
+
+If you set <PlatformLink to="/configuration/options#propagateTraceparent">`propagateTraceparent` option</PlatformLink> to `true`, you also need to allow the `traceparent` header:
+
+```
+Access-Control-Allow-Headers: sentry-trace, baggage, traceparent
+```
 
 ## Disabling Trace Propagation
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

To be merged after https://github.com/getsentry/sentry-javascript/pull/17509 was released

This PR adds documentation for the new, browser-SDK-only, `propagateTraceparent` option (see [develop docs](https://develop.sentry.dev/sdk/telemetry/traces/#propagatetraceparent)). It also adjusts our "Dealing with CORS Issues" page to include `traceparent` in the `CORS` configuration if users opted into the option.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
