### PR TITLE
docs(js): Document useRunAfterProductionCompileHook for Next.js

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
@@ -282,6 +282,23 @@ Enables React component name tracking. When enabled, it annotates React componen
 
 A list of React component names to exclude from component annotation.
 
+</SdkOption>
+
+<SdkOption name="useRunAfterProductionCompileHook" type="boolean" defaultValue="false(webpack)|true(turbopack)">
+
+<Alert level="info" title="Version support">
+    You can use this option with Next.js version 15.4.1 and later.
+  </Alert>
+
+Enables the use of the [`runAfterProductionCompile` hook from Next.js](https://nextjs.org/docs/app/building-your-application/configuring/running-post-build-tasks#the-runafterproductioncompile-hook) to upload sourcemaps after the build is completed.
+
+- This option is set to `true` by default for Turbopack as there are no alternative ways to upload sourcemaps here.
+- This option is set to `false` for Webpack as the default behavior is to upload sourcemaps during the build process using the [Sentry Webpack Plugin](https://github.com/getsentry/sentry-javascript-bundler-plugins).
+
+**Important:** Enabling this option will mutate your Next.js build output by injecting [Debug IDs](/platforms/javascript/guides/nextjs/sourcemaps/troubleshooting_js/debug-ids/) via the Sentry CLI. If you are relying on any sort of integrity hashes for your build artifacts, you will need to disable this option.
+
+
+
 </SdkOption>  
 
 <SdkOption


### PR DESCRIPTION
documents https://github.com/getsentry/sentry-javascript/pull/17721