### PR TITLE
docs: Simplify OTLP "Dedicated Integrations" section

### DIFF
--- a/docs/concepts/otlp/index.mdx
+++ b/docs/concepts/otlp/index.mdx
@@ -243,7 +243,7 @@ The following SDKs support the `propagateTraceparent` option:
 
 ## Dedicated Integrations
 
-The following SDKs have dedicated integrations that make setting up OTLP a breeze.
+The following SDKs have dedicated integrations that make OTLP setup easy:
 
 - <LinkWithPlatformIcon
     platform="python"


### PR DESCRIPTION
I am concerned that the idiom "make setting up OTLP a breeze" may not be immediately understood by non-native English speakers, especially those with a more basic proficiency level.

To ensure our docs are accessible to a global audience, I propose replacing the idiom with a direct statement that the integrations "make OTLP setup easy."