### PR TITLE
fix(agents): update insights url

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/ai-agents-module.mdx
@@ -64,7 +64,7 @@ The JavaScript SDK supports automatic instrumentation for some AI libraries. We 
 
 ## Manual Instrumentation
 
-If you're using a library that Sentry does not automatically instrument, you can manually instrument your code to capture spans. For your AI agents data to show up in the Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/agents/), two spans must be created and have well-defined names and data attributes. See below.
+If you're using a library that Sentry does not automatically instrument, you can manually instrument your code to capture spans. For your AI agents data to show up in the Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/agents/), two spans must be created and have well-defined names and data attributes. See below.
 
 ## Spans
 

--- a/docs/platforms/python/integrations/openai-agents/index.mdx
+++ b/docs/platforms/python/integrations/openai-agents/index.mdx
@@ -12,7 +12,7 @@ The support for **OpenAI Agents SDK** is in its beta phase. Please test locally 
 This integration connects Sentry with the [OpenAI Python SDK](https://openai.github.io/openai-agents-python/).
 The integration has been confirmed to work with OpenAI Agents version 0.0.19.
 
-Once you've installed this SDK, you can use [Sentry AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/agents/), a Sentry dashboard that helps you understand what's going on with your AI agents.
+Once you've installed this SDK, you can use [Sentry AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/agents/), a Sentry dashboard that helps you understand what's going on with your AI agents.
 
 Sentry AI Agents monitoring will automatically collect information about agents, tools, prompts, tokens, and models.
 

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -22,7 +22,7 @@ The Python SDK supports automatic instrumentation for some AI libraries. We reco
 
 ## Manual Instrumentation
 
-For your AI agents data to show up in the Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/agents/), two spans must be created and have well-defined names and data attributes. See below.
+For your AI agents data to show up in the Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/agents/), two spans must be created and have well-defined names and data attributes. See below.
 
 The [@sentry_sdk.trace()](/platforms/python/tracing/instrumentation/custom-instrumentation/#span-templates) decorator can also be used to create these spans.
 

--- a/docs/product/insights/ai/agents/dashboard.mdx
+++ b/docs/product/insights/ai/agents/dashboard.mdx
@@ -4,7 +4,7 @@ sidebar_order: 10
 description: "Learn how to use Sentry's AI Agents Dashboard."
 ---
 
-Once you've [configured the Sentry SDK](/product/insights/ai/agents/getting-started/) for your AI agent project, you'll start receiving data in the Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/agents/) dashboard.
+Once you've [configured the Sentry SDK](/product/insights/ai/agents/getting-started/) for your AI agent project, you'll start receiving data in the Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/agents/) dashboard.
 
 The main dashboard provides a comprehensive view of all your AI agent activities, performance metrics, and recent executions.
 


### PR DESCRIPTION
- AI Insights is available at `/insights/ai/agents/`, not `/insights/agents/` ->  fix this