### PR TITLE
docs(otlp): change status to open beta

### DIFF
--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -9,7 +9,7 @@ Sentry can ingest [OpenTelemetry](https://opentelemetry.io) traces and logs dire
 
 ## OpenTelemetry Traces
 
-<Include name="feature-available-alpha-tracing.mdx" />
+<Include name="feature-available-open-beta-tracing.mdx" />
 
 If you have an existing OpenTelemetry trace instrumentation, you can configure your OpenTelemetry exporter to send traces to Sentry directly. Sentry's OTLP ingestion traces endpoint is currently in development, and has a few known limitations:
 
@@ -69,7 +69,7 @@ sdk.start();
 
 ## OpenTelemetry Logs
 
-<Include name="feature-available-ea-logs.mdx" />
+<Include name="feature-available-open-beta-logs.mdx" />
 
 If you have an existing OpenTelemetry log instrumentation, you can configure your OpenTelemetry exporter to send logs to Sentry directly. Sentry's OTLP ingestion logs endpoint has the following known limitations:
 

--- a/includes/feature-available-alpha-tracing.mdx
+++ b/includes/feature-available-alpha-tracing.mdx
@@ -1,5 +1,0 @@
-<Alert>
-
-This feature is in alpha and is only available if your organization is participating in its limited release. Please reach out to [feedback-tracing@sentry.io](mailto:feedback-tracing@sentry.io) if you want access. Features in alpha are still in-progress and may have bugs. We recognize the irony.
-
-</Alert>

--- a/includes/feature-available-ea-logs.mdx
+++ b/includes/feature-available-ea-logs.mdx
@@ -1,5 +1,0 @@
-<Alert>
-
-This feature is available only if you're in the <a href="/organization/early-adopter-features/" target="_blank">Early Adopter program</a>. Please reach out to [feedback-logging@sentry.io](mailto:feedback-logging@sentry.io) if have feedback or questions. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-</Alert>

--- a/includes/feature-available-open-beta-logs.mdx
+++ b/includes/feature-available-open-beta-logs.mdx
@@ -1,0 +1,5 @@
+<Alert>
+
+This feature is currently in open beta. Please reach out to [feedback-logging@sentry.io](mailto:feedback-logging@sentry.io) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+
+</Alert>

--- a/includes/feature-available-open-beta-tracing.mdx
+++ b/includes/feature-available-open-beta-tracing.mdx
@@ -1,0 +1,5 @@
+<Alert>
+
+This feature is currently in open beta. Please reach out to [feedback-tracing@sentry.io](mailto:feedback-tracing@sentry.io) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+
+</Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

The OTLP traces and logs endpoints are entering open beta today. Update the OTLP docs page to indicate their new status.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Oct 22, 2025
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
