### PR TITLE
feat(platform): Remove border from code highlights

### DIFF
--- a/src/components/codeHighlights/codeHighlights.tsx
+++ b/src/components/codeHighlights/codeHighlights.tsx
@@ -132,7 +132,6 @@ const HighlightBlockContainer = styled('div')`
   background-color: rgba(239, 239, 239, 0.06);
   position: relative;
 
-  border: 1px solid var(--accent-11);
   border-left: 4px solid var(--accent-purple);
   border-radius: 6px;
 


### PR DESCRIPTION
**before:**

<img width="1190" height="560" alt="Screenshot 2025-11-13 at 10 04 56" src="https://github.com/user-attachments/assets/343f48e5-216e-46ce-9b49-f0cd9f060710" />

**after:**

<img width="1178" height="524" alt="Screenshot 2025-11-13 at 10 16 40" src="https://github.com/user-attachments/assets/a4e44444-da6c-4e31-8223-e5c8e18d6890" />
