### PR TITLE
Fixing JS framework formatting for redirect pages

### DIFF
--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -43,8 +43,8 @@ export default async function Page(props: {
     key: string;
     title: string;
     url: string;
-    isGuide?: boolean;
     parentPlatform?: string;
+    shouldBeNested?: boolean;
   };
 
   const platformOrGuideList: PlatformOrGuide[] = [];
@@ -116,7 +116,7 @@ export default async function Page(props: {
           title: guide.title ?? guide.name ?? '',
           url: guide.url ?? '', // Always use the guide-specific URL
           icon: `${platformEntry.key}-${guide.name}`,
-          isGuide: mainPlatformNode ? true : false, // Only nest if parent exists
+          shouldBeNested: mainPlatformNode ? true : false, // Only nest if parent exists
           parentPlatform: platformEntry.key,
         });
       }
@@ -152,7 +152,7 @@ export default async function Page(props: {
 
       <ul>
         {platformOrGuideList.map(p => (
-          <li key={p.key} style={{marginLeft: p.isGuide ? '20px' : '0'}}>
+          <li key={p.key} style={{marginLeft: p.shouldBeNested ? '20px' : '0'}}>
             <SmartLink to={`${p.url}${pathname}`}>
               <PlatformIcon
                 size={16}


### PR DESCRIPTION
## DESCRIBE YOUR PR
**Summary**
Enhanced the platform redirect system to show individual JavaScript frameworks (React, Vue, Angular, etc.) as separate, nested options under the main JavaScript platform. This provides users with a more customized and framework-specific experience when selecting their platform. Also added better logic to check for guide paths because Dart also wasn't showing up due to being nested.

**Problem**
When users clicked platform-redirect links (like /platform-redirect/?next=/session-replay/privacy/), they only saw top-level platforms (JavaScript, Android, React Native). This didn't reflect that many JavaScript frameworks have different support levels for specific features, and users couldn't easily select their specific framework for a more tailored experience. They also did not see Dart, which was nested under a Dart/Flutter guide.

**Solution**
- Automatic Framework Detection: The system now reads the `notSupported` frontmatter from JavaScript documentation pages to determine which frameworks support each feature. Added more robust logic to search for guides under each platform if main platform paths are empty. 

- Visual Nesting: JavaScript frameworks are indented under the main JavaScript platform for clear hierarchy
Smart Positioning: JavaScript and its frameworks appear at the end of the platform list
Framework-Specific URLs: Each framework links to the main JavaScript documentation for that feature

Example pages: 
https://sentry-docs-git-platform-redirect-privacy-fix.sentry.dev/platform-redirect/?next=/session-replay/configuration/#network-details

https://sentry-docs-git-platform-redirect-privacy-fix.sentry.dev/platform-redirect/?next=/session-replay/privacy/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)