### PR TITLE
ref(develop/spans): Clarify span attribute `unit` and `type` types

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -163,7 +163,7 @@ Attributes are stored as key-value pairs where each value is an object with type
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `type` | string | Yes | The data type of the attribute value. Values: `"string"`, `"integer"`, `"double"`, `"boolean", `"string[]"`, `"integer[]"`, `"double[]"`, `"boolean[]"` |
+| `type` | string | Yes | The data type of the attribute value. Values: `"string"`, `"integer"`, `"double"`, `"boolean"`, `"string[]"`, `"integer[]"`, `"double[]"`, `"boolean[]"` |
 | `value` | any | Yes | The actual attribute value, must match the specified type |
 | `unit` | string | No | The unit of the attribute value. Example values: `"millisecond"`, `"second"`, `"byte"`, `"ratio"`. Units MUST be one of the [MetricUnit](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html)s supported by Relay, excluding `""`, `"none"` or custom units. |
 


### PR DESCRIPTION
Follow-up from https://github.com/getsentry/sentry-docs/pull/15546 to align the span protocol attribute unit definition. 
Also adjusts the valid `type` values to support arrays of primitives 
