### PR TITLE
docs(nuxt): use correct module path in a snippet

### DIFF
--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -106,7 +106,7 @@ We recommend you store your Sentry [Data Source Name](/concepts/key-terms/dsn-ex
 
 ```javascript {filename:nuxt.config.ts}
 export default defineNuxtConfig({
-  modules: ["@sentry/nuxt"],
+  modules: ["@sentry/nuxt/module"],
   runtimeConfig: {
     public: {
       sentry: {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Noticed that a snippet in [Nuxt manual setup guide](https://docs.sentry.io/platforms/javascript/guides/nuxt/manual-setup/#configure-client-side-sentry) is using incorrect module path when registering it.

It it is using `@sentry/nuxt` instead of `@sentry/nuxt/module` which is the correct path.

<img width="2336" height="720" alt="CleanShot 2025-09-24 at 14 34 37@2x" src="https://github.com/user-attachments/assets/10f611bc-80ea-4874-83e8-8be4f567f1a3" />

I verified this by copying the snippet into a Nuxt project, it throws:

```
RollupError: [plugin impound] Importing directly from module entry-points is not allowed. [importing @sentry/nuxt from sentry.server.config.ts]
```

So here I'm just fixing and after the change it would match the other snippets that have the correct path used.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)