### PR TITLE
docs(flutter): Fix extraneous single quote in size analysis docs 

### DIFF
--- a/docs/platforms/dart/guides/flutter/size-analysis/index.mdx
+++ b/docs/platforms/dart/guides/flutter/size-analysis/index.mdx
@@ -22,7 +22,7 @@ description: Upload Flutter builds to Sentry for size analysis.
 
 ## Getting Started - Android
 
-<Include name="size-analysis/ci-alert" />'
+<Include name="size-analysis/ci-alert" />
 
 **Accepted Upload Formats**: AAB (preferred) | APK
 


### PR DESCRIPTION
## Summary

- Remove stray single quote character from Flutter size analysis documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)