### PR TITLE
fix(codeowners): don't support GitLab syntax

### DIFF
--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -68,9 +68,9 @@ Now that we have code mappings, we are able to transform the paths in your CODEO
 
 You can import and incrementally add the mappings between your "source control teams/users" and "Sentry Teams/users", using [external team/user mappings](/product/issues/ownership-rules/#external-teamuser-mappings). Sentry uses the "external team/user mappings" to convert the owners in your CODEOWNERS file into their equivalents in Sentry. Sentry will automatically ignore rules that are missing team/user mappings.
 
-We support GitHub CODEOWNERS file syntax. You can find more details about the syntax [in GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), including [details on unsupported syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
+We support GitHub CODEOWNERS file syntax. You can find more details about the syntax [in GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), including [details on unsupported syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions), with one exception: we do not support exclusions (lines without owners). 
 
-Note that we do not support [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference) that isn't also supported by GitHub. For example, we do not support sections, `!` exclusions, etc.
+Note that we do not support [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference) that isn't also supported by GitHub. For example, we do not support sections, `!` negations, etc.
 
 <Alert>
 

--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -68,7 +68,7 @@ Now that we have code mappings, we are able to transform the paths in your CODEO
 
 You can import and incrementally add the mappings between your "source control teams/users" and "Sentry Teams/users", using [external team/user mappings](/product/issues/ownership-rules/#external-teamuser-mappings). Sentry uses the "external team/user mappings" to convert the owners in your CODEOWNERS file into their equivalents in Sentry. Sentry will automatically ignore rules that are missing team/user mappings.
 
-We support GitHub CODEOWNERS file syntax. You can find more details about the syntax [in GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), including [details on unsupported syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions), with one exception: we do not support exclusions (lines without owners). 
+We support GitHub CODEOWNERS file syntax, with one exception: we do not support exclusions (lines without owners). You can find more details about the syntax [in GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), including [details on unsupported syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions).
 
 Note that we also do not support [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference) that isn't also supported by GitHub. For example, we do not support sections, `!` negations, etc.
 

--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -70,7 +70,7 @@ You can import and incrementally add the mappings between your "source control t
 
 We support GitHub CODEOWNERS file syntax. You can find more details about the syntax [in GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), including [details on unsupported syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions), with one exception: we do not support exclusions (lines without owners). 
 
-Note that we do not support [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference) that isn't also supported by GitHub. For example, we do not support sections, `!` negations, etc.
+Note that we also do not support [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference) that isn't also supported by GitHub. For example, we do not support sections, `!` negations, etc.
 
 <Alert>
 

--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -68,13 +68,9 @@ Now that we have code mappings, we are able to transform the paths in your CODEO
 
 You can import and incrementally add the mappings between your "source control teams/users" and "Sentry Teams/users", using [external team/user mappings](/product/issues/ownership-rules/#external-teamuser-mappings). Sentry uses the "external team/user mappings" to convert the owners in your CODEOWNERS file into their equivalents in Sentry. Sentry will automatically ignore rules that are missing team/user mappings.
 
-This feature supports GitHub and GitLab CODEOWNERS file syntax with the following exceptions:
+We support GitHub CODEOWNERS file syntax. You can find more details about the syntax [in GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), including [details on unsupported syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
 
-- Escaping a pattern starting with `#` using `\` so it is treated as a pattern and not a comment
-- Using `!` to negate a pattern
-- Using `[ ]` to define a character range
-- [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference/)
-- [GitHub CODEOWNERS syntax exceptions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions)
+Note that we do not support [GitLab CODEOWNERS syntax](https://docs.gitlab.com/user/project/codeowners/reference) that isn't also supported by GitHub. For example, we do not support sections, `!` exclusions, etc.
 
 <Alert>
 


### PR DESCRIPTION
We mention that we support GitLab syntax, even though we don't really support it, and there's substantial differences between GitHub and GitLab syntax. Explicitly mention that we support GitHub syntax, and don't support special GitLab things like sections. See https://github.com/getsentry/sentry/issues/86351 for an example


Resolves https://github.com/getsentry/sentry-docs/issues/9565

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)