### PR TITLE
docs(react-native): Clarify TabNavigator behavior for Time to Display…

### DIFF
--- a/docs/platforms/react-native/tracing/instrumentation/time-to-display.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/time-to-display.mdx
@@ -26,6 +26,19 @@ To automatically measure Time to Initial Display of React Navigation Screens, en
 
 - Time to Initial Display is only available for React Navigation version 5 and above.
 
+### Using Time to Display with TabNavigator
+
+When using React Navigation’s `TabNavigator` or other navigators that **preload or re-use routes**, automatic instrumentation with `enableTimeToInitialDisplay` may not always create a `TimeToInitialDisplay` span. This is because auto-TTID only records the first time a route is seen; on preloaded or already-visited routes, TTID may be skipped. Since `TimeToFullDisplay` depends on an active TTID span, this can result in missing TTFD spans in Sentry.
+
+Recent versions of the React Native SDK have introduced fixes and fallbacks for some of these cases. However, Sentry’s mobile team has verified that **custom/manual instrumentation remains the most reliable solution** today, particularly for tabbed navigation scenarios.
+
+We recommend explicitly adding both components on screens within a `TabNavigator`:
+
+```jsx
+<TimeToInitialDisplay record={true} />
+<TimeToFullDisplay record={isLoading === false} />
+```
+
 ## Time To Initial Display Overwrite
 
 When the automatically captured Time to Initial Display doesn't meet your requirements, you can overwrite it by using `Sentry.TimeToInitialDisplay` component.


### PR DESCRIPTION
… (TTID/TTFD); recommend manual instrumentation in tabbed flows

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Updates the React Native “Time to Display” docs to call out caveats when using React Navigation’s TabNavigator (or other preloaded/re-used routes). Automatic TTID may be skipped on already-seen/preloaded routes, which can also prevent TTFD from recording. Recommends explicit manual instrumentation for tabbed navigation scenarios and provides example usage.

New content added in docs/platforms/react-native/tracing/instrumentation/time-to-display.mdx under “Using Time to Display with TabNavigator”.
Example included:
<TimeToInitialDisplay record={true} />
<TimeToFullDisplay record={isLoading === false} />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
