### PR TITLE
ref: Allign badges with Sentry’s in-product ones

### DIFF
--- a/src/components/sidebar/style.module.scss
+++ b/src/components/sidebar/style.module.scss
@@ -172,17 +172,11 @@
   font-weight: 600;
   line-height: 1;
   letter-spacing: 0.08em;
-  color: #d97706; /* amber-600 for good contrast in light mode */
-  background-color: transparent;
-  border: 2px solid #f59e0b; /* amber-500 warning color */
+  color: rgb(24, 20, 35);
+  background-color: rgb(255, 208, 14);
   border-radius: 0.25rem;
   white-space: nowrap;
   flex-shrink: 0;
-}
-
-:global(.dark) .beta-badge {
-  color: #fafaf9; /* off-white for dark mode */
-  border-color: #fbbf24; /* amber-400 for dark mode */
 }
 
 .new-badge {
@@ -193,17 +187,11 @@
   font-weight: 600;
   line-height: 1;
   letter-spacing: 0.08em;
-  color: #059669; /* emerald-600 for good contrast in light mode */
-  background-color: transparent;
-  border: 2px solid #10b981; /* emerald-500 success green */
+  color: rgb(24, 20, 35);
+  background-color: rgb(0, 242, 97);
   border-radius: 0.25rem;
   white-space: nowrap;
   flex-shrink: 0;
-}
-
-:global(.dark) .new-badge {
-  color: #fafaf9; /* off-white for dark mode */
-  border-color: #34d399; /* emerald-400 for dark mode */
 }
 
 .sidebar-separator {


### PR DESCRIPTION
**Before**

<img width="301" height="395" alt="Slack 2025-11-19 19 42 23" src="https://github.com/user-attachments/assets/47698abb-b634-47fa-830b-12f04e0a355c" />
<img width="297" height="401" alt="Firefox 2025-11-19 19 42 24" src="https://github.com/user-attachments/assets/4764e780-0e13-48aa-8890-49d7ae15436d" />

**After**

<img width="301" height="396" alt="Cursor 2025-11-19 19 41 41" src="https://github.com/user-attachments/assets/90bd88c6-d8c8-4420-b3a0-bd184e49b905" />
<img width="296" height="394" alt="Cursor 2025-11-19 19 41 54" src="https://github.com/user-attachments/assets/2268a86e-3e56-4f0e-8026-f0dfb6ea132b" />

Colors are the same we use for `sentry.io`.