### PR TITLE
ref(develop/scopes): Clarify unit type for attributes

### DIFF
--- a/develop-docs/sdk/telemetry/scopes.mdx
+++ b/develop-docs/sdk/telemetry/scopes.mdx
@@ -61,7 +61,7 @@ Users MUST be able to attach attributes to any scope using a dedicated method (e
 Attributes are key-value pairs where each value is either a an attribute value or an object containing:
 
 - `value`: The actual attribute value, which MUST match the specified type
-- `unit` (optional): The unit of measurement (e.g., `"millisecond"`, `"second"`, `"byte"`, `"ration"`).
+- `unit` (optional): The unit of measurement (e.g., `"millisecond"`, `"second"`, `"byte"`, `"ratio"`).
   - SDKs MAY delay adding support for units for the moment, but MUST be able to do so at a later date without a breaking change.
   - SDKS MUST allow setting all units supported by Relay's [`MetricUnit` enum](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html) but MUST NOT allow custom units (i.e. arbitrary strings, defined in [`CustomUnit`](https://getsentry.github.io/relay/relay_metrics/struct.CustomUnit.html)) or "none" units (`''` or `'none'`).
 - `type` (optional): The type of the attribute. SDKs SHOULD NOT expose this to users if they can reliably infer the type from the value. If not, SDKs MAY allow or require users to set the `type` explicitly.


### PR DESCRIPTION
For now we specify units on attributes as follows:
- accept all `MetricUnit`s (see [Relay](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html))
  - except for `''`, `'none'`
  - except for custom units (arbitrary strings). <-- we can revisit this if we want to widen the type here

We recognize that attribute units are therefore typed more strictly than e.g. units for metrics (they currently also accept custom units) but we can adjust both in either direction in the future.