### PR TITLE
fix(span-first): Update attribute type from 'float' to 'double'

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -142,7 +142,7 @@ Attributes are stored as key-value pairs where each value is an object with type
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `type` | string | Yes | The data type of the attribute value. Values: `"string"`, `"integer"`, `"float"`, `"boolean"` |
+| `type` | string | Yes | The data type of the attribute value. Values: `"string"`, `"integer"`, `"double"`, `"boolean"` |
 | `value` | any | Yes | The actual attribute value, must match the specified type |
 | `unit` | string | No | The unit of the attribute value. Example values: `"ms"`, `"s"`, `"bytes"`, `"count"`, `"percent"` |
 


### PR DESCRIPTION
Checked with @Dav1dde -- we should send type `'double'` for floating point numbers.
