### PR TITLE
feat(develop): document `traceIgnoreStatusCodes`

### DIFF
--- a/develop-docs/sdk/telemetry/traces/index.mdx
+++ b/develop-docs/sdk/telemetry/traces/index.mdx
@@ -135,7 +135,7 @@ If suitable for the platform, the collection MAY also admit pairs of integers, d
 
 The option applies exclusively to incoming requests, and therefore MUST only be implemented in server SDKs.
 
-The SDK MUST honor this option by inspecting the [`http.response.status_code`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#:~:text=1437-,http.response.status_code,-int) attribute on each transaction/root span when it's finished.
+The SDK MUST honor this option by inspecting the [`http.response.status_code`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#:~:text=1437-,http.response.status_code,-int) attribute on each transaction/root span before it's finished.
 If the value of this attribute matches one of the status codes in `traceIgnoreStatusCodes`, the SDK MUST set the transaction's [sampling decision](https://develop.sentry.dev/sdk/telemetry/traces/#sampling) to `not sampled`.
 
 Note that a prerequisite to implement this option is that every HTTP server integration MUST record the [`http.response.status_code`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#:~:text=1437-,http.response.status_code,-int) attribute as defined in the OTEL spec.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Documents the `traceIgnoreStatusCodes` option for SDKs.
This is a proposal on how to implement it.

This contrasts with the implementation in JS because there it's an option on `httpIntegration`.

However, to make this work for OTEL instrumentation too, we need to make it a client option (as in POTEL SDKs there might be no concept of OTEL "integration" to pass parameters to), and rely on the span attribute (because that's the only thing the SDK sees from the spans generated by OTEL instrumentation).

Another option in non-POTEL SDKs would be to implement it as an option on each integration, but this way to specify the option and implement it makes it consistent across SDKs (regardless of POTEL/non-POTEL).