### PR TITLE
fix(apple): Clarify prewarmed app starts

### DIFF
--- a/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -132,9 +132,10 @@ Cold and warm start are Mobile Vitals, which you can learn about in the [full do
 
 ### Prewarmed App Start Tracing
 
-Starting with iOS 15, the system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. In these cases, we won’t be able to reliably measure the app start. Enable the `enablePreWarmedAppStartTracing` feature to collect prewarmed app starts.
+Starting with iOS 15, the operating system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. Enable the `enablePreWarmedAppStartTracing` feature to collect prewarmed app starts, which will be enabled by default in V9.
 
-Once enabled, the SDK drops the first app start span if prewarming pauses. This approach shortens the app start duration, but it accurately represents the span of time from when a user clicks the app icon to when the app is responsive.
+When the OS prewarms your app process, it already does some of the initialization steps of a normal app start before the user taps the app icon. This can be anywhere from seconds to minutes or hours before your app is fully launched. Therefore, the SDK doesn't add the **Pre Runtime Init** and the **Runtime Init to Pre Main Initializers** spans. This approach shortens the app start duration, but it represents the time from when a user clicks the app icon to when the app is responsive.
+
 With this feature, the SDK differentiates between four different app start types, which it adds to the app context of the transaction:
 
 - **Non-prewarmed cold start** (See _cold start_ definition above.)


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Clearly point out that the prewarmed app start tracing drops two spans and remove the confusing part of not being able to reliably measuring app starts.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
