### PR TITLE
docs(fix): Update Issues > Issue Details Docs to Clarify Feature Flag Change Tracking

### DIFF
--- a/docs/product/issues/issue-details/index.mdx
+++ b/docs/product/issues/issue-details/index.mdx
@@ -190,11 +190,11 @@ Enabling one or more of our [evaluation tracking integrations](/product/explore/
 
 Setting up evaluation tracking also allows you to use Issues Search in conjunction with feature flags. On Issues Search, using the `flags` keyword will allow you to filter for issues containing errors where the feature flag evaluated value is true or false. This allows you to quickly find all errors where a specific flag evaluation and its value of interest are present. See [searchable properties](/concepts/search/searchable-properties/issues/#flags) for more details about the search syntax.
 
-Enabling a [change tracking integration](/product/explore/feature-flags/#change-tracking) will enable annotations on the event volume chart. These lines mark feature flag changes and can help identify regressions caused by a feature flag definition change.
+Enabling both [change tracking](/product/explore/feature-flags/#change-tracking) and evaluation tracking integrations adds feature flag change annotations to the event volume chart and unlocks suspect feature flag detection. Feature flag change annotations help you identify regressions caused by updates to a feature flag’s definition. An annotation will only appear for flags that were evaluated before the error event occurred.
 
 ![Feature Flag Release Chart](./img/ff-release.png)
 
-Enabling both a change tracking integration and a evaluation tracking integration will enable suspect feature flag detection. Sentry will attempt to identify feature flags which might have caused an error event and highlight them for review.
+With suspect feature flag detection, Sentry automatically highlights feature flags that may have contributed to an error event, making it easier to review and pinpoint potential causes.
 
 ### Event Grouping Information
 


### PR DESCRIPTION
Update description on feature flag change tracking to make it clear that evaluation tracking needs to be enabled in order to see feature flag change annotations