### PR TITLE
fix(langgraph-docs): wrong integration casing

### DIFF
--- a/docs/platforms/python/integrations/langgraph/index.mdx
+++ b/docs/platforms/python/integrations/langgraph/index.mdx
@@ -97,11 +97,11 @@ It may take a couple of moments for the data to appear in [sentry.io](https://se
 
 ## Options
 
-By adding `LangGraphIntegration` to your `sentry_sdk.init()` call explicitly, you can set options for `LangGraphIntegration` to change its behavior:
+By adding `LanggraphIntegration` to your `sentry_sdk.init()` call explicitly, you can set options for `LanggraphIntegration` to change its behavior:
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.langgraph import LangGraphIntegration
+from sentry_sdk.integrations.langgraph import LanggraphIntegration
 
 sentry_sdk.init(
     # ...
@@ -109,14 +109,14 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
     integrations=[
-        LangGraphIntegration(
+        LanggraphIntegration(
             include_prompts=False,  # LLM inputs/outputs will be not sent to Sentry, despite send_default_pii=True
         ),
     ],
 )
 ```
 
-You can pass the following keyword arguments to `LangGraphIntegration()`:
+You can pass the following keyword arguments to `LanggraphIntegration()`:
 
 - `include_prompts`
 


### PR DESCRIPTION
- Correct integration name in docs: integration is called `LanggraphIntegration`, not`LangGraphintegration`
- Closes TET-1122