### PR TITLE
fix: Update GitHub app URL from apps/sentry-io to /apps/sentry

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -56,7 +56,7 @@ Sentry owner, manager, or admin permissions, and GitHub owner permissions are re
 
 The GitHub integration is available for all projects under your Sentry organization. You can connect multiple GitHub organizations to one Sentry organization. Connecting a GitHub organisation to multiple Sentry organisations is supported on Sentry organisations on a Business or Enterprise plans (not supported for GitHub Enterprise Server).
 
-While you can install the GitHub integration from [GitHub](https://github.com/apps/sentry-io), we recommend installing it from Sentry for a more streamlined process.
+While you can install the GitHub integration from [GitHub](https://github.com/apps/sentry), we recommend installing it from Sentry for a more streamlined process.
 
 ### GitHub Permissions
 

--- a/docs/product/test-analytics/index.mdx
+++ b/docs/product/test-analytics/index.mdx
@@ -22,7 +22,7 @@ Sentry Test Analytics provides actionable insights into your CI test runs, helpi
 
 ![Test Analytics Dashboard](./img/TA-dash.png)
 
-To use Sentry Test Analytics, you’ll need to install the [Sentry app](https://github.com/apps/sentry-io) on your GitHub organization or specific repositories. Once installed, choose your JUnit XML Report framework and [set your permissions](#permissions-and-repository-tokens) using a repository secret.
+To use Sentry Test Analytics, you'll need to install the [Sentry app](https://github.com/apps/sentry) on your GitHub organization or specific repositories. Once installed, choose your JUnit XML Report framework and [set your permissions](#permissions-and-repository-tokens) using a repository secret.
 
 <Alert>
 **The only test result file format we support is JUnit XML**. Most test frameworks support outputting test results in this format, with some configuration.


### PR DESCRIPTION
This PR updates all instances of the GitHub app URL from `apps/sentry-io` to `/apps/sentry` to reflect the current correct URL.

## Changes
- Updated URL in `docs/product/test-analytics/index.mdx`
- Updated URL in `docs/organization/integrations/source-code-mgmt/github/index.mdx`

The old URL (`https://github.com/apps/sentry-io`) has been replaced with the correct URL (`https://github.com/apps/sentry`) in both locations.