### PR TITLE
fix(native): options duplicate entry and default values

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -68,15 +68,9 @@ Whether Crashpad should delay application shutdown until the upload of the crash
 
 <SdkOption name="propagate_traceparent" type="bool" defaultValue="false">
 
-Controls whether the SDK should propagate the W3C `traceparent` HTTP header alongside the `sentry-trace` header for [distributed tracing](https://docs.sentry.io/platforms/native/tracing/trace-propagation/custom-instrumentation/). This option defaults to `false`.
+Controls whether the SDK should propagate the W3C `traceparent` HTTP header alongside the `sentry-trace` header for [distributed tracing](https://docs.sentry.io/platforms/native/tracing/trace-propagation/custom-instrumentation/).
 
 </SdkOption>
-
-<ConfigKey name="propagate-traceparent">
-
-Controls whether the SDK should propagate the W3C `traceparent` HTTP header alongside the `sentry-trace` header for [distributed tracing](https://docs.sentry.io/platforms/native/tracing/trace-propagation/custom-instrumentation/). This option defaults to `false`.
-
-</ConfigKey>
 
 ## Hooks
 
@@ -120,7 +114,7 @@ A function responsible for determining the percentage chance a given transaction
 
 <SdkOption name="enable_logs" type="bool" defaultValue="false">
 
-This option enables the [logging integration](/platforms/native/logs), which allows the SDK to capture logs and send them to Sentry. This is disabled by default.
+This option enables the [logging integration](/platforms/native/logs), which allows the SDK to capture logs and send them to Sentry.
 
 </SdkOption>
 


### PR DESCRIPTION
Vercel preview: https://sentry-docs-git-joshuamoelans-patch-1.sentry.dev/platforms/native/configuration/options/
Current docs: https://docs.sentry.io/platforms/native/configuration/options/

## DESCRIBE YOUR PR
Fixes a minor duplication introduced by https://github.com/getsentry/sentry-docs/pull/15171 & removes some unnecessary mentions of default values (since we now have them nicely tabulated).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
