### PR TITLE
feat(apple): Add docs for screenshot masking options

### DIFF
--- a/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/screenshots/index.mdx
@@ -139,7 +139,7 @@ By default, the overlay will be opaque. To configure the opacity, pass the desir
 SentrySDK.replay.showMaskPreview(0.5) // 0.5 opacity to render the preview semi-transparent
 ```
 
-Make sure not accidentally include this in your release build by e.g. wrapping it in a `#if DEBUG` block.
+Make sure not to accidentally include this in your release build—for example, by wrapping it in a `#if DEBUG` block.
 
 ```swift
 #if DEBUG


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds documentation about configuring masking of screenshots. Based on the already existing session replay masking documentation. As the two options sets are different (`options.sessionReplay.*` vs `options.screenshot.*`) we should duplicate the documentation for now in case of drift. 

We need to revisit this issue with https://github.com/getsentry/sentry-cocoa/issues/6060

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
