### PR TITLE
fix(docs): Add ProGuard related properties to MAUI MSBuild page

### DIFF
--- a/docs/platforms/dotnet/common/configuration/msbuild.mdx
+++ b/docs/platforms/dotnet/common/configuration/msbuild.mdx
@@ -174,6 +174,13 @@ Sentry will try to determine the release version automatically by checking the f
 
 </ConfigKey>
 
+<ConfigKey name="SentryProGuardUUID" supported={["dotnet.maui"]}>
+
+Manually set your ProGuard UUID. This UUID will be used to [upload ProGuard mapping to Sentry](cli/dif/#proguard-mapping-upload), and setting APK's metadata.
+If not defined, Sentry will [generate a UUID](../../data-management/debug-files/identifiers/#proguard-uuids) for you.
+
+</ConfigKey>
+
 <ConfigKey name="SentrySetCommits">
 
 Enable `SentrySetCommits` to automatically [associate commits with the release](/cli/releases/#commit-integration).
@@ -183,6 +190,25 @@ Enable `SentrySetCommits` to automatically [associate commits with the release](
 <ConfigKey name="SentrySetCommitOptions">
 
 By default, when `SentrySetCommits` is enabled, the SDK will set commits with the `--auto` flag. The optional `SentrySetCommitOptions` property allows you to override this to provide whatever flags you want to the `set-commits` CLI command.
+
+</ConfigKey>
+
+<ConfigKey name="SentryUploadAndroidProGuardMapping" supported={["dotnet.maui"]}>
+
+Controls uploading ProGuard mapping file to Sentry after the build. Defaults to `false` (disabled).
+
+Set to `true` to upload ProGuard mapping file to Sentry.
+Your resulting APK will be injected with the metadata `io.sentry.proguard-uuid`. `AndroidManifest.xml` will contain a metadata entry such as the following:
+
+```xml
+<meta-data
+    android:name="io.sentry.proguard-uuid"
+    android:value="YOUR-UUID-HERE" />
+```
+
+Do not overwrite `io.sentry.proguard-uuid` metadata directly. See [SentryProGuardUUID](#SentryProGuardUUID) to set your own ProGuard UUID.
+
+`UseSentryCLI` must be set to `true` for the ProGuard mapping upload to work.
 
 </ConfigKey>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds more information about Proguard mapping file upload feature we have in .NET MAUI app.

Should be merged after this change is merged:
- https://github.com/getsentry/sentry-dotnet/pull/4532

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
