### PR TITLE
docs(godot): Update before-send examples

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -246,9 +246,11 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 	if event.environment.contains("editor"):
 		# Discard event if running from the editor.
 		return null
-	if event.message.contains("Bruno"):
+	var error_message: String = event.get_exception_value(0)
+	if error_message.contains("Bruno"):
 		# Remove sensitive information from the event.
-		event.message = event.message.replace("Bruno", "REDACTED")
+		var redacted_message := error_message.replace("Bruno", "REDACTED")
+		event.set_exception_value(0, redacted_message)
 	return event
 ```
 

--- a/platform-includes/configuration/before-send/godot.mdx
+++ b/platform-includes/configuration/before-send/godot.mdx
@@ -10,11 +10,13 @@ func _initialize() -> void:
 	)
 
 func _before_send(event: SentryEvent) -> SentryEvent:
-	if event.environment == "debug":
-		# Discard event if running in a debug build.
+	if event.environment.contains("editor"):
+		# Discard event if running from the editor.
 		return null
-	if event.message.contains("Bruno"):
+	var error_message: String = event.get_exception_value(0)
+	if error_message.contains("Bruno"):
 		# Remove sensitive information from the event.
-		event.message = event.message.replace("Bruno", "REDACTED")
+		var redacted_message := error_message.replace("Bruno", "REDACTED")
+		event.set_exception_value(0, redacted_message)
 	return event
 ```

--- a/platform-includes/configuration/config-intro/godot.mdx
+++ b/platform-includes/configuration/config-intro/godot.mdx
@@ -35,12 +35,14 @@ func _initialize() -> void:
 	)
 
 func _before_send(event: SentryEvent) -> SentryEvent:
-	if event.environment == "debug":
-		# Discard event if running in a debug build.
+	if event.environment.contains("editor"):
+		# Discard event if running from the editor.
 		return null
-	if event.message.contains("Bruno"):
-		# Scrub sensitive information from the event.
-		event.message = event.message.replace("Bruno", "REDACTED")
+	var error_message: String = event.get_exception_value(0)
+	if error_message.contains("Bruno"):
+		# Remove sensitive information from the event.
+		var redacted_message := error_message.replace("Bruno", "REDACTED")
+		event.set_exception_value(0, redacted_message)
 	return event
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

In Godot SDK, update the `before_send` examples to use exception value instead of message for filtering error events.  

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
