### PR TITLE
godot(docs): Document App Hang options

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -122,6 +122,24 @@ This option is turned off by default.
 
 </SdkOption>
 
+<SdkOption name="app_hang_tracking" type="bool" defaultValue="false">
+
+If `true`, enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in `app_hang_timeout_sec`. This helps identify performance issues where the application becomes frozen or unresponsive.
+
+<Alert title="Note">
+
+This feature is only supported on Android, iOS, and macOS platforms.
+
+</Alert>
+
+</SdkOption>
+
+<SdkOption name="app_hang_timeout_sec" type="float" defaultValue="5.0">
+
+Specifies the timeout duration in seconds after which the application is considered to have hanged. When `app_hang_tracking` is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
+
+</SdkOption>
+
 ## GUI-only Options
 
 These options are only available in the **Project Settings** window.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document App Hang tracking options in the Godot SDK added in:
- https://github.com/getsentry/sentry-godot/pull/429

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
