### PR TITLE
fix Deno AI sdks auto instrumentation links

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -23,6 +23,7 @@ supported:
   - javascript.remix
   - javascript.astro
   - javascript.bun
+  - javascript.deno
   - javascript.tanstackstart-react
 ---
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/ai-agents-module.mdx
@@ -7,6 +7,7 @@ supported:
   - javascript.aws-lambda
   - javascript.azure-functions
   - javascript.connect
+  - javascript.deno
   - javascript.express
   - javascript.fastify
   - javascript.gcp-functions
@@ -15,7 +16,6 @@ supported:
   - javascript.koa
   - javascript.nestjs
   - javascript.bun
-  - javascript.deno
   - javascript.nextjs
   - javascript.nuxt
   - javascript.astro


### PR DESCRIPTION
closes #14694

Deno is a supported runtime for both the OpenAI and Vercel AI js sdks.

- [Vercel AI SDK](https://ai-sdk.dev/docs/getting-started/navigating-the-library#choosing-the-right-tool-for-your-environment)
- [OpenAI SDK](https://deno.com/blog/openai_sdk_deno)