### PR TITLE
Add mobile performance score section

### DIFF
--- a/docs/product/insights/mobile/mobile-vitals/index.mdx
+++ b/docs/product/insights/mobile/mobile-vitals/index.mdx
@@ -32,6 +32,15 @@ In the example below, the detail view of a transaction displays the warm start m
 
 While the SDKs differentiate between cold and warm starts, they don't track hot starts or resumes. To get more insight into your cold and warm start metrics, you can use the [App Starts](/product/insights/mobile/mobile-vitals/app-starts/) feature.
 
+## Performance Score
+
+Sentry categorizes average app start durations as follows:
+
+| Metric | Good | Meh | Poor |
+| --- | --- | --- | --- |
+| Average Cold App Start | less than 3s | between 3s and 5s | greater than 5s |
+| Average Warm App Start | less than 1s | between 1s and 2s | greater than 2s |
+
 ## Slow and Frozen Frames
 
 To track the responsiveness of the user interface, Sentry measures _slow frames_ and _frozen frames_. Both indicate if the rendering of a frame is taking too long, causing the UI to appear laggy or frozen.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adds a "Performance Score" section to the Mobile Vitals documentation (`/product/insights/mobile/mobile-vitals/`) with a table detailing the thresholds for "Good", "Meh", and "Poor" average cold and warm app start times. This change addresses a user request to clarify how these mobile vital metrics are scored within Sentry, similar to the existing Web Vitals performance score documentation.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/CP4UUUF1S/p1757717238899059?thread_ts=1757717238.899059&cid=CP4UUUF1S)

<a href="https://cursor.com/background-agent?bcId=bc-28ada3ac-ccde-4738-b6c9-01b1e878dfd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28ada3ac-ccde-4738-b6c9-01b1e878dfd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

