### PR TITLE
feat(browser): Add simpler `makeMultiplexedTransport` docs for automatic matcher

### DIFF
--- a/docs/platforms/javascript/common/best-practices/micro-frontends.mdx
+++ b/docs/platforms/javascript/common/best-practices/micro-frontends.mdx
@@ -123,27 +123,13 @@ import {
   makeFetchTransport,
   moduleMetadataIntegration,
   makeMultiplexedTransport,
+  MULTIPLEXED_TRANSPORT_EXTRA_KEY,
 } from "@sentry/browser";
-
-const EXTRA_KEY = "ROUTE_TO";
-
-const transport = makeMultiplexedTransport(makeFetchTransport, (args) => {
-  const event = args.getEvent();
-  if (
-    event &&
-    event.extra &&
-    EXTRA_KEY in event.extra &&
-    Array.isArray(event.extra[EXTRA_KEY])
-  ) {
-    return event.extra[EXTRA_KEY];
-  }
-  return [];
-});
 
 init({
   dsn: "__DEFAULT_DSN__",
   integrations: [moduleMetadataIntegration()],
-  transport,
+  transport: makeMultiplexedTransport(makeFetchTransport),
   beforeSend: (event) => {
     if (event?.exception?.values?.[0].stacktrace.frames) {
       const frames = event.exception.values[0].stacktrace.frames;
@@ -156,7 +142,7 @@ init({
       if (routeTo.length) {
         event.extra = {
           ...event.extra,
-          [EXTRA_KEY]: routeTo,
+          [MULTIPLEXED_TRANSPORT_EXTRA_KEY]: routeTo,
         };
       }
     }
@@ -186,28 +172,10 @@ init({
 ></script>
 
 <script>
-  const EXTRA_KEY = "ROUTE_TO";
-
-  const transport = Sentry.makeMultiplexedTransport(
-    Sentry.makeFetchTransport,
-    (args) => {
-      const event = args.getEvent();
-      if (
-        event &&
-        event.extra &&
-        EXTRA_KEY in event.extra &&
-        Array.isArray(event.extra[EXTRA_KEY])
-      ) {
-        return event.extra[EXTRA_KEY];
-      }
-      return [];
-    }
-  );
-
   Sentry.init({
     dsn: "__DEFAULT_DSN__",
     integrations: [Sentry.moduleMetadataIntegration()],
-    transport,
+    transport: Sentry.makeMultiplexedTransport(Sentry.makeFetchTransport),
     beforeSend: (event) => {
       if (event?.exception?.values?.[0].stacktrace.frames) {
         const frames = event.exception.values[0].stacktrace.frames;
@@ -220,7 +188,7 @@ init({
         if (routeTo.length) {
           event.extra = {
             ...event.extra,
-            [EXTRA_KEY]: routeTo,
+            [Sentry.MULTIPLEXED_TRANSPORT_EXTRA_KEY]: routeTo,
           };
         }
       }
@@ -249,11 +217,42 @@ will return matches for errors, transactions, and replays.
 ## Manually Route Errors to Different Projects
 
 If you want more control to be able to explicitly specify the destination for each individual `captureException`,
-you can use the more advanced interface multiplexed transport offers.
+you can use the multiplexed transport's API to route events to specific projects.
 
 <Alert>Requires SDK version `7.59.0` or higher.</Alert>
 
-The example below uses a `feature` tag to determine which Sentry project to
+### Using the Default Matcher
+
+The simplest way to manually route events is by using the default matcher with `MULTIPLEXED_TRANSPORT_EXTRA_KEY`:
+
+```js
+import {
+  captureException,
+  init,
+  makeFetchTransport,
+  makeMultiplexedTransport,
+  MULTIPLEXED_TRANSPORT_EXTRA_KEY,
+} from "@sentry/browser";
+
+init({
+  dsn: "__FALLBACK_DSN__",
+  transport: makeMultiplexedTransport(makeFetchTransport),
+});
+
+// Route a specific error to different projects
+captureException(new Error("oh no!"), {
+  extra: {
+    [MULTIPLEXED_TRANSPORT_EXTRA_KEY]: [
+      { dsn: "__CART_DSN__", release: "cart@1.0.0" },
+      { dsn: "__GALLERY_DSN__", release: "gallery@1.2.0" },
+    ],
+  },
+});
+```
+
+### Using a Custom Matcher
+
+For more advanced routing logic, you can provide a custom matcher function. The example below uses a `feature` tag to determine which Sentry project to
 send the event to. If the event doesn't have a `feature` tag, we send it to the
 fallback DSN defined in `Sentry.init`.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

With [10.28.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.28.0) we released a simpler way to work with micro-frontends by building an automatic base matcher into `makeMultiplexedTransport`.

These docs reflect the change on top of showcasing how to set up a manual matcher.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+
