### PR TITLE
fix(docs): fix typo on AI in Sentry page

### DIFF
--- a/docs/product/ai-in-sentry/index.mdx
+++ b/docs/product/ai-in-sentry/index.mdx
@@ -25,7 +25,7 @@ Sentry Prevent AI is a generative AI assistant developed by Sentry, available in
 
 ### Query Assistant
 
-**You can ask Seer to query your traces and spans data via natural language queries and find relevant samples of compute metrics without building the whole query manually 
+You can ask Seer to query your traces and spans data via natural language queries and find relevant samples of compute metrics without building the whole query manually 
 
 ## Privacy and security
 


### PR DESCRIPTION
Removing asterisks below

<img width="1906" height="218" alt="Screenshot 2025-09-12 at 11 27 59 AM" src="https://github.com/user-attachments/assets/ff1cbc8d-5393-4832-9d82-8b2a45dca49c" />
