### PR TITLE
docs(javascript): Change default value for `maxValueLength`

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -136,7 +136,7 @@ Sentry.init({
 
 </SdkOption>
 
-<SdkOption name="maxValueLength" type='number' defaultValue='250'>
+<SdkOption name="maxValueLength" type='number'>
 
 Maximum number of characters every string property on events sent to Sentry can have before it will be truncated.
 

--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -48,7 +48,7 @@ For more details, see the [full documentation on Event Payload](https://develop.
 
 <Expandable permalink title="Max JSON payload size">
 
-`maxValueLength` has a default value of 250, but you can adjust this value according to your needs if your messages are longer. Please note that not every single value is affected by this option.
+By default, `maxValueLength` is undefined and nothing is truncated, but you can change this value according to your needs if your messages are longer (for example, to `250`). Please note that not every single value is affected by this option.
 
 </Expandable>
 
@@ -670,10 +670,10 @@ shamefully-hoist=true
     ```
 
   </Expandable>
-  
+
   <Expandable permalink title="Client Instrumentation Hook - Slow execution detected">
     Seeing this warning in your dev build might be misleading due to Next.js dev server internals.
-    
+
     In case you are using Session Replay and experience performance issues with the client instrumentation hook, you can try lazy-loading session replay as described [here](/platforms/javascript/guides/nextjs/session-replay/#lazy-loading-replay).
 
     If you want to init the SDK itself at a later point, this will result in tracing data loosing accuracy and errors could happen before the SDK is initialized. This should be a tradeoff you make based on your use case, although we recommend initializing the SDK as early as possible.


### PR DESCRIPTION

## DESCRIBE YOUR PR

PR https://github.com/getsentry/sentry-javascript/pull/18043 removed the default value of `maxValueLength`

part of https://github.com/getsentry/sentry-javascript/issues/17389
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


