### PR TITLE
docs(react testing): Update testing docs to demo nested route fields

### DIFF
--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -77,6 +77,8 @@ router.navigate('/new/path/');
 router.navigate(-1); // Simulates clicking the back button
 ```
 
+### Route Param Values
+
 If you need to test route param values (as in `useParams()`), the `route` will need to be provided in the config:
 
 ```tsx
@@ -97,6 +99,8 @@ const {router} = render(<TestComponent />, {
 expect(screen.getByText('123')).toBeInTheDocument();
 ```
 
+### Outlet Context
+
 If you need to test outlet param values (as in `useOutletContext()`), you can pass them inside the `initialRouterConfig` object.
 
 ```tsx
@@ -113,6 +117,8 @@ const { router } = render(<TestComponent />, {
 
 expect(screen.getByText('123')).toBeInTheDocument();
 ```
+
+### Nested Routes
 
 If directly setting outlet context isn't enough, instead you want to render some nested routes you can do that too!
 

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -169,7 +169,7 @@ expect(screen.getByText('Settings > Default')).toBeInTheDocument();
 render(<SettingsWrapper />, {
   initialRouterConfig: {
     location: {
-      pathname: '/settings/123',
+      pathname: '/settings/123/',
     },
     route: '/settings/:projectId',
     children: [

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -138,7 +138,7 @@ We can configure the in-memory router to know about just the route tree that you
 ```tsx
 // settingsWrapper.tsx
 export interface OutletContext {
-  settings: {name: string}
+ name: string,
 }
 
 export function useCustomOutletContext() {

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -137,8 +137,8 @@ Suppose routes.tsx defines some nested routes like:
 We can configure the in-memory router to know about just the route tree that you need. Remember to render the wrapper component itself, and the router + route child components will render themsevles.
 ```tsx
 // settingsWrapper.tsx
-export interface OutletContext {
- name: string,
+interface OutletContext {
+  name: string;
 }
 
 export function useCustomOutletContext() {
@@ -146,20 +146,21 @@ export function useCustomOutletContext() {
 }
 
 export default function SettingsWrapper() {
-  return <Outlet context={{name: 'Default'} as OutletContext} />;
+  const context: OutletContext = {name: "Default"};
+  return <Outlet context={context} />;
 }
 
 // settingsIndex.tsx
 function SettingsIndex() {
-  const {settings} = useCustomOutletContext();
-  return <div>Settings > {settings.name}</div>;
+  const {name} = useCustomOutletContext();
+  return <div>Settings > {name}</div>;
 }
 
 // projectSettings.tsx
 function ProjectSettings() {
-  const {settings} = useCustomOutletContext();
+  const {name} = useCustomOutletContext();
   const {projectId} = useParams();
-  return <div>Settings > {settings.name} > Project: {projectId}</div>;
+  return <div>Settings > {name} > Project: {projectId}</div>;
 }
 
 // settingsIndex.spec.tsx

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -136,20 +136,34 @@ Suppose routes.tsx defines some nested routes like:
 
 We can configure the in-memory router to know about just the route tree that you need. Remember to render the wrapper component itself, and the router + route child components will render themsevles.
 ```tsx
-function SettingsWrapper() {
-  const settings = useSettings(); // returns `{name: 'Default'}` or something
-  return <Outlet settings={settings} />;
+// settingsWrapper.tsx
+export interface OutletContext {
+  settings: {name: string}
 }
+
+export function useCustomOutletContext() {
+  return useOutletContext<OutletContext>();
+}
+
+export default function SettingsWrapper() {
+  const settings = useSettings(); // returns `{name: 'Default'}` or something
+  return <Outlet settings={settings as OutletContext} />;
+}
+
+// settingsIndex.tsx
 function SettingsIndex() {
-  const {settings} = useOutletContext();
+  const {settings} = useCustomOutletContext();
   return <div>Settings > {settings.name}</div>;
 }
+
+// accountSettings.tsx
 function AccountSettings() {
-  const {settings} = useOutletContext();
+  const {settings} = useCustomOutletContext();
   const {projectId} = useParams();
   return <div>Settings > {settings.name} > Project: {projectId}</div>;
 }
 
+// tests.spec.tsx
 render(<SettingsWrapper />, {
   initialRouterConfig: {
     location: {

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -97,6 +97,84 @@ const {router} = render(<TestComponent />, {
 expect(screen.getByText('123')).toBeInTheDocument();
 ```
 
+If you need to test outlet param values (as in `useOutletContext()`), you can pass them inside the `initialRouterConfig` object.
+
+```tsx
+function TestComponent() {
+  const { id } = useOutletContext();
+  return <div>{id}</div>;
+}
+
+const { router } = render(<TestComponent />, {
+  initialRouterConfig: {
+    outletContext: { id: '123' },
+  },
+});
+
+expect(screen.getByText('123')).toBeInTheDocument();
+```
+
+If directly setting outlet context isn't enough, instead you want to render some nested routes you can do that too!
+
+Suppose routes.tsx defines some nested routes like:
+```tsx
+{
+  path: 'settings/',
+  component: SettingsWrapper,
+  children: [
+    {index: true, component: SettingsIndex},
+    {path: ':projectID/', component: ProjectSettings},
+  ]
+}
+```
+
+We can configure the in-memory router to know about just the route tree that you need. Remember to render the wrapper component itself, and the router + route child components will render themsevles.
+```tsx
+function SettingsWrapper() {
+  return <Outlet />;
+}
+function SettingsIndex() {
+  return <div>Settings Index</div>;
+}
+function AccountSettings() {
+  const {projectID} = useParams();
+  return <div>Project: {projectID}</div>;
+}
+
+render(<SettingsWrapper />, {
+  initialRouterConfig: {
+    location: {
+      pathname: '/settings/',
+    },
+    route: '/settings/',
+    children: [
+      {
+        index: true,
+        element: <SettingsIndex />,
+      },
+    ],
+  },
+});
+expect(screen.getByText('Setting Index')).toBeInTheDocument();
+
+render(<SettingsWrapper />, {
+  initialRouterConfig: {
+    location: {
+      pathname: '/settings/123',
+    },
+    route: '/settings/:projectId',
+    children: [
+      {
+        path: ':projectId/',
+        element: <AccountSettings />,
+      },
+    ],
+  },
+});
+expect(screen.getByText('Project: 123')).toBeInTheDocument();
+```
+
+
 ## Querying
 
 - use `getBy...` as much as possible

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -123,7 +123,7 @@ Suppose routes.tsx defines some nested routes like:
   component: SettingsWrapper,
   children: [
     {index: true, component: SettingsIndex},
-    {path: ':projectID/', component: ProjectSettings},
+    {path: ':projectId/', component: ProjectSettings},
   ]
 }
 ```
@@ -137,8 +137,8 @@ function SettingsIndex() {
   return <div>Settings Index</div>;
 }
 function AccountSettings() {
-  const {projectID} = useParams();
-  return <div>Project: {projectID}</div>;
+  const {projectId} = useParams();
+  return <div>Project: {projectId}</div>;
 }
 
 render(<SettingsWrapper />, {

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -146,8 +146,7 @@ export function useCustomOutletContext() {
 }
 
 export default function SettingsWrapper() {
-  const settings = useSettings(); // returns `{name: 'Default'}` or something
-  return <Outlet settings={settings as OutletContext} />;
+  return <Outlet context={{name: 'Default'} as OutletContext} />;
 }
 
 // settingsIndex.tsx
@@ -156,14 +155,14 @@ function SettingsIndex() {
   return <div>Settings > {settings.name}</div>;
 }
 
-// accountSettings.tsx
-function AccountSettings() {
+// projectSettings.tsx
+function ProjectSettings() {
   const {settings} = useCustomOutletContext();
   const {projectId} = useParams();
   return <div>Settings > {settings.name} > Project: {projectId}</div>;
 }
 
-// tests.spec.tsx
+// settingsIndex.spec.tsx
 render(<SettingsWrapper />, {
   initialRouterConfig: {
     location: {
@@ -180,6 +179,7 @@ render(<SettingsWrapper />, {
 });
 expect(screen.getByText('Settings > Default')).toBeInTheDocument();
 
+// projectSettings.spec.tsx
 render(<SettingsWrapper />, {
   initialRouterConfig: {
     location: {
@@ -189,7 +189,7 @@ render(<SettingsWrapper />, {
     children: [
       {
         path: ':projectId/',
-        element: <AccountSettings />,
+        element: <ProjectSettings />,
       },
     ],
   },

--- a/develop-docs/frontend/using-rtl.mdx
+++ b/develop-docs/frontend/using-rtl.mdx
@@ -131,14 +131,17 @@ Suppose routes.tsx defines some nested routes like:
 We can configure the in-memory router to know about just the route tree that you need. Remember to render the wrapper component itself, and the router + route child components will render themsevles.
 ```tsx
 function SettingsWrapper() {
-  return <Outlet />;
+  const settings = useSettings(); // returns `{name: 'Default'}` or something
+  return <Outlet settings={settings} />;
 }
 function SettingsIndex() {
-  return <div>Settings Index</div>;
+  const {settings} = useOutletContext();
+  return <div>Settings > {settings.name}</div>;
 }
 function AccountSettings() {
+  const {settings} = useOutletContext();
   const {projectId} = useParams();
-  return <div>Project: {projectId}</div>;
+  return <div>Settings > {settings.name} > Project: {projectId}</div>;
 }
 
 render(<SettingsWrapper />, {
@@ -155,7 +158,7 @@ render(<SettingsWrapper />, {
     ],
   },
 });
-expect(screen.getByText('Setting Index')).toBeInTheDocument();
+expect(screen.getByText('Settings > Default')).toBeInTheDocument();
 
 render(<SettingsWrapper />, {
   initialRouterConfig: {
@@ -171,7 +174,7 @@ render(<SettingsWrapper />, {
     ],
   },
 });
-expect(screen.getByText('Project: 123')).toBeInTheDocument();
+expect(screen.getByText('Settings > Default > Project: 123')).toBeInTheDocument();
 ```
 
 


### PR DESCRIPTION
This documents some new nested-route fields that were added in https://github.com/getsentry/sentry/pull/100481

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend RTL testing docs with outlet context configuration and nested routes examples, plus a clarified route param section.
> 
> - **Docs (Using React Testing Library)**:
>   - **Route Param Values**: Add a dedicated heading and example clarifying use of `route` for `useParams()`.
>   - **Outlet Context**: Document passing `initialRouterConfig.outletContext` and consuming via `useOutletContext()`.
>   - **Nested Routes**:
>     - Show configuring an in-memory route tree via `initialRouterConfig.children`.
>     - Add wrapper `Outlet` with typed context and custom hook, plus examples for index and param child routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1398546d63fafa6e9271c533ba335a8581a3e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->