### PR TITLE
Investigate search bar focus bug in docs

### DIFF
--- a/src/docTree.ts
+++ b/src/docTree.ts
@@ -376,7 +376,7 @@ function extractGuides(platformNode: DocNode): PlatformGuide[] {
   const defaultGuide = platformNode.frontmatter.platformTitle
     ? {
         ...nodeToGuide(platformNode.slug, platformNode),
-        key: platformNode.slug,
+        key: `${platformNode.slug}-platform`,
       }
     : undefined;
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
This PR resolves an issue where the platform search bar in the left navigation would lose focus on the JavaScript platform, specifically when "Browser JavaScript" was selected.

The root cause was a key collision: the "Browser JavaScript" platform's `platformTitle` configuration caused a virtual guide to be created with the same key (`javascript`) as the platform itself. This collision triggered special handling in the `PlatformSelector` component that led to the focus loss.

The fix modifies `src/docTree.ts` to append `-platform` to the virtual guide's key (e.g., `javascript-platform`), preventing the collision and restoring normal focus behavior for the search bar.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/C090UM766J2/p1757544890171669?thread_ts=1757544890.171669&cid=C090UM766J2)

<a href="https://cursor.com/background-agent?bcId=bc-35f9d74e-0d62-4250-a112-37ced1f68837">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35f9d74e-0d62-4250-a112-37ced1f68837">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

