### PR TITLE
feat: Add example collector config to otlp docs + extra cleanup

### DIFF
--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -39,7 +39,7 @@ You can configure your OTEL collector instance to send traces to Sentry directly
 ```yaml {filename: otel-collector.yaml}
 exporters:
   otlphttp:
-    traces_endpoint: __OTLP_TRACES_URL___
+    traces_endpoint: ___OTLP_TRACES_URL___
     headers:
       x-sentry-auth: "sentry sentry_key=___PUBLIC_KEY___"
     compression: gzip
@@ -97,7 +97,7 @@ You can configure your OTEL collector instance to send logs to Sentry directly. 
 ```yaml {filename: otel-collector.yaml}
 exporters:
   otlphttp:
-    logs_endpoint: __OTLP_LOGS_URL___
+    logs_endpoint: ___OTLP_LOGS_URL___
     headers:
       x-sentry-auth: "sentry sentry_key=___PUBLIC_KEY___"
     compression: gzip

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -17,6 +17,12 @@ If you have an existing OpenTelemetry trace instrumentation, you can configure y
 - Span links are partially supported. We ingest and display span links, but they cannot be searched, filtered, or aggregated. Links are shown in the [Trace View](/concepts/key-terms/tracing/trace-view/).
 - Array attributes are partially supported. We ingest and display array attributes, but they cannot be searched, filtered, or aggregated. Array attributes are shown in the [Trace View](/concepts/key-terms/tracing/trace-view/).
 
+You can find the values of Sentry's OTLP traces endpoint and public key in your Sentry project settings.
+
+1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.
+2. Select a project from the list.
+3. Go to the "Client Keys (DSN)" sub-page for this project under the "SDK Setup" heading.
+
 The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
 
 ```bash {filename: .env}
@@ -24,7 +30,26 @@ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="___OTLP_TRACES_URL___"
 export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-sentry-auth=sentry sentry_key=___PUBLIC_KEY___"
 ```
 
-Alternatively, you can configure the OpenTelemetry Exporter directly in your application code. Here is an example with the OpenTelemetry Node SDK:
+If you prefer to explicitly configure an OpenTelemetry SDK or OTEL collector instance, see the following:
+
+### Using the OTEL Collector
+
+You can configure your OTEL collector instance to send traces to Sentry directly. This requires you to add an `otlphttp` exporter to your collector instance.
+
+```yaml {filename: otel-collector.yaml}
+exporters:
+  otlphttp:
+    traces_endpoint: __OTLP_TRACES_URL___
+    headers:
+      x-sentry-auth: "sentry sentry_key=___PUBLIC_KEY___"
+    compression: gzip
+    encoding: proto
+    timeout: 30s
+```
+
+### Using an OpenTelemetry SDK
+
+You can configure the OpenTelemetry Exporter directly in your application code. Here is an example with the OpenTelemetry Node SDK:
 
 ```typescript {filename: app.ts}
 import { NodeSDK } from "@opentelemetry/sdk-node";
@@ -42,12 +67,6 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-You can find the values of Sentry's OTLP traces endpoint and public key in your Sentry project settings.
-
-1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.
-2. Select a project from the list.
-3. Go to the "Client Keys (DSN)" sub-page for this project under the "SDK Setup" heading.
-
 ## OpenTelemetry Logs
 
 <Include name="feature-available-ea-logs.mdx" />
@@ -56,12 +75,37 @@ If you have an existing OpenTelemetry log instrumentation, you can configure you
 
 - Array attributes are partially supported. We ingest and display array attributes, but they cannot be searched, filtered, or aggregated.
 
-The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the trace endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
+You can find the values of Sentry's OTLP logs endpoint and public key in your Sentry project settings.
+
+1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.
+2. Select a project from the list.
+3. Go to the "Client Keys (DSN)" sub-page for this project under the "SDK Setup" heading.
+
+The easiest way to configure an OpenTelemetry exporter is with environment variables. You'll need to configure the logs endpoint URL, as well as the authentication headers. Set these variables on the server where your application is running.
 
 ```bash {filename: .env}
 export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="___OTLP_LOGS_URL___"
 export OTEL_EXPORTER_OTLP_LOGS_HEADERS="x-sentry-auth=sentry sentry_key=___PUBLIC_KEY___"
 ```
+
+If you prefer to explicitly configure an OpenTelemetry SDK or OTEL collector instance, see the following:
+
+### Using the OTEL Collector
+
+You can configure your OTEL collector instance to send logs to Sentry directly. This requires you to add an `otlphttp` exporter to your collector instance.
+
+```yaml {filename: otel-collector.yaml}
+exporters:
+  otlphttp:
+    logs_endpoint: __OTLP_LOGS_URL___
+    headers:
+      x-sentry-auth: "sentry sentry_key=___PUBLIC_KEY___"
+    compression: gzip
+    encoding: proto
+    timeout: 30s
+```
+
+### Using an OpenTelemetry SDK
 
 Alternatively, you can configure the OpenTelemetry Exporter directly in your application code. Here is an example with the OpenTelemetry Node SDK:
 
@@ -85,12 +129,6 @@ const loggerProvider = new LoggerProvider({
 const logger = loggerProvider.getLogger("default", "1.0.0");
 ```
 
-You can find the values of Sentry's OTLP logs endpoint and public key in your Sentry project settings.
-
-1. Go to the [Settings > Projects](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/) page in Sentry.
-2. Select a project from the list.
-3. Go to the "Client Keys (DSN)" sub-page for this project under the "SDK Setup" heading.
-
 ## Distributed Tracing between Sentry Instrumentation and OpenTelemetry Instrumentation
 
 If you have a frontend or services instrumented with the Sentry SDK, and you are also instrumenting with OpenTelemetry, you can use the `propagateTraceparent` exposed in the Sentry SDK to propagate the W3C Trace Context `traceparent` header to the OpenTelemetry instrumentation. This will allow you to continue traces from Sentry instrumented services.
@@ -102,7 +140,7 @@ The following SDKs support the `propagateTraceparent` option:
 - <LinkWithPlatformIcon
     platform="javascript.browser"
     label="Browser JavaScript"
-    url="platforms/javascript/configuration/options/#propagateTraceparent"
+    url="/platforms/javascript/configuration/options/#propagateTraceparent"
   />
 - <LinkWithPlatformIcon
     platform="javascript.angular"
@@ -115,84 +153,14 @@ The following SDKs support the `propagateTraceparent` option:
     url="/platforms/javascript/guides/astro/configuration/options/#propagateTraceparent"
   />
 - <LinkWithPlatformIcon
-    platform="javascript.aws-lambda"
-    label="AWS Lambda"
-    url="/platforms/javascript/guides/aws-lambda/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.azure-functions"
-    label="Azure Functions"
-    url="/platforms/javascript/guides/azure-functions/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.bun"
-    label="Bun"
-    url="/platforms/javascript/guides/bun/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.cloudflare"
-    label="Cloudflare"
-    url="/platforms/javascript/guides/cloudflare/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.connect"
-    label="Connect"
-    url="/platforms/javascript/guides/connect/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.electron"
-    label="Electron"
-    url="/platforms/javascript/guides/electron/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
     platform="javascript.ember"
     label="Ember"
     url="/platforms/javascript/guides/ember/configuration/options/#propagateTraceparent"
   />
 - <LinkWithPlatformIcon
-    platform="javascript.express"
-    label="Express"
-    url="/platforms/javascript/guides/express/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.fastify"
-    label="Fastify"
-    url="/platforms/javascript/guides/fastify/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
     platform="javascript.gatsby"
     label="Gatsby"
     url="/platforms/javascript/guides/gatsby/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.gcp-functions"
-    label="Google Cloud Functions"
-    url="/platforms/javascript/guides/gcp-functions/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.hapi"
-    label="Hapi"
-    url="/platforms/javascript/guides/hapi/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.hono"
-    label="Hono"
-    url="/platforms/javascript/guides/hono/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.koa"
-    label="Koa"
-    url="/platforms/javascript/guides/koa/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.nestjs"
-    label="Nest.js"
-    url="/platforms/javascript/guides/nestjs/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
-    platform="javascript.node"
-    label="Node.js"
-    url="/platforms/javascript/guides/node/configuration/options/#propagateTraceparent"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nextjs"
@@ -240,11 +208,6 @@ The following SDKs support the `propagateTraceparent` option:
     url="/platforms/javascript/guides/sveltekit/configuration/options/#propagateTraceparent"
   />
 - <LinkWithPlatformIcon
-    platform="javascript.tanstackstart-react"
-    label="TanStack Start"
-    url="/platforms/javascript/guides/tanstackstart-react/configuration/options/#propagateTraceparent"
-  />
-- <LinkWithPlatformIcon
     platform="javascript.vue"
     label="Vue"
     url="/platforms/javascript/guides/vue/configuration/options/#propagateTraceparent"
@@ -253,4 +216,17 @@ The following SDKs support the `propagateTraceparent` option:
     platform="javascript.wasm"
     label="Wasm"
     url="/platforms/javascript/guides/wasm/configuration/options/#propagateTraceparent"
+  />
+
+### Mobile
+
+- <LinkWithPlatformIcon
+    platform="android"
+    label="Android"
+    url="/platforms/android/configuration/options/#propagate-traceparent"
+  />
+- <LinkWithPlatformIcon
+    platform="dart.flutter"
+    label="Flutter"
+    url="/platforms/dart/guides/flutter/configuration/options/#propagate-traceparent"
   />

--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -34,7 +34,7 @@ If you prefer to explicitly configure an OpenTelemetry SDK or OTEL collector ins
 
 ### Using the OTEL Collector
 
-You can configure your OTEL collector instance to send traces to Sentry directly. This requires you to add an `otlphttp` exporter to your collector instance.
+You can configure your OTEL collector instance to send traces to Sentry directly. This requires you to add an `otlphttp` exporter to your collector instance. Sentry's OTLP endpoints are project-specific, so you might also need to add a [routing connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector) to route traces to the correct project.
 
 ```yaml {filename: otel-collector.yaml}
 exporters:
@@ -92,7 +92,7 @@ If you prefer to explicitly configure an OpenTelemetry SDK or OTEL collector ins
 
 ### Using the OTEL Collector
 
-You can configure your OTEL collector instance to send logs to Sentry directly. This requires you to add an `otlphttp` exporter to your collector instance.
+You can configure your OTEL collector instance to send logs to Sentry directly. This requires you to add an `otlphttp` exporter to your collector instance. Sentry's OTLP endpoints are project-specific, so you might also need to add a [routing connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector) to route logs to the correct project.
 
 ```yaml {filename: otel-collector.yaml}
 exporters:

--- a/src/components/codeContext.tsx
+++ b/src/components/codeContext.tsx
@@ -88,8 +88,8 @@ export const DEFAULTS: CodeKeywords = {
       MINIDUMP_URL:
         'https://o0.ingest.sentry.io/api/0/minidump/?sentry_key=examplePublicKey',
       UNREAL_URL: 'https://o0.ingest.sentry.io/api/0/unreal/examplePublicKey/',
-      OTLP_TRACES_URL: 'https://o0.ingest.sentry.io/api/0/integration/otlp/v1/traces/',
-      OTLP_LOGS_URL: 'https://o0.ingest.sentry.io/api/0/integration/otlp/v1/logs/',
+      OTLP_TRACES_URL: 'https://o0.ingest.sentry.io/api/0/integration/otlp/v1/traces',
+      OTLP_LOGS_URL: 'https://o0.ingest.sentry.io/api/0/integration/otlp/v1/logs',
       title: `example-org / example-project`,
     },
   ],
@@ -142,11 +142,11 @@ const formatUnrealEngineURL = ({scheme, host, pathname, publicKey}: Dsn) => {
 };
 
 const formatOtlpTracesUrl = ({scheme, host, pathname}: Dsn) => {
-  return `${scheme}${host}/api${pathname}/integration/otlp/v1/traces/`;
+  return `${scheme}${host}/api${pathname}/integration/otlp/v1/traces`;
 };
 
 const formatOtlpLogsUrl = ({scheme, host, pathname}: Dsn) => {
-  return `${scheme}${host}/api${pathname}/integration/otlp/v1/logs/`;
+  return `${scheme}${host}/api${pathname}/integration/otlp/v1/logs`;
 };
 
 const formatApiUrl = ({scheme, host}: Dsn) => {


### PR DESCRIPTION
1. re-organize sections in otlp docs
2. add example collector config for both traces and logs
3. add android and flutter sdks to traceparent section (as per https://linear.app/getsentry/project/implement-traceparent-support-in-client-sdks-d842ae07e7d4/updates)
4. removes backend js platforms from traceparent section
