### PR TITLE
feat(integrations): Update Sentry Agent for Linear beta callout

### DIFF
--- a/docs/organization/integrations/issue-tracking/sentry-linear-agent/index.mdx
+++ b/docs/organization/integrations/issue-tracking/sentry-linear-agent/index.mdx
@@ -6,7 +6,7 @@ description: "Learn more about the Sentry Agent for Linear, which allows users t
 
 <Alert title="Beta">
 
-**Sentry Agent for Linear** is in its beta phase. It is currently only available for US based Sentry.io organizations. Changes to the UX and the agent functionality should be expected.
+**Sentry Agent for Linear** is in its beta phase. It is currently only available for US-based Sentry.io organizations. Changes to the UX and the agent functionality should be expected.
 
 </Alert>
 


### PR DESCRIPTION
## Summary

- Updated the beta callout for Sentry Agent for Linear to include US availability information
- Added clarification that the agent is currently only available for US based Sentry.io organizations
- Minor wording adjustment for consistency ("the agent functionality" instead of "functionality")