### PR TITLE
Update multiple org compatibility

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -49,7 +49,7 @@ Sentry owner, manager, or admin permissions, and GitHub owner permissions are re
 
 9. You can now [configure](#configure) the integration.
 
-The GitHub integration is available for all projects under your Sentry organization. You can connect multiple GitHub organizations to one Sentry organization, but you **cannot** connect a single GitHub organization to multiple Sentry organizations.
+The GitHub integration is available for all projects under your Sentry organization. You can connect multiple GitHub organizations to one Sentry organization. Connecting a GitHub organisation to multiple Sentry organisations is supported on Sentry organisations on a Business or Enterprise plans (not supported for GitHub Enterprise Server).
 
 While you can install the GitHub integration from [GitHub](https://github.com/apps/sentry-io), we recommend installing it from Sentry for a more streamlined process.
 


### PR DESCRIPTION
Since June it is possible to integrate multiple sentry orgs to the same GH org. Upsdating limitation note in the docs:
- https://sentry.io/changelog/github-multi-org-linking/