### PR TITLE
docs: Remove generic references from ruby

### DIFF
--- a/docs/platforms/ruby/common/configuration/filtering.mdx
+++ b/docs/platforms/ruby/common/configuration/filtering.mdx
@@ -30,7 +30,7 @@ Typically, a `hint` holds the original exception so that additional data can be 
 
 <PlatformContent includePath="configuration/before-send-hint" />
 
-When the SDK creates an event or breadcrumb for transmission, that transmission is typically created from some sort of source object. For instance, an error event is typically created from a log record or exception instance. For better customization, SDKs send these objects to certain callbacks (<PlatformIdentifier name="before-send" />, <PlatformIdentifier name="before-breadcrumb" /> or the event processor system in the SDK).
+When the SDK creates an event or breadcrumb for transmission, that transmission is typically created from some sort of source object. For instance, an error event is typically created from a log record or exception instance. For better customization, the SDK sends these objects to certain callbacks (<PlatformIdentifier name="before-send" />, <PlatformIdentifier name="before-breadcrumb" /> and event processors).
 
 ### Using Hints
 
@@ -43,7 +43,7 @@ Event and breadcrumb `hints` are objects containing various information used to 
 
 For events, hints contain properties such as `event_id`, `originalException`, `syntheticException` (used internally to generate cleaner stack trace), and any other arbitrary `data` that you attach.
 
-For breadcrumbs, the use of `hints` is implementation dependent. For XHR requests, the hint contains the xhr object itself; for user interactions the hint contains the DOM element and event name and so forth.
+For breadcrumbs, the use of `hints` depends on the type of breadcrumb.
 
 <PlatformContent includePath="configuration/before-send-fingerprint">
 

--- a/docs/platforms/ruby/common/configuration/options.mdx
+++ b/docs/platforms/ruby/common/configuration/options.mdx
@@ -358,7 +358,7 @@ end
 
 <SdkOption name="before_breadcrumb" type="lambda | proc">
 
-This function is called with an SDK-specific breadcrumb object before the breadcrumb is added to the scope. When `nil` is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
+This function is called with a breadcrumb object before the breadcrumb is added to the scope. When `nil` is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the first argument, which contains the breadcrumb object.
 The callback typically gets a second argument (called a "hint") which contains the original object from which the breadcrumb was created to further customize what the breadcrumb should look like.
 
 <PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb/" />

--- a/docs/platforms/ruby/common/configuration/sampling.mdx
+++ b/docs/platforms/ruby/common/configuration/sampling.mdx
@@ -58,7 +58,7 @@ By default, none of these options are set, meaning no transactions will be sent 
 
 ### Default Sampling Context Data
 
-The information contained in the <PlatformIdentifier name="sampling-context" /> object passed to the <PlatformIdentifier name="traces-sampler" /> when a transaction is created varies by platform and integration.
+The information contained in the <PlatformIdentifier name="sampling-context" /> object passed to the <PlatformIdentifier name="traces-sampler" /> when a transaction is created varies by integration.
 
 <PlatformContent includePath="performance/default-sampling-context" />
 

--- a/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/ruby/common/data-management/sensitive-data/index.mdx
@@ -19,15 +19,13 @@ These are some great examples for data scrubbing that every company should think
 
 We offer the following options depending on your legal and operational needs:
 
-- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Different SDKs have different capabilities, and configuration changes require a redeployment of your application.
+- filtering or scrubbing sensitive data within the SDK, so that data is _not sent to_ Sentry. Configuration changes require a redeployment of your application.
 - [configuring server-side scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) to ensure Sentry does _not store_ data. Configuration changes are done in the Sentry UI and apply immediately for new events.
 - [running a local Relay](/product/relay/) on your own server between the SDK and Sentry, so that data is _not sent to_ Sentry while configuration can still be applied without deploying.
 
 <Alert>
 
 Ensure that your team is aware of your company's policy around what can and cannot be sent to Sentry. We recommend determining this policy early in your implementation and communicating it as well as enforcing it via code review.
-
-If you are using Sentry in your mobile app, read our [frequently asked questions about mobile data privacy](/security-legal-pii/security/mobile-privacy/) to assist with Apple App Store and Google Play app privacy details.
 
 </Alert>
 
@@ -37,7 +35,7 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ### <PlatformIdentifier name="before-send" /> & <PlatformIdentifier name="before-send-transaction" />
 
-SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked before an error or message event is sent and can be used to modify event data to remove sensitive information. Some SDKs also provide a <PlatformIdentifier name="before-send-transaction" /> hook which does the same thing for transactions. We recommend using <PlatformIdentifier name="before-send" /> and <PlatformIdentifier name="before-send-transaction" /> in the SDKs to **scrub any data before it is sent**, to ensure that sensitive data never leaves the local environment.
+The SDK provides a <PlatformIdentifier name="before-send" /> hook, which is invoked before an error or message event is sent and can be used to modify event data to remove sensitive information. The SDK also provide a <PlatformIdentifier name="before-send-transaction" /> hook which does the same thing for transactions. We recommend using <PlatformIdentifier name="before-send" /> and <PlatformIdentifier name="before-send-transaction" /> in the SDK to **scrub any data before it is sent**, to ensure that sensitive data never leaves the local environment.
 
 <PlatformContent includePath="configuration/before-send/" />
 

--- a/docs/platforms/ruby/common/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/breadcrumbs/index.mdx
@@ -21,7 +21,7 @@ Manually record a breadcrumb:
 
 <PlatformContent includePath="enriching-events/breadcrumbs/breadcrumbs-example" />
 
-The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which many SDKs will set automatically for you), and `data`, which is the place to put any additional information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
+The available breadcrumb keys are `type`, `category`, `message`, `level`, `timestamp` (which defaults to the system's wall-clock time), and `data`, which is the place to put any additional information you'd like the breadcrumb to include. Using keys other than these six won't cause an error, but will result in the data being dropped when the event is processed by Sentry.
 
 ## Automatic Breadcrumbs
 
@@ -31,7 +31,7 @@ The available breadcrumb keys are `type`, `category`, `message`, `level`, `times
 
 SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook.
 
-This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
+This hook is passed an already assembled breadcrumb and <PlatformLink to="/configuration/filtering/#using-hints">a `hint` object</PlatformLink> containing extra metadata. The function can modify the breadcrumb or decide to discard it entirely by returning `null`:
 
 <PlatformContent includePath="enriching-events/breadcrumbs/before-breadcrumb" />
 

--- a/docs/platforms/ruby/common/enriching-events/context/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/context/index.mdx
@@ -29,7 +29,7 @@ Learn more about conventions for common contexts in the [contexts interface deve
 
 When sending context, _consider payload size limits_. Sentry does not recommend sending the entire application state and large data blobs in contexts. If you exceed the maximum payload size, Sentry will respond with HTTP error `413 Payload Too Large` and reject the event.
 
-The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. Some SDKs can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/expected-features/data-handling/).
+The Sentry SDK will try its best to accommodate the data you send and trim large context payloads. The SDK can truncate parts of the event; for more details, see the [developer documentation on SDK data handling](https://develop.sentry.dev/sdk/expected-features/data-handling/).
 
 ## Additional Data
 

--- a/docs/platforms/ruby/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/identify-user/index.mdx
@@ -22,11 +22,9 @@ An alternative, or addition, to the username. Sentry is aware of email addresses
 ### `ip_address`
 
 The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user.
-Serverside SDKs that instrument incoming requests will attempt to pull the IP address from the HTTP request data (`request.env.REMOTE_ADDR` field in JSON), if available. That might require <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
+The SDK will attempt to pull the IP address from the HTTP request data on incoming requests (`request.env.REMOTE_ADDR` field in JSON), if available. That requires <PlatformIdentifier name="send-default-pii" /> set to `true` in the SDK options.
 
-If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server.
-
-If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
+If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `null`.
 
 To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 

--- a/docs/platforms/ruby/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/scopes/index.mdx
@@ -1,11 +1,10 @@
 ---
 title: Scopes and Hubs
-description: "SDKs will typically automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
+description: "The SDK will in most cases automatically manage the scopes for you in the framework integrations. Learn what a scope is and how you can use it to your advantage."
 ---
 
 When an event is captured and sent to Sentry, SDKs will merge that event data with extra
-information from the current scope. SDKs will typically automatically manage the scopes
-for you in the framework integrations and you don't need to think about them. However,
+information from the current scope. The SDK will in most cases automatically manage the scopes for you in the framework integrations and you don't need to think about them. However,
 you should know what a scope is and how you can use it for your advantage.
 
 ## What's a Scope, What's a Hub

--- a/docs/platforms/ruby/common/tracing/instrumentation/performance-metrics.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/performance-metrics.mdx
@@ -4,7 +4,7 @@ description: "Learn how to attach performance metrics to your transactions."
 sidebar_order: 20
 ---
 
-Sentry's SDKs support sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
+The SDK supports sending performance metrics data to Sentry. These are numeric values attached to transactions that are aggregated and displayed in Sentry.
 
 ## Custom Measurements
 

--- a/docs/platforms/ruby/common/usage/sdk-fingerprinting/index.mdx
+++ b/docs/platforms/ruby/common/usage/sdk-fingerprinting/index.mdx
@@ -11,7 +11,7 @@ By default, Sentry will run one of our built-in grouping algorithms to generate 
 1. In your SDK, using SDK Fingerprinting, as documented below
 2. In your project, using [Fingerprint Rules](/concepts/data-management/event-grouping/fingerprint-rules/) or [Stack Trace Rules](/concepts/data-management/event-grouping/stack-trace-rules/)
 
-In supported SDKs, you can override Sentry's default grouping that passes the fingerprint attribute as an array of strings. The length of a fingerprint's array is not restricted. This works similarly to the [fingerprint rules functionality](/concepts/data-management/event-grouping/fingerprint-rules/), which is always available and can achieve similar results.
+You can override Sentry's default grouping that passes the fingerprint attribute as an array of strings. The length of a fingerprint's array is not restricted. This works similarly to the [fingerprint rules functionality](/concepts/data-management/event-grouping/fingerprint-rules/), which  can achieve similar results.
 
 ## Basic Example
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

Modelled after https://github.com/getsentry/sentry-docs/pull/15072

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
