### PR TITLE
docs(dotnet): add additional MSBuild properties

### DIFF
--- a/docs/platforms/dotnet/common/configuration/msbuild.mdx
+++ b/docs/platforms/dotnet/common/configuration/msbuild.mdx
@@ -228,3 +228,39 @@ them, be very careful that their values are not committed to source control or a
 A more secure approach is to set authentication via environment variable or `~/.sentryclirc` file,
 
 </Alert>
+
+## Additional Project Configuration
+
+### Project Properties
+
+<ConfigKey name="SentryImplicitUsings">
+
+C# 10.0 or greater support the language feature _'global using directive'_.
+Depending on the type of .NET project SDK, the MSBuild property [ImplicitUsings](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#implicitusings) automatically adds a set of default `global using` directives to your C# projects.
+When `ImplicitUsings` are enabled, the Sentry SDK also adds commonly used `global using` directives to your C# projects.
+
+If you have namespace conflicts, you can opt out of Sentry's `global using` directives when `ImplicitUsings` are enabled:
+```xml
+<PropertyGroup>
+  <SentryImplicitUsings>false</SentryImplicitUsings>
+</PropertyGroup>
+```
+
+_Available since [version 4.0.0](https://github.com/getsentry/sentry-dotnet/releases/tag/4.0.0)_
+
+</ConfigKey>
+
+<ConfigKey name="SentryNative">
+
+The Sentry .NET SDK wraps the [Sentry Native SDK](/platforms/native).
+
+In case you run into issues with the native dependencies, you can opt out of including the Sentry Native SDK via:
+```xml
+<PropertyGroup>
+  <SentryNative>false</SentryNative>
+</PropertyGroup>
+```
+
+_Available since [version 5.6.0](https://github.com/getsentry/sentry-dotnet/releases/tag/5.6.0)_
+
+</ConfigKey>


### PR DESCRIPTION
## DESCRIBE YOUR PR
The .NET SDK includes the Sentry CLI, and offers MSBuild properties to configure the Sentry CLI, which is already documented.
The .NET SDK includes additional MSBuild properties for users to customize the .NET SDK that are only implicitly documented so far:
- Adding explicit documentation for the non-Sentry-CLI MSBuild properties.

Supersedes #13482.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
