### PR TITLE
fix: reset regex lastIndex to prevent keyword matching failures 

### DIFF
--- a/src/components/codeKeywords/codeKeywords.tsx
+++ b/src/components/codeKeywords/codeKeywords.tsx
@@ -23,11 +23,11 @@ export function makeKeywordsClickable(children: React.ReactNode) {
       arr.push(updatedChild);
       return arr;
     }
-    
+
     // Reset regex lastIndex before testing to avoid stale state from previous matches
     ORG_AUTH_TOKEN_REGEX.lastIndex = 0;
     KEYWORDS_REGEX.lastIndex = 0;
-    
+
     if (ORG_AUTH_TOKEN_REGEX.test(child)) {
       makeOrgAuthTokenClickable(arr, child);
     } else if (KEYWORDS_REGEX.test(child)) {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This fixes a nuanced regex issue that was creating cases where keywords were converting correctly in some places but not in other instances on the same page. 

The regex here uses a global flag which is stateful and each regex `.test()` call inherits lastIndex from the previous call. If lastIndex > string.length, the test fails and doesn't convert the keyword. This small update makes sure every `.test()` call starts fresh with lastIndex = 0 so every string is searched from the beginning. 

**PROD: https://docs.sentry.io/product/drains/integration/vercel/
PREVIEW: https://sentry-docs-git-stale-keyword-fix.sentry.dev/product/drains/integration/vercel/**

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
