### PR TITLE
chore(dotnet): Blazor WASM profiling is not supported

### DIFF
--- a/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
@@ -28,6 +28,7 @@ If you don't see any profiling data in [sentry.io](https://sentry.io), you can t
   - .NET Framework; we only support .NET 8.0+
   - Native AOT - this is only supported for iOS and Mac Catalyst (alongside the standard Mono AOT)
   - Android - currently not supported at all
+  - Blazor WebAssembly
 
 ### `Unknown` frames
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
In the issue linked below, they have tried to use profiling in Blazor WebAssembly, but nowhere in the docs explicitly state that Blazor WebAssembly profiling is not supported.

* https://github.com/getsentry/sentry-dotnet/issues/3523

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] ~~Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->~~
- [ ] ~~Other deadline: <!-- ENTER DATE HERE -->~~
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
