### PR TITLE
Update noProxy list in index.mdx

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -138,7 +138,7 @@ By default Sentry sends anonymous usage statistics to the Sentry team. It helps 
   "proxies": {
     "httpProxy": "http://proxy:3128",
     "httpsProxy": "http://proxy:3128",
-    "noProxy": "smtp,memcached,redis,postgres,kafka,clickhouse,snuba-api,symbolicator,web,worker,nginx,relay,vroom,taskbroker,172.17.0.0/16,127.0.0.0/8"
+    "noProxy": "smtp,memcached,redis,postgres,pgbouncer,kafka,clickhouse,seaweedfs,snuba-api,symbolicator,web,worker,nginx,relay,vroom,taskbroker,172.17.0.0/16,127.0.0.0/8"
   }
 }
 ```


### PR DESCRIPTION
With the new changes in 25.9.0 it seems we should add pgbouncer and seaweedfs to the no proxy list as well.


