### PR TITLE
fix(develop-docs): Clearing scope attributes

### DIFF
--- a/develop-docs/sdk/telemetry/scopes.mdx
+++ b/develop-docs/sdk/telemetry/scopes.mdx
@@ -92,7 +92,7 @@ sentry_sdk.get_global_scope().set_attributes({
 
 The method SHOULD accept a dictionary/map/object where:
 - Keys are attribute names (strings)
-- Values are either directly values or attribute objects/dictionaries with `value`, and optionally `unit` properties (see [example](#example-usage)). 
+- Values are either directly values or attribute objects/dictionaries with `value`, and optionally `unit` properties (see [example](#example-usage)).
 - The SDK SHOULD infer the `type` of the attribute at serialization time to spare users from setting a (potentially incorrect) `type`. Depending on platform or constraints, the SDK MAY instead also allow or require users to set the `type` explicitly.
 
 #### Behavior
@@ -103,6 +103,7 @@ The method SHOULD accept a dictionary/map/object where:
 - When the same attribute key exists in multiple scopes, the more specific scope's value takes precedence (current > isolation > global)
 - When the same attribute key exists on the current log or metric, it MUST take precedence over an attribute with the same key set on any scope (log/metric > current > isolation > global)
 - The SDK SHOULD keep the attribute format consistent with the user-set format until user-provided processing callbacks like `before_send_log` have been called. This ensures compatibility with already existing callbacks and avoids unexpected changes to the attribute format.
+- Calling `scope.clear()` MUST remove all attributes from the corresponding scope.
 
 See [Span Protocol - Common Attribute Keys](/sdk/telemetry/spans/span-protocol/#common-attribute-keys) for a list of standard attributes and [Sentry Conventions](https://github.com/getsentry/sentry-conventions/) for the complete attribute registry.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

@cleptric is this expected behavior? I didn't find anything mentioning that and I'm unsure if clear should clear all attributes. If yes, please review the PR. If not, then I close it.

Clarify that calling scope.clear also removes the attributes.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
