### PR TITLE
feat(develop): Add session id to log attributes

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -278,6 +278,7 @@ By default the SDK should attach the following attributes to a log:
 3. `sentry.sdk.name`: The name of the SDK that sent the log
 4. `sentry.sdk.version`: The version of the SDK that sent the log
 5. `sentry.replay_id`: The replay id of the replay that was active when the log was collected. This should not be set if there was no active replay.
+6. `sentry.session_id`: The session ID of the active [session](/sdk/telemetry/sessions/) when the SDK collected the log. This should not be set if there was no active session.
 
 ```json
 {
@@ -285,7 +286,8 @@ By default the SDK should attach the following attributes to a log:
   "sentry.release": "1.0.0",
   "sentry.sdk.name": "sentry.javascript.node",
   "sentry.sdk.version": "9.11.0",
-  "sentry.replay_id": "36b75d9fa11f45459412a96c41bdf691"
+  "sentry.replay_id": "36b75d9fa11f45459412a96c41bdf691",
+  "sentry.session_id": "7c7b6585-f901-4351-bf8d-02711b721929"
 }
 ```
 


### PR DESCRIPTION

## DESCRIBE YOUR PR

Add the session ID to the default attributes of logs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
