### PR TITLE
ref(nextjs): Move manual instrumentation examples for ai into Edge section

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
@@ -77,30 +77,6 @@ const response = await client.messages.create({
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.nextjs']}>
-
-This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument the Anthropic client:
-
-```javascript
-import * as Sentry from "@sentry/nextjs";
-import Anthropic from "@anthropic-ai/sdk";
-
-const anthropic = new Anthropic();
-const client = Sentry.instrumentAnthropicAiClient(anthropic, {
-  recordInputs: true,
-  recordOutputs: true,
-});
-
-// Use the wrapped client instead of the original anthropic instance
-const response = await client.messages.create({
-  model: "claude-3-5-sonnet-20241022",
-  max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
-
-</PlatformSection>
-
 ## Options
 
 ### `recordInputs`
@@ -144,6 +120,32 @@ By default this integration adds tracing support to Anthropic API method calls i
 - `beta.messages.create()` - Beta messages API
 
 The integration will automatically detect streaming vs non-streaming requests and handle them appropriately.
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+## Edge runtime
+
+This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument the Anthropic client:
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+import Anthropic from "@anthropic-ai/sdk";
+
+const anthropic = new Anthropic();
+const client = Sentry.instrumentAnthropicAiClient(anthropic, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+// Use the wrapped client instead of the original anthropic instance
+const response = await client.messages.create({
+  model: "claude-3-5-sonnet-20241022",
+  max_tokens: 1024,
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+</PlatformSection>
 
 ## Supported Versions
 

--- a/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
@@ -73,26 +73,6 @@ const result = await client.models.generateContent("Hello!");
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.nextjs']}>
-
-This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument the Google Gen AI client:
-
-```javascript
-import * as Sentry from "@sentry/nextjs";
-import { GoogleGenAI } from "@google/genai";
-
-const genAI = new GoogleGenAI(process.env.API_KEY);
-const client = Sentry.instrumentGoogleGenAIClient(genAI, {
-  recordInputs: true,
-  recordOutputs: true,
-});
-
-// Use the wrapped client instead of the original genAI instance
-const result = await client.models.generateContent("Hello!");
-```
-
-</PlatformSection>
-
 ## Options
 
 ### `recordInputs`
@@ -134,6 +114,28 @@ By default this integration adds tracing support to Google Gen AI SDK method cal
 - `sendMessageStream()` - Stream messages in chat sessions.
 
 The integration will automatically detect streaming vs non-streaming requests and handle them appropriately.
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+## Edge runtime
+
+This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument the Google Gen AI client:
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+import { GoogleGenAI } from "@google/genai";
+
+const genAI = new GoogleGenAI(process.env.API_KEY);
+const client = Sentry.instrumentGoogleGenAIClient(genAI, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+// Use the wrapped client instead of the original genAI instance
+const result = await client.models.generateContent("Hello!");
+```
+
+</PlatformSection>
 
 ## Supported Versions
 

--- a/docs/platforms/javascript/common/configuration/integrations/openai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openai.mdx
@@ -76,29 +76,6 @@ const response = await client.chat.completions.create({
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.nextjs']}>
-
-This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument the OpenAI client:
-
-```javascript
-import * as Sentry from "@sentry/nextjs";
-import OpenAI from "openai";
-
-const openai = new OpenAI();
-const client = Sentry.instrumentOpenAiClient(openai, {
-  recordInputs: true,
-  recordOutputs: true,
-});
-
-// Use the wrapped client instead of the original openai instance
-const response = await client.chat.completions.create({
-  model: "gpt-4o",
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
-
-</PlatformSection>
-
 ## Options
 
 ### `recordInputs`
@@ -137,6 +114,31 @@ By default this integration adds tracing support to OpenAI API method calls incl
 - `responses.create()` - Response API requests
 
 The integration will automatically detect streaming vs non-streaming requests and handle them appropriately.
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+## Edge runtime
+
+This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument the OpenAI client:
+
+```javascript
+import * as Sentry from "@sentry/nextjs";
+import OpenAI from "openai";
+
+const openai = new OpenAI();
+const client = Sentry.instrumentOpenAiClient(openai, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+// Use the wrapped client instead of the original openai instance
+const response = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+</PlatformSection>
 
 ## Supported Versions
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

These snippets are only needed when running the Edge runtime but this is only called out in the paragraph above which on first glance is easy to miss leading to people double instrumenting clients and potentially running into undefined behavior.

This PR restructures these sections.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+
