### PR TITLE
chore(ai): add information about gen_ai.request.messages size limits

### DIFF
--- a/develop-docs/sdk/expected-features/data-handling.mdx
+++ b/develop-docs/sdk/expected-features/data-handling.mdx
@@ -121,6 +121,7 @@ Fields in the event payload that allow user-specified or dynamic values are rest
 - Messages are limited to 8192 characters.
 - HTTP data (the body) is limited to 8kB. Always trim HTTP data before attaching it to the event.
 - Stack traces are limited to 50 frames. If more are sent, data will be removed from the middle of the stack.
+- Input messages in AI integrations recorded in the span attribute `gen_ai.request.messages` are limited to 20kB per span. Messages are trimmed and truncated if they exceed the limit, retaining the most recent messages.
 
 Additionally, size limits apply to all store requests for the total size of the request, event payload, and attachments. Sentry rejects all requests exceeding these limits. Please refer the following resources for the exact size limits:
 

--- a/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
+++ b/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
@@ -191,3 +191,7 @@ Some attributes are common to all AI Agents spans:
 | `"openai"`          | OpenAI                            |
 | `"perplexity"`      | Perplexity                        |
 | `"xai"`             | xAI                               |
+
+## Size Limits
+In addition to the [general size limits](/concepts/data-management/size-limits/) for events, spans, and attachments, there are specific size limits for AI integrations:
+- Input messages in AI integrations recorded in the span attribute `gen_ai.request.messages` are limited to 20kB per span. Messages are trimmed and truncated if they exceed the limit, retaining the most recent messages.


### PR DESCRIPTION
- Add product and develop docs about size limits for `gen_ai.request.messages`

Closes TET-1295