### PR TITLE
fix(python): Update note on default behavior in StrawberryIntegration

### DIFF
--- a/docs/platforms/python/integrations/strawberry/index.mdx
+++ b/docs/platforms/python/integrations/strawberry/index.mdx
@@ -123,8 +123,7 @@ Strawberry supports both synchronous and asynchronous execution of GraphQL
 queries. If you have at least one async resolver, you should initialize
 `StrawberryIntegration` with `async_execution=True`, otherwise set it to `False`.
 
-The SDK will make a best-effort guess if `async_execution` is not provided,
-based on installed web frameworks.
+By default, the SDK will use the synchronous version of the integration.
 
 ```python
 sentry_sdk.init(


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
We changed the default behavior of the integration in the latest Python SDK release.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: ASAP as we just released this
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
