### PR TITLE
chore(issues): clarify `assigned_or_suggested` filter

### DIFF
--- a/docs/concepts/search/searchable-properties/issues.mdx
+++ b/docs/concepts/search/searchable-properties/issues.mdx
@@ -36,7 +36,7 @@ Returns issues assigned to the defined user(s) or team(s). Values can be a user 
 
 ### `assigned_or_suggested`
 
-Returns issues that are assigned to or suggested to be assigned to the defined user(s) or team(s). Suggested assignees are found by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee/suggestion, `my_teams` or `#team-name` for teams you belong to.
+Returns issues that are either assigned to the defined user(s) or team(s), or suggested to be assigned to the defined user(s) or team(s) and are currently unassigned. Suggested assignees are found by matching [ownership rules](/product/issues/ownership-rules/) and [suspect commits](/product/issues/suspect-commits/). Values can be a user ID (your email address), `me` for yourself, `none` for no assignee/suggestion, `my_teams` or `#team-name` for teams you belong to.
 
 - **Type:** team or org user
 


### PR DESCRIPTION
Clarify that when using the `assigned_or_suggested` filter, issues that are suggested but assigned to other users/teams will not appear in the search.

Closes https://github.com/getsentry/sentry/issues/40485

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)