### PR TITLE
ref(develop/spans): Replace `is_remote` with `is_segment` in Span Protocol

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -148,7 +148,7 @@ The envelope item payload must contain an `items` array with span one and up to 
 | `parent_span_id` | string | No | 16-character hexadecimal string (a valid uuid4 without dashes) |
 | `name` | string | Yes | A low cardinality description of what the span represents (e.g., "GET /users", "database.query") |
 | `status` | string | Yes | Status of the span operation. Either `"ok"` or `"error"` |
-| `is_sgement` | boolean | Yes | Whether the span is a segment span |
+| `is_segment` | boolean | Yes | Whether the span is a segment span |
 | `kind` | string | Yes | The kind of span. Values: `"server"`, `"client"`, `"producer"`, `"consumer"`, `"internal"` |
 | `start_timestamp` | number | Yes | Unix timestamp (with fractional microseconds) when the span was started |
 | `end_timestamp` | number | Yes | Unix timestamp (with fractional microseconds) when the span was ended |


### PR DESCRIPTION
We decided to remove the `is_remote` field on the Span v2 items in favour of the new `is_segment` field.