### PR TITLE
Fix: PNG images being embedded as binary in local dev

### DIFF
--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -685,7 +685,8 @@ export async function getFileBySlug(slug: string): Promise<SlugFile> {
 
       // Set write to false to prevent esbuild from writing files automatically.
       // We'll handle writing manually to gracefully handle read-only filesystems (e.g., Lambda runtime)
-      options.write = !!process.env.CI;
+      // In local dev, we need write=true to avoid images being embedded as binary data
+      options.write = process.env.NODE_ENV === 'development' || !!process.env.CI;
 
       return options;
     },


### PR DESCRIPTION
In local development, esbuild's write option was set to false, causing PNG images to be embedded as binary data in the JavaScript output instead of being written as external files. This resulted in 'Invalid or unexpected token' errors when rendering pages with images.

Now setting write=true for both development and CI environments, while keeping it false for production Lambda runtime where the filesystem is read-only.

Fixes issues multiple developers were experiencing in local dev.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Local build is broken until this fix goes through
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
