### PR TITLE
docs(sessions): Add docs for unhandled session status

### DIFF
--- a/develop-docs/sdk/telemetry/sessions/index.mdx
+++ b/develop-docs/sdk/telemetry/sessions/index.mdx
@@ -134,6 +134,7 @@ it must not be updated anymore.
 
 - `ok`: The session is currently in progress but healthy. This can be the terminal state of a session.
 - `exited`: The session terminated normally.
+- `unhandled`: The session terminated with an unhandled error.
 - `crashed`: The session terminated in a crash.
 - `abnormal`: The session encountered a non crash related abnormal exit.
 
@@ -217,6 +218,7 @@ something like this:
 - `did`: _Optional_. The distinct user id of the group.
 - `exited`: _Optional_. The number of sessions with status `"exited"` _without_ any errors.
 - `abnormal`: _Optional_. The number of sessions with status `"abnormal"`.
+- `unhandled`: _Optional_. The number of sessions with status `"unhandled"`.
 - `crashed`: _Optional_. The number of sessions with status `"crashed"`.
 - `errored`: _Optional_. The number of sessions with status `"exited"` that had a non-zero `errors` count.
 
@@ -265,7 +267,7 @@ deduplicate the total session count as an optimization. If the initial
 ### Terminal Session States
 
 A session can exist in one of two states: in progress or terminated. A terminated
-session must not receive further updates. `exited`, `crashed` and `abnormal`
+session must not receive further updates. `exited`, `unhandled`, `crashed` and `abnormal`
 are all terminal states. When a session reaches this state the client must
 not report any more session updates or start a new session.
 
@@ -276,33 +278,43 @@ SDKs are encouraged to distinguish between different ways of ending a session:
   sessions ending in `exited` will be considered for session durations.
   A session is allowed to go to `exited` even if errors occurred.
 
+- `unhandled`: a session should be reported as unhandled under the following cases:
+
+  - an unhandled error occurred and there is a natural session end (eg: end of HTTP request).
+  - the application did not handle an error, but the language or framework prevented the process from terminating.
+
 - `crashed`: a session should be reported as crashed under the following cases:
 
-  - an unhandled error occurred and there is a natural session end (eg: end of HTTP request)
-  - a complete crash of the application occurred (crash to desktop, termination)
-  - a user feedback dialog is surfaced to the user. After this, the SDK must start a new session as if it fully crashed.;
+  - a complete crash of the application occurred (crash to desktop, termination).
+  - a user feedback dialog is surfaced to the user. After this, the SDK must start a new session as if it fully crashed.
 
 - `abnormal`: SDKs are encouraged to always transition a session to `exited` or
   `crashed` if they can do so. For SDKs that are capable of always ending sessions, they should end a
   session in `abnormal` if they could not detect the application shutting down
   correctly. Examples for abnormal sessions:
 
-  - a computer was shut down / lost power
-  - the user force closed an application through `kill -9` or the task manager
+  - a computer was shut down / lost power.
+  - the user force closed an application through `kill -9` or the task manager.
 
   Abnormal session ends are normally to be recorded on application restart.
 
-### Crashed, Abnormal vs Errored
+### Crashed, Unhandled, Abnormal vs Errored
 
-A session is supposed to transition to `crashed` when it encountered an unhandled
-error such as a full application crash. For applications that cannot fully
-crash such as a website, it's acceptable to transition to the crashed state if
-the user encountered an error dialog. For server environments where we create sessions
-for every incoming request, `crashed` is basically like status code `500` internal server error.
-So if there is an unhandled error happening during the request, the session should be `crashed`.
+A session is supposed to transition to `crashed` when it encountered an a full 
+application crash and the process terminated. For applications that cannot fully
+crash, such as a website, `unhandled` is more appropriate.
+It's acceptable to transition to the `crashed` state if the user encountered an
+error dialog.
+For server environments where we create sessions for every incoming request,
+`unhandled` is basically like status code `500` internal server error.
 
-Abnormal are sessions of which their fate is unknown. For desktop applications, for instance, it makes sense to transition a session to abnormal if it was stored
-but the exit of the application was not observed but also did not crash. These are situations where the user forced the app to close via the
+Note that `unhandled` became supported on the server in v25.9.0, prior to that
+`crashed` was used for all of the cases above.
+
+`abnormal` are sessions of which their fate is unknown. For desktop
+applications, for instance, it makes sense to transition a session to `abnormal`
+if it was stored but the exit of the application was not observed but also did
+not crash. These are situations where the user forced the app to close via the
 task manager, the machine lost power or other situations. A session can be
 _stored_ by persisting it to disk eagerly. This saved file can be detected on
 application restart to close the session as `abnormal`.

--- a/docs/platforms/android/configuration/releases.mdx
+++ b/docs/platforms/android/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/apple/common/configuration/releases.mdx
+++ b/docs/platforms/apple/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 <Alert>
 

--- a/docs/platforms/dart/guides/flutter/configuration/releases.mdx
+++ b/docs/platforms/dart/guides/flutter/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/dotnet/common/configuration/releases.mdx
+++ b/docs/platforms/dotnet/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/godot/configuration/releases.mdx
+++ b/docs/platforms/godot/configuration/releases.mdx
@@ -33,7 +33,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/java/common/configuration/releases.mdx
+++ b/docs/platforms/java/common/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/javascript/common/configuration/releases.mdx
+++ b/docs/platforms/javascript/common/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 
 In order to monitor release health, the SDK sends session data.

--- a/docs/platforms/native/common/configuration/releases.mdx
+++ b/docs/platforms/native/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/powershell/configuration/releases.mdx
+++ b/docs/platforms/powershell/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/python/configuration/releases.mdx
+++ b/docs/platforms/python/configuration/releases.mdx
@@ -46,6 +46,6 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends <PlatformLink to="/configuration/sessions/">sessions</PlatformLink>.

--- a/docs/platforms/python/configuration/sessions.mdx
+++ b/docs/platforms/python/configuration/sessions.mdx
@@ -10,6 +10,6 @@ A session represents the interaction between the user and the application. Sessi
 
 ## Tracking Release Health With Sessions
 
-Sessions are used to monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Sessions are used to monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, you need to set a <PlatformLink to="/configuration/releases/">release</PlatformLink>.

--- a/docs/platforms/react-native/configuration/releases.mdx
+++ b/docs/platforms/react-native/configuration/releases.mdx
@@ -29,7 +29,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/ruby/common/configuration/releases.mdx
+++ b/docs/platforms/ruby/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/rust/common/configuration/releases.mdx
+++ b/docs/platforms/rust/common/configuration/releases.mdx
@@ -27,7 +27,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/unity/configuration/releases.mdx
+++ b/docs/platforms/unity/configuration/releases.mdx
@@ -33,7 +33,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as it relates to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/platforms/unreal/configuration/releases.mdx
+++ b/docs/platforms/unreal/configuration/releases.mdx
@@ -33,7 +33,7 @@ After configuring your SDK, you can install a repository integration or manually
 
 ## Release Health
 
-Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as they relate to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
+Monitor the [health of releases](/product/releases/health/) by observing user adoption, usage of the application, percentage of [crashes](/product/releases/health/#crashes--unhandled), and [session data](/product/releases/health/#sessions). Release health will provide insight into the impact of crashes and bugs as they relate to user experience, and reveal trends with each new issue through the [Release Details](/product/releases/release-details/) graphs and filters.
 
 In order to monitor release health, the SDK sends session data.
 

--- a/docs/product/alerts/alert-types.mdx
+++ b/docs/product/alerts/alert-types.mdx
@@ -60,7 +60,7 @@ Error alerts are useful for monitoring the overall level of errors in your proje
 
 ### Sessions (Crash Rate Alerts)
 
-Crash rate alerts can give you a better picture of the health of your app on a per project basis or in a specific release. They trigger when the crash-free percentage for either [sessions or users](/product/releases/health/#active-sessionsusers) falls below a specific threshold. This could happen because of a spike in the number of session or user [crashes](/product/releases/health/#crashes).
+Crash rate alerts can give you a better picture of the health of your app on a per project basis or in a specific release. They trigger when the crash-free percentage for either [sessions or users](/product/releases/health/#active-sessionsusers) falls below a specific threshold. This could happen because of a spike in the number of session or user [crashes](/product/releases/health/#crashes--unhandled).
 
 - **Crash Free Session Rate:** <a name="crash-free-session-rate"></a>
   Alerts when the number of crashed sessions exceeds the threshold you set. A session begins when a user starts the application and ends when it’s closed or sent to the background. A crash is when a session ends due to an error.

--- a/docs/product/releases/health/index.mdx
+++ b/docs/product/releases/health/index.mdx
@@ -10,7 +10,7 @@ Note, that Sessions (as described below) are not the same as a [Session Replay](
 
 </Alert>
 
-You can monitor the health of releases by observing user adoption, usage of your application, percentage of [crashes](#crashes), and [session data](#sessions). Release health data provides insight into the impact of crashes and bugs related to user experience and reveals trends with each new issue through the release details, graphs, and filters. This data is primarily displayed on the [Releases](/product/releases/) and [Release Details](/product/releases/release-details) pages, but is also reflected in other parts of [sentry.io](https://sentry.io).
+You can monitor the health of releases by observing user adoption, usage of your application, percentage of [crashes](#crashes--unhandled), and [session data](#sessions). Release health data provides insight into the impact of crashes and bugs related to user experience and reveals trends with each new issue through the release details, graphs, and filters. This data is primarily displayed on the [Releases](/product/releases/) and [Release Details](/product/releases/release-details) pages, but is also reflected in other parts of [sentry.io](https://sentry.io).
 
 > Many SDKs automatically manage the start and end of [sessions](#sessions) when the SDK is initialized, but release health configuration is key to ensuring you're receiving useful data, so check out our information on [which SDKs support release health](/product/releases/setup/#release-health) for links to configuring the SDK, as needed.
 
@@ -85,9 +85,11 @@ Depending on your "Display" selection, the sort options for the **Releases** pag
 
 ![Sort By: Active Users dropdown](./img/release_active_users.png)
 
-## Crashes
+## Crashes & Unhandled
 
-A _crash_ is when the application had an explicit unhandled error or hard crash. You'll typically be able to view the corresponding issue that captures this event in [sentry.io](https://sentry.io), and errors that did not cause the end of the application should not be included. To search for crash events in **Discover** or on the **Issues** page, filter by `error.unhandled:true`.
+A _crash_ is when the application had a hard crash, while _unhandled_ is when an error that wasn't explicitly handled by the application. You'll typically be able to view the corresponding issue that captures this event in [sentry.io](https://sentry.io), and errors that did not cause the end of the application should not be included. To search for crash events in **Discover** or on the **Issues** page, filter by `error.unhandled:true`.
+
+Starting with v25.9.0, Sentry differentiates between crashes and unhandled errors and both are counted separately. Check your SDK release notes and update to the latest version to support _unhandled_ session status.
 
 ### Crash Free Sessions/Users
 
@@ -112,6 +114,14 @@ Please note that the number of crashes is not expected to match the number of cr
 ### Crashed Users
 
 The number of users that experienced a crash in the specified time range.
+
+## Sessions vs. Issues
+
+One common misconception is that session data is derived from issues, and that the numbers can be cross referenced. This is not the case.
+
+Session data is unconditionally sent from SDKs when the integration is enabled (it is enabled by default in most SDKs). This dataset tracks every session as it is started and ended, and includes only basic tags related to release and environment. In contrast, Issues are derived from error events, which are subject to [inbound filters](/concepts/data-management/filtering/) and [sampling](/platform-redirect/?next=/configuration/sampling/) and [quota](/pricing/quotas/) limits.
+
+These two systems work in parallel to provide different views of your application's health. Session data enables the Release Adoption and Release Health charts and views which show you the health of your application at a high level, with no sampling or filtering applied. Issues data enables you to drill down into specific issues and have all the context you need to fix it.
 
 ## Release Adoption
 
@@ -166,9 +176,13 @@ A session can have one of the following statuses:
 
 The application timed out, froze, or was forced to quit by the operating system. There is usually no corresponding Sentry issue, as this is a passive action.
 
+### Unhandled
+
+The application had an explicit error that was not explicitly [unhandled](#crashes--unhandled). The language or framework prevented the process from terminating.
+
 ### Crashed
 
-The application had an explicit unhandled error or hard [crash](#crashes).
+The application had a hard [crash](#crashes--unhandled).
 
 ### Errored
 

--- a/docs/product/releases/release-details.mdx
+++ b/docs/product/releases/release-details.mdx
@@ -13,7 +13,7 @@ The **Release Details** page focuses on an individual release. Elements of the r
 The graph at the top of the page provides insights into the health of your release by allowing you to choose which metric it displays. Select the time range that you want to review (the default range is the entire release period) and choose from these metrics in the table below the graph:
 
 - [Crash Free Session Rate](/product/releases/health/#crash-free-sessionsusers)
-- [Healthy](/product/releases/health/#healthy), [Abnormal](/product/releases/health/#abnormal), [Errored](/product/releases/health/#errored) session rate
+- [Healthy](/product/releases/health/#healthy), [Abnormal](/product/releases/health/#abnormal), [Errored](/product/releases/health/#errored), [Unhandled](/product/releases/health/#unhandled) session rate
 - [Crash Free User Rate](/product/releases/health/#crash-free-sessionsusers)
 - Crashed Session Rate
 - [Crashed User Rate](/product/releases/health/#crashed-users)
@@ -24,7 +24,7 @@ The graph at the top of the page provides insights into the health of your relea
 
 In the table below the graph, percentage-based metrics of this release are compared to the average of all releases, so you can spot any differences in trend.
 
-[Errored](/product/releases/health/#errored) sessions are likely to result in handled issues, and [crashed](/product/releases/health/#crashes) sessions in unhandled issues. Click on the issues links to see them in the [Issues](/product/issues/) page.
+[Errored](/product/releases/health/#errored) sessions are likely to result in handled issues, and [crashed](/product/releases/health/#crashes--unhandled) sessions in unhandled issues. Click on the issues links to see them in the [Issues](/product/issues/) page.
 
 Click on any option in the graph legend to hide it. For example, in a "Session Count" graph, you might hide "Healthy" sessions to see "Crashed" ones in better scale. In the image below, the healthy sessions are displayed, but there are so many healthy sessions compared to all other session types that the crashed ones become invisible in the graph:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adding docs to describe the new Session status type: `unhandled`.

This status is only for Session data, not Issues!

We've basically taken the existing `crashed` status and split it into two parts: 
- A crashed session comes from an exception that was not handled by the application, and the language/framework did not handle it either **resulting in a crash**.
- An unhandled session comes from an exception that was not handled by the application, but the language/framework **does not allow** the application to exit/crash/terminate/etc.

### SDK Maintainers

As SDKs adopt this new status they will probably want to update pages like https://docs.sentry.io/platforms/javascript/configuration/releases/ to include a note about the new status, and the version when it was first supported.

**Regardless of the SDK version, self-serve users will need server v25.9.0 to support `unhandled` properly.**

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

