### PR TITLE
feat(js): Add documentation for `setActiveSpanInBrowser(span: Span)`

### DIFF
--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -639,7 +639,7 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
 <SdkApi
  name="setActiveSpanInBrowser"
  signature="function setActiveSpanInBrowser(span: Span): void"
- availableSince="10.14.0"
+ availableSince="10.15.0"
  categorySupported={["browser"]}
  parameters={[
   {

--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -637,6 +637,51 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
 </SdkApi>
 
 <SdkApi
+ name="setSpanActive"
+ signature="function setSpanActive(span: Span): void"
+ availableSince="10.14.0"
+ categorySupported={["browser"]}
+ parameters={[
+  {
+    name: "span",
+    required: true,
+    type: "Span",
+    description: "The span to be set active"
+  }
+ ]}
+ >
+  Sets the passed span as the active span on the current scope.
+  You most likely don't need this functionality but should [use `startActiveSpan`](#startActiveSpan) 
+  instead.
+  However, in some situations, you might prefer a span being active outside of a callback. 
+  In this case, the combination of [`startInactiveSpan`](#startInactiveSpan) with this function
+  allows you to start a span, hold a reference to it and keep it active until you end it, without
+  the active duration being bound to the callback (as opposed to [`startSpanManual`](#startSpanManual)).
+  
+  
+  <Expandable title='Examples'>
+  ```javascript
+  let checkoutSpan;
+  
+  on('startCheckout', () => {
+    checkoutSpan = Sentry.startInactiveSpan({name: 'checkout-flow'});
+    Sentry.setSpanActive(checkoutSpan);
+  })
+  
+  doSomeWork();
+  
+  on('endCheckout', () => {
+    // Ending the span automatically removes it as the active span on the scope
+    checkoutSpan.end();
+  })
+  ```
+</Expandable>
+
+See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</PlatformLink> for more information on how to work with spans.
+
+</SdkApi>
+
+<SdkApi
   name="continueTrace"
   signature="function continueTrace<T>(options: TraceOptions, callback: () => T): T"
   parameters={[

--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -651,7 +651,7 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
  ]}
  >
   Sets the passed span as the active span on the current scope.
-  You most likely don't need this functionality but should [use `startActiveSpan`](#startActiveSpan) 
+  You most likely don't need this functionality and should [use `startActiveSpan`](#startActiveSpan) 
   instead.
   However, in some situations, you might prefer a span being active outside of a callback. 
   In this case, the combination of [`startInactiveSpan`](#startInactiveSpan) with this function

--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -637,8 +637,8 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
 </SdkApi>
 
 <SdkApi
- name="setSpanActive"
- signature="function setSpanActive(span: Span): void"
+ name="setActiveSpanInBrowser"
+ signature="function setActiveSpanInBrowser(span: Span): void"
  availableSince="10.14.0"
  categorySupported={["browser"]}
  parameters={[
@@ -665,7 +665,7 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
   
   on('startCheckout', () => {
     checkoutSpan = Sentry.startInactiveSpan({name: 'checkout-flow'});
-    Sentry.setSpanActive(checkoutSpan);
+    Sentry.setActiveSpanInBrowser(checkoutSpan);
   })
   
   doSomeWork();

--- a/docs/platforms/javascript/common/apis.mdx
+++ b/docs/platforms/javascript/common/apis.mdx
@@ -641,17 +641,9 @@ See <PlatformLink to="/tracing/instrumentation/">Tracing Instrumentation</Platfo
  signature="function setActiveSpanInBrowser(span: Span): void"
  availableSince="10.15.0"
  categorySupported={["browser"]}
- parameters={[
-  {
-    name: "span",
-    required: true,
-    type: "Span",
-    description: "The span to be set active"
-  }
- ]}
  >
   Sets the passed span as the active span on the current scope.
-  You most likely don't need this functionality and should [use `startActiveSpan`](#startActiveSpan) 
+  You most likely don't need this functionality and should [use `startSpan`](#startSpan) 
   instead.
   However, in some situations, you might prefer a span being active outside of a callback. 
   In this case, the combination of [`startInactiveSpan`](#startInactiveSpan) with this function

--- a/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
@@ -108,7 +108,9 @@ To add spans that aren't active, you can create independent spans. This is usefu
 <PlatformCategorySection supported={['browser']}>
 
   ### Setting an inactive span active (browser only)
-
+  
+  _Available Since: `10.15.0`_
+  
   In browser environments, you might run into use cases, where the callback-based span APIs are not sufficient.
   In such cases (see example below), you can use `startInactiveSpan` to start an initially inactive span and then 
   set it active until you manually end the span.

--- a/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
@@ -102,7 +102,32 @@ Sometimes, you do not want the span to be ended automatically when the callback 
 
 To add spans that aren't active, you can create independent spans. This is useful when you have work that is grouped together under a single parent span, but is independent from the currently active span. However, in most cases you'll want to create and use the [startSpan](#starting-an-active-span-startspan) API from above.
 
+
 <PlatformContent includePath="performance/start-inactive-span" />
+
+<PlatformCategorySection supported={['browser']}>
+
+  In some cases, you may need to start an inactive span and make it the active span.
+  In contrast to [startSpanManual](#starting-an-active-span-with-manual-end-startspanmanual), the period for which 
+  the span is active is not bound to the callback. Instead, it will remain active until you manually end the span.
+
+  ```javascript
+  let checkoutSpan;
+  
+  on('startCheckout', () => {
+    checkoutSpan = Sentry.startInactiveSpan({name: 'checkout-flow'});
+    Sentry.setSpanActive(checkoutSpan);
+  })
+  
+  doSomeWork();
+  
+  on('endCheckout', () => {
+    // Ending the span automatically removes it as the active span on the scope
+    checkoutSpan.end();
+  })
+  ```
+
+</PlatformCategorySection>
 
 ## Starting Spans as Children of a Specific Span
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
@@ -107,25 +107,36 @@ To add spans that aren't active, you can create independent spans. This is usefu
 
 <PlatformCategorySection supported={['browser']}>
 
-  In some cases, you may need to start an inactive span and make it the active span.
-  In contrast to [startSpanManual](#starting-an-active-span-with-manual-end-startspanmanual), the period for which 
-  the span is active is not bound to the callback. Instead, it will remain active until you manually end the span.
+  ### Setting an inactive span active (browser only)
+
+  In browser environments, you might run into use cases, where the callback-based span APIs are not sufficient.
+  In such cases (see example below), you can use `startInactiveSpan` to start an initially inactive span and then 
+  set it active until you manually end the span.
 
   ```javascript
   let checkoutSpan;
   
   on('startCheckout', () => {
     checkoutSpan = Sentry.startInactiveSpan({name: 'checkout-flow'});
-    Sentry.setSpanActive(checkoutSpan);
+    Sentry.setActiveSpanInBrowser(checkoutSpan);
   })
   
   doSomeWork();
   
   on('endCheckout', () => {
-    // Ending the span automatically removes it as the active span on the scope
+    // Ending the span automatically removes it as the active span
     checkoutSpan.end();
   })
   ```
+  
+  Using `startInactiveSpan` in combination with `setActiveSpanInBrowser` allows you to create an inactive span that can be made active until you manually end it. In contrast, [`startSpanManual`](#starting-an-active-span-with-manual-end-startspanmanual) allows you to end the span manually at any point, but it only remains active within the callback.
+  
+  <Alert>
+  
+  Note that `setActiveSpanInBrowser` is only available in browser environments! If you're running code in the server
+  (for example for server-side rendering), make sure to guard this call to only run in the browser.
+  
+  </Alert>
 
 </PlatformCategorySection>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Adds documentation for `Sentry. setActiveSpanInBrowser(span)` which is added via https://github.com/getsentry/sentry-javascript/pull/17714. To be merged only after the feature was released. This is still based on #15006 because I need the `availableSince` prop on the `SdkApi` component.

closes https://linear.app/getsentry/issue/FE-608/docs-for-setspanactive

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
