### PR TITLE
ref(js): Clarify min version of `ignoreSpans` and fix incorrect platformCategory excludes

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -409,7 +409,6 @@ If you want to disable trace propagation, you can set this option to `[]`.
   </SdkOption>
 </PlatformCategorySection>
 
-<PlatformCategorySection supported={['browser']}>
 
 <SdkOption name="beforeSendTransaction" type='(event: TransactionEvent, hint: EventHint) => TransactionEvent | null'>
 
@@ -433,7 +432,7 @@ Please note that the `span` you receive as an argument is a serialized object, n
 
 </SdkOption>
 
-<SdkOption name="ignoreSpans" type='Array<string | RegExp | {name?: string | RegExp, op?: string | RegExp}>' defaultValue='[]'>
+<SdkOption name="ignoreSpans" type='Array<string | RegExp | {name?: string | RegExp, op?: string | RegExp}>' defaultValue='[]' availableSince='10.2.0'>
 
 A list of strings or regex patterns matching span names that shouldn't be sent to Sentry. When using strings, partial matches will be filtered out, so if you need to filter by exact match, use regex patterns instead. You can also provide an object with a `name` and `op` property to match both the span name and the operation name. Note that at least `name` or `op` must be provided.
 
@@ -445,9 +444,7 @@ By default, no spans are ignored.
 
 <PlatformCategorySection supported={['browser']}>
 
-<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false'>
-
-_Available since: `10.10.0`_
+<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false' availableSince='10.10.0'>
 
 If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/) to outgoing Http requests made via `fetch` or `XMLHttpRequest`.
 This header is attached in addition to the `sentry-trace` and `baggage` headers.
@@ -463,6 +460,8 @@ Note that this option is only available for browser SDKs.
 </SdkOption>
 
 </PlatformCategorySection>
+
+<PlatformCategorySection supported={['browser']}>
 
 ## Session Replay Options
 


### PR DESCRIPTION
This PR 

- adds an `availableSince` property to the `ignoreSpans` filter option
- removes and repositions a `PlatformCategorySection` component which incorrectly excluded a couple of tracing options from server-side JS guides.