### PR TITLE
chore(develop-docs): add chore as a category for commit messages

### DIFF
--- a/develop-docs/engineering-practices/commit-messages.mdx
+++ b/develop-docs/engineering-practices/commit-messages.mdx
@@ -120,6 +120,10 @@ Must be one of the following:
       </td>
     </tr>
     <tr>
+      <th>chore:</th>
+      <td>Necessary changes for qualitative improvements that don't affect functionality, e.g. updating dependencies or adding instrumentation</td>
+    </tr>
+    <tr>
       <th>style:</th>
       <td>
         Changes that do not affect the meaning of the code (white-space,


### PR DESCRIPTION
- Add `chore` as a category for commit messages - we use this commit type routinely, but for some reason it's not a valid reason in develop docs