### PR TITLE
fix(MCP): redirect to new URL

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -1242,7 +1242,6 @@ const userDocsRedirects = [
     source: '/platforms/dotnet/guides/google-cloud-functions/profiling/:path*',
     destination: '/platforms/dotnet/profiling/',
   },
-  // MCP monitoring redirects
   {
     source: '/product/insights/mcp/',
     destination: '/product/insights/ai/mcp/',


### PR DESCRIPTION
At somepoint we changed MCP docs routes, so we had a 404 on a page. Added a redirect to fix this, from `/product/insights/mcp/` to `/product/insights/ai/mcp/`.