### PR TITLE
feat: Add docs about vercel drains via vercel marketplace integration

### DIFF
--- a/docs/organization/integrations/deployment/vercel/index.mdx
+++ b/docs/organization/integrations/deployment/vercel/index.mdx
@@ -16,7 +16,8 @@ If you make changes to your organization slug, you'll need to update your config
 
 </Alert>
 
-Connect your Sentry and Vercel projects to automatically notify Sentry of every deployment and upload source maps for your Next.js application.
+Connect your Sentry and Vercel projects to automatically notify Sentry of every deployment and upload source maps for your Next.js application. You can also set up Vercel Drains to forward logs and traces data from Vercel to Sentry.
+
 To learn more about using Sentry in your Next.js app, check out the [Next.js SDK](/platforms/javascript/guides/nextjs/).
 
 ### Install
@@ -69,6 +70,10 @@ Use Vercel to [link projects](#project-linking) for uploading source maps and no
 - Add a Sentry bundler plugin to your bundler configuration ([webpack plugin](https://www.npmjs.com/package/@sentry/webpack-plugin), [Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin), [Esbuild Plugin](https://www.npmjs.com/package/@sentry/esbuild-plugin), [Rollup Plugin](https://www.npmjs.com/package/@sentry/rollup-plugin)). If you are using Sentry's Next.js, or SvelteKit SDKs this will already have been done for you.
 - In case you already have a Vercel project integrated with Sentry, ensure the Sentry project you link is the one you're already using to report errors.
 
+### Drains
+
+You can set up [Vercel Drains](https://vercel.com/docs/drains) via the Vercel integration to forward logs and traces data from Vercel to Sentry. See the [Vercel Drains documentation](/product/drains/integration/vercel/#automatic-drain-setup) for more information.
+
 ### Uninstallation
 
 1. You can uninstall the integration from Vercel or Sentry. To do so in Sentry, navigate to **Settings > Integrations > Vercel > Configurations**, click "Uninstall", and confirm.
@@ -79,11 +84,13 @@ Use Vercel to [link projects](#project-linking) for uploading source maps and no
 
 ### Troubleshooting
 
-#### Failed to fetch
+<Expandable title="Failed to fetch">
 
 ![Failed to fetch error message](./img/vercel_failed_to_fetch.png)
 
 This issue typically occurs if you have an ad blocker blocking the conversation between Vercel and Sentry during setup. To remediate the issue, disable your ad blocker and go through the installation flow again.
+
+</Expandable>
 
 ## Vercel Marketplace
 
@@ -102,7 +109,9 @@ Subscription settings can only be modified within Sentry. During setup, organiza
 ### User Access
 
 <Alert>
-  Only the individual who sets up Sentry using the one-click workflow will have a Sentry user account created for them. To enable single sign-on access from Vercel for other users, they must be invited to the Sentry organization.
+  Only the individual who sets up Sentry using the one-click workflow will have
+  a Sentry user account created for them. To enable single sign-on access from
+  Vercel for other users, they must be invited to the Sentry organization.
 </Alert>
 
 Vercel users will have single sign-on access to Sentry using the "Open in Sentry" button within Vercel, and will be able to create new projects in either Vercel or Sentry.
@@ -113,10 +122,13 @@ Users will still be able to login to their Sentry organization directly, without
 
 For every project configured, the following environment variables will be set within the Vercel deployment:
 
-- **SENTRY_PROJECT**
-- **SENTRY_AUTH_TOKEN**
-- **NEXT_PUBLIC_SENTRY_DSN**
-- **SENTRY_ORG**
+- **SENTRY_PROJECT**: Your configured Sentry project
+- **SENTRY_AUTH_TOKEN**: The Sentry authentication token for the Vercel Internal Integration
+- **NEXT_PUBLIC_SENTRY_DSN**: The DSN for your Sentry project
+- **SENTRY_ORG**: Your Sentry organization
+- **SENTRY_VERCEL_LOG_DRAIN_URL**: The Vercel Log Drain URL for your Sentry project (used for Vercel Log Drains)
+- **SENTRY_OTLP_TRACES_URL**: The OTLP Traces Drain URL for your Sentry project (used for Vercel Trace Drains)
+- **SENTRY_PUBLIC_KEY**: The public key for your Sentry project (used for authentication with log/trace drains)
 
 ### Integration Deletion
 

--- a/docs/product/drains/integration/vercel.mdx
+++ b/docs/product/drains/integration/vercel.mdx
@@ -4,7 +4,10 @@ sidebar_order: 40
 description: Learn how to set up Vercel drains to forward logs and traces data to Sentry.
 ---
 
-Vercel Drains let you forward traces and logs from applications running on Vercel to Sentry.
+Vercel Drains let you forward traces and logs from applications running on Vercel to Sentry. For more information on Vercel Drains, see the [Vercel drain documentation](https://vercel.com/docs/drains). Currently only Logs and Traces are supported.
+
+- **Logs**: Runtime, build, and static logs from your deployments
+- **Traces**: Distributed tracing data collected via OpenTelemetry (OTLP) from your applications
 
 ## Prerequisites
 
@@ -13,30 +16,34 @@ Before you begin, ensure you have:
 - A Vercel project that you want to monitor
 - A Sentry project you want to send data to
 
-## Set up a Drain
+## Automatic Drain Setup
 
-To set up a Drain in Vercel you'll need to create a new Drain in the Vercel settings. For more information on Vercel Drains, please see the [Vercel drain documentation](https://vercel.com/docs/drains).
+If you've installed the [Sentry Vercel Integration](https://vercel.com/marketplace/sentry), you can set up a drain via the integration.
+
+If you haven't installed the integration, you can follow the instructions in the [Sentry Vercel Integration documentation](/organization/integrations/deployment/vercel/#install) to install the integration.
+
+Then you can add a Drain from your Vercel team's Integrations tab.
+
+1. From the Vercel dashboard, view the integrations list by clicking the **Integrations** tab.
+2. Select the **Sentry** integration from the integrations list to view the integration settings.
+3. Click **Manage** and select your installed product
+4. Under **Drains**, click **Add Drain** to create a new drain.
+5. Configure which project you would like to send data from and click **Create Drain** to create the drain.
+
+## Manual Drain Setup
+
+To set up a Drain in Vercel manually, you'll need to create a new Drain in the Vercel settings.
 
 1. From the Vercel dashboard, go to **Team Settings > Drains** and click **Add Drain**.
-2. Choose a data type. Currently only Logs and Traces are supported.
+2. Choose a data type.
 
-- [Logs](#log-drains): Runtime, build, and static logs from your deployments (supports custom endpoints and native integrations)
-- [Traces](#trace-drains): Distributed tracing data in OpenTelemetry format (supports custom endpoints and native integrations)
-
-### Log Drains
+### Manual Log Drain Setup
 
 After selecting the Logs data type, you'll need to configure the drain to send data to Sentry.
 
 1. Provide a name for your drain and select which projects should send data to your endpoint. You can choose all projects or select specific ones.
 2. Configure the sampling rate to control the volume of data sent to your drain. We recommend sampling 100% of the data to ensure you get all the data you need.
-3. Select which log sources to collect
-
-- **Functions**: Outputs log data from Vercel Functions like API Routes
-- **Edge Functions**: Outputs log data from Vercel Functions or Routing Middleware using Edge runtime
-- **Static Files**: Collects logs for static assets like HTML and CSS files
-- **Rewrites**: Collects log results for external [rewrites](https://vercel.com/docs/project-configuration#rewrites) to a different domain
-- **Builds**: Outputs log data from the Build Step
-- **Firewall**: Outputs log data from requests denied by [Vercel Firewall](https://vercel.com/docs/vercel-firewall) rules
+3. Select which log sources to collect. See [Log Source Details](#log-source-details) for more information.
 
 4. Select which environments to drain from. You can choose to drain from all environments or select specific ones.
 5. Under the custom endpoint tab add the Sentry Vercel Log Drain Endpoint in the URL field. You can find the endpoint in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **Vercel**. You can select either JSON or NDJSON encoding.
@@ -53,7 +60,7 @@ x-sentry-auth: sentry sentry_key=___PUBLIC_KEY___
 
 7. To test that the log drain is working, you can send a test log to your drain by clicking the Test button.
 
-### Trace Drains
+### Manual Trace Drain Setup
 
 After selecting the Traces data type, you'll need to configure the drain to send data to Sentry.
 
@@ -72,6 +79,12 @@ x-sentry-auth: sentry sentry_key=___PUBLIC_KEY___
 ```
 
 5. To test that the trace drain is working, you can send a test trace to your drain by clicking the Test button.
+
+<Alert level="warning">
+
+Sending [metrics](/product/explore/metrics/) via Vercel Metric Drains (Speed Insights, Web Analytics) are currently not currently supported. If you're interested this support for this please reach out on [GitHub](https://github.com/getsentry/sentry/issues/103488) or or email us at [feedback-metrics@sentry.io](mailto:feedback-metrics@sentry.io).
+
+</Alert>
 
 ## Troubleshooting
 
@@ -92,3 +105,14 @@ x-sentry-auth: sentry sentry_key=___PUBLIC_KEY___
   use a combination of the `vercel.project_name`, `vercel.deployment_id`, and
   `vercel.build_id` fields to grab logs from a specific build.
 </Expandable>
+
+## Log Source Details
+
+Vercel Log Drains support the following log sources:
+
+- **Functions**: Outputs log data from Vercel Functions like API Routes
+- **Edge Functions**: Outputs log data from Vercel Functions or Routing Middleware using Edge runtime
+- **Static Files**: Collects logs for static assets like HTML and CSS files
+- **Rewrites**: Collects log results for external [rewrites](https://vercel.com/docs/project-configuration#rewrites) to a different domain
+- **Builds**: Outputs log data from the Build Step
+- **Firewall**: Outputs log data from requests denied by [Vercel Firewall](https://vercel.com/docs/vercel-firewall) rules


### PR DESCRIPTION
Documents support for log/trace drains with https://vercel.com/marketplace/sentry.

This support was added with https://github.com/getsentry/getsentry/pull/18932.