### PR TITLE
add rate limit docs for logs

### DIFF
--- a/develop-docs/sdk/expected-features/rate-limiting.mdx
+++ b/develop-docs/sdk/expected-features/rate-limiting.mdx
@@ -88,6 +88,7 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
   - `error`: Error events.
   - `transaction`: Transaction type events.
   - `span`: Span type events.
+  - `log_item`: Log events.
   - `security`: Events with event_type `csp`
   - `attachment`: Attachment bytes stored (unused for rate limiting)
   - `session`: Session update events


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Noticed that the rate limit type for logs is missing on the main page, while it was added here: https://develop.sentry.dev/sdk/telemetry/logs/#data-category-and-rate-limiting. Adding the rate limit to the page.