### PR TITLE
neat (docs) content width

### DIFF
--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -137,9 +137,8 @@ export function DocPage({
         /* At toc breakpoint (1490px), constrain content to leave room for TOC */
         @media (min-width: 1490px) {
           #doc-content {
-            /* Calculate max width: viewport - sidebar - TOC - gaps - padding */
-            /* Leave room for: sidebar (300px) + TOC (250px) + gaps (48px) + padding (96px) */
-            max-width: calc(100vw - 300px - 250px - 48px - 96px);
+            /* Calculate max width: viewport - sidebar - TOC */
+            max-width: calc(100vw - 300px - 250px);
           }
         }
         @media (min-width: 2057px) {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
| Before | After |
|--------|--------|
| <img width="3004" height="2070" alt="CleanShot 2025-11-19 at 19 49 57@2x" src="https://github.com/user-attachments/assets/ccd7e639-a646-4b12-b49c-78e63dbee339" /> | <img width="3004" height="2056" alt="CleanShot 2025-11-19 at 19 49 35@2x" src="https://github.com/user-attachments/assets/31b05912-5cb9-41c7-a7a9-cf3715ac555f" /> | 

Just calculating TOS and Sidebar width makes sense, padding is handled inside the container

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
