### PR TITLE
feat(python): Document ways to add attachments before sending an event

### DIFF
--- a/docs/platforms/python/enriching-events/attachments/index.mdx
+++ b/docs/platforms/python/enriching-events/attachments/index.mdx
@@ -19,6 +19,29 @@ Attachments persist for 30 days; if your total storage included in your quota is
 
 Learn more about how attachments impact your [quota](/pricing/quotas/).
 
+## Add or Modify Attachments Before Sending
+
+It's possible to add, remove, or modify attachments before an event is sent by way of
+the <PlatformLink to="/configuration/options/#before-send"><PlatformIdentifier name="before-send" /></PlatformLink>
+hook or an event processor.
+
+
+```python
+import sentry_sdk
+
+from sentry_sdk.scope import add_global_event_processor
+from sentry_sdk.types import Event, Hint
+from sentry_sdk.attachments import Attachment
+
+sentry_sdk.init()
+
+def event_processor(event: Event, hint: Hint):
+    hint["attachments"].append(Attachment(bytes=b"Hello World!", filename="attachment.txt"))
+    return event
+
+add_global_event_processor(event_processor)
+```
+
 ### Access to Attachments
 
 To limit access to attachments, navigate to your organization's **General Settings**, then select the _Attachments Access_ dropdown to set appropriate access — any member of your organization, the organization billing owner, member, admin, manager, or owner.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

A user asked if we support adding attachment in our hooks because JS documents it explicitly. Since we support the same methods we should document them so users do not believe the Python SDK lacks the options to add attachments before an event is sent out. See https://github.com/getsentry/sentry-python/discussions/4763

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
