### PR TITLE
docs(fix): Update Issues > Feature Flag docs To Clarify Feature Flag Change Tracking

### DIFF
--- a/docs/product/issues/issue-details/feature-flags/index.mdx
+++ b/docs/product/issues/issue-details/feature-flags/index.mdx
@@ -48,7 +48,7 @@ Change tracking enables Sentry to listen for additions, removals, and modificati
 
 ![Flag Change Tracking](./img/FlagChangeTracking.png)
 
-Within an issue, the audit log is represented in the "event" chart and presents itself as a "release" line. The lines will only appear for flags that were evaluated before the error event occurred; however, feature flag definition changes (audit log) can still occur after an error. This feature requires evaluation tracking to be enabled. 
+Within an issue, the audit log is represented in the "event" chart and presents itself as a "release" line. The lines will only appear for flags that were evaluated before the error event occurred; however, feature flag definition changes from the audit log can still occur after an error. This feature requires evaluation tracking to be enabled. 
 
 ![Flag Change Issue](./img/FlagChangeIssue.png)
 


### PR DESCRIPTION
Update description on feature flag change tracking to make it clear that evaluation tracking needs to be enabled in order to see feature flag change annotations
