### PR TITLE
Unreal Engine: Add notice about loading custom callback handler classes

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -159,6 +159,12 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 The callbacks you set as hooks will be called on the thread where the event happened. If the event occurs on a non-game thread during garbage collection the callback will not be invoked.
 
+<Alert>
+
+If your callback handler class is part of another plugin, ensure that plugin is loaded before the Sentry SDK. Otherwise, the handler won't be found during Sentry settings deserialization at engine startup and won't be executed.
+
+</Alert>
+
 <ConfigKey name="before-send">
 
 This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.


### PR DESCRIPTION
This PR adds a notice to the Unreal plugin configuration documentation highlighting the importance of plugin loading order when configuring custom callback handlers.