### PR TITLE
fix(pii): Regex101 supports a Rust dialect now

### DIFF
--- a/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/advanced-datascrubbing.mdx
@@ -49,7 +49,7 @@ Rules generally consist of three parts:
 
   - Do not write `/[a-zA-Z0-9]+/g`, as that will search for a literal `/` and `/g`.
   - For case-insensitivity, prefix your regex with `(?i)`.
-  - If you're trying to use one of the popular regex "IDEs" like [regex101.com](https://regex101.com/), Golang is usually closest to how Sentry understands your regex.
+  - If you're trying to use one of the popular regex "IDEs" like [regex101.com](https://regex101.com/) select the Rust dialect.
   - Escape using `\`, e.g. `\*` is a literal `*`. This works for any of the following characters: `\.+*?()|[]{}^$`.
 
 - _Credit Card Numbers_: Any substrings that look like credit card numbers.


### PR DESCRIPTION
## DESCRIBE YOUR PR

`regex101` supports Rust now, also Rust Regex support is now generally much more common and is exactly what we use internally.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
