### PR TITLE
docs(sourcemaps): Remove mentions of `sentry-cli sourcemaps explain`

### DIFF
--- a/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-troubleshooting/javascript.mdx
@@ -1,21 +1,4 @@
-Setting up source maps can be tricky, but it's worth it to get it right. To troubleshoot your source maps set up, you can either:
-
-1. Use our automated verification tool inside `sentry-cli`, or
-2. Follow the manual steps listed below
-
-## Use the Sentry CLI
-
-To use the automated verification process, install and configure the Sentry [Command Line Interface](/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
-
-For example, "Event ID: c2ad049f":
-
-![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)
-
-```shell
-sentry-cli sourcemaps explain c2ad049fd9e448ada7849df94575e019
-```
-
-The CLI output should give you useful information about what went wrong with your source maps setup.
+Setting up source maps can be tricky, but it's worth it to get it right. You can follow the steps below to troubleshoot your source maps set up.
 
 <PlatformSection notSupported={["javascript.electron"]}>
 

--- a/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
+++ b/platform-includes/sourcemaps/legacy-uploading-methods/javascript.mdx
@@ -267,31 +267,6 @@ Sentry.init({
 
 If you followed all of the steps above but still have issues setting up source maps using the legacy method this section will try to help troubleshoot your setup.
 
-To troubleshoot your source maps set up, you can either:
-
-1. Use our automated verification tool inside `sentry-cli`, or
-2. Follow the manual steps listed below
-
-### Use the Sentry CLI
-
-To use the automated verification process, install and configure the Sentry [Command Line Interface](/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
-
-<Alert title="Note" level="warning">
-
-The `sourcemaps explain` command requires an auth token with the following scopes: `project:admin`, `release:admin`, `event:read`, and `organization:read`. We recommend creating an [internal integration token](/organization/integrations/integration-platform/internal-integration/) over a personal token.
-
-</Alert>
-
-For example, "Event ID: c2ad049f":
-
-![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)
-
-```shell
-sentry-cli sourcemaps explain c2ad049fd9e448ada7849df94575e019
-```
-
-The CLI output should give you useful information about what went wrong with your source maps setup.
-
 <PlatformSection notSupported={["javascript.electron"]}>
 
 ### Verify a release is configured in your SDK

--- a/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -30,27 +30,9 @@ Dependency versions that require the legacy method of uploading source maps incl
 
 </Alert>
 
-Setting up source maps can be tricky, but it's worth it to get it right. To troubleshoot your source maps set up, you can either:
+Setting up source maps can be tricky, but it's worth it to get it right. You can follow the steps below to troubleshoot your source maps set up.
 
-1. Use our automated verification tool inside `sentry-cli`, or
-2. Follow the manual steps listed below
-
-## Use the CLI
-
-To use the automated verification process, install and configure the Sentry [Command Line Interface](/cli/). Then, use the `sourcemaps explain` command, calling it with the relevant event ID, found in the top-left corner of the **Issue Details** page in [sentry.io](https://sentry.io).
-
-For example, "Event ID: c2ad049f":
-
-![Image highlighting where to find the ID of an event on Sentry](./img/event_id.png)
-
-```shell
-sentry-cli sourcemaps explain c2ad049fd9e448ada7849df94575e019
-```
-
-The CLI output should give you useful information about what went wrong with your source maps setup.
-If it doesn't, let us know by filing an issue on our [Sentry CLI repo](https://github.com/getsentry/sentry-cli) so we can make it better.
-
-## Follow Manual Steps
+## Troubleshooting Steps
 
 ### Verify Artifacts Are Uploaded
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
`sentry-cli sourcemaps explain` has been deprecated for some time, and is scheduled for removal (https://github.com/getsentry/sentry-cli/issues/2865, [CLI-195](https://linear.app/getsentry/issue/CLI-195/remove-sentry-cli-sourcemaps-explain-command)). So, we should remove all mentions of the command from the docs, and point users to alternative debugging steps, instead.

Resolves #15471
Resolves [DOCS-2346](https://linear.app/getsentry/issue/DOCS-2346/remove-mentions-of-sentry-cli-sourcemaps-explain-from-the-docs)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)