### PR TITLE
feat(js): Link javascript usage page to api docs

### DIFF
--- a/docs/platforms/javascript/common/usage/index.mdx
+++ b/docs/platforms/javascript/common/usage/index.mdx
@@ -25,7 +25,7 @@ While capturing an event, you can also record the breadcrumbs that lead up to th
 
 <PlatformContent includePath="capture-error" />
 
-You can learn more about the <PlatformLink to="/apis/#captureexception">`captureException` API</PlatformLink> in our API documentation.
+You can learn more about the <PlatformLink to="/apis/#captureException">`captureException` API</PlatformLink> in our API documentation.
 
 ## Capturing Messages
 
@@ -35,4 +35,4 @@ Messages show up as issues on your issue stream, with the message as the issue n
 
 <PlatformContent includePath="capture-message" />
 
-You can learn more about the <PlatformLink to="/apis/#capturemessage">`captureMessage` API</PlatformLink> in our API documentation.
+You can learn more about the <PlatformLink to="/apis/#captureMessage">`captureMessage` API</PlatformLink> in our API documentation.

--- a/docs/platforms/javascript/common/usage/index.mdx
+++ b/docs/platforms/javascript/common/usage/index.mdx
@@ -25,6 +25,8 @@ While capturing an event, you can also record the breadcrumbs that lead up to th
 
 <PlatformContent includePath="capture-error" />
 
+You can learn more about the <PlatformLink to="/apis/#captureexception">`captureException` API</PlatformLink> in our API documentation.
+
 ## Capturing Messages
 
 Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically, our SDKs don't automatically capture messages, but you can capture them manually.
@@ -32,3 +34,5 @@ Another common operation is to capture a bare message. A message is textual info
 Messages show up as issues on your issue stream, with the message as the issue name.
 
 <PlatformContent includePath="capture-message" />
+
+You can learn more about the <PlatformLink to="/apis/#capturemessage">`captureMessage` API</PlatformLink> in our API documentation.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adds links to the `captureException` and `captureMessage` API documentation within their respective sections on the JavaScript usage page (`docs/platforms/javascript/common/usage/index.mdx`).

This change addresses user feedback requesting to see the interface of these functions, not just examples, by providing direct links to the API documentation.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/C8H0BQRDJ/p1758172270306919?thread_ts=1758172270.306919&cid=C8H0BQRDJ)

<a href="https://cursor.com/background-agent?bcId=bc-37faa50f-ca32-43fb-801b-a9df2c9925ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37faa50f-ca32-43fb-801b-a9df2c9925ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

