### PR TITLE
Fix Deprecated Reference to with_transaction()

### DIFF
--- a/docs/platforms/rust/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/rust/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -128,5 +128,5 @@ use tower::ServiceBuilder;
 
 let layer = ServiceBuilder::new()
     .layer(NewSentryLayer::new_from_top())
-    .layer(SentryHttpLayer::with_transaction());
+    .layer(SentryHttpLayer::enable_transaction());
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
`with_transaction()` was deprecated in 0.38.0 per the docs, `enable_transaction()` should be used instead.

https://docs.rs/sentry-tower/latest/sentry_tower/struct.SentryHttpLayer.html#impl-SentryHttpLayer

## IS YOUR CHANGE URGENT?  

Not urgent

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
