### PR TITLE
feat(js-integrations): langgraph docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
@@ -34,7 +34,7 @@ This integration requires SDK version `10.25.0` or higher.
 
 _Import name: `Sentry.langChainIntegration`_
 
-LangGraph is instrumented via the [LangChain integration](./langchain), which automatically captures spans for LangGraph operations including agent invocations, graph executions, and node operations.
+LangGraph is instrumented via the [`langChainIntegration`](./langchain), which automatically captures spans for LangGraph operations including agent invocations, graph executions, and node operations.
 
 ## Usage Example
 
@@ -62,7 +62,7 @@ const result = await agent.invoke({
 
 ## Configuration
 
-For configuration options, runtime-specific setup, and detailed information, see the [LangChain integration documentation](./langchain).
+For configuration options, runtime-specific setup, and detailed information, see the [LangChain integration documentation](/platforms/javascript/guides/node/configuration/integrations/langchain/).
 
 ## Supported Versions
 


### PR DESCRIPTION
Adds a short page for JS LangGraph which references the LangChain integration docs.

Closes: [TET-1407: Sentry docs for JS langgraph](https://linear.app/getsentry/issue/TET-1407/sentry-docs-for-js-langgraph)