### PR TITLE
Moved AWS Lambda docs from Notion to develop docs

### DIFF
--- a/develop-docs/sdk/platform-specifics/serverless-sdks/aws-lambda-development-environment.mdx
+++ b/develop-docs/sdk/platform-specifics/serverless-sdks/aws-lambda-development-environment.mdx
@@ -1,0 +1,205 @@
+---
+title: AWS Lambda Development Environment
+sidebar_order: 200
+---
+
+This guide will explain how you can setup a development environment to work on the [AWS Lambda Integration](https://docs.sentry.io/product/integrations/cloud-monitoring/aws-lambda/). The development environment is a local instance of `sentry` and configuration in AWS to make everything work together.
+
+<Alert level="warning" title="IMPORTANT">
+
+**This guide is only if you want to send data from an AWS Lambda function to your local `sentry` instance.**
+
+When working on the Sentry AWS Lambda layer from one of the SDKs, the workflow is that you have your example Lambda function in a dev account on AWS and then deploy your local layer to the dev account and attach it to your example function. How do to this in Python is described in the [contribution guide](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md#contributing-to-sentry-aws-lambda-layer) of the Python SDK.
+
+</Alert>
+
+## Configuration of AWS
+
+To emulate a Sentry integration with a project base on AWS Lambda functions you need:
+
+- One AWS account representing Sentry having an IAM and a S3 Bucket containing a JSON config file.
+- One AWS account representing the user that has a example Lambda function.
+
+### What You Need in Detail
+
+- For the **“Sentry Account”** in AWS we assume the AWS Account ID is `1111 1111 1111` in this guide. This account can be the shared official dev AWS account of Sentry, or you can create a personal one (credit card required for this)
+- Create an **IAM user** in the **“Sentry account”** that can create S3 buckets, and has permission to assume roles. The policy that can be directly attached to the IAM user looks like this:
+
+  _TODO: check if we can restrict those permissions more_
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "VisualEditor0",
+        "Effect": "Allow",
+        "Action": "sts:AssumeRole",
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+
+- A **S3 Bucket in “Sentry Account”** that is accessible by the public to host the CloudFormation configuration file. (more on this later). The S3 Bucket Policy should look like this (in this example “sentry-dev-cloudformation” is the name of the S3 bucket):
+
+  _TODO: check if we can restrict those permissions more_
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "Statement1",
+        "Effect": "Allow",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "arn:aws:s3:::sentry-dev-cloudformation",
+          "arn:aws:s3:::sentry-dev-cloudformation/dev.json"
+        ]
+      }
+    ]
+  }
+  ```
+
+- An **CloudFormation configuration file** called `dev.json` that lives in the S3 bucket in “Sentry account” as mentioned above. The `dev.json` file is a pointer to a “Sentry account” user. The file must be readable by the customer.
+  The dev.json must look like this. You need to replace `arn:aws:iam::111111111111:user/sentry` with the ARN of your user:
+
+      *TODO: check if we can restrict those permissions more.*
+
+      ```json
+      {
+        "Description": "This stack grants write access to your Lambda functions in order to add Sentry error and performance monitoring. After pressing create, wait for the stack to be created before copying your AWS account number and region into the Sentry installation modal.",
+        "Resources": {
+          "SentryRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+              "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Principal": {
+                      "AWS": "arn:aws:iam::111111111111:user/sentry"
+                    },
+                    "Action": [
+                      "sts:AssumeRole"
+                    ],
+                    "Condition": {
+                      "StringEquals": {
+                        "sts:ExternalId": {
+                          "Ref": "ExternalId"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "Path": "/",
+              "RoleName": "SentryRole",
+              "ManagedPolicyArns": [],
+              "Policies": [
+                {
+                  "PolicyName": "sentry-policy",
+                  "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                      {
+                        "Effect": "Allow",
+                        "Action": [
+                          "lambda:UpdateFunctionConfiguration",
+                          "lambda:ListFunctions",
+                          "lambda:ListLayerVersions",
+                          "lambda:GetFunction",
+                          "lambda:GetLayerVersion",
+                          "organizations:DescribeAccount"
+                        ],
+                        "Resource": "*"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "Parameters": {
+          "ExternalId": {
+            "Description": "External ID for securing the role - Do not change",
+            "Type": "String"
+          }
+        }
+      }
+      ```
+
+      This CloudFormation config file basically gives the user in the “Sentry account” access to assume a role in the “User account” to augment the Lambda functions (add the Sentry Lambda Layer) to instrument them for sending errors/metrics to Sentry
+
+- One **AWS** account representing the user and where the Lambda functions of the user live. This account we will call the **User account”** (and we will assume the AWS Account ID is `2222 2222 2222`)
+  The **“Sentry account”** and the **“User account”** can also be the same account.
+
+Ok, so now you have two AWS accounts and you have set up your CloudFormation config in a S3 bucket that is accessible to the world. Great!
+
+## Configuration of Local Sentry Instance
+
+You need just a default installation of `sentry` on your computer. Please install it following the [Development Environment Setup Guide](https://develop.sentry.dev/development-infrastructure/environment/).
+
+Now you have to tell your sentry installation what AWS account to use and where it can find the CloudFormation configuration.
+
+You can do this by adding the following parameter to your `~/.sentry/config.yml` file:
+
+```yaml
+aws-lambda.access-key-id: AKIBRN4AXJUFIG4EWYNA
+aws-lambda.secret-access-key: Iuy2GZYMhFZM7UDL4zQvaQ8lieXLNY6Cu2po2Xoj
+aws-lambda.cloudformation-url: https://sentry-dev-cloudformation.s3.eu-central-1.amazonaws.com/dev.json
+aws-lambda.node.layer-version: "37"
+aws-lambda.python.layer-version: "142"
+```
+
+Explanation:
+
+- `aws-lambda.access-key-id` AWS access key id of the IAM user created in the “Sentry Account”.
+- `aws-lambda.secret-access-key`AWS secret access key of the IAM user created in the “Sentry Account”.
+- `aws-lambda.cloudformation-url` public accessible URL of the CloudFormation config file that lives in a S3 bucket in the “Sentry Account”.
+- `aws-lambda.node.layer-version` the version of the Lambda layer that should be used for Node Lambda functions. (This is because I was unable to get the system to grab the version from the registry by itself.) This version number can be found here: [https://github.com/getsentry/sentry-release-registry/tree/master/aws-lambda-layers](https://github.com/getsentry/sentry-release-registry/tree/master/aws-lambda-layers) (Hint: every region can have another version of the Layer installed.)
+- `aws-lambda.python.layer-version` same as above but for Python based Lambda functions.
+
+## Configuration of Ngrok
+
+With [Ngrok](https://ngrok.com/) you get an URL that points to your local computer. So everyone on the internet can talk to your Sentry installation on your computer.
+
+This is needed so your AWS Lambda function can send its errors/tracing to your local Sentry installation.
+
+Follow the instructions on the [Ngrok documentation](https://develop.sentry.dev/development/ngrok/) page to install ngrok.
+
+Now start Ngrok like the following:
+
+```bash
+ngrok http 8000
+```
+
+If ngrok starts it outputs the URL that your computer is now available at. Copy the HTTP URL (it should look something like `http://xxxx-xxx-xxx-x-xxx.ngrok.io`).
+
+If you follow the guide in the ngrok page linked above you will get access to the Sentry Ngrok account and you can create a subdomain that is custom and not always changing when you restart ngrok. This is highly recommended.
+
+You now have to tell your sentry installation its new URL by adding the following line to your `~/.sentry/config.yml` :
+
+```yaml
+system.url-prefix: "http://xxxx-xxx-xxx-x-xxx.ngrok.io"
+```
+
+Make sure to restart all the development environment, to make sure everyone knows about the new URL. (with `devservices down && devservices up`)
+
+## Start the Local Sentry Server
+
+If you now run your local Sentry with this command and it will have all the information it needs:
+
+```bash
+devservices serve
+```
+
+Now everything is ready for serverless integration development.
+
+## Add Sentry to Your Lambda Functions
+
+Log into your local sentry environment at your ngrok URL and follow the [AWS Lambda Guide](https://docs.sentry.io/product/integrations/cloud-monitoring/aws-lambda/) in our documentation to add Sentry instrumentation to your demo AWS Lambda function.

--- a/develop-docs/sdk/platform-specifics/serverless-sdks/aws-lambda.mdx
+++ b/develop-docs/sdk/platform-specifics/serverless-sdks/aws-lambda.mdx
@@ -1,6 +1,6 @@
 ---
-title: AWS Lambda
-sidebar_order: 10
+title: AWS Lambda Primer
+sidebar_order: 100
 ---
 
 Lambda functions can be written in numerous programming languages (JavaScript,

--- a/develop-docs/sdk/platform-specifics/serverless-sdks/download-production-lambda-layer.mdx
+++ b/develop-docs/sdk/platform-specifics/serverless-sdks/download-production-lambda-layer.mdx
@@ -1,0 +1,43 @@
+---
+title: How to Download Production Sentry Lambda Layer
+sidebar_order: 300
+---
+
+You need to have the [AWS CLI](https://aws.amazon.com/cli/) installed and configured to have access to the production Sentry AWS account.
+
+Then you can get information about the Sentry Lambda layer with this command:
+```bash
+aws lambda get-layer-version --layer-name arn:aws:lambda:eu-central-1:943013980633:layer:SentryPythonServerlessSDK --version-number 142
+```
+Make sure you have the region (in the example `eu-central-1`) and the version number (in the example `142`) to the version of the layer you want to download. If you want to download the Javascript layer use `SentryNodeServerlessSDKvX` (replacing `X` with the version of the JS SDK is in the layer) instead of `SentryPythonServerlessSDK`.
+
+Output will be something like this:
+
+```bash
+{
+    "Content": {
+        "Location": "https://awslambda-eu-cent-1-layers.s3.eu-central-1.amazonaws.com/snapshots/943013980633/SentryPythonServerlessSDK-008d308b-4dc8-46c4-b7f2-48c31e187a85?versionId=xxx&X-Amz-Security-Token=xxx&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260825T072152Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=xxx&X-Amz-Signature=xxx",
+        "CodeSha256": "L/xPQraARPazFPwChPLlzETN2emli4UIgabUOu34bZ4=",
+        "CodeSize": 9883188
+    },
+    "LayerArn": "arn:aws:lambda:eu-central-1:943013980633:layer:SentryPythonServerlessSDK",
+    "LayerVersionArn": "arn:aws:lambda:eu-central-1:943013980633:layer:SentryPythonServerlessSDK:35",
+    "Description": "",
+    "CreatedDate": "2026-08-16T11:15:45.768+0000",
+    "Version": 142,
+    "CompatibleRuntimes": [
+        "...",
+        "python3.13",
+        "python3.14"
+    ],
+    "LicenseInfo": "MIT"
+}
+```
+
+Then pick the `Location` and download the layer as zip file:
+
+```bash
+curl -o layer.zip https://awslambda-eu-cent-1-layers.s3.eu-central-1.amazonaws.com/snapshots/943013980633/SentryPythonServerlessSDK-008d308b-4dc8-46c4-b7f2-48c31e187a85?versionId=xxx&X-Amz-Security-Token=xxx&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260825T072152Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=xxx&X-Amz-Signature=xxx
+```
+
+Now your layer is in `layer.zip`. Enjoy!


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This documentation was before in Notion:
https://www.notion.so/sentry/Serverless-Development-Environment-AWS-Lambda-61c4578c23784b5c9a54ab01b9b6daad

To have everything in `develop` docs I move it here and the page in Notion will be deleted.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
