### PR TITLE
feat: Move Vercel Log Drain to GA

### DIFF
--- a/docs/organization/early-adopter-features/index.mdx
+++ b/docs/organization/early-adopter-features/index.mdx
@@ -24,4 +24,3 @@ Limitations:
 - [Dynamic Alerts](/product/alerts/create-alerts/metric-alert-config/#dynamic-alerts)
 - [New Trace Explorer With Span Metrics](/product/explore/new-trace-explorer/)
 - [Size Analysis](/product/size-analysis/)
-- [Vercel Log Drains](/product/drains/integration/vercel/)

--- a/docs/product/drains/integration/vercel.mdx
+++ b/docs/product/drains/integration/vercel.mdx
@@ -25,12 +25,6 @@ To set up a Drain in Vercel you'll need to create a new Drain in the Vercel sett
 
 ### Log Drains
 
-<Alert>
-
-This feature is available only if you're in the <a href="/organization/early-adopter-features/" target="_blank">Early Adopter program</a>. Please reach out to [feedback-logging@sentry.io](mailto:feedback-logging@sentry.io) if you have feedback or questions. Features available to Early Adopters are still in-progress and may have bugs. We recognize the irony.
-
-</Alert>
-
 After selecting the Logs data type, you'll need to configure the drain to send data to Sentry.
 
 1. Provide a name for your drain and select which projects should send data to your endpoint. You can choose all projects or select specific ones.
@@ -59,12 +53,6 @@ x-sentry-auth: sentry sentry_key=___PUBLIC_KEY___
 
 7. To test that the log drain is working, you can send a test log to your drain by clicking the Test button.
 
-<Alert level="warning">
-
-Vercel Log Drains have some known limitations. This is being tracked in [this GitHub issue](https://github.com/getsentry/sentry/issues/103095).
-
-</Alert>
-
 ### Trace Drains
 
 After selecting the Traces data type, you'll need to configure the drain to send data to Sentry.
@@ -84,3 +72,23 @@ x-sentry-auth: sentry sentry_key=___PUBLIC_KEY___
 ```
 
 5. To test that the trace drain is working, you can send a test trace to your drain by clicking the Test button.
+
+## Troubleshooting
+
+<Expandable title="Logs with empty messages">
+  Some logs from the `static` or `edge` source have an empty log message. This
+  is intended behavior, the vercel log drain schema intentionally sets an empty
+  log message for some of these logs.
+</Expandable>
+
+<Expandable title="Logs from `static` source show up in Sentry but not the Vercel dashboard">
+  If you drain logs with source `static` (**Static Files**) from Vercel, they
+  will show up in Sentry but in the Vercel Dashboard. By default the Vercel
+  dashboard does not show these logs.
+</Expandable>
+
+<Expandable title="Trace-connected build logs">
+  Build logs forwarded from Vercel are not trace-connected by default. You can
+  use a combination of the `vercel.project_name`, `vercel.deployment_id`, and
+  `vercel.build_id` fields to grab logs from a specific build.
+</Expandable>


### PR DESCRIPTION
Moves Vercel Log Drains to GA.

ref https://linear.app/getsentry/issue/LOGS-394/ga-vercel-log-drains