### PR TITLE
RN: Update APPLICATION_EXTENSION_API_ONLY troubleshooting guide

### DIFF
--- a/docs/platforms/react-native/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/troubleshooting/index.mdx
@@ -133,9 +133,23 @@ The Xcode integration reads `dist` from `CFBundleVersion` but Xcode Cloud builds
 export SENTRY_DIST=$CI_BUILD_NUMBER
 ```
 
+## iOS: Sentry User Feedback UI cannot be used from app extensions.
+
+If you see an error similar to `'SentryUserFeedbackIntegration' is unavailable: not available on iOS - Sentry User Feedback UI cannot be used from app extensions` during the application build process, please make sure that the `APPLICATION_EXTENSION_API_ONLY` is set to `NO`. You can achive that with the following in your `Podfile`.
+
+```ruby {filename:ios/Podfile}
+installer.pods_project.targets.each do |target|
+  target.build_configurations.each do |config|
+    if target.name == 'Sentry'
+      config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'NO'
+    end
+  end
+end
+```
+
 ## Unknown receiver '\<SomeReceiver\>', Use of undeclared identifier '\<SomeIdentifier\>'
 
-If you see an error like `Unknown receiver 'SwiftDescriptor'` or `Use of undeclared identifier 'SentryLog'` during the application build process, there's a conflict stemming from `APPLICATION_EXTENSION_API_ONLY`. By default, the Sentry Cocoapod is configured with `APPLICATION_EXTENSION_API_ONLY=YES`, but some `post_install` script likely changed it. To fix this error, add the following to the `Podfile`.
+If you see an error like `Unknown receiver 'SwiftDescriptor'` or `Use of undeclared identifier 'SentryLog'` during the application build process (in SDK versions prior to `6.18.0`), there's a conflict stemming from `APPLICATION_EXTENSION_API_ONLY`. By default, the Sentry Cocoapod is configured with `APPLICATION_EXTENSION_API_ONLY=YES`, but some `post_install` script likely changed it. To fix this error, add the following to the `Podfile`.
 
 ```ruby {filename:ios/Podfile}
 post_install do |installer|


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

* This is a follow up to https://github.com/getsentry/sentry-react-native/issues/5099 and https://github.com/getsentry/sentry-react-native/issues/5222 adding the suggested solution to the doc
* After the removal of the `APPLICATION_EXTENSION_API_ONLY` with https://github.com/getsentry/sentry-cocoa/pull/5524 in [Cocoa 8.53.2](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8532) / [RN 6.18](https://github.com/getsentry/sentry-react-native/blob/main/CHANGELOG.md#6180) the `Unknown receiver` error should not occur (added the version in parentheses for now instead of removing).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
