### PR TITLE
ref(logging): Update logging integration docs to better integrate Sentry logs

### DIFF
--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -56,7 +56,7 @@ This will capture both logs and send them to Sentry Logs. Additionally, an error
 
 ## Behavior
 
-As long as `enable_logs` is `True`, logs with a level of `INFO` and higher will be captured as Sentry logs. The threshold can be configured via the [`sentry_logs_level` option](#options).
+As long as `enable_logs` is `True`, logs with a level of `INFO` and higher will be captured as Sentry logs if the log level set in the `logging` module is `INFO` or below. The threshold can be configured via the [`sentry_logs_level` option](#options).
 
 Additionally, the logging integration will create an error event from all `ERROR`-level logs. This feature is configurable via the [`event_level` integration option](#options).
 


### PR DESCRIPTION
The Python stdlib logging integration docs page still emphasizes breadcrumbs and creating error events, and logs are sidelined even though they're the main feature. Updating to reflect this.

**Direct link to preview:** https://sentry-docs-git-ivana-pythonstdlib-logging-docs-revamp.sentry.dev/platforms/python/integrations/logging/

Ref https://github.com/getsentry/sentry-python/issues/5090

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
