### PR TITLE
fix(js): Fix span status example

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
@@ -108,36 +108,36 @@ To add spans that aren't active, you can create independent spans. This is usefu
 <PlatformCategorySection supported={['browser']}>
 
   ### Setting an inactive span active (browser only)
-  
+
   _Available Since: `10.15.0`_
-  
+
   In browser environments, you might run into use cases, where the callback-based span APIs are not sufficient.
-  In such cases (see example below), you can use `startInactiveSpan` to start an initially inactive span and then 
+  In such cases (see example below), you can use `startInactiveSpan` to start an initially inactive span and then
   set it active until you manually end the span.
 
   ```javascript
   let checkoutSpan;
-  
+
   on('startCheckout', () => {
     checkoutSpan = Sentry.startInactiveSpan({name: 'checkout-flow'});
     Sentry.setActiveSpanInBrowser(checkoutSpan);
   })
-  
+
   doSomeWork();
-  
+
   on('endCheckout', () => {
     // Ending the span automatically removes it as the active span
     checkoutSpan.end();
   })
   ```
-  
+
   Using `startInactiveSpan` in combination with `setActiveSpanInBrowser` allows you to create an inactive span that can be made active until you manually end it. In contrast, [`startSpanManual`](#starting-an-active-span-with-manual-end-startspanmanual) allows you to end the span manually at any point, but it only remains active within the callback.
-  
+
   <Alert>
-  
+
   Note that `setActiveSpanInBrowser` is only available in browser environments! If you're running code in the server
   (for example for server-side rendering), make sure to guard this call to only run in the browser.
-  
+
   </Alert>
 
 </PlatformCategorySection>
@@ -260,7 +260,7 @@ By default, spans will have an `unknown` status. You can manually update the sta
 // 0: unknown
 // 1: ok
 // 2: error
-span.setStatus({ status: 2 });
+span.setStatus({ code: 2 });
 ```
 
 Alternatively, you can also use the <PlatformLink to='/apis/#setHttpStatus'>`Sentry.setHttpStatus()`</PlatformLink> utility function to set a more specific error status.


### PR DESCRIPTION
This snippet was incorrect.

Closes https://github.com/getsentry/sentry-javascript/issues/17808

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the `span.setStatus` example to use the `code` property instead of `status` in JavaScript tracing docs.
> 
> - **Docs (JavaScript tracing)**:
>   - Correct `span.setStatus` example to use `{ code: 2 }` instead of `{ status: 2 }` in `docs/platforms/javascript/common/tracing/instrumentation/index.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a5896ef89bf7b1961f06b7e66eb066140317707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->