### PR TITLE
docs(size-analysis): Update sentry-cli version requirements (EME-382)

### DIFF
--- a/docs/platforms/apple/guides/ios/size-analysis/index.mdx
+++ b/docs/platforms/apple/guides/ios/size-analysis/index.mdx
@@ -12,7 +12,7 @@ description: Upload iOS builds to Sentry for size analysis.
 
 **Accepted Formats**: XCArchive (preferred) | IPA
 
-**Upload Mechanisms**: [Fastlane Plugin](#uploading-with-fastlane) (version 1.34.0 or higher) _or_ [Sentry CLI](#uploading-with-the-sentry-cli)
+**Upload Mechanisms**: [Fastlane Plugin](#uploading-with-fastlane) _or_ [Sentry CLI](#uploading-with-the-sentry-cli)
 
 ### Uploading With Fastlane
 

--- a/includes/size-analysis/upload-cli-android.mdx
+++ b/includes/size-analysis/upload-cli-android.mdx
@@ -1,4 +1,8 @@
-1. Install the [sentry-cli](/cli/) (version `2.57.0` or higher)
+1. Install the [sentry-cli](/cli/) (version `{{@inject apps.version('sentry-cli') }}`)
+
+   <Alert>
+   We recommend using the latest version for the best possible experience, but at a minimum version `2.58.2` is required.
+   </Alert>
 
 2. Authenticate the Sentry CLI by [following these steps](https://docs.sentry.io/cli/configuration/#to-authenticate-manually)
 

--- a/includes/size-analysis/upload-cli-ios.mdx
+++ b/includes/size-analysis/upload-cli-ios.mdx
@@ -1,4 +1,8 @@
-1. Install the [sentry-cli](/cli/) (version `2.57.0` or higher)
+1. Install the [sentry-cli](/cli/) (version `{{@inject apps.version('sentry-cli') }}`)
+
+   <Alert>
+   We recommend using the latest version for the best possible experience, but at a minimum version `2.58.2` is required.
+   </Alert>
 
 2. Authenticate the Sentry CLI by [following these steps](https://docs.sentry.io/cli/configuration/#to-authenticate-manually)
 


### PR DESCRIPTION
## Summary
- Updates size analysis docs to use dynamic version injection for sentry-cli
- Adds note specifying minimum required version of 2.58.2
- Changes Note component to Alert component in include files
- Removes duplicate fastlane plugin version reference

Fixes EME-382

🤖 Generated with [Claude Code](https://claude.com/claude-code)