### PR TITLE
ref(develop/scopes): Remove attribute `type` as a user-provided property

### DIFF
--- a/develop-docs/sdk/telemetry/scopes.mdx
+++ b/develop-docs/sdk/telemetry/scopes.mdx
@@ -61,7 +61,7 @@ Users MUST be able to attach attributes to any scope using a dedicated method (e
 Attributes are key-value pairs where each value is either a an attribute value or an object containing:
 
 - `value`: The actual attribute value, which MUST match the specified type
-- `unit` (optional): The unit of measurement (e.g., `"ms"`, `"s"`, `"bytes"`, `"count"`, `"percent"` or any other string value). SDKs MAY refrain from supporting units for the moment.
+- `unit` (optional): The unit of measurement (e.g., `"ms"`, `"s"`, `"bytes"`, `"count"`, `"percent"` or any other string value). SDKs MAY NOT add support for units for the moment, but MUST be able to do so at a later date without a breaking change.
 - `type` (optional): The type of the attribute. SDKs SHOULD NOT expose this to users if they can reliably infer the type from the value. If not, SDKs MAY allow or require users to set the `type` explicitly.
 
 #### Example Usage


### PR DESCRIPTION
This is a proposal after working on scope attributes for JS. We don't have to merge this but IMHO it makes sense.

This PR makes a slight change to the scope attributes specification:

When users want to set a scope attribute with a unit, the previous spec currently required them to also pass `type` explicitly. 

```ts
// previously
scope.setAttribute({
  simpleAttr: 'hi',
  attrWithUnit: {value: 120, type: 'integer', unit: 'ms'}
})

// now
scope.setAttribute({
  simpleAttr: 'hi',
  attrWithUnit: {value: 120, unit: 'ms'}, // serilized to integer attribute with value 120, unit ms
  attrWithoutUnit: {value: 120}, // serialized to integer attribute with value 120
  attrWithObject: {foo: 'bar'} // serialized to stringified string attribute
})
```

This PR changes to spec to preferrably remove the `type` property from the attribute object in favour of letting the SDK internally check and set the correct type. Two advantages:
1. Less overhead for users
2. No/less room for error for languages where we can't type strictly

This is a SHOULD, so if SDKs are constrained in some way, they can still require the user to pass the type explicitly.

Furthermore, this PR also updates a recommendation to leave set attribute format as-is, so that users can consume the attributes in `beforeSendLog` and other callbacks, in the same structure as they are initially set. This again is a SHOULD because most importantly, it must be compatible with how attributes are consumed in said callbacks today already.