### PR TITLE
chore(agents): add redirect

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -968,6 +968,10 @@ const userDocsRedirects = [
     destination: '/product/insights/ai/agents/:path*',
   },
   {
+    source: '/platforms/javascript/tracing/instrumentation/ai-agents-module',
+  destination: '/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module',
+  },
+  {
     source: '/product/insights/retention-priorities/',
     destination: '/organization/dynamic-sampling/',
   },

--- a/redirects.js
+++ b/redirects.js
@@ -969,7 +969,7 @@ const userDocsRedirects = [
   },
   {
     source: '/platforms/javascript/tracing/instrumentation/ai-agents-module',
-  destination: '/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module',
+    destination: '/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module',
   },
   {
     source: '/product/insights/retention-priorities/',


### PR DESCRIPTION
- The current top google result for `sentry ai agents docs` leads to a 404 after https://github.com/getsentry/sentry-docs/pull/14755
- This adds a redirect to the new URL