### PR TITLE
feat(logs): Add `sentry.replay_id` to logs spec

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -405,8 +405,6 @@ Logs should be associated with traces if possible. If a log is recorded during a
 
 Logs should be associated with replays if possible. If a log is recorded during an active replay, the SDK should set the `sentry.replay_id` attribute to the replay id of the replay that was active when the log was collected.
 
-In the future we will support attaching replay id's to logs by reading `sentry.replay_id` from the Dynamic Sampling Context (baggage). This allows server-side SDKs to attach the replay id their logs.
-
 ### Other
 
 If `debug` is set to `true` in SDK init, calls to the Sentry logger API should also print to the console with the appropriate log level. This will help debugging logging setups.


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/SDK-35/update-develop-docs-to-mention-sentryreplay-id-attribute

Attaching a replay id directly to logs makes it easy for users to go from log -> replay. It also vastly simplifies querying for logs in the frontend.

Right now we have only specced attaching replay to client-side logs, but in the future we can add the functionality that sdks can parse baggage to grab the `replay_id` and attach the id to logs.