### PR TITLE
fix(native): `crashpad` is the default backend on all desktop platforms

### DIFF
--- a/platform-includes/getting-started-install/native.mdx
+++ b/platform-includes/getting-started-install/native.mdx
@@ -59,6 +59,6 @@ tree /f install
 
 <Alert level="warning" title="Bundling crashpad_handler">
 
-When using the _Crashpad backend_, which is the default on Windows and macOS, the `crashpad_handler` binary has to be shipped alongside the application binary. See the [Crashpad documentation](/platforms/native/configuration/backends/crashpad/) for more information.
+When using the _Crashpad backend_, which is the default on all supported Desktop platforms (Windows, Linux and macOS), the `crashpad_handler` binary has to be shipped alongside the application binary. See the [Crashpad documentation](/platforms/native/configuration/backends/crashpad/) for more information.
 
 </Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

_Crashpad_ is the default backend for all Desktop platforms since [version 0.7.0 of the Native SDK](https://github.com/getsentry/sentry-native/releases/tag/0.7.0). However, the installation guide still only mentions _Windows_ and _macOS_ in the related "Bundling Alert". Since this is the first page most users will see when they head for Native SDK documentation, it should be absolutely clear that they most likely run a _crashpad_ backend on all Desktop platforms.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)