### PR TITLE
ref(develop/sdks): Clarify Exception Mechanism interface

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/exception.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/exception.mdx
@@ -67,7 +67,7 @@ The identifier of the capturing mechanism that captured the exception.
 The chosen mechanism `type` MUST help users as well as Sentry employees determine the responsible mechanism for capturing the exception. 
 This is either instrumentation within our SDKs or users manually capturing exceptions (for example via `captureException`). 
 
-The `type` MUST be _reasonably unique_ so that identifying e.g. the integration or SDK API responsible for capturing is possible. 
+The `type` MUST be _reasonably unique_  to make it possible to identify the integration or SDK API that performed the capture.
 There's no strict uniqueness requirement as in certain situations, multiple paths exist within one instrumentation, in which case it is fine to use a common mechanism `type`.
 
 For user-invoked exception captures (e.g. via `captureException`), the `type` MUST be set to `'generic'`.
@@ -154,7 +154,7 @@ Optional (`boolean`)
 
 Flag indicating that this error is synthetic. 
 Synthetic errors are errors that carry little meaning by themselves. 
-This may be because they are created at a central place (like a crash handler), and are all called the same: `Error`, `Segfault` etc.
+This may be because they are all created at a central place (like a crash handler), and share the same title: `Error`, `Segfault` etc.
 When the flag is set, Sentry will then try to use other information (top in-app frame function) rather than the exception type and value in the UI for the primary event display.
 Furthermore, if this flag is set, Sentry will ignore the exception `type` when grouping the exception into issues.
 This flag SHOULD be set for all "segfaults" for instance as every single error group would look very similar otherwise. 


### PR DESCRIPTION
This PR clarifies the exception `Mechanism` interface, specifically the purpose and naming conventions for `mechanism.type`:

- it now explicitly states that `type` should be used to indicate the "origin" or callsite of the exception, so that we can distinguish where an exception was captured. For instance, user vs. SDK but in case of the latter, type should be specific enough to know which instrumentation/integration within the SDK.
- it suggests to use [Trace Origin](https://develop.sentry.dev/sdk/telemetry/traces/trace-origin/)-esque naming for SDK-captured events with the main motivation of this being an already established naming scheme that works well enough for this use case. 

To be clear, SDKs don't have to change anything right now, but should they want to ([like we did in JS](https://github.com/getsentry/sentry-javascript/issues/17212)), this reworked doc should provide more clarity than the short descriptions previously.

(I have another PR coming up with some refactors changes all over this doc but wanted to get this reviewed and accepted first since it actually changes content)  

closes https://github.com/getsentry/sentry-javascript/issues/17266
closes https://github.com/getsentry/sentry-javascript/issues/17212 (finally)