### PR TITLE
docs(dotnet/logs): .NET APIs are now stable

### DIFF
--- a/platform-includes/logs/options/dotnet.mdx
+++ b/platform-includes/logs/options/dotnet.mdx
@@ -1,4 +1,4 @@
-#### Experimental.EnableLogs
+#### EnableLogs
 
 <PlatformSection notSupported={["dotnet.aspnetcore", "dotnet.azure-functions-worker", "dotnet.blazor-webassembly", "dotnet.extensions-logging", "dotnet.maui", "dotnet.serilog"]}>
 Set to `true` in order to enable the `SentrySdk.Logger` APIs.
@@ -12,17 +12,17 @@ Set to `true` in order to enable the logging integration via the `ILogger<TCateg
 Set to `true` in order to enable the logging integration via the `Log`/`Logger` APIs.
 </PlatformSection>
 
-#### Experimental.SetBeforeSendLog
+#### SetBeforeSendLog
 
-To filter logs, or update them before they are sent to Sentry, you can use the `Experimental.SetBeforeSendLog(Func<SentryLog, SentryLog?>)` option.
+To filter logs, or update them before they are sent to Sentry, you can use the `SetBeforeSendLog(Func<SentryLog, SentryLog?>)` option.
 
 ```csharp
 options =>
 {
     options.Dsn = "___PUBLIC_DSN___";
-    options.Experimental.EnableLogs = true;
+    options.EnableLogs = true;
     // a callback that is invoked before sending a log to Sentry
-    options.Experimental.SetBeforeSendLog(static log =>
+    options.SetBeforeSendLog(static log =>
     {
         // filter out all info logs
         if (log.Level is SentryLogLevel.Info)
@@ -44,7 +44,7 @@ options =>
 });
 ```
 
-The callback function set via `Experimental.SetBeforeSendLog(Func<SentryLog, SentryLog?>)` receives a log object, and should return the log object if you want it to be sent to Sentry, or `null` if you want to discard it.
+The callback function set via `SetBeforeSendLog(Func<SentryLog, SentryLog?>)` receives a log object, and should return the log object if you want it to be sent to Sentry, or `null` if you want to discard it.
 
 The log object of type `SentryLog` has the following members:
 - `Timestamp` Property: (`DateTimeOffset`) The timestamp of the log.

--- a/platform-includes/logs/setup/dotnet.mdx
+++ b/platform-includes/logs/setup/dotnet.mdx
@@ -1,4 +1,4 @@
-To enable logging, you need to initialize the SDK with the `Experimental.EnableLogs` option set to `true`.
+To enable logging, you need to initialize the SDK with the `EnableLogs` option set to `true`.
 
 <PlatformSection notSupported={["dotnet.aspnetcore", "dotnet.aws-lambda", "dotnet.azure-functions-worker", "dotnet.blazor-webassembly", "dotnet.extensions-logging", "dotnet.maui", "dotnet.serilog"]}>
 
@@ -7,7 +7,7 @@ SentrySdk.Init(options =>
 {
     options.Dsn = "___PUBLIC_DSN___";
     // Enable logs to be sent to Sentry
-    options.Experimental.EnableLogs = true;
+    options.EnableLogs = true;
 });
 ```
 
@@ -20,7 +20,7 @@ SentrySdk.Init(options =>
 {
     options.Dsn = "___PUBLIC_DSN___";
     // Enable logs to be sent to Sentry
-    options.Experimental.EnableLogs = true;
+    options.EnableLogs = true;
 });
 ```
 
@@ -33,7 +33,7 @@ SentrySdk.Init(options =>
 {
     options.Dsn = "___PUBLIC_DSN___";
     // Enable logs to be sent to Sentry
-    options.Experimental.EnableLogs = true;
+    options.EnableLogs = true;
 });
 ```
 
@@ -45,9 +45,7 @@ SentrySdk.Init(options =>
 {
   "Sentry": {
     "Dsn": "___PUBLIC_DSN___",
-    "Experimental": {
-      "EnableLogs": true
-    }
+    "EnableLogs": true
   }
 }
 ```
@@ -61,7 +59,7 @@ SentrySdk.Init(options =>
 {
     options.Dsn = "___PUBLIC_DSN___";
     // Enable logs to be sent to Sentry
-    options.Experimental.EnableLogs = true;
+    options.EnableLogs = true;
 });
 ```
 

--- a/platform-includes/logs/usage/dotnet.mdx
+++ b/platform-includes/logs/usage/dotnet.mdx
@@ -11,11 +11,6 @@ SentrySdk.Logger.LogInfo("A simple log message");
 SentrySdk.Logger.LogError("A {0} log message", "formatted");
 ```
 
-<Alert title="Note">
-During the experimental phase of the feature, we will provide more method overloads for convenient invocation in common scenarios.
-Additionally, we may provide method overloads that are not based on _composite format strings_, but on _interpolated strings_.
-</Alert>
-
 </PlatformSection>
 
 <PlatformSection supported={["dotnet.aspnetcore", "dotnet.azure-functions-worker", "dotnet.blazor-webassembly", "dotnet.extensions-logging", "dotnet.maui"]}>


### PR DESCRIPTION
## DESCRIBE YOUR PR
The next major version of the Sentry .NET SDK (`6.0.0`, published together/soon after the release of .NET 10.0) no longer marks Logs-related APIs as _Experimental_.

Related Change in `getsentry/sentry-dotnet`
- getsentry/sentry-dotnet#4699

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: together/soon after the .NET 10 / Sentry SDK 6.0 release
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
