### PR TITLE
Fix prevent-cli url

### DIFF
--- a/docs/product/test-analytics/sentry-prevent-cli/index.mdx
+++ b/docs/product/test-analytics/sentry-prevent-cli/index.mdx
@@ -19,32 +19,32 @@ pip install sentry-prevent-cli
 For `binary platforms`, use the following commands to download the latest version of the Sentry Prevent CLI.
 
 ```bash {tabTitle:macos}
-curl -L https://github.com/getsentry/sentry-prevent-cli/releases/latest/download/sentry-prevent-cli-macos -o sentry-prevent-cli_macos
+curl -L https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli-macos -o sentry-prevent-cli_macos
 chmod +x sentry-prevent-cli_macos
 ```
 
 ```bash {tabTitle:linux x64_64}
-curl -L https://github.com/getsentry/sentry-prevent-cli/releases/latest/download/sentry-prevent-cli-linux -o sentry-prevent-cli_linux_x64_64
+curl -L https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli-linux -o sentry-prevent-cli_linux_x64_64
 chmod +x sentry-prevent-cli_linux_x64_64
 ```
 
 ```bash {tabTitle:linux arm64}
-curl -L https://github.com/getsentry/sentry-prevent-cli/releases/latest/download/sentry-prevent-cli-linux-arm64 -o sentry-prevent-cli_linux_arm64
+curl -L https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli-linux-arm64 -o sentry-prevent-cli_linux_arm64
 chmod +x sentry-prevent-cli_linux_arm64
 ```
 
 ```bash {tabTitle:alpine linux x64_64}
-curl -L https://github.com/getsentry/sentry-prevent-cli/releases/latest/download/sentry-prevent-cli-alpine -o sentry-prevent-cli_alpine_x64_64
+curl -L https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli-alpine -o sentry-prevent-cli_alpine_x64_64
 chmod +x sentry-prevent-cli_alpine_x64_64
 ```
 
 ```bash {tabTitle:alpine linux arm64}
-curl -L https://github.com/getsentry/sentry-prevent-cli/releases/latest/download/sentry-prevent-cli-alpine-arm64 -o sentry-prevent-cli_alpine_arm64
+curl -L https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli-alpine-arm64 -o sentry-prevent-cli_alpine_arm64
 chmod +x sentry-prevent-cli_alpine_arm64
 ```
 
 ```bash {tabTitle:windows}
-curl -L https://github.com/getsentry/sentry-prevent-cli/releases/latest/download/sentry-prevent-cli-windows.exe -o sentry-prevent-cli_windows.exe
+curl -L https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli-windows.exe -o sentry-prevent-cli_windows.exe
 ```
 ## Uploading Test Results
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

These docs are using an incorrect url

(Personally I would prefer if you update the project itself to be sentry-prevent-cli)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
