### PR TITLE
fix(chartcuterie): Update yarn -> pnpm

### DIFF
--- a/develop-docs/services/chartcuterie.mdx
+++ b/develop-docs/services/chartcuterie.mdx
@@ -101,14 +101,14 @@ To enable Chartcuterie in your local developer environment first enable it in
 your `config.yml`:
 
 ```yml
-# Enable charctuerie
+# Enable chartcuterie
 chart-rendering.enabled: true
 ```
 
 Currently you need to manually build the configuration module in your development environment.
 
 ```shell
-yarn build-chartcuterie-config
+pnpm build-chartcuterie-config
 ```
 
 You can then boot the Chartcuterie devservice. If the devservice doesn't start
@@ -141,7 +141,7 @@ Chartcuterie.
 
 ### Updating chart types locally
 
-Currently you need to rebuild the configuration module using `yarn
+Currently you need to rebuild the configuration module using `pnpm
 build-chartcuterie-config` on every change. This may be improved in the future.
 
 ## How it works


### PR DESCRIPTION
We use `pnpm` instead of `yarn` now so update the Chartcuterie docs to reflect that. I also fixed a typo.