### PR TITLE
Document ipcNamespace option for Sentry Electron

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -290,7 +290,7 @@ Sentry.init({
 });
 ```
 
-When set, the IPC channels used by Sentry will be prefixed with the specified namespace.
+When set, the IPC channels used by Sentry will be prefixed with the specified namespace. Note that you need to configure the same namespace in your main process, renderer processes, and preload scripts for proper communication. See the <PlatformLink to="/platforms/javascript/guides/electron/#custom-ipc-namespace">Custom IPC Namespace section</PlatformLink> for complete setup instructions.
 
 </SdkOption>
 

--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -213,18 +213,42 @@ init({
 
 ### Custom IPC Namespace
 
-If your Electron application uses multiple IPC channels and you want to prevent potential conflicts between them, you can specify a custom namespace for the IPC channels used by Sentry with the `ipcNamespace` option:
+If your Electron application uses multiple IPC channels and you want to prevent potential conflicts between them, you can specify a custom namespace for the IPC channels used by Sentry with the `ipcNamespace` option.
+
+To use a custom namespace, you need to configure it in all three contexts: main process, renderer processes, and preload scripts.
+
+**In the main process:**
 
 ```javascript
 import * as Sentry from "@sentry/electron/main";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  ipcNamespace: "myAppSentry",
+  ipcNamespace: "some-app",
 });
 ```
 
-When set, the IPC channels used by Sentry will be prefixed with the specified namespace, helping to avoid conflicts with other IPC channels in your application. For more configuration options, see the <PlatformLink to="/configuration/options/#ipcNamespace">configuration options documentation</PlatformLink>.
+**In renderer processes:**
+
+```javascript
+import * as Sentry from '@sentry/electron/renderer';
+
+Sentry.init({
+  ipcNamespace: 'some-app',
+});
+```
+
+**In preload scripts:**
+
+```javascript
+import { hookupIpc } from '@sentry/electron/preload-namespaced';
+
+hookupIpc('some-app');
+```
+
+When set, the IPC channels used by Sentry will be prefixed with the specified namespace (e.g., `some-app`), helping to avoid conflicts with other IPC channels in your application. Make sure to use the same namespace value across all processes for proper communication.
+
+For more configuration options, see the <PlatformLink to="/configuration/options/#ipcNamespace">configuration options documentation</PlatformLink>.
 
 ### Preload Injection
 


### PR DESCRIPTION
Documents https://github.com/getsentry/sentry-electron/pull/1234

## DESCRIBE YOUR PR
This PR documents the `ipcNamespace` option for the Sentry Electron SDK. This option allows users to specify a custom namespace for Sentry's IPC channels, preventing potential conflicts in applications that use multiple IPC channels.

The documentation has been added to:
*   The main Electron guide (`docs/platforms/javascript/guides/electron/index.mdx`) with a new "Custom IPC Namespace" subsection.
*   The common configuration options page (`docs/platforms/javascript/common/configuration/options.mdx`) with a detailed `SdkOption` entry.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/D0913PZP35W/p1758212038049479?thread_ts=1758212038.049479&cid=D0913PZP35W)

<a href="https://cursor.com/background-agent?bcId=bc-1e45b0f6-7e47-45dd-80df-7c8f432ef00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e45b0f6-7e47-45dd-80df-7c8f432ef00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

