### PR TITLE
docs(react-router): Rename "library" to "data/declarative"

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -16,9 +16,9 @@ categories:
   you have any feedback or concerns.
 </Alert>
 
-<Alert title='Looking for library mode?' level='info'>
+<Alert title='Looking for data/declarative mode?' level='info'>
 
-If you're using React Router in library mode, follow the instructions in our [React guide](/platforms/javascript/guides/react/features/react-router/v7).
+If you're using React Router in data or declarative mode, follow the instructions in our [React guide](/platforms/javascript/guides/react/features/react-router/v7).
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
+++ b/docs/platforms/javascript/guides/react/features/react-router/v7.mdx
@@ -1,5 +1,5 @@
 ---
-title: React Router v7 (library mode)
+title: React Router v7 (non-framework)
 description: "Learn how to instrument your React Router v7 application with Sentry."
 sidebar_order: 10
 ---
@@ -14,7 +14,7 @@ automatically captures rendering errors:
 
 <TableOfContents ignoreIds={["set-up-a-custom-error-boundary", "next-steps"]} />
 
-## Usage with `createBrowserRouter` or `createMemoryRouter`
+## Usage with `createBrowserRouter` or `createMemoryRouter` (Data Mode)
 
 To instrument your React Router, update your `Sentry.browserTracingIntegration` to `Sentry.reactRouterV7BrowserTracingIntegration` within `Sentry.init` and provide the required React hooks and router functions. Then, wrap the router instance created by `createBrowserRouter` or `createMemoryRouter` with one of the following functions:
 
@@ -56,7 +56,7 @@ const router = sentryCreateBrowserRouter([
 ]);
 ```
 
-## Usage With `<Routes />` Component
+## Usage With `<Routes />` Component (Declarative Mode)
 
 If you're using the `<Routes />` component to define your routes, update your `Sentry.browserTracingIntegration` to `Sentry.reactRouterV7BrowserTracingIntegration` inside `Sentry.init` and provide the required React hooks and router functions. Then, wrap `<Routes />` using `Sentry.withSentryReactRouterV7Routing`. This creates a higher order component, which will enable Sentry to reach your router context. You can also use `Sentry.withSentryReactRouterV7Routing` for routes inside `BrowserRouter`, `MemoryRouter`, and `HashRouter` components.
 

--- a/docs/platforms/javascript/guides/react/index.mdx
+++ b/docs/platforms/javascript/guides/react/index.mdx
@@ -182,7 +182,7 @@ import * as Sentry from "@sentry/react";
 If you're using `react-router` in your application, you need to set up the Sentry integration for your specific React Router version to trace `navigation` events.\
 Select your React Router version to start instrumenting your routing:
 
-- [React Router v7 (library mode)](features/react-router/v7)
+- [React Router v7 (non-framework)](features/react-router/v7)
 - [React Router v6](features/react-router/v6)
 - [Older React Router versions](features/react-router)
 - [TanStack Router](features/tanstack-router)


### PR DESCRIPTION

## DESCRIBE YOUR PR


This updates the wording of the React Router modes to be aligned with their modes (framework, data, declarative - [source](https://reactrouter.com/start/modes)).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

