### PR TITLE
docs(size-analysis): Align code boxes and remove vcsInfo links

### DIFF
--- a/includes/size-analysis/upload-cli-android.mdx
+++ b/includes/size-analysis/upload-cli-android.mdx
@@ -6,13 +6,13 @@
 
 4. Invoke the following CLI command to trigger the upload:
 
-```bash
-sentry-cli build upload app.aab \
-  --org your-org \
-  --project your-project \
-  --build-configuration Release
-```
+   ```bash
+   sentry-cli build upload app.aab \
+     --org your-org \
+     --project your-project \
+     --build-configuration Release
+   ```
 
 5. After an upload has successfully processed, confirm the metadata is correct in the Sentry UI
 
-![Upload metadata =400x](./images/android-metadata.png)
+   ![Upload metadata =400x](./images/android-metadata.png)

--- a/includes/size-analysis/upload-cli-ios.mdx
+++ b/includes/size-analysis/upload-cli-ios.mdx
@@ -6,13 +6,13 @@
 
 4. Invoke the following CLI command to trigger the upload:
 
-```bash
-sentry-cli build upload app.xcarchive \
-  --org your-org \
-  --project your-project \
-  --build-configuration Release
-```
+   ```bash
+   sentry-cli build upload app.xcarchive \
+     --org your-org \
+     --project your-project \
+     --build-configuration Release
+   ```
 
 5. After an upload has successfully processed, confirm the metadata is correct in the Sentry UI
 
-![Upload metadata =400x](./images/ios-metadata.png)
+   ![Upload metadata =400x](./images/ios-metadata.png)

--- a/includes/size-analysis/upload-fastlane.mdx
+++ b/includes/size-analysis/upload-fastlane.mdx
@@ -26,7 +26,7 @@ The Fastlane plugin can be used to upload XCArchive or IPA builds to Sentry. On 
 
 4. After an upload has successfully processed, confirm the metadata is correct in the Sentry UI
 
-![Upload metadata =400x](./images/ios-metadata.png)
+   ![Upload metadata =400x](./images/ios-metadata.png)
 
 The Fastlane plugin automatically detects all build metadata. If needed, the metadata values can be overridden by passing parameters to `sentry_upload_build`:
 

--- a/includes/size-analysis/upload-gradle.mdx
+++ b/includes/size-analysis/upload-gradle.mdx
@@ -1,14 +1,14 @@
-The Gradle plugin automatically detects build metadata from your git repository. On GitHub Actions, all metadata is automatically detected. On other CI systems, you may need to manually set some values using the [`vcsInfo`](https://developer.android.com/reference/tools/gradle-api/8.8/com/android/build/api/dsl/VcsInfo) extension.
+The Gradle plugin automatically detects build metadata from your git repository. On GitHub Actions, all metadata is automatically detected. On other CI systems, you may need to manually set some values using the `vcsInfo` extension.
 
 1. Configure the [Sentry Android Gradle plugin](/platforms/android/configuration/gradle/) with at least version `6.0.0-beta1`
 
 2. Set the auth token as an environment variable to be used when running your release build.
 
-<OrgAuthTokenNote />
+   <OrgAuthTokenNote />
 
-```bash
-export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
-```
+   ```bash
+   export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+   ```
 
 3. Enable uploading for size analysis for CI builds.
 
@@ -40,11 +40,11 @@ export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 
 5. After an upload has successfully processed, confirm the metadata is correct in the Sentry UI
 
-![Upload metadata =400x](./images/android-metadata.png)
+   ![Upload metadata =400x](./images/android-metadata.png)
 
 ### Overriding Metadata
 
-The Gradle plugin automatically detects build metadata from your git repository. On GitHub Actions, all metadata is automatically detected. On other CI systems, you may need to manually set some values using the (`vcsInfo`)[https://developer.android.com/reference/tools/gradle-api/8.8/com/android/build/api/dsl/VcsInfo] extension.
+The Gradle plugin automatically detects build metadata from your git repository. On GitHub Actions, all metadata is automatically detected. On other CI systems, you may need to manually set some values using the `vcsInfo` extension.
 
 Configure overrides in your Gradle build configuration:
 


### PR DESCRIPTION
## Summary

- Align code boxes and images in numbered lists across size analysis upload documentation
- Remove external links to Android developer documentation for `vcsInfo` extension
- Improves visual consistency and readability of documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)