### PR TITLE
feat(platform): Bump platformicons & add langgraph platform

### DIFF
--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -45,7 +45,7 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 | <LinkWithPlatformIcon platform="openai"          label="OpenAI" url="/platforms/python/integrations/openai" />                     |        ✓         |
 | <LinkWithPlatformIcon platform="openai-agents"   label="OpenAI Agents SDK" url="/platforms/python/integrations/openai-agents" />   |                  |
 | <LinkWithPlatformIcon platform="langchain"       label="LangChain" url="/platforms/python/integrations/langchain" />               |        ✓         |
-| <LinkWithPlatformIcon platform="langchain"       label="LangGraph" url="/platforms/python/integrations/langgraph" />               |        ✓         |
+| <LinkWithPlatformIcon platform="langgraph"       label="LangGraph" url="/platforms/python/integrations/langgraph" />               |        ✓         |
 
 ### Data Processing
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^1.6.6",
     "p-limit": "^6.2.0",
-    "platformicons": "^8.0.4",
+    "platformicons": "^9.0.1",
     "prism-sentry": "^1.0.2",
     "query-string": "^6.13.1",
     "react": "^19.0.0",

--- a/src/components/platformIcon.tsx
+++ b/src/components/platformIcon.tsx
@@ -78,6 +78,7 @@ import JavascriptSVG from 'platformicons/svg/javascript.svg';
 import KoaSVG from 'platformicons/svg/koa.svg';
 import KotlinSVG from 'platformicons/svg/kotlin.svg';
 import LangchainSVG from 'platformicons/svg/langchain.svg';
+import LanggraphSVG from 'platformicons/svg/langgraph.svg';
 import LaravelSVG from 'platformicons/svg/laravel.svg';
 import LinuxSVG from 'platformicons/svg/linux.svg';
 import LitestarSVG from 'platformicons/svg/litestar.svg';
@@ -222,6 +223,7 @@ import JavascriptSVGLarge from 'platformicons/svg_80x80/javascript.svg';
 import KoaSVGLarge from 'platformicons/svg_80x80/koa.svg';
 import KotlinSVGLarge from 'platformicons/svg_80x80/kotlin.svg';
 import LangchainSVGLarge from 'platformicons/svg_80x80/langchain.svg';
+import LanggraphSVGLarge from 'platformicons/svg_80x80/langgraph.svg';
 import LaravelSVGLarge from 'platformicons/svg_80x80/laravel.svg';
 import LinuxSVGLarge from 'platformicons/svg_80x80/linux.svg';
 import LitestarSVGLarge from 'platformicons/svg_80x80/litestar.svg';
@@ -614,6 +616,10 @@ const formatToSVG = {
     sm: LangchainSVG,
     lg: LangchainSVGLarge,
   },
+  langgraph: {
+    sm: LanggraphSVG,
+    lg: LanggraphSVGLarge,
+  },
   laravel: {
     sm: LaravelSVG,
     lg: LaravelSVGLarge,
@@ -975,6 +981,7 @@ export const PLATFORM_TO_ICON = {
   kotlin: 'kotlin',
   'kotlin-android': 'android',
   langchain: 'langchain',
+  langgraph: 'langgraph',
   linux: 'linux',
   native: 'nativec',
   'native-qt': 'qt',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11552,10 +11552,10 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
-platformicons@^8.0.4:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.4.tgz#f26e79b7bfbce1d8ae3af382215efe0ad6e19fcf"
-  integrity sha512-hvIWouaTtmnHv/JD42LwOg4MOd020q8Vf1Xs8uzqiA5+cqsiYqhR22WNV+Vzx6+T1K8ZLO9LV8+FvpFargKdlw==
+platformicons@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-9.0.1.tgz#7c9bb9ab0687cc73339d98d80a84eb0cb951a929"
+  integrity sha512-eI73sY+Hqn6eIwuf+wv5+r7E8AsXS+k9YaiNdW1swjp7GftJCVejCS1sCFRB/bmAr5Fyi6B1tbqKwrE3TlWs9A==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
- Bump platformicons to 9.0.1
- Add the Langgraph SVGs and the langgraph platform
- Use the Langgraph platform in the Python integration docs

Closes TET-1225