### PR TITLE
feat(python): Make proxy options clearer

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -263,7 +263,7 @@ Transports are used to send events to Sentry. Transports can be customized to so
 
 <SdkOption name="http_proxy" defaultValue='None' type='Optional[str]'>
 
-When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https_proxy` is configured.
+When set, a proxy can be configured for outbound requests. This is also used for HTTPS requests, unless a separate `https_proxy` is configured.
 
 If not set or set to `None`, the SDK will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `http_proxy` environment variable will be picked up.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
It's currently not documented how to make the Python SDK not use any proxy. The available options for setting a proxy are confusing, with `None` meaning we'll actually try to pick up proxy configuration from environment variables. In order to not use a proxy, the options need to be set to `""`. Documenting this.

**Direct link to preview:** https://sentry-docs-git-ivana-pythonupdate-proxy-options.sentry.dev/platforms/python/configuration/options/#http_proxy

Closes https://github.com/getsentry/sentry-python/issues/4726

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
