### PR TITLE
fix(issue ownership): Clarify that groups with assignees are never reassigned

### DIFF
--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -8,7 +8,7 @@ description: "Learn how to set up ownership rules to automatically assign issues
 
 Sentry offers multiple ways to define the "ownership" of an issue. With ownership defined, we can automatically assign issues and send alerts to the owner. Sentry defines ownership with _code owners_ and _ownership rules_. Code owners functionality lets you import your [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) or [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) CODEOWNERS file, and then we assign issues according to those file paths. Ownership rules allow you to override the assignments based on code owners and provide advanced matcher types (for example, urls and tags). These rules can also match on the file paths of files in the stack trace, URL of the request, or event tags.
 
-If a user manually assigns an issue after it has been automatically assigned by Sentry, future auto-assignment will be turned off for that issue.
+Once an issue has been assigned, whether manually by a user or automatically by Sentry, future auto-assignment will be turned off for that issue.
 
 ## Methods
 
@@ -165,7 +165,7 @@ You can automatically assign issues to their owners by enabling the "Auto-assign
 
 ![Select from dropdown to automatically assign issues to their owners.](./img/auto-assign-issue-owner.png)
 
-If an issue has been assigned manually in the past, new events will not change the current assignee. If an issue has not been assigned and a new event has multiple owners, Sentry assigns it to the owner(s) from the last matching rule (regardless of the rule `type`).
+If an issue has been assigned in the past, manually or automatically, new events will not change the current assignee. If an issue has not been assigned and a new event has multiple owners, Sentry assigns it to the owner(s) from the last matching rule (regardless of the rule `type`).
 
 Please keep in mind that auto-assignment may be skipped if a project is creating too many new issues at a given time due to rate limits. We'll try to auto-assign it the next time an event comes in for those skipped issues. If you are encountering this limit with non-recurring issues, you may want to take a look at [issue grouping](/concepts/data-management/event-grouping/) strategies.
 


### PR DESCRIPTION
Resolves [ID-227](https://linear.app/getsentry/issue/ID-227/issue-owners-are-not-reordered-when-rules-are-reordered).

Follow-up to [this PR](https://github.com/getsentry/sentry/pull/98750). Updates the [Ownership Rules documentation](https://docs.sentry.io/product/issues/ownership-rules/) to clarify the intended behavior. Our post processing logic will never attempt to reassign a group if an assignee already exists, even if the cache has expired and/or the ownership rules have changed in the interim.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
