### PR TITLE
Updating Android options to include types and defaults

### DIFF
--- a/docs/platforms/android/configuration/options.mdx
+++ b/docs/platforms/android/configuration/options.mdx
@@ -88,8 +88,15 @@ Note that enabling this option may increase the payload size of events sent to S
 
 </SdkOption>
 
-<SdkOption name="sendDefaultPii" type="bool" defaultValue="false">
 <SdkOption name="collectAdditionalContext" type="bool" defaultValue="true">
+
+Controls whether the SDK collects additional device context (such as battery level, memory usage, storage state, and connectivity) to enrich events. Disabling this can reduce file I/O and help avoid Android StrictMode violations or ANR triggers on some devices at the cost of losing that context on events.
+
+AndroidManifest.xml key: `io.sentry.additional-context`.
+
+</SdkOption>
+
+<SdkOption name="sendDefaultPii" type="bool" defaultValue="false">
 
 If this flag is enabled, certain personally identifiable information (PII) is added by active integrations.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adding the metadata for Android options since converting to `SDKoption`

Preview: https://sentry-docs-git-android-options-update.sentry.dev/platforms/android/configuration/options/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)