### PR TITLE
docs(size-analysis): Use version variable for Fastlane plugin

### DIFF
--- a/includes/size-analysis/upload-fastlane.mdx
+++ b/includes/size-analysis/upload-fastlane.mdx
@@ -1,6 +1,6 @@
 The Fastlane plugin can be used to upload XCArchive or IPA builds to Sentry. On GitHub Actions, Fastlane will automatically detect your [build's metadata](#upload-metadata) and include it in the upload. In other Continuous Integration (CI) environments, you may need to manually set metadata values.
 
-1. Configure the [Sentry Fastlane plugin](/platforms/apple/guides/ios/dsym/#sentry-fastlane-plugin) (version `1.35.0` or higher):
+1. Configure the [Sentry Fastlane plugin](/platforms/apple/guides/ios/dsym/#sentry-fastlane-plugin) (version `{{@inject packages.version('sentry.cocoa.fastlane') }}`):
 
    ```ruby
    bundle exec fastlane add_plugin fastlane-plugin-sentry


### PR DESCRIPTION
## Summary
- Replace hardcoded version `1.35.0` with dynamic version variable `{{@inject packages.version('sentry.cocoa.fastlane') }}` in the Fastlane upload documentation
- Remove "or higher" text from version requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)