### PR TITLE
fix(apple): App Start Type in App Context

### DIFF
--- a/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -135,7 +135,7 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. Enable the `enablePreWarmedAppStartTracing` feature to collect prewarmed app starts.
 
 Once enabled, the SDK drops the first app start span if prewarming pauses. This approach shortens the app start duration, but it accurately represents the span of time from when a user clicks the app icon to when the app is responsive.
-With this feature, the SDK differentiates between four different app start types:
+With this feature, the SDK differentiates between four different app start types, which it adds to the app context of the transaction:
 
 - **Non-prewarmed cold start** (See _cold start_ definition above.)
 - **Non-prewarmed warm start** (See _warm start_ definition above.)


### PR DESCRIPTION



## DESCRIBE YOUR PR

Explain that the SDK adds the app start type to the app context for prewarmed app start tracing.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

