### PR TITLE
Update replay page to clarify LIVE indicator for replays

### DIFF
--- a/docs/product/explore/session-replay/replay-page-and-filters.mdx
+++ b/docs/product/explore/session-replay/replay-page-and-filters.mdx
@@ -15,12 +15,13 @@ You can search for or browse replays of user sessions on the **Replay** page, wh
 - **Activity**: The activity level as determined by the number of errors encountered, their duration, and the number of UI events.
 - **Dead Clicks**: User clicks on `a` and `button` tags that do not result in any page activity after 7 seconds (i.e. no HTML was added, removed, or updated; no visual changes were observed in the page).
 - **Rage Clicks**: Five or more clicks on a dead element (it exhibits no page activity after 7 seconds.) Rage clicks are a subset of dead clicks.
+- **LIVE**: If a replay is still in progress, you will see a LIVE indicator that means the Replay is still happening right now. 
 
 The **Replay** page also has two widgets titled "Most Dead Clicks" and "Most Rage Clicks" that show the selectors with the most rage or dead clicks. Expanding the selector will show example replays where that selector was clicked. You can also click the "See all selectors" button to view all selectors that have gotten rage or dead clicks. SDK version `7.60.1` or higher is required to see rage and dead click data on the **Replay** page.
 
 By default, the IP address is used to identify each replay on this page. This can be changed in your organization and project settings. If you’d like to set an email or a username instead, call [Sentry.setUser()](/platform-redirect/?next=/enriching-events/identify-user) in your client-side configuration. If you’ve enabled the option to prevent storing of IP addresses in either your project-level or organization-wide settings, the IP address will appear redacted on the **Replay** page. For more information, read about [several data scrubbing options](/security-legal-pii/scrubbing/server-side-scrubbing/) in the Sentry app on either an organization or a project level.
 
-Replays can appear on this page while they’re still in progress. You can’t delete in-progress replays.
+Replays can appear on this page while they’re still in progress. You will see a LIVE indicator for replays that are still in progress. You can’t delete in-progress replays.
 
 Each replay will bring users to the [**Replay Details**](/product/explore/session-replay/web/replay-details/) page.
 


### PR DESCRIPTION
Clarified the description of in-progress replays by adding a note about the LIVE indicator.

## DESCRIBE YOUR PR
Add documentation for LIVE replays. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+
