### PR TITLE
docs(js): Update turbopack support notes

### DIFF
--- a/includes/nextjs-turbopack-warning-expandable.mdx
+++ b/includes/nextjs-turbopack-warning-expandable.mdx
@@ -1,11 +1,5 @@
-<Expandable level="warning" title="Are you using Turbopack?">
+<Expandable level="info" title="Are you using Turbopack?">
 
-The Sentry SDK doesn't yet fully support Turbopack production builds (`next build --turbopack`) as Turbopack production builds are still in alpha.
-
-If you upgraded the Sentry SDK to the latest version and installed Next.js on version `15.3.0` or later, the SDK will capture all data as expected, however, it is currently not possible to apply sourcemaps to Turbopack production builds.
-
-Turbopack in dev-mode (`next dev --turbopack`) is fully supported for Next.js 15.3.0 and later. To verify your Sentry setup, temporarily remove the `--turbo` if you're on older Next.js versions.
-
-Check the latest information on [Sentry's support for Turbopack on GitHub](https://github.com/getsentry/sentry-javascript/issues/8105).
+The Sentry SDK fully supports Turbopack production builds (`next build --turbopack`) starting with `@sentry/nextjs@10.13.0`. 
 
 </Expandable>

--- a/platform-includes/sourcemaps/overview/javascript.nextjs.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.nextjs.mdx
@@ -56,13 +56,7 @@ module.exports = withSentryConfig(
 ```
 ### Turbopack Considerations
 
-**Important:** The Sentry SDK doesn't yet fully support Turbopack production builds (`next build --turbopack`) as Turbopack production builds are still in alpha.
-
-- **Turbopack dev mode** (`next dev --turbopack`) is fully supported for Next.js 15.3.0+
-- **Turbopack production builds** are not currently supported for source map upload
-- If you're using Turbopack, remove the `--turbo` flag for production builds until full support is available
-
-Check the latest information on [Sentry's support for Turbopack on GitHub](https://github.com/getsentry/sentry-javascript/issues/8105).
+Sourcemaps for Turbopack production builds are supported starting with `@sentry/nextjs@10.13.0`.
 
 ### Troubleshooting
 


### PR DESCRIPTION
We support turbopack prod builds starting with `@sentry/nextjs@10.13.0` - this PR updates the content for this in docs.