### PR TITLE
chore: Update Carthage installation instructions with xcframework only

### DIFF
--- a/docs/platforms/apple/common/install/carthage.mdx
+++ b/docs/platforms/apple/common/install/carthage.mdx
@@ -9,7 +9,7 @@ To integrate Sentry into your Xcode project using Carthage, specify it in your _
 github "getsentry/sentry-cocoa" "{{@inject packages.version('sentry.cocoa') }}"
 ```
 
-Run `carthage update` to download the framework and drag the built _Sentry.xcframework_ into your Xcode project. We also provide a pre-built version for every release, which can be downloaded at [releases on GitHub](https://github.com/getsentry/sentry-cocoa/releases).
+Run `carthage update --use-xcframeworks` to download the framework and drag the built _Sentry.xcframework_ into your Xcode project.
 
 Sentry's Carthage setup generates 3 different frameworks:
 
@@ -23,4 +23,10 @@ The SDK supports integrating Sentry with VisionOS via Carthage on `sentry-cocoa 
 
 ## Macs with Apple Silicon and XCFrameworks
 
-If you're using Sentry via Carthage on Macs with Apple Silicon or want to use XCFrameworks, please use Carthage >= 0.37.0, which introduced [support for XCFramework](https://github.com/Carthage/Carthage/releases/tag/0.37.0). Make sure to use `carthage build --use-xcframeworks --no-use-binaries` after running `carthage update --use-xcframeworks`. Carthage 0.37.0 needs to rebuild the XCFramework from source because it can't handle GitHub dependencies that download binaries. Learn more in their [release notes](https://github.com/Carthage/Carthage/releases/tag/0.37.0).
+If you're using Sentry via Carthage on Macs with Apple Silicon or want to use XCFrameworks, please use Carthage >= 0.38.0, which introduced [support for XCFramework downloaded from Github Releases](https://github.com/Carthage/Carthage/releases/tag/0.38.0). 
+
+## Deprecating support from building from source 
+
+Starting with `sentry-cocoa 9.0.0`, only XCFramework distribution is officially supported. Run `carthage update --use-xcframeworks` to use the pre-built XCFrameworks that Sentry provides with each release.
+
+While using `carthage build --use-xcframeworks --no-use-binaries` to rebuild from source might work, this approach is *not* officially supported and may cause issues. For officially supported integration, always use the pre-built XCFrameworks.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Updates Carthage installation instructions to follow the `sentry-cocoa` decision to only officially support installation with prebuilt XCFrameworks.

See https://github.com/getsentry/sentry-cocoa/issues/6542

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)