### PR TITLE
ref(develop): Clarify telemetry data > scope attribute precedence

### DIFF
--- a/develop-docs/sdk/telemetry/scopes.mdx
+++ b/develop-docs/sdk/telemetry/scopes.mdx
@@ -100,7 +100,7 @@ The method SHOULD accept a dictionary/map/object where:
 - Attributes set on the isolation scope MUST be applied to all logs and metrics in that execution context
 - Attributes set on the current scope MUST be applied only to the current log and current metric
 - When the same attribute key exists in multiple scopes, the more specific scope's value takes precedence (current > isolation > global)
-- Attributes set on the current log or metric MUST take precedence over an attribute with the same key set on any scope (log/metric > current > isolation > global)
+- When the same attribute key exists on the current log or metric, it MUST take precedence over an attribute with the same key set on any scope (log/metric > current > isolation > global)
 
 See [Span Protocol - Common Attribute Keys](/sdk/telemetry/spans/span-protocol/#common-attribute-keys) for a list of standard attributes and [Sentry Conventions](https://github.com/getsentry/sentry-conventions/) for the complete attribute registry.
 


### PR DESCRIPTION
In case of an attribute "collision" between individual telemetry attributes and scope attributes, the telemtetry data's attribute should take precedence.