### PR TITLE
Fix wrong value in sentry.options.max_request_body_size

### DIFF
--- a/docs/platforms/php/guides/symfony/data-management/data-collected.mdx
+++ b/docs/platforms/php/guides/symfony/data-management/data-collected.mdx
@@ -50,7 +50,7 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
   -Uploaded files in the request bodies are never sent to Sentry
 - **The size of the request body:** There's an <PlatformLink to="/configuration/options/#max_request_body_size">max_request_body_size option</PlatformLink> that's set to `medium` by default. This means that larger request bodies aren't sent to Sentry.
 
-If you want to prevent bodies from being sent to Sentry altogether, set `max_request_body_size` to `'never'`.
+If you want to prevent bodies from being sent to Sentry altogether, set `max_request_body_size` to `'none'`.
 
 ## Source Context
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Using "never" as value for `sentry.options.max_request_body_size` will result in an error: 

The value "never" is not allowed for path "sentry.options.max_request_body_size". Permissible values: "none", "small", "medium", "always"

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
