### PR TITLE
feat: Re-organize log and trace drains page

### DIFF
--- a/docs/product/drains/index.mdx
+++ b/docs/product/drains/index.mdx
@@ -10,7 +10,7 @@ Drains and forwarders let you send [logs](/product/explore/logs/) and [traces](/
 
 - You want to capture **platform-level telemetry** from your hosting infrastructure (e.g., Vercel Build Logs, Cloudflare Workers Traces).
 - You **can't install Sentry SDKs** directly in your application (e.g., Nginx Traces, Postgres Logs)
-- You're using an existing OpenTelemetry pipeline and want to start routing logs and traces data to Sentry via OTLP.
+- You're using an existing OpenTelemetry pipeline and want to start routing logs and traces data to Sentry via Sentry's [OpenTelemetry support](/concepts/otlp/).
 
 <Alert level="info">
 


### PR DESCRIPTION
After doing a read through of https://github.com/getsentry/sentry-docs/issues/15595, I realized we could probably better incorporate details on forwarders, which I added as part of https://github.com/getsentry/sentry-docs/pull/15623.

This hopefully makes this section a bit easier to grok, which is important as I'm going to link to this doc from onboarding within a couple of days, so it's going to get a lot more traffic.

Thank you @KyleTryon for kick starting the work on this, made it much easier for me to conceptualize the needed sections on this.

https://sentry-docs-git-abhi-refactor-drains-index.sentry.dev/product/drains/