### PR TITLE
fix: Allow '0' in project IDs for reverse proxy

### DIFF
--- a/develop-docs/self-hosted/experimental/reverse-proxy.mdx
+++ b/develop-docs/self-hosted/experimental/reverse-proxy.mdx
@@ -22,13 +22,13 @@ We recommend TLS termination to be done on your own dedicated load balancer or p
 
 Certain self-hosted deployments requires the dashboard to be accessed only via internal network. But, they also need to provide public Sentry ingestion endpoint for client devices such as mobile and desktop apps. You can expose some of these endpoints publicly:
 
-- `/api/[1-9]+/envelope/` - Main endpoint for submitting event from SDK
-- `/api/[1-9]+/minidump/` - Endpoint for submitting minidump from native SDKs
-- `/api/[1-9]+/security/` - Endpoint for submitting security-related such as CSP errors
-- `/api/[1-9]+/store/` - Old endpoint for submitting event from SDK, it is deprecated.
-- `/api/[1-9]+/unreal/` - Endpoint for submitting crash report from Unreal Engine SDK
+- `/api/[0-9]+/envelope/` - Main endpoint for submitting event from SDK
+- `/api/[0-9]+/minidump/` - Endpoint for submitting minidump from native SDKs
+- `/api/[0-9]+/security/` - Endpoint for submitting security-related such as CSP errors
+- `/api/[0-9]+/store/` - Old endpoint for submitting event from SDK, it is deprecated.
+- `/api/[0-9]+/unreal/` - Endpoint for submitting crash report from Unreal Engine SDK
 
-The `[1-9]+` is a regular expression string that is acquired from the project DSN.
+The `[0-9]+` is a regular expression string that is acquired from the project DSN.
 
 ## Rate Limiting
 
@@ -76,7 +76,7 @@ server {
     # by removing the other `location` directive.
     #
     # It is recomended to put a rate limiter on the ingest endpoints.
-    location ~ ^/api/[1-9]+/(envelope|minidump|security|store|unreal)/ {
+    location ~ ^/api/[0-9]+/(envelope|minidump|security|store|unreal)/ {
         add_header Access-Control-Allow-Origin * always;
         add_header Access-Control-Allow-Credentials false always;
         add_header Access-Control-Allow-Methods GET,POST,PUT always;
@@ -127,7 +127,7 @@ sentry.yourcompany.com {
     # by removing the other `handle` directive.
     #
     # It is recomended to put a rate limiter on the ingest endpoints.
-    @ingest_endpoint path_regexp ^/api/[1-9]+/(envelope|minidump|security|store|unreal)/
+    @ingest_endpoint path_regexp ^/api/[0-9]+/(envelope|minidump|security|store|unreal)/
 
     handle @ingest_endpoint {
         header {
@@ -197,7 +197,7 @@ http:
         - web       # Assuming this your HTTP entrypoint
         - websecure # Assuming this is your HTTPS entrypoint
       service: sentry@file
-      rule: "Host(`sentry.yourcompany.com`) && PathRegexp(`^/api/[1-9]+/(envelope|minidump|security|store|unreal)`)"
+      rule: "Host(`sentry.yourcompany.com`) && PathRegexp(`^/api/[0-9]+/(envelope|minidump|security|store|unreal)`)"
       tls:
         certResolver: letsencrypt # Assuming you have a TLS certificate resolver named "letsencrypt"
       middlewares:
@@ -300,7 +300,7 @@ frontend https_bind
     mode http
 
     acl sentry_domain   hdr(host) -i sentry.yourcompany.com
-    acl ingest_endpoint path_reg -i /api/[1-9]+/(envelope|minidump|security|store|unreal)/
+    acl ingest_endpoint path_reg -i /api/[0-9]+/(envelope|minidump|security|store|unreal)/
 
     # Handle CORS-related headers for ingest endpoints.
     # You can also only expose the ingest endpoints only,


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Added the `0` symbol to the list of allowed characters for project IDs in the reverse proxy configuration. This restores proxy functionality for DSNs like:

```
https://public@sentry.example.com/10
https://public@sentry.example.com/100
https://public@sentry.example.com/101
etc.
```

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

