### PR TITLE
fix(powershell): use correct boolean syntax in documentation

### DIFF
--- a/platform-includes/configuration/config-intro/powershell.mdx
+++ b/platform-includes/configuration/config-intro/powershell.mdx
@@ -23,6 +23,6 @@ Start-Sentry {
     $_.TracesSampleRate = 0.1
 
     # If you'd like to include data that potentially includes PII, such as Machine Name
-    $_.SendDefaultPii = true
+    $_.SendDefaultPii = $true
 }
 ```

--- a/platform-includes/getting-started-config/powershell.mdx
+++ b/platform-includes/getting-started-config/powershell.mdx
@@ -10,6 +10,6 @@ Start-Sentry {
     $_.Dsn = '___PUBLIC_DSN___'
 
     # If you'd like to include data that potentially includes PII, such as Machine Name
-    $_.SendDefaultPii = true
+    $_.SendDefaultPii = $true
 }
 ```


### PR DESCRIPTION
## Summary
- Fix PowerShell boolean syntax in documentation examples
- Change `true` to `$true` in SendDefaultPii configuration examples

## Problem
The documentation was showing incorrect PowerShell syntax using `true` instead of `$true`. In PowerShell, boolean values must be prefixed with `$`.

## Changes
- Updated `platform-includes/configuration/config-intro/powershell.mdx`
- Updated `platform-includes/getting-started-config/powershell.mdx`

Fixes https://github.com/getsentry/sentry-powershell/issues/90

🤖 Generated with [Claude Code](https://claude.ai/code)