### PR TITLE
chore(slack): Add slack manifest for easy slack app creation

### DIFF
--- a/develop-docs/integrations/slack/index.mdx
+++ b/develop-docs/integrations/slack/index.mdx
@@ -10,27 +10,30 @@ To use Sentry’s Slack integration you’ll need to create a Slack app. Navigat
 ![Create](./create.png)
 
 ### Ways to Create a Slack App
-There will be two options, `From a manifest` and `From scratch`, we have provided a manifest template below for convenience.
-**NOTE**: If you choose to use the manifest provided, you must still configure your sentry environment with the slack app's Client Secret, Client ID and Signing Secret as directed in [From Scratch](#from-scratch)
+There will be two options: `From a manifest` and `From scratch`, we have provided a manifest template below for convenience.  
+**NOTE**: If you choose to use the manifest provided, you must still configure your sentry environment with the slack app's Client Secret, Client ID, and Signing Secret as directed in [From Scratch](#from-scratch)
 
 #### From Manifest
-Make sure to replace all instances of `{YOUR_NAME}` and `{YOUR_DOMAIN}`!
+Make sure to replace all instances of `{YOUR_DOMAIN}`!
+**NOTE**: For Sentry employee's we reccomend appending the your name to the end of the bot's name and slash command 
 <Expandable title="JSON Manifest for Slack App">
-
+<Alert title="Note">
+    If you're a Sentry employee, when creating the slash command and the bot names please append your name to the end(e.g `/sentry-{YOUR_NAME}`, `sentry-test-{YOUR_NAME} etc.).
+</Alert>
 ```json
 {
     "display_information": {
-        "name": "{YOUR_NAME}-sentry-test"
+        "name": "sentry-test"
     },
     "features": {
         "bot_user": {
-            "display_name": "{YOUR_NAME}-sentry-bot",
+            "display_name": "sentry-bot",
             "always_online": true
         },
         "slash_commands": [
             {
-                "command": "/{YOUR_NAME}-sentry",
-                "url": "https://{YOUR_DOMAIN}/extensions/slack/commands/",
+                "command": "/sentry",
+                "url": "{YOUR_DOMAIN}/extensions/slack/commands/",
                 "description": "List all commands",
                 "should_escape": false
             }
@@ -38,7 +41,7 @@ Make sure to replace all instances of `{YOUR_NAME}` and `{YOUR_DOMAIN}`!
     },
     "oauth_config": {
         "redirect_urls": [
-            "https://{YOUR_DOMAIN}/extensions/slack/setup/"
+            "{YOUR_DOMAIN}/extensions/slack/setup/"
         ],
         "scopes": {
             "user": [
@@ -64,7 +67,7 @@ Make sure to replace all instances of `{YOUR_NAME}` and `{YOUR_DOMAIN}`!
     },
     "settings": {
         "event_subscriptions": {
-            "request_url": "https://{YOUR_DOMAIN}/extensions/slack/event/",
+            "request_url": "{YOUR_DOMAIN}/extensions/slack/event/",
             "user_events": [
                 "link_shared"
             ],
@@ -75,8 +78,8 @@ Make sure to replace all instances of `{YOUR_NAME}` and `{YOUR_DOMAIN}`!
         },
         "interactivity": {
             "is_enabled": true,
-            "request_url": "https://{YOUR_DOMAIN}/extensions/slack/action/",
-            "message_menu_options_url": "https://{YOUR_DOMAIN}/extensions/slack/options-load/"
+            "request_url": "{YOUR_DOMAIN}/extensions/slack/action/",
+            "message_menu_options_url": "{YOUR_DOMAIN}/extensions/slack/options-load/"
         },
         "org_deploy_enabled": false,
         "socket_mode_enabled": false,

--- a/develop-docs/integrations/slack/index.mdx
+++ b/develop-docs/integrations/slack/index.mdx
@@ -10,7 +10,8 @@ To use Sentry’s Slack integration you’ll need to create a Slack app. Navigat
 ![Create](./create.png)
 
 ### Ways to Create a Slack App
-There will be two options, `From a manifest` and `From scratch`. Below we have included a JSON manifest but if you want more customization of the app, please select `From scratch` and continue reading.
+There will be two options, `From a manifest` and `From scratch`, we have provided a manifest template below for convenience.
+**NOTE**: If you choose to use the manifest provided, you must still configure your sentry environment with the slack app's Client Secret, Client ID and Signing Secret as directed in [From Scratch](#from-scratch)
 
 #### From Manifest
 Make sure to replace all instances of `{YOUR_NAME}` and `{YOUR_DOMAIN}`!

--- a/develop-docs/integrations/slack/index.mdx
+++ b/develop-docs/integrations/slack/index.mdx
@@ -9,32 +9,35 @@ To use Sentry’s Slack integration you’ll need to create a Slack app. Navigat
 
 ![Create](./create.png)
 
-There will be two options, `From a manifest`, `From scratch`. Below we have included a JSON manifest but if you want more customization of the app, please select `From scratch` continue reading.
+### Ways to Create a Slack App
+There will be two options, `From a manifest` and `From scratch`. Below we have included a JSON manifest but if you want more customization of the app, please select `From scratch` and continue reading.
 
+#### From Manifest
+Make sure to replace all instances of `{YOUR_NAME}` and `{YOUR_DOMAIN}`!
 <Expandable title="JSON Manifest for Slack App">
 
 ```json
 {
     "display_information": {
-        "name": "christina-test"
+        "name": "{YOUR_NAME}-sentry-test"
     },
     "features": {
         "bot_user": {
-            "display_name": "christina-test-np-bot",
+            "display_name": "{YOUR_NAME}-sentry-bot",
             "always_online": true
         },
         "slash_commands": [
             {
-                "command": "/christinatest-sentry",
-                "url": "https://christina-devserver.ngrok.io/extensions/slack/commands/",
-                "description": "UH idk",
+                "command": "/{YOUR_NAME}-sentry",
+                "url": "https://{YOUR_DOMAIN}/extensions/slack/commands/",
+                "description": "List all commands",
                 "should_escape": false
             }
         ]
     },
     "oauth_config": {
         "redirect_urls": [
-            "https://christina-devserver.ngrok.io/extensions/slack/setup/"
+            "https://{YOUR_DOMAIN}/extensions/slack/setup/"
         ],
         "scopes": {
             "user": [
@@ -60,7 +63,7 @@ There will be two options, `From a manifest`, `From scratch`. Below we have incl
     },
     "settings": {
         "event_subscriptions": {
-            "request_url": "https://christina-devserver.ngrok.io/extensions/slack/event/",
+            "request_url": "https://{YOUR_DOMAIN}/extensions/slack/event/",
             "user_events": [
                 "link_shared"
             ],
@@ -71,8 +74,8 @@ There will be two options, `From a manifest`, `From scratch`. Below we have incl
         },
         "interactivity": {
             "is_enabled": true,
-            "request_url": "https://christina-devserver.ngrok.io/extensions/slack/action/",
-            "message_menu_options_url": "https://christina-devserver.ngrok.io/extensions/slack/options-load/"
+            "request_url": "https://{YOUR_DOMAIN}/extensions/slack/action/",
+            "message_menu_options_url": "https://{YOUR_DOMAIN}/extensions/slack/options-load/"
         },
         "org_deploy_enabled": false,
         "socket_mode_enabled": false,
@@ -80,9 +83,9 @@ There will be two options, `From a manifest`, `From scratch`. Below we have incl
     }
 }
 ```
-
 </Expandable>
 
+#### From Scratch
 After naming your app and connecting your workspace, navigate to __Basic Information__. Here you’ll find your Client ID, Client Secret, and Verification token that lets your app access the Slack API.
 
 Here’s where you’ll connect your self-hosted Sentry instance to your newly created Slack app.

--- a/develop-docs/integrations/slack/index.mdx
+++ b/develop-docs/integrations/slack/index.mdx
@@ -9,6 +9,80 @@ To use Sentry’s Slack integration you’ll need to create a Slack app. Navigat
 
 ![Create](./create.png)
 
+There will be two options, `From a manifest`, `From scratch`. Below we have included a JSON manifest but if you want more customization of the app, please select `From scratch` continue reading.
+
+<Expandable title="JSON Manifest for Slack App">
+
+```json
+{
+    "display_information": {
+        "name": "christina-test"
+    },
+    "features": {
+        "bot_user": {
+            "display_name": "christina-test-np-bot",
+            "always_online": true
+        },
+        "slash_commands": [
+            {
+                "command": "/christinatest-sentry",
+                "url": "https://christina-devserver.ngrok.io/extensions/slack/commands/",
+                "description": "UH idk",
+                "should_escape": false
+            }
+        ]
+    },
+    "oauth_config": {
+        "redirect_urls": [
+            "https://christina-devserver.ngrok.io/extensions/slack/setup/"
+        ],
+        "scopes": {
+            "user": [
+                "links:read",
+                "users:read",
+                "users:read.email"
+            ],
+            "bot": [
+                "channels:read",
+                "chat:write",
+                "chat:write.customize",
+                "chat:write.public",
+                "commands",
+                "groups:read",
+                "im:history",
+                "im:read",
+                "links:read",
+                "links:write",
+                "team:read",
+                "users:read"
+            ]
+        }
+    },
+    "settings": {
+        "event_subscriptions": {
+            "request_url": "https://christina-devserver.ngrok.io/extensions/slack/event/",
+            "user_events": [
+                "link_shared"
+            ],
+            "bot_events": [
+                "link_shared",
+                "message.im"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true,
+            "request_url": "https://christina-devserver.ngrok.io/extensions/slack/action/",
+            "message_menu_options_url": "https://christina-devserver.ngrok.io/extensions/slack/options-load/"
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": false,
+        "token_rotation_enabled": false
+    }
+}
+```
+
+</Expandable>
+
 After naming your app and connecting your workspace, navigate to __Basic Information__. Here you’ll find your Client ID, Client Secret, and Verification token that lets your app access the Slack API.
 
 Here’s where you’ll connect your self-hosted Sentry instance to your newly created Slack app.


### PR DESCRIPTION
## DESCRIBE YOUR PR
For notification platform cli tool, unfortunately users currently need to create a slack app to test their notifications via cli, so this makes a little easier with a pre-built manifest to speed up app creation. Adds a toggle :0) and a bit more info on ways to create a slack app.

Toggle & Images
<img width="1422" height="871" alt="image" src="https://github.com/user-attachments/assets/33826d84-e72b-41d3-b554-335aa356c461" />

<img width="1170" height="509" alt="image" src="https://github.com/user-attachments/assets/464ce615-c92e-4e4d-a448-f20649009956" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

