### PR TITLE
fix: typos in TanStack Start docs

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -105,6 +105,8 @@ export const getRouter = () => {
 +     // ___PRODUCT_OPTION_END___ session-replay
 +   });
   }
+  
+  return router;
 }
 ```
 
@@ -256,7 +258,7 @@ To verify that Sentry captures errors and creates issues in your Sentry project,
 <OnboardingOption optionId="performance">
 ### Tracing
 
-To test tracing, create a new file like `src/routes/api/sentry-example.ts` to create a test route `/sentry-example`:
+To test tracing, create a new file like `src/routes/api/sentry-example.ts` to create a test route `/api/sentry-example`:
 
 ```typescript {filename:src/routes/api/sentry-example.ts}
 import { createFileRoute } from "@tanstack/react-router";


### PR DESCRIPTION
add missing return and fix test route name
