### PR TITLE
Fix(Develop): Change unit from 's' to 'second' in telemetry docs

### DIFF
--- a/develop-docs/sdk/telemetry/scopes.mdx
+++ b/develop-docs/sdk/telemetry/scopes.mdx
@@ -72,7 +72,7 @@ Sentry.getGlobalScope().setAttributes({
   "app.feature_flag.enabled": true,
   "app.session_duration": {
     value: 3600,
-    unit: "s"
+    unit: "second"
   }
 });
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

The snippet is using the incorrect unit, I altered it so the JavaScript matches the correct unit.
<img width="1052" height="421" alt="image" src="https://github.com/user-attachments/assets/a8b7080a-7183-4b0b-b027-008dd68bbc80" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
