### PR TITLE
fix: Update browser profiling docs to warn about local profiling with Chrome DevTools

### DIFF
--- a/platform-includes/profiling/browser-profiling/javascript.mdx
+++ b/platform-includes/profiling/browser-profiling/javascript.mdx
@@ -46,6 +46,12 @@ Configuration should happen as early as possible in your application's lifecycle
 
 <PlatformContent includePath="profiling/automatic-instrumentation-setup" />
 
+<Alert level="warning" title="Local Profiling with Chrome DevTools">
+
+When you enable `browserProfilingIntegration` in your SDK configuration, Chrome will incorrectly attribute regular rendering work as “Profiling Overhead” if you are doing local profiling via the Chrome DevTools Performance panel. To avoid this, disable or remove the integration when profiling with Chrome DevTools. 
+
+</Alert>
+
 ## The Difference Between DevTools & Sentry's JavaScript Browser Profiler
 
 What does Sentry's JavaScript browser profile offer that Chrome DevTools does not?


### PR DESCRIPTION
Added warning about browserProfilingIntegration in Chrome DevTools.

We disabled this in development for Sentry: https://github.com/getsentry/sentry/pull/103249

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
