### PR TITLE
docs: Add Makeplane integration documentation

### DIFF
--- a/docs/organization/integrations/issue-tracking/index.mdx
+++ b/docs/organization/integrations/issue-tracking/index.mdx
@@ -18,7 +18,7 @@ description: "Learn more about Sentry's issue tracking integrations."
 - [Kitemaker](/organization/integrations/issue-tracking/kitemaker/)
 - [Linear](/organization/integrations/issue-tracking/linear/)
 - [Linear (Sentry Agent)](/organization/integrations/issue-tracking/sentry-linear-agent/)
-- [Makeplane](/organization/integrations/issue-tracking/makeplane/)
+- [Plane](/organization/integrations/issue-tracking/makeplane/)
 - [Shortcut](/organization/integrations/issue-tracking/shortcut/)
 - [Sourcegraph](/organization/integrations/issue-tracking/sourcegraph/)
 - [StarSling](/organization/integrations/issue-tracking/starsling/) 

--- a/docs/organization/integrations/issue-tracking/makeplane/index.mdx
+++ b/docs/organization/integrations/issue-tracking/makeplane/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: Makeplane
+title: Plane
 sidebar_order: 1
 
-description: "Learn about Sentry's Makeplane integration."
+description: "Learn about Sentry's Plane integration."
 ---
 
 The Makeplane (Plane) integration enables automatic creation of Plane issues from Sentry alerts, supports linking Sentry issues to Plane issues, and keeps their status in sync for streamlined error tracking and resolution. This integration is maintained and supported by Plane; for more details reach out to support@plane.so.
@@ -17,4 +17,4 @@ Sentry owner, manager, or admin permissions are required to install this integra
 
 1. Navigate to **Settings > Integrations > Makeplane**
 
-2. Follow the full [Makeplane installation instructions](https://docs.plane.so/integrations/sentry).
+2. Follow the full [Plane installation instructions](https://docs.plane.so/integrations/sentry).


### PR DESCRIPTION
This PR adds documentation for the Makeplane integration to the issue tracking integrations section.