### PR TITLE
feat(span-first): Add common `sentry.segment.id` span attribute

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -175,6 +175,7 @@ Empty attributes must be emitted.
 | `sentry.release` | string | The release version of the application |
 | `sentry.environment` | string | The environment name (e.g., "production", "staging", "development") |
 | `sentry.segment.name` | string | The segment name (e.g., "GET /users") |
+| `sentry.segment.id` | string | The segment span id |
 | `os.name` | string | The operating system name (e.g., "Linux", "Windows", "macOS") |
 | `browser.name` | string | The browser name (e.g., "Chrome", "Firefox", "Safari") |
 | `user.id` | string | The user ID (gated by `sendDefaultPii`) |


### PR DESCRIPTION
Let's also send the segment span id on every span for now. 