### PR TITLE
fix: Network failures drop envelope on 429

### DIFF
--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -255,7 +255,7 @@ When SDKs receive an `HTTP 2xx` status code response from Sentry, they **MUST** 
 
 If Sentry returns an `HTTP 4xx` or `HTTP 5xx` status code, SDKs:
 
-- **MUST**discard the envelope
+- **MUST** discard the envelope
 - **MUST** record a [client report](/sdk/telemetry/client-reports) with the discard reason `send_error`, except for `HTTP 429` responses, see below.
 
 For an `HTTP 429` response, SDKs:


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarify that SDKs must also drop envelopes on 429 responses.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

