### PR TITLE
feat(js): Add `reportPageLoaded()` documentation

### DIFF
--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -722,10 +722,10 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
   Signals to the Sentry SDK that the initial page was fully loaded.
   Requires the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#enableReportPageLoaded">`enableReportPageLoaded` option</PlatformLink> in `browserTracingIntegration` to
   be set to `true`. Once called, the SDK ends the pageload span automatically,
+
   By default, the SDK takes care of ending the pageload span automatically, based on
   a period of inactivity where no new child spans are added to the pageload trace.
-
-  You can use explicit pageload reporting if the inactivity heuristics of
+  You can alternatively use explicit pageload reporting if the inactivity heuristics of
   `browserTracingIntegration` don't work well for your use case.
   However, you must ensure that you call `reportPageLoaded` in every situation.
   If `reportPageLoaded` is not called, the pageload span will be ended after 30 seconds

--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -712,6 +712,39 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
   `browserTracingIntegration` has not been enabled.
 </SdkApi>
 
+<SdkApi
+  name="reportPageLoaded"
+  signature="function reportPageLoaded(): void"
+  categorySupported={["browser"]}
+  availableSince="10.13.0"
+>
+
+  Signals to the Sentry SDK that the initial page was fully loaded.
+  Requires the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#enableReportPageLoaded">`enableReportPageLoaded` option</PlatformLink> in `browserTracingIntegration` to
+  be set to `true`. Once called, the SDK ends the pageload span explicitly.
+  By default, the SDK takes care of ending the pageload span automatically, based on
+  a period of inactivity where no new child spans are added to the pageload trace.
+
+  You can use explicit pageload reporting if the inactivity heuristics of
+  `browserTracingIntegration` don't work well for your use case.
+  However, you must ensure that you call `reportPageLoaded` in every situation.
+  If `reportPageLoaded` is not called, the pageload span will be ended after 30 seconds
+  or whatever custom value is set on the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#enableReportPageLoaded">`finalTimeout` option</PlatformLink>.
+
+
+  <Expandable title="Examples">
+  ```javascript
+  Sentry.init({
+    // 1. Enable manual page load reporting:
+    integrations: [browserTracingIntegration({ enableReportPageLoaded: true })]
+  })
+
+  // 2. Whenever you consider the page loaded:
+  Sentry.reportPageLoaded();
+  ```
+  </Expandable>
+</SdkApi>
+
 ## Tracing Utilities
 
 These utilities can be used for more advanced tracing use cases.

--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -721,7 +721,7 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
 
   Signals to the Sentry SDK that the initial page was fully loaded.
   Requires the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#enableReportPageLoaded">`enableReportPageLoaded` option</PlatformLink> in `browserTracingIntegration` to
-  be set to `true`. Once called, the SDK ends the pageload span explicitly.
+  be set to `true`. Once called, the SDK ends the pageload span automatically,
   By default, the SDK takes care of ending the pageload span automatically, based on
   a period of inactivity where no new child spans are added to the pageload trace.
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -131,6 +131,13 @@ This flag enables or disables creation of `pageload` span on first pageload.
 
 </SdkOption>
 
+
+<SdkOption name="enableReportPageLoaded" type='boolean' defaultValue='false' availableSince='10.13.0'>
+
+This option determines whether the <PlatformLink to="/apis/#reportPageLoaded">`Sentry.reportPageLoaded()` function</PlatformLink> is enabled.
+
+</SdkOption>
+
 <SdkOption name="markBackgroundSpans" type='boolean' defaultValue='true'>
 
 This option flags pageload/navigation spans when tabs are moved to the background with "cancelled". Because browser background tab timing is not suited for precise measurements of operations and can affect your statistics in nondeterministic ways, we recommend that this option be enabled.

--- a/src/components/sdkApi.tsx
+++ b/src/components/sdkApi.tsx
@@ -26,6 +26,7 @@ type Props = {
   name: string;
   parameters: ParameterDef[];
   signature: string;
+  availableSince?: string;
   categorySupported?: PlatformCategory[];
   children?: React.ReactNode;
   language?: string;
@@ -35,6 +36,7 @@ export function SdkApi({
   name,
   children,
   signature,
+  availableSince,
   parameters = [],
   language,
   categorySupported = [],
@@ -51,9 +53,12 @@ export function SdkApi({
       {showServerLikeOnly && (
         <div className="italic text-sm">Only available on Server</div>
       )}
-
       <pre className="mt-2 mb-2 text-sm">{codeToJsx(signature, lang)}</pre>
-
+      {availableSince && (
+        <p className="italic">
+          Available Since: <code>{availableSince}</code>
+        </p>
+      )}
       {parameters.length ? (
         <Expandable title="Parameters">
           <div className="space-y-3">
@@ -63,7 +68,6 @@ export function SdkApi({
           </div>
         </Expandable>
       ) : null}
-
       {children}
     </SdkDefinition>
   );


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR adds documentation for the new `reportPageLoaded()` API which is coupled to the new `enableReportPageLoaded` option in the `browserTracingIntegration`. Both have been added via https://github.com/getsentry/sentry-javascript/pull/17724 and released in [10.13.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.13.0).

Also added a new `availableSince` prop to the `SdkApi` component.

closes https://linear.app/getsentry/issue/FE-607/docs-for-reportpageloaded

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
