### PR TITLE
docs(nextjs): Move webpack build config under `webpack` namespace

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
@@ -222,6 +222,21 @@ Enables the use of the [`runAfterProductionCompile` hook from Next.js](https://n
 
 </SdkOption>
 
+<SdkOption name="disableManifestInjection" type="boolean|undefined" defaultValue="false">
+
+Disables automatic injection of the route manifest into the client bundle.
+
+The route manifest is a build-time generated mapping of your Next.js App Router routes that enables Sentry to group transactions by parameterized route names (e.g., `/users/:id` instead of `/users/123`, `/users/456`, etc.).
+
+**Disable this option if:**
+
+- You want to minimize client bundle size
+- You're experiencing build issues related to route scanning
+- You prefer raw URLs in transaction names
+- You're only using the Pages Router (this feature is only supported in the App Router)
+
+</SdkOption>
+
 ## Next.js Webpack Options
 
 <Alert level="info">
@@ -286,21 +301,6 @@ Automatically create cron monitors in Sentry for your Vercel Cron Jobs if config
     This option is considered unstable, and its API may change in a breaking way
     in any release.
   </Alert>
-</SdkOption>
-
-<SdkOption name="disableManifestInjection" type="boolean|undefined" defaultValue="false">
-
-Disables automatic injection of the route manifest into the client bundle.
-
-The route manifest is a build-time generated mapping of your Next.js App Router routes that enables Sentry to group transactions by parameterized route names (e.g., `/users/:id` instead of `/users/123`, `/users/456`, etc.).
-
-**Disable this option if:**
-
-- You want to minimize client bundle size
-- You're experiencing build issues related to route scanning
-- You prefer raw URLs in transaction names
-- You're only using the Pages Router (this feature is only supported in the App Router)
-
 </SdkOption>
 
 <SdkOption name="webpack.reactComponentAnnotation.enabled" type="boolean" defaultValue="false">


### PR DESCRIPTION
We are moving the only-webpack related configurations under `webpack` namespace to better fit our goal of communicating the SDK readiness for Turbopack by default.

This involved moving several options to be nested under a `webpack` path in the build configuration. 

This is meant to be released once this https://github.com/getsentry/sentry-javascript/pull/18343/ goes live, so I will keep this open until then. Will keep it in draft as well.

The SDK PR adds warnings for those deprecated options and warns users about using them if detected so I don't think we need to do that here once it goes live.