### PR TITLE
docs(cli): Remove Proguard release association mention

### DIFF
--- a/docs/cli/dif.mdx
+++ b/docs/cli/dif.mdx
@@ -226,24 +226,6 @@ sentry-cli upload-proguard \
     app/build/outputs/mapping/{BuildVariant}/mapping.txt
 ```
 
-Additionally, you can associate the ProGuard mapping file to a specific release:
-
-<Alert>
-
-This step is not required for deobfuscation to work but can help you identify which release a mapping file belongs to when multiple files exist for the same app.
-
-</Alert>
-
-```bash {5-7}
-# Associate the mapping file to the release my.app.id@1.0.0+1
-sentry-cli upload-proguard \
-    --uuid A_VALID_UUID \
-    app/build/outputs/mapping/{BuildVariant}/mapping.txt \
-    --app-id my.app.id \
-    --version 1.0.0 \
-    --version-code 1
-```
-
 After the upload, Sentry deobfuscates future events.
 To make sure that it worked, you can check _Project Settings > ProGuard_ and see if the upload mapping files are listed.
 


### PR DESCRIPTION
We are removing the association between ProGuard files and releases. The association is already no longer visible in Sentry, and the CLI arguments to specify an associated release will be deprecated in the next version of Sentry CLI.

Resolves #15229
Resolves DOCS-2317
