### PR TITLE
feat(python): Document thread pool propagation improvement

### DIFF
--- a/docs/platforms/python/integrations/default-integrations.mdx
+++ b/docs/platforms/python/integrations/default-integrations.mdx
@@ -86,7 +86,9 @@ Reports crashing threads.
 
 This integration also accepts an option `propagate_scope`, which influences the way data is transferred between threads. If set to `True` (default), the current scope will be shared between threads and scope data (such as tags) will be transferred from the parent thread to the child thread.
 
-Next are two code samples that demonstrate what boilerplate you would have to write without `propagate_scope`. This boilerplate is still sometimes necessary if you want to propagate context data into a thread pool, for example.
+Context data is automatically propagated in `concurrent.futures` thread pools beginning with version 2.41.0, when `propagate_scope` is `True`.
+
+Next are two code samples that demonstrate what boilerplate you would have to write without `propagate_scope`. This boilerplate is necessary if you want to propagate context data into a thread pool before version 2.41.0, for example.
 
 ### Manual propagation
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The Python SDK automatically handles scope propagation where users previously had to write some code.

Closes https://github.com/getsentry/sentry-python/issues/4672

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
