### PR TITLE
Fix `useNavigationContainerRef` code snippet selection range in expo-router.mdx

### DIFF
--- a/docs/platforms/react-native/tracing/instrumentation/expo-router.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/expo-router.mdx
@@ -10,7 +10,7 @@ Sentry's React Native SDK package ships with instrumentation for Expo Router. Th
 
 The code snippet below shows how to initialize the instrumentation.
 
-```javascript {6-8, 15-16, 20-25} {filename: app/_layout.tsx}
+```javascript {6-8, 15-16, 22-27} {filename: app/_layout.tsx}
 import React from 'react';
 import { Slot, useNavigationContainerRef } from 'expo-router';
 import { isRunningInExpoGo } from 'expo';


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

The copy paste selection range was off by 2 lines.

<img width="1211" height="227" alt="Screenshot 2025-10-30 at 15 08 53" src="https://github.com/user-attachments/assets/1e12f817-6f55-42a1-b111-aaa634f26f3e" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
