### PR TITLE
docs(js): Update default attribute docs for metrics

### DIFF
--- a/platform-includes/metrics/default-attributes/javascript.mdx
+++ b/platform-includes/metrics/default-attributes/javascript.mdx
@@ -16,8 +16,8 @@ The SDK will optionally attach user information as attributes (guarded by [`send
 
 ### Browser Attributes
 
-The SDK will optionally attach browser information as attributes:
+The SDK will attach browser information as attributes:
 
-1. `browser.name` (added during ingestion, guarded by [`sendDefaultPii`](/platforms/javascript/configuration/options/#sendDefaultPii))
-2. `browser.version` (added during ingestion, guarded by [`sendDefaultPii`](/platforms/javascript/configuration/options/#sendDefaultPii))
+1. `browser.name` (added during ingestion)
+2. `browser.version` (added during ingestion)
 3. `sentry.replay_id`: The replay id of the replay that was active when the metric was collected. (added during ingestion by Relay)


### PR DESCRIPTION
`browser.name` and `browser.version` are not gated by `sendDefaultPii`