### PR TITLE
feat(develop): Add `monitor` category to rate limiting docs

### DIFF
--- a/develop-docs/sdk/expected-features/rate-limiting.mdx
+++ b/develop-docs/sdk/expected-features/rate-limiting.mdx
@@ -87,6 +87,7 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
   - `default`: Events with an event_type not listed explicitly below.
   - `error`: Error events.
   - `transaction`: Transaction type events.
+  - `monitor`: Monitor check-ins.
   - `span`: Span type events.
   - `log_item`: Log events.
   - `security`: Events with event_type `csp`


### PR DESCRIPTION
Adds the missing category, as defined in Relay: https://github.com/getsentry/relay/blob/a00af6b85faff6c60e66bfdd54adb7c9f1d856c2/relay-base-schema/src/data_category.rs#L49