### PR TITLE
feat(digests): Add more explanatory test about the min/max delivery interval

### DIFF
--- a/docs/product/alerts/create-alerts/issue-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/issue-alert-config.mdx
@@ -143,6 +143,6 @@ In **[Project] > Settings > Alerts**, you can configure alert email subject temp
 
 The digests feature only works for issue alert emails (not notifications sent through integrations), and unlike the [action interval](#action-interval-rate-limit), limits the total number of alert emails sent for the project. This project-level setting allows you to control the minimum and maximum delivery intervals for alerts.
 
-The minimum interval determines the earliest time that another digest will be sent (when compared to the previously sent email). Subsequent alerts will delay the next digest email, up until the maximum interval. If there hasn’t been a recent digest, the first alert is delivered immediately.
+The minimum interval sets how soon another digest can be sent after the previous one. Each new alert resets the timer, delaying the next digest until the maximum interval is reached. If there hasn’t been a recent digest, the first alert is delivered immediately.
 
 ![A sliding adjustment scale for the frequency of alert emails.](./img/alert-digest.png)


### PR DESCRIPTION
I've added additional information to the explain how the min/max interval works for the digest delivery interval.

This was in response to this user's feedback: https://github.com/getsentry/sentry/issues/100651

<img width="1191" height="672" alt="CleanShot 2025-10-08 at 10 32 58" src="https://github.com/user-attachments/assets/0a1191b3-ff07-4264-b8e1-8149a86c1c35" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+