### PR TITLE
docs(develop-docs): fix link in logs page

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -348,7 +348,7 @@ By default, Relay should parse the user agent attached to an incoming log envelo
 
 For backend SDKs (Node.js, Python, PHP, etc.), the SDKs should attach the following:
 
-1. `server.address`: The address of the server that sent the log. Equivalent to [`server_name`](sdk/data-model/event-payloads/#optional-attributes) we attach to errors and transactions.
+1. `server.address`: The address of the server that sent the log. Equivalent to [`server_name`](/sdk/data-model/event-payloads/#optional-attributes) we attach to errors and transactions.
 
 ```json
 {


### PR DESCRIPTION
## DESCRIBE YOUR PR
Fixing a internal link in the `develop-docs` of `logs`, that currently results in "Page Not Found".

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
