### PR TITLE
feat(drains): Add vercel log drain docs

### DIFF
--- a/docs/product/drains/index.mdx
+++ b/docs/product/drains/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Drains and Forwarders
+title: Log and Trace Drains
 sidebar_order: 75
 description: Learn how to set up trace and log drains and forwarders to send data to Sentry.
 ---

--- a/docs/product/drains/integration/vercel.mdx
+++ b/docs/product/drains/integration/vercel.mdx
@@ -4,8 +4,6 @@ sidebar_order: 75
 description: Learn how to set up Vercel drains to send forward logs and traces data to Sentry.
 ---
 
-<Include name="feature-available-closed-alpha.mdx" />
-
 To set up a Drain in Vercel you'll need to create a new Drain in the Vercel settings. For more information on Vercel Drains, please see the [Vercel drain documentation](https://vercel.com/docs/drains).
 
 1. From the Vercel dashboard, go to **Team Settings > Drains** and click **Add Drain**.
@@ -15,6 +13,12 @@ To set up a Drain in Vercel you'll need to create a new Drain in the Vercel sett
 - [Traces](#trace-drains)
 
 ## Log Drains
+
+<Alert>
+
+Vercel Log Drains support is currently in closed alpha. Please reach out to [feedback-logging@sentry.io](mailto:feedback-logging@sentry.io) if you have feedback or questions. Features in alpha are still in-progress and may have bugs. We recognize the irony.
+
+</Alert>
 
 After selecting the Logs data type, you'll need to configure the drain to send data to Sentry.
 

--- a/includes/feature-available-closed-alpha.mdx
+++ b/includes/feature-available-closed-alpha.mdx
@@ -1,5 +1,0 @@
-<Alert>
-
-This feature is in closed alpha. Please reach out to [feedback-logging@sentry.io](mailto:feedback-logging@sentry.io) if you have feedback or questions. Features in alpha are still in-progress and may have bugs. We recognize the irony.
-
-</Alert>


### PR DESCRIPTION
This PR adds a new product page for drains, and adds a page for vercel log drains as well. Vercel drains are marked as closed alpha for now, but will be promoted to EA this week.