### PR TITLE
fix: Disable ISR to prevent ENOENT errors and reduce function invocations

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -45,6 +45,7 @@ export async function generateStaticParams() {
 // Only render paths returned by generateStaticParams
 export const dynamicParams = false;
 export const dynamic = 'force-static';
+export const revalidate = false;
 
 const mdxComponentsWithWrapper = mdxComponents(
   {Include, PlatformContent},


### PR DESCRIPTION

<img width="4112" height="2408" alt="CleanShot 2025-11-25 at 18 43 00@2x" src="https://github.com/user-attachments/assets/4f21bfe2-b62f-4101-b1b9-3d5ce5da77bd" />

<img width="2612" height="1884" alt="CleanShot 2025-11-25 at 18 44 20@2x" src="https://github.com/user-attachments/assets/acc3febb-5718-4635-86f1-f4b5bc83e756" />


## Problem
ISR cache misses triggered runtime page regeneration, which called `getDocsFrontMatter()` attempting to access `docs/**/*`. Since `docs/**/*` is excluded from deployment to avoid the 250MB function limit, this caused ENOENT errors.

## Impact
- Error rate: **94.1%**
- Function duration: **5x increase** (40ms → 210ms)
- Started: October 29, 2025

## Solution
Disable ISR with `revalidate = false`. All pages are pre-rendered at build time and never need runtime regeneration.

## Expected Result
- Error rate: 0%
- Function duration: back to ~40ms baseline
- Function invocations reduced to static file serving only