### PR TITLE
meta(CODEOWNERS): move .NET from GDX to Backend SDKs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@
 # /docs/platforms/react-native/ @getsentry/team-mobile-cross-platform
 # /docs/platforms/javascript/guides/cordova/ @getsentry/team-mobile-cross-platform
 
-# /docs/platforms/dotnet/ @getsentry/gdx
 # /docs/platforms/godot/ @getsentry/gdx
 # /docs/platforms/nintendo-switch/ @getsentry/gdx
 # /docs/platforms/playstation/ @getsentry/gdx
@@ -22,6 +21,7 @@
 # /docs/platforms/unreal/ @getsentry/gdx
 # /docs/platforms/xbox/ @getsentry/gdx
 
+# /docs/platforms/dotnet/ @getsentry/team-web-sdk-backend
 # /docs/platforms/java/ @getsentry/team-web-sdk-backend
 # /docs/platforms/native/ @getsentry/product-owners-sdks-native
 # /docs/platforms/rust/ @getsentry/team-web-sdk-backend


### PR DESCRIPTION
## DESCRIBE YOUR PR
The .NET SDK (`getsentry/sentry-dotnet`) moved from _Team GDX_ to _Team Web SDK Backend_.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): ASAP
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
