### PR TITLE
ref(loguru): Integrate Sentry logs into Loguru integration page better

### DIFF
--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -7,7 +7,7 @@ The [Loguru](https://github.com/Delgan/loguru#readme) integration lets you captu
 
 The [`logging`](/platforms/python/integrations/logging) integration provides most of the Loguru functionality and most examples on that page work with Loguru.
 
-<Alert level="info" title="Did you mean logs instead?">
+<Alert level="info" title="Sentry Logs for Loguru">
 
 Enable the Sentry Logs feature with `sentry_sdk.init(enable_logs=True)` to unlock Sentry's full logging power. With Sentry Logs, you can search, filter, and analyze logs from across your entire application in one place.
 


### PR DESCRIPTION
Update Loguru integration docs:
- make it clearer what the integration actually does (since it currently serves three different features)
- make it clearer how to configure each
- emphasize the Sentry Logs part as that is the main feature

**Direct link to preview:** https://sentry-docs-git-ivana-pythonlogging-docs-revamp.sentry.dev/platforms/python/integrations/loguru/

Ref https://github.com/getsentry/sentry-python/issues/5090

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
