### PR TITLE
fix(python-mcp): Add MCP integration to snippets

### DIFF
--- a/docs/platforms/python/integrations/mcp/index.mdx
+++ b/docs/platforms/python/integrations/mcp/index.mdx
@@ -38,9 +38,23 @@ uv add "sentry-sdk[mcp]"
 
 ## Configure
 
-If you have the `mcp` package in your dependencies, the MCP integration will be enabled automatically when you initialize the Sentry SDK.
+Simply update your `sentry_sdk.init()` call to include the `MCPIntegration()`.
 
-<PlatformContent includePath="getting-started-config" />
+```python
+import sentry_sdk
+from sentry_sdk.integrations.mcp import MCPIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    traces_sample_rate=1.0,
+    # Add data like tool inputs/outputs;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
+)
+```
 
 ## Verify
 
@@ -63,6 +77,9 @@ sentry_sdk.init(
     # Add data like tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
 )
 
 # Create the MCP server
@@ -115,6 +132,9 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
     send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
 )
 
 # Create the low-level MCP server


### PR DESCRIPTION
The MCP integration is not automatically enabled.
Update copy and snippets to reflect that.

- fixes [TET-1439: Add integration init in MCP setup docs](https://linear.app/getsentry/issue/TET-1439/add-integration-init-in-mcp-setup-docs)