### PR TITLE
RN: Update Codepush instructions to use a separate dir for sourcemaps

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
@@ -23,7 +23,7 @@ export default codePush(Sentry.wrap(App));
 
 ## Create CodePush Release
 
-To ensure Sentry can symbolicate events from your CodePush releases, you need to generate and upload the necessary assets. When creating a CodePush release, include the `--sourcemap-output-dir` flag to generate source maps. This allows you to upload these files to Sentry in the next step.
+To ensure Sentry can symbolicate events from your CodePush releases, you need to generate and upload the necessary assets. When creating a CodePush release, include the `--sourcemap-output-dir` flag to generate source maps in a separate directory. This allows you to upload these files to Sentry in the next step.
 
 ```bash {tabTitle:JSC (Standalone)}
 code-push-standalone release-react \
@@ -31,22 +31,22 @@ code-push-standalone release-react \
   "${PLATFORM}" \
   --deploymentName "${DEPLOYMENT_NAME}" \
   --outputDir ./build \
-  --sourcemapOutput ./build
+  --sourcemapOutput ./sourcemaps
 ```
 
 ```bash {tabTitle:Hermes (Standalone)}
-rm -rf ./build
+rm -rf ./build ./sourcemaps
 CODEPUSH_COMMAND="code-push-standalone release-react \
   \"${APP_NAME}\" \
   \"${PLATFORM}\" \
   --deploymentName \"${DEPLOYMENT_NAME}\" \
   --useHermes \
   --outputDir ./build \
-  --sourcemapOutput ./build"
+  --sourcemapOutput ./sourcemaps"
 
 DEBUG_ID=$(eval "$CODEPUSH_COMMAND" | tee /dev/tty | grep -o 'Bundle Debug ID: [0-9a-f-]*' | sed 's/Bundle Debug ID: //')
 
-MAP_FILE=$(find ./build -name "*.map" -type f)
+MAP_FILE=$(find ./sourcemaps -name "*.map" -type f)
 jq -c ". + {\"debug_id\": \"${DEBUG_ID}\"}" "${MAP_FILE}" > "${MAP_FILE}.tmp"
 mv "${MAP_FILE}.tmp" "${MAP_FILE}"
 ```
@@ -56,21 +56,21 @@ appcenter codepush release-react \
   --app "${APP_NAME}" \
   --deployment-name "${DEPLOYMENT_NAME}" \
   --output-dir ./build \
-  --sourcemap-output-dir ./build
+  --sourcemap-output-dir ./sourcemaps
 ```
 
 ```bash {tabTitle:Hermes (AppCenter)}
-rm -rf ./build
+rm -rf ./build ./sourcemaps
 CODEPUSH_COMMAND="appcenter codepush release-react \
   --app \"${APP_NAME}\" \
   --deployment-name \"${DEPLOYMENT_NAME}\" \
   --use-hermes \
   --output-dir ./build \
-  --sourcemap-output-dir ./build"
+  --sourcemap-output-dir ./sourcemaps"
 
 DEBUG_ID=$(eval "$CODEPUSH_COMMAND" | tee /dev/tty | grep -o 'Bundle Debug ID: [0-9a-f-]*' | sed 's/Bundle Debug ID: //')
 
-MAP_FILE=$(find ./build -name "*.map" -type f)
+MAP_FILE=$(find ./sourcemaps -name "*.map" -type f)
 jq -c ". + {\"debug_id\": \"${DEBUG_ID}\"}" "${MAP_FILE}" > "${MAP_FILE}.tmp"
 mv "${MAP_FILE}.tmp" "${MAP_FILE}"
 ```
@@ -97,7 +97,7 @@ To upload source maps for your CodePush release, use the `sourcemaps upload` com
 npx sentry-cli sourcemaps upload \
   --debug-id-reference \
   --strip-prefix /path/to/project/root \
-  ./build
+  ./sourcemaps
 ```
 
 ## Notes


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

Fixes https://github.com/getsentry/sentry-react-native/issues/5148

Updates Codepush instructions to use a separate dir for sourcemaps to avoid including them in releases

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
