### PR TITLE
docs(fix): remove extra angle bracket from docs link

### DIFF
--- a/docs/concepts/search/searchable-properties/session-replay.mdx
+++ b/docs/concepts/search/searchable-properties/session-replay.mdx
@@ -102,7 +102,7 @@ The `title` of an element that was clicked. For example, `Save this comment` wou
 
 ### `count_dead_clicks`
 
-The number of [dead clicks](/product/explore/session-replay/replay-page-and-filters/#:~:text=Dead%20Clicks%3A%20User%20clicks%20on%20a%20and%20button%20tags%20that%20do%20not%20result%20in%20any%20page%20activity%20after%207%20seconds) within a replay.
+The number of [dead clicks](/product/explore/session-replay/replay-page-and-filters/#:~:text=Dead%20Clicks%3A%20User%20clicks%20on%20a%20and%20button%20tags%20that%20do%20not%20result%20in%20any%20page%20activity%20after%207%20seconds%20(i.e.%20no%20HTML%20was%20added%2C%20removed%2C%20or%20updated%3B%20no%20visual%20changes%20were%20observed%20in%20the%20page).) within a replay.
 
 - **Type:** number
 
@@ -138,7 +138,7 @@ The number of URLs that the user visited during a replay recording.
 
 ### `dead.selector`
 
-Similar to the `click.selector` search property, but only queries on [dead clicks](/product/explore/session-replay/replay-page-and-filters/#:~:text=Dead%20Clicks%3A%20User%20clicks%20on%20a%20and%20button%20tags%20that%20do%20not%20result%20in%20any%20page%20activity%20after%207%20seconds). An element identified using a subset of CSS selector syntax. For example, `#section-1` or `span.active` or `span[role=button]` or `.active[role=button]` would all match the element `<span id="section-1" class="active" role="button"/>`. Note that, CSS combinators, pseudo selectors, and attr selectors other than `=` are not supported.
+Similar to the `click.selector` search property, but only queries on [dead clicks](/product/explore/session-replay/replay-page-and-filters/#:~:text=Dead%20Clicks%3A%20User%20clicks%20on%20a%20and%20button%20tags%20that%20do%20not%20result%20in%20any%20page%20activity%20after%207%20seconds%20(i.e.%20no%20HTML%20was%20added%2C%20removed%2C%20or%20updated%3B%20no%20visual%20changes%20were%20observed%20in%20the%20page).). An element identified using a subset of CSS selector syntax. For example, `#section-1` or `span.active` or `span[role=button]` or `.active[role=button]` would all match the element `<span id="section-1" class="active" role="button"/>`. Note that, CSS combinators, pseudo selectors, and attr selectors other than `=` are not supported.
 
 - **Type:** string
 
@@ -228,7 +228,7 @@ The id of the project.
 
 ### `rage.selector`
 
-Similar to the `click.selector` search property, but only queries on [rage clicks](</product/explore/session-replay/replay-page-and-filters/#:~:text=Rage%20Clicks%3A%20Five%20or%20more%20clicks%20on%20a%20dead%20element%20(it%20exhibits%20no%20page%20activity%20after%207%20seconds.)%20Rage%20clicks%20are%20a%20subset%20of%20dead%20clicks>). An element identified using a subset of CSS selector syntax. For example, `#section-1` or `span.active` or `span[role=button]` or `.active[role=button]` would all match the element `<span id="section-1" class="active" role="button"/>`. Note that, CSS combinators, pseudo selectors, and attr selectors other than `=` are not supported.
+Similar to the `click.selector` search property, but only queries on [rage clicks](/product/explore/session-replay/replay-page-and-filters/#:~:text=Rage%20Clicks%3A%20Five%20or%20more%20clicks%20on%20a%20dead%20element%20(it%20exhibits%20no%20page%20activity%20after%207%20seconds.)%20Rage%20clicks%20are%20a%20subset%20of%20dead%20clicks). An element identified using a subset of CSS selector syntax. For example, `#section-1` or `span.active` or `span[role=button]` or `.active[role=button]` would all match the element `<span id="section-1" class="active" role="button"/>`. Note that, CSS combinators, pseudo selectors, and attr selectors other than `=` are not supported.
 
 - **Type:** string
 


### PR DESCRIPTION
Removing extra angle bracket from docs link inside Searchable Properties page

