### PR TITLE
fix(session health): Fix links to `#crashes` and `#sessions` sections of /product/releases/health

### DIFF
--- a/docs/platforms/android/configuration/releases.mdx
+++ b/docs/platforms/android/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/apple/common/configuration/releases.mdx
+++ b/docs/platforms/apple/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 <Alert>
 

--- a/docs/platforms/dart/guides/flutter/configuration/releases.mdx
+++ b/docs/platforms/dart/guides/flutter/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/dotnet/common/configuration/releases.mdx
+++ b/docs/platforms/dotnet/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/godot/configuration/releases.mdx
+++ b/docs/platforms/godot/configuration/releases.mdx
@@ -33,7 +33,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/java/common/configuration/releases.mdx
+++ b/docs/platforms/java/common/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/javascript/common/configuration/releases.mdx
+++ b/docs/platforms/javascript/common/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 
 In order to monitor release health, the SDK sends session data.

--- a/docs/platforms/native/common/configuration/releases.mdx
+++ b/docs/platforms/native/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/powershell/configuration/releases.mdx
+++ b/docs/platforms/powershell/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/python/configuration/releases.mdx
+++ b/docs/platforms/python/configuration/releases.mdx
@@ -46,6 +46,6 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends <PlatformLink to="/configuration/sessions/">sessions</PlatformLink>.

--- a/docs/platforms/python/configuration/sessions.mdx
+++ b/docs/platforms/python/configuration/sessions.mdx
@@ -10,6 +10,6 @@ A session represents the interaction between the user and the application. Sessi
 
 ## Tracking Release Health With Sessions
 
-Sessions are used to monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Sessions are used to monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, you need to set a <PlatformLink to="/configuration/releases/">release</PlatformLink>.

--- a/docs/platforms/react-native/configuration/releases.mdx
+++ b/docs/platforms/react-native/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/ruby/common/configuration/releases.mdx
+++ b/docs/platforms/ruby/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/rust/common/configuration/releases.mdx
+++ b/docs/platforms/rust/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/unity/configuration/releases.mdx
+++ b/docs/platforms/unity/configuration/releases.mdx
@@ -33,7 +33,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/unreal/configuration/releases.mdx
+++ b/docs/platforms/unreal/configuration/releases.mdx
@@ -33,7 +33,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crash), and [session data](/product/releases/health/#session). Release health will provide insight into the impact of crashes and bugs as they relate to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as they relate to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/product/alerts/alert-types.mdx
+++ b/docs/product/alerts/alert-types.mdx
@@ -60,7 +60,7 @@ Error alerts are useful for monitoring the overall level of errors in your proje
 
 ### Sessions (Crash Rate Alerts)
 
-Crash rate alerts can give you a better picture of the health of your app on a per project basis or in a specific release. They trigger when the crash-free percentage for either [sessions or users](/product/releases/health/#active-sessionsusers) falls below a specific threshold. This could happen because of a spike in the number of session or user [crashes](/product/releases/health/#crash).
+Crash rate alerts can give you a better picture of the health of your app on a per project basis or in a specific release. They trigger when the crash-free percentage for either [sessions or users](/product/releases/health/#active-sessionsusers) falls below a specific threshold. This could happen because of a spike in the number of session or user [crashes](/product/releases/health/#crashes).
 
 - **Crash Free Session Rate:** <a name="crash-free-session-rate"></a>
   Alerts when the number of crashed sessions exceeds the threshold you set. A session begins when a user starts the application and ends when it’s closed or sent to the background. A crash is when a session ends due to an error.

--- a/docs/product/releases/health/index.mdx
+++ b/docs/product/releases/health/index.mdx
@@ -168,7 +168,7 @@ The application timed out, froze, or was forced to quit by the operating system.
 
 ### Crashed
 
-The application had an explicit unhandled error or hard [crash](#crash).
+The application had an explicit unhandled error or hard [crash](#crashes).
 
 ### Errored
 

--- a/docs/product/releases/release-details.mdx
+++ b/docs/product/releases/release-details.mdx
@@ -24,7 +24,7 @@ The graph at the top of the page provides insights into the health of your relea
 
 In the table below the graph, percentage-based metrics of this release are compared to the average of all releases, so you can spot any differences in trend.
 
-[Errored](/product/releases/health/#errored) sessions are likely to result in handled issues, and [crashed](/product/releases/health/#crash) sessions in unhandled issues. Click on the issues links to see them in the [Issues](/product/issues/) page.
+[Errored](/product/releases/health/#errored) sessions are likely to result in handled issues, and [crashed](/product/releases/health/#crashes) sessions in unhandled issues. Click on the issues links to see them in the [Issues](/product/issues/) page.
 
 Click on any option in the graph legend to hide it. For example, in a "Session Count" graph, you might hide "Healthy" sessions to see "Crashed" ones in better scale. In the image below, the healthy sessions are displayed, but there are so many healthy sessions compared to all other session types that the crashed ones become invisible in the graph:
 

--- a/platform-includes/configuration/auto-session-tracking/javascript.mdx
+++ b/platform-includes/configuration/auto-session-tracking/javascript.mdx
@@ -32,12 +32,12 @@ Sentry.init({
 });
 ```
 
-</PlatformSection >
+</PlatformSection>
 </PlatformCategorySection>
 
 Sessions are marked as:
 
-- crashed if an _unhandled error_ or _unhandled promise rejection_ bubbled up to the global handler.
-- errored if the SDK captures an event that contains an exception (this includes manually captured errors).
+- `crashed` if an _unhandled error_ or _unhandled promise rejection_ bubbled up to the global handler.
+- `errored` if the SDK captures an event that contains an exception (this includes manually captured errors).
 
 To receive data on user adoption, such as users crash free rate percentage, and the number of users that have adopted a specific release, set the user on the [`initialScope`](/platforms/javascript/configuration/options/#initial-scope) when initializing the SDK.


### PR DESCRIPTION
The links point to this page: https://docs.sentry.io/product/releases/health/

Now the hash part will scroll the user to an appropriate part of the page