### PR TITLE
chore(dynamic-sampling): add notice that we will remove the get samples button

### DIFF
--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -206,9 +206,9 @@ We deprioritize health check type transactions because while they're important f
 
 ### Get Samples
 
-<Info>
+<Alert>
 The "Get Samples" button and the investigation rules that go along with it will be retired in Spring 2026. From that point on, you will no longer be able to create new investigation rules.
-</Info>
+</Alert>
 
 Our automated dynamic sampling priorities work well in a generic manner to collect a baseline of samples because they prioritize retaining data that's valuable for any customer at any given time. However, there are certain scenarios, such as investigating a particular issue, when very specific data becomes temporarily more important. In such cases, the automated sampling priorities may not provide enough samples, so you may want to create investigation rules.
 


### PR DESCRIPTION
- As we will be removing the Get Samples button as part of our move to Span First, we want to shout this out in the docs

Closes TET-1479