### PR TITLE
Update metrics usage documentation for Python

### DIFF
--- a/platform-includes/metrics/usage/python.mdx
+++ b/platform-includes/metrics/usage/python.mdx
@@ -1,4 +1,4 @@
-Once the feature is enabled on the SDK and the SDK is initialized, you can send metrics using the `sentry_sdk.metrics` APIs.
+Metrics are enabled by default. Once you initialize the SDK, you can send metrics using the `sentry_sdk.metrics` APIs.
 
 The `metrics` namespace exposes three methods that you can use to capture different types of metric information: `count`, `gauge`, and `distribution`.
 


### PR DESCRIPTION
The Python Metrics Usage section text had a leftover sentence from when Metrics used to be an experimental feature. I've changed the wording so it doesn't confuse users to think they still need to enable the feature somehow.