### PR TITLE
fix(python): `mcp.transport` correct values

### DIFF
--- a/docs/platforms/python/integrations/mcp/index.mdx
+++ b/docs/platforms/python/integrations/mcp/index.mdx
@@ -181,7 +181,7 @@ For each operation, the following span data attributes are captured:
 
 **General (all operations):**
 - `mcp.method.name`: The MCP method name (e.g., `tools/call`, `prompts/get`, `resources/read`)
-- `mcp.transport`: Transport type (`http` for streamable HTTP, `sse` for server sent events, `stdio`)
+- `mcp.transport`: Transport type (`http` for Streamable HTTP, `sse` for Server-Sent Events or `stdio`)
 - `mcp.request_id`: Request identifier (when available)
 - `mcp.session_id`: Session identifier (when available)
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Correcting emitted values for `mcp.transport` attributes.

Contributes to https://linear.app/getsentry/issue/TET-1354/mcp-transport-vs-network-transport

Addressing changes from here https://github.com/getsentry/sentry-python/pull/5063


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
