### PR TITLE
docs: Remove generic references from Java and Kotlin

### DIFF
--- a/docs/platforms/java/common/configuration/draining.mdx
+++ b/docs/platforms/java/common/configuration/draining.mdx
@@ -4,7 +4,6 @@ sidebar_order: 70
 description: "Learn more about the default behavior of our SDK if the application shuts down unexpectedly."
 ---
 
-The default behavior of most SDKs is to send out events over the network
-asynchronously in the background. This means that some events might be lost if the application shuts down unexpectedly. The SDKs provide mechanisms to cope with this.
+By default the SDK sends out events over the network on a background thread. This means that some events might be lost if the application shuts down unexpectedly. The SDK provides mechanisms to cope with this.
 
 <PlatformContent includePath="configuration/drain-example" />

--- a/docs/platforms/java/common/configuration/filtering.mdx
+++ b/docs/platforms/java/common/configuration/filtering.mdx
@@ -38,7 +38,7 @@ Typically, a `hint` holds the original exception so that additional data can be 
 
 <PlatformContent includePath="configuration/before-send-hint" />
 
-When the SDK creates an event or breadcrumb for transmission, that transmission is typically created from some sort of source object. For instance, an error event is typically created from a log record or exception instance. For better customization, SDKs send these objects to certain callbacks (<PlatformIdentifier name="before-send" />, <PlatformIdentifier name="before-breadcrumb" /> or the event processor system in the SDK).
+When the SDK creates an event or breadcrumb for transmission, that transmission is typically created from some sort of source object. For instance, an error event is typically created from a log record or exception instance. For better customization, the SDK sends these objects to certain callbacks (<PlatformIdentifier name="before-send" />, <PlatformIdentifier name="before-breadcrumb" /> and event processors).
 
 ### Using Hints
 
@@ -51,7 +51,7 @@ Event and breadcrumb `hints` are objects containing various information used to 
 
 For events, hints contain properties such as `event_id`, `originalException`, `syntheticException` (used internally to generate cleaner stack trace), and any other arbitrary `data` that you attach.
 
-For breadcrumbs, the use of `hints` is implementation dependent. For XHR requests, the hint contains the xhr object itself; for user interactions the hint contains the DOM element and event name and so forth.
+For breadcrumbs, the use of `hints` depends on the type of breadcrumb.
 
 <PlatformContent includePath="configuration/before-send-fingerprint">
 

--- a/docs/platforms/java/common/configuration/options.mdx
+++ b/docs/platforms/java/common/configuration/options.mdx
@@ -241,7 +241,7 @@ When set, a proxy can be configured that should be used for outbound requests. T
 
 <ConfigKey name="shutdown-timeout-millis">
 
-Controls how many seconds to wait before shutting down. The SDK sends events from a background queue. This queue is given a certain amount to drain pending events. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
+Controls how many seconds to wait before shutting down. The SDK sends events from a background queue. This queue is given a certain amount to drain pending events. The default is two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 
 </ConfigKey>
 

--- a/docs/platforms/java/common/configuration/options.mdx
+++ b/docs/platforms/java/common/configuration/options.mdx
@@ -102,12 +102,6 @@ Note that enabling this option may increase the payload size of events sent to S
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations. By default, no such data is sent.
 
-<Alert>
-
-If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
-
-</Alert>
-
 This option is turned off by default.
 
 If you enable this option, be sure to manually remove what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
@@ -204,7 +198,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 <ConfigKey name="before-send">
 
-This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
+This function is called with the event payload, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
 By the time <PlatformIdentifier name="before-send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
@@ -212,13 +206,13 @@ By the time <PlatformIdentifier name="before-send" /> is executed, all scope dat
 
 <ConfigKey name="before-send-transaction">
 
-This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
+This function is called with a transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 
 </ConfigKey>
 
 <ConfigKey name="before-breadcrumb">
 
-This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
+This function is called with a breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
 
 </ConfigKey>
@@ -235,7 +229,7 @@ Transports are used to send events to Sentry. Transports can be customized to so
 
 <ConfigKey name="transport">
 
-Switches out the transport used to send events. How this works depends on the SDK. It can, for instance, be used to capture events for unit-testing or to send it through some more complex setup that requires proxy authentication.
+Switches out the transport used to send events. It can, for instance, be used to capture events for unit-testing or to send it through some more complex setup that requires proxy authentication.
 
 </ConfigKey>
 
@@ -247,7 +241,7 @@ When set, a proxy can be configured that should be used for outbound requests. T
 
 <ConfigKey name="shutdown-timeout-millis">
 
-Controls how many seconds to wait before shutting down. Sentry SDKs send events from a background queue. This queue is given a certain amount to drain pending events. The default is SDK specific but typically around two seconds. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
+Controls how many seconds to wait before shutting down. The SDK sends events from a background queue. This queue is given a certain amount to drain pending events. Setting this value too low may cause problems for sending events from command line applications. Setting the value too high will cause the application to block for a long time for users experiencing network connectivity problems.
 
 </ConfigKey>
 

--- a/docs/platforms/java/common/configuration/sampling.mdx
+++ b/docs/platforms/java/common/configuration/sampling.mdx
@@ -60,7 +60,7 @@ By default, none of these options are set, meaning no transactions will be sent 
 
 ### Default Sampling Context Data
 
-The information contained in the <PlatformIdentifier name="sampling-context" /> object passed to the <PlatformIdentifier name="traces-sampler" /> when a transaction is created varies by platform and integration.
+The information contained in the <PlatformIdentifier name="sampling-context" /> object passed to the <PlatformIdentifier name="traces-sampler" /> when a transaction is created varies by integration.
 
 <PlatformContent includePath="performance/default-sampling-context" />
 

--- a/docs/platforms/java/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/java/common/data-management/sensitive-data/index.mdx
@@ -19,7 +19,7 @@ These are some great examples for data scrubbing that every company should think
 
 We offer the following options depending on your legal and operational needs:
 
-- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
+- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Configuration changes require a redeployment of your application.
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
@@ -27,13 +27,11 @@ We offer the following options depending on your legal and operational needs:
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
 
-If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
-
 </Alert>
 
 ## Personally Identifiable Information (PII)
 
-Our newer SDKs do not purposefully send PII to stay on the safe side. This behavior is controlled by an option called [`send-default-pii`](../../configuration/options/#send-default-pii).
+The SDK purposefully does not send PII to stay on the safe side. This behavior is controlled by an option called [`send-default-pii`](../../configuration/options/#send-default-pii).
 
 Turning this option on is required for certain features in Sentry to work, but also means you will need to be even more careful about what data is being sent to Sentry (using the options below).
 
@@ -43,7 +41,7 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ### <PlatformIdentifier name="before-send" /> & <PlatformIdentifier name="before-send-transaction" />
 
-SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked before an error or message event is sent and can be used to modify event data to remove sensitive information. Some SDKs also provide a <PlatformIdentifier name="before-send-transaction" /> hook which does the same thing for transactions. We recommend using <PlatformIdentifier name="before-send" /> and <PlatformIdentifier name="before-send-transaction" /> in the SDKs to **scrub any data before it is sent**, to ensure that sensitive data never leaves the local environment.
+The SDK provides a <PlatformIdentifier name="before-send" /> hook, which is invoked before an error or message event is sent and can be used to modify event data to remove sensitive information. The SDK also provide a <PlatformIdentifier name="before-send-transaction" /> hook which does the same thing for transactions. We recommend using <PlatformIdentifier name="before-send" /> and <PlatformIdentifier name="before-send-transaction" /> in the SDK to **scrub any data before it is sent**, to ensure that sensitive data never leaves the local environment.
 
 <PlatformContent includePath="configuration/before-send/" />
 

--- a/docs/platforms/java/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/java/common/enriching-events/breadcrumbs/index.mdx
@@ -29,7 +29,7 @@ Manually record a breadcrumb:
 
 SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook.
 
-This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
+This hook is passed an already assembled breadcrumb and <PlatformLink to="/configuration/filtering/#using-hints">a `hint` object</PlatformLink> containing extra metadata. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
 
 <PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />
 

--- a/docs/platforms/java/common/enriching-events/context/index.mdx
+++ b/docs/platforms/java/common/enriching-events/context/index.mdx
@@ -29,7 +29,7 @@ Learn more about conventions for common contexts in the [contexts interface deve
 
 When sending context, _consider payload size limits_. Sentry does not recommend sending the entire application state and large data blobs in contexts. If you exceed the maximum payload size, Sentry will respond with HTTP error `413 Payload Too Large` and reject the event.
 
-The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. Some SDKs can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/expected-features/data-handling/).
+The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. The SDK can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/expected-features/data-handling/).
 
 ## Additional Data
 

--- a/docs/platforms/java/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/java/common/enriching-events/identify-user/index.mdx
@@ -22,11 +22,9 @@ An alternative, or addition, to the username. Sentry is aware of email addresses
 ### `ip_address`
 
 The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user.
-Serverside SDKs that instrument incoming requests will attempt to pull the IP address from the HTTP request data (`request.env.REMOTE_ADDR` field in JSON), if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
+The SDK will attempt to pull the IP address from the HTTP request data on incoming requests (`request.env.REMOTE_ADDR` field in JSON), if available. That requires <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
 
-If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server.
-
-If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
+If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `null`.
 
 To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 

--- a/docs/platforms/java/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/java/common/enriching-events/scopes/index.mdx
@@ -1,11 +1,10 @@
 ---
 title: Scopes
-description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
+description: "The SDK will in most cases automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra
-information from the current scope. SDKs will typically automatically manage the scopes
-for you in the framework integrations and you don't need to think about them. However,
+information from the current scope. The SDK will in most cases automatically manage the scopes for you in the framework integrations and you don't need to think about them. However,
 you should know what a scope is and how you can use it to your advantage.
 
 ## What's a Scope?

--- a/docs/platforms/java/common/enriching-events/scopes/index__v7.x.mdx
+++ b/docs/platforms/java/common/enriching-events/scopes/index__v7.x.mdx
@@ -1,11 +1,10 @@
 ---
 title: Scopes and Hubs
-description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
+description: "The SDK will in most cases automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra
-information from the current scope. SDKs will typically automatically manage the scopes
-for you in the framework integrations and you don't need to think about them. However,
+information from the current scope. The SDK will in most cases automatically manage the scopes for you in the framework integrations and you don't need to think about them. However,
 you should know what a scope is and how you can use it for your advantage.
 
 ## What's a Scope, What's a Hub

--- a/docs/platforms/java/common/tracing/instrumentation/performance-metrics.mdx
+++ b/docs/platforms/java/common/tracing/instrumentation/performance-metrics.mdx
@@ -4,7 +4,7 @@ description: "Learn how to attach performance metrics to your transactions."
 sidebar_order: 20
 ---
 
-Sentry's SDKs support sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
+The SDK supports sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
 
 ## Custom Measurements
 

--- a/docs/platforms/java/common/usage/sdk-fingerprinting/index.mdx
+++ b/docs/platforms/java/common/usage/sdk-fingerprinting/index.mdx
@@ -11,7 +11,7 @@ By default, Sentry will run one of our built-in grouping algorithms to generate 
 1. In your SDK, using SDK Fingerprinting, as documented below
 2. In your project, using [Fingerprint Rules](/concepts/data-management/event-grouping/fingerprint-rules/) or [Stack Trace Rules](/concepts/data-management/event-grouping/stack-trace-rules/)
 
-In supported SDKs, you can override Sentry's default grouping that passes the fingerprint attribute as an array of strings. The length of a fingerprint's array is not restricted. This works similarly to the [fingerprint rules functionality](/concepts/data-management/event-grouping/fingerprint-rules/), which is always available and can achieve similar results.
+You can override Sentry's default grouping that passes the fingerprint attribute as an array of strings. The length of a fingerprint's array is not restricted. This works similarly to the [fingerprint rules functionality](/concepts/data-management/event-grouping/fingerprint-rules/), which  can achieve similar results.
 
 ## Basic Example
 

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/configuration/draining.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/configuration/draining.mdx
@@ -4,7 +4,6 @@ sidebar_order: 70
 description: "Learn more about the default behavior of our SDK if the application shuts down unexpectedly."
 ---
 
-The default behavior of most SDKs is to send out events over the network
-asynchronously in the background. This means that some events might be lost if the application shuts down unexpectedly. The SDKs provide mechanisms to cope with this.
+By default the SDK sends out events over the network on a background thread. This means that some events might be lost if the application shuts down unexpectedly. The SDK provides mechanisms to cope with this.
 
 <PlatformContent includePath="configuration/drain-example" />

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/configuration/options.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/configuration/options.mdx
@@ -110,7 +110,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 <ConfigKey name="before-send">
 
-This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
+This function is called with the event payload, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
 By the time <PlatformIdentifier name="before-send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
@@ -118,13 +118,13 @@ By the time <PlatformIdentifier name="before-send" /> is executed, all scope dat
 
 <ConfigKey name="before-send-transaction">
 
-This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
+This function is called with a transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 
 </ConfigKey>
 
 <ConfigKey name="before-breadcrumb">
 
-This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
+This function is called with a breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
 
 </ConfigKey>

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/data-management/sensitive-data/index.mdx
@@ -19,7 +19,7 @@ These are some great examples for data scrubbing that every company should think
 
 We offer the following options depending on your legal and operational needs:
 
-- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
+- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Configuration changes require a redeployment of your application.
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/breadcrumbs/index.mdx
@@ -29,6 +29,6 @@ Manually record a breadcrumb:
 
 SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook.
 
-This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
+This hook is passed an already assembled breadcrumb and <PlatformLink to="/configuration/filtering/#using-hints">a `hint` object</PlatformLink> containing extra metadata. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
 
 <PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/context/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/context/index.mdx
@@ -29,7 +29,7 @@ Learn more about conventions for common contexts in the [contexts interface deve
 
 When sending context, _consider payload size limits_. Sentry does not recommend sending the entire application state and large data blobs in contexts. If you exceed the maximum payload size, Sentry will respond with HTTP error `413 Payload Too Large` and reject the event.
 
-The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. Some SDKs can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/expected-features/data-handling/).
+The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. The SDK can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/expected-features/data-handling/).
 
 ## Additional Data
 

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/scopes/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/scopes/index.mdx
@@ -1,11 +1,10 @@
 ---
 title: Scopes and Hubs
-description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
+description: "The SDK will in most cases automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra
-information from the current scope. SDKs will typically automatically manage the scopes
-for you in the framework integrations and you don't need to think about them. However,
+information from the current scope. The SDK will in most cases automatically manage the scopes for you in the framework integrations and you don't need to think about them. However,
 you should know what a scope is and how you can use it for your advantage.
 
 ## What's a Scope, What's a Hub


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

Modelled after https://github.com/getsentry/sentry-docs/pull/15072

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes Java and Kotlin docs to SDK-specific phrasing, simplifying hooks/options, and clarifying hints, draining, sampling, PII, and timeouts.
> 
> - **Java docs**:
>   - **Configuration**:
>     - `draining.mdx`: Reworded to “the SDK” and background thread behavior.
>     - `filtering.mdx`: Clarified callbacks/event processors wording; generalized breadcrumb hints.
>     - `options.mdx`: Simplified hook descriptions; clarified `transport`; set `shutdown-timeout-millis` default to `2s`.
>     - `sampling.mdx`: Sampling context now varies by integration.
>   - **Data Management**:
>     - `sensitive-data/index.mdx`: Rephrased PII defaults; streamlined scrubbing guidance; removed mobile privacy alert.
>   - **Enriching Events**:
>     - `breadcrumbs/index.mdx`: Added linkified hint reference; clarified hint usage.
>     - `context/index.mdx`: Simplified truncation note (SDK can truncate).
>     - `identify-user/index.mdx`: Simplified IP handling (`{{auto}}`, default `null`); note requires `send-default-pii`.
>     - `scopes/index.mdx` and `scopes/index__v7.x.mdx`: Updated descriptions to “the SDK” phrasing.
>   - **Tracing**:
>     - `performance-metrics.mdx`: Simplified intro to “the SDK supports…”.
>   - **Usage**:
>     - `sdk-fingerprinting/index.mdx`: Simplified wording; removed “supported SDKs” language.
> - **Kotlin Multiplatform guides**:
>   - `configuration/draining.mdx`: Same “the SDK” rewording.
>   - `configuration/options.mdx`: Simplified hook descriptions.
>   - `data-management/sensitive-data/index.mdx`: Kept mobile privacy alert; minor wording cleanup.
>   - `enriching-events/breadcrumbs/index.mdx`: Linkified hint reference.
>   - `enriching-events/context/index.mdx`: Simplified truncation note.
>   - `enriching-events/scopes/index.mdx`: Updated descriptions to “the SDK” phrasing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4a3b853bcc786b25b53209a476c3dbef86f51eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->