### PR TITLE
fix: Remove OTLP logs from EA list

### DIFF
--- a/docs/organization/early-adopter-features/index.mdx
+++ b/docs/organization/early-adopter-features/index.mdx
@@ -22,4 +22,3 @@ Limitations:
 - [Span Summary](/product/insights/overview/transaction-summary/#span-summary)
 - [Dynamic Alerts](/product/alerts/create-alerts/metric-alert-config/#dynamic-alerts)
 - [New Trace Explorer With Span Metrics](/product/explore/new-trace-explorer/)
-- [OpenTelemetry (OTLP) Logs Endpoint](/concepts/otlp/#opentelemetry-logs)


### PR DESCRIPTION
This was moved into open beta with https://github.com/getsentry/sentry-docs/pull/15285, we can remove it now.