### PR TITLE
docs(size-analysis): Update sentry-android-gradle-plugin to 6.0.0-beta.2

### DIFF
--- a/includes/size-analysis/upload-gradle.mdx
+++ b/includes/size-analysis/upload-gradle.mdx
@@ -1,6 +1,6 @@
 The Gradle plugin automatically detects build metadata from your git repository. On GitHub Actions, all metadata is automatically detected. On other CI systems, you may need to manually set some values using the `vcsInfo` extension.
 
-1. Configure the [Sentry Android Gradle plugin](/platforms/android/configuration/gradle/) with at least version `6.0.0-beta1`
+1. Configure the [Sentry Android Gradle plugin](/platforms/android/configuration/gradle/) with at least version `6.0.0-beta.2`
 
 2. Set the auth token as an environment variable to be used when running your release build.
 


### PR DESCRIPTION
## Summary

Updates the minimum version requirement for the Sentry Android Gradle plugin in size analysis documentation from `6.0.0-beta1` to `6.0.0-beta.2`.

This change affects the documentation for:
- Android size analysis
- React Native size analysis (Android)
- Flutter size analysis (Android)

🤖 Generated with [Claude Code](https://claude.com/claude-code)