### PR TITLE
Correct `markBackgroundSpan` option in JS browser tracing

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -86,7 +86,7 @@ You will need to configure your web server [CORS](https://developer.mozilla.org/
 <SdkOption name="shouldCreateSpanForRequest" type='(url: string) => boolean'>
 
 This function can be used to filter out unwanted spans such as XHRs running
-health checks or something similar. 
+health checks or something similar.
 
 <PlatformContent includePath="performance/filter-span-example" />
 
@@ -138,7 +138,7 @@ This option determines whether the <PlatformLink to="/apis/#reportPageLoaded">`S
 
 </SdkOption>
 
-<SdkOption name="markBackgroundSpans" type='boolean' defaultValue='true'>
+<SdkOption name="markBackgroundSpan" type='boolean' defaultValue='true'>
 
 This option flags pageload/navigation spans when tabs are moved to the background with "cancelled". Because browser background tab timing is not suited for precise measurements of operations and can affect your statistics in nondeterministic ways, we recommend that this option be enabled.
 


### PR DESCRIPTION
Corrected the `markBackgroundSpan` option of JS browser tracing integration docs.

Implementation reference: [Link](https://github.com/getsentry/sentry-javascript/blob/3deeecd8d5e5d3b4be68c7e22982e2d0d26a1a62/packages/browser/src/tracing/browserTracingIntegration.ts#L109)