### PR TITLE
docs(devservices): Fill out all the `devservices up --modes=` possibilities

### DIFF
--- a/develop-docs/development-infrastructure/devservices.mdx
+++ b/develop-docs/development-infrastructure/devservices.mdx
@@ -74,16 +74,32 @@ docker volume rm sentry_postgres-data
 
 Common modes in sentry:
 
-- `symbolicator`: Bring up sentry dependencies and symbolicator
-- `chartcuterie`: Bring up sentry dependencies and chartcuterie
-- `taskbroker`: Bring up sentry dependencies, taskbroker, taskworker, and taskworker-scheduler
+- `default`: Bring up sentry dependencies and relay
+- `migrations`: Bring up postgres and redis
 - `minimal`: Bring up minimal services for local development
-- `profiling`: Bring up sentry dependencies, vroom, and profiling consumers
-- `crons`: Brings up sentry dependencies and monitor consumers
-- `tracing`: Brings up sentry dependencies and everything necessary for transactions, spans, and metrics
-- `ingest`: Brings up the most common sentry dependencies to support ingestion of errors and transactions
-- `ingest-all`: Brings up sentry dependencies to support ingesting everything
 - `full`: Bring up all services (symbolicator, taskbroker, snuba, vroom, etc)
+- `taskbroker`: Bring up sentry dependencies, taskbroker, taskworker, and taskworker-scheduler
+- `memcached`: Bring up sentry dependencies and memcached
+
+Modes for specific development scenarios:
+- `chartcuterie`: Bring up sentry dependencies and chartcuterie
+- `crons`: Brings up sentry dependencies and monitor consumers
+- `launchpad`: Bring up sentry dependencies and launchpad
+- `objectstore`: Bring up sentry dependencies and objectstore
+- `profiling`: Bring up sentry dependencies, vroom, and profiling consumers
+- `replay`: Bring up sentry dependencies and replay
+- `symbolicator`: Bring up sentry dependencies and symbolicator
+- `tracing`: Brings up sentry dependencies and everything necessary for transactions, spans, and metrics
+
+Ingest Specific:
+- `ingest`: Brings up the most common sentry dependencies to support ingestion of errors, transactions and attachments
+- `ingest-all`: Brings up sentry dependencies to support ingesting everything
+
+CI Specific:
+- `acceptance-ci`: Bring up sentry dependencies and everything necessary for acceptance CI
+- `backend-ci`: Bring up sentry dependencies and everything necessary for backend CI
+
+
 
 ```shell
 devservices up --mode symbolicator


### PR DESCRIPTION
I noticed that the mode `migrations` wasn't in the list, so i wanted to add that.

But then i went and added everything else and threw them into some categories that seemed reasonable. Idk if this is the best grouping, or needed at all, but it's easy enough to throw the idea out there and then delete it if it's too much.