### PR TITLE
fix(apple): Simplify app start tracing

### DIFF
--- a/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -110,8 +110,7 @@ Sentry's App Start instrumentation aims to be as comprehensive and representativ
 For example, Sentry measures the duration from process start, including the time before before runtime initialization and before the first application object is loaded, until the first frame is rendered to the user.
 
 </Alert>
-
-Since [sentry-cocoa 8.18.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.18.0) the SDK creates the following app start spans:
+The Cocoa SDK creates the following app start spans:
 
 - **Pre Runtime Init**: from the process start time to the runtime init.
 - **Runtime Init to Pre Main Initializers**: from runtime init to pre main initializers.
@@ -120,13 +119,6 @@ Since [sentry-cocoa 8.18.0](https://github.com/getsentry/sentry-cocoa/releases/t
 - **Initial Frame Render**: from the [`didFinishLaunchingNotification`][didfinishlaunching] to [`UIWindowDidBecomeVisibleNotification`][uiwindow]. When enabling the option `enablePerformanceV2` this is from the [`didFinishLaunchingNotification`][didfinishlaunching] until the app renders its first frame.
 
 ![App Start Transaction](./img/app-start-transaction.png)
-
-Before [sentry-cocoa 8.18.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.18.0) the SDK creates the following app start spans:
-
-- **Pre Runtime Init**: from the process start time to the runtime init.
-- **Runtime Init to Pre Main Initializers**: from runtime init to pre main initializers.
-- **UIKit and Application Init**: from pre main initializers to [`didFinishLaunchingNotification`][didfinishlaunching].
-- **Initial Frame Render**: from the [`didFinishLaunchingNotification`][didfinishlaunching] to [`UIWindowDidBecomeVisibleNotification`][uiwindow].
 
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/insights/mobile/mobile-vitals).
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Remove the section on before Cocoa SDK v 8.18.0, which we released in Jan 2024, to simplify the app start tracing docs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

