### PR TITLE
fix(native): raise CMake 4 requirement on `SDKROOT`

### DIFF
--- a/platform-includes/getting-started-install/native.mdx
+++ b/platform-includes/getting-started-install/native.mdx
@@ -5,6 +5,8 @@ To build the SDK, download the latest sources from the [Releases page](https://g
 For example, `CMake` can be used like this (on macOS):
 
 ```shell
+# When using CMake 4 ensure you have valid SDKROOT defined in your environment.
+export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 # Configure the CMake build into the `build` directory with crashpad (the default
 # backend on macOS, thus optional to specify). Specifying `RelWithDebInfo` as the
 # `CMAKE_BUILD_TYPE` is also optional because it is the default in sentry-native
@@ -26,8 +28,9 @@ install
    ├── libsentry.dylib
    └── libsentry.dylib.dSYM
 ```
+(For further details on the `SDKROOT` usage with CMake please consult the [macOS build section in the SDK README](https://github.com/getsentry/sentry-native?tab=readme-ov-file#building-and-installation))
 
-contrast the above with the build-steps for a typical msbuild project on Windows:
+Contrast the above with the build-steps for a typical `msbuild` project on Windows:
 
 ```shell
 # The msbuild generator ignores the CMAKE_BUILD_TYPE because it contains all


### PR DESCRIPTION
## DESCRIBE YOUR PR

This adds exporting `SDKROOT` to the installation instructions of the Native SDK on macOS. CMake 4 requires this to build the SDK correctly.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)