### PR TITLE
fix: Remove duplicate sdk section in metrics getting started docs

### DIFF
--- a/docs/product/explore/metrics/getting-started/index.mdx
+++ b/docs/product/explore/metrics/getting-started/index.mdx
@@ -282,7 +282,7 @@ We're actively working on adding Metrics functionality to additional SDKs. Check
     url="https://github.com/getsentry/sentry-dart/issues/3350"
   />
 
-If you don't see your platform listed above, please reach out to us on [GitHub](https://github.com/getsentry/sentry/discussions/102275) or [Discord](https://discord.gg/sentry), we'll get it prioritized!
+If you don't see your platform listed above, please reach out to us on [GitHub](https://github.com/getsentry/sentry/discussions/102275), [Discord](https://discord.gg/sentry) or contact us at [feedback-metrics@sentry.io](mailto:feedback-metrics@sentry.io), we'll get it prioritized!
 
 ## Quick Start Examples
 
@@ -440,8 +440,3 @@ Add metrics at key decision points in your code:
 - **At service boundaries**: Monitor external API calls, database queries
 - **Business logic**: Capture important business events
 - **Resource usage**: Track queue depths, connection pools, cache sizes
-
-## Upcoming SDKs
-
-We're actively working on adding Metrics functionality to additional SDKs. If you don't see your platform listed above, please reach out to us on [GitHub](https://github.com/getsentry/sentry/discussions/102275) or contact us at [feedback-metrics@sentry.io](mailto:feedback-metrics@sentry.io).
-


### PR DESCRIPTION
We had two `Upcoming SDKs` sections, this removes one in favour of another.