### PR TITLE
fix casing Github -> GitHub

### DIFF
--- a/docs/product/ai-in-sentry/ai-code-review/index.mdx
+++ b/docs/product/ai-in-sentry/ai-code-review/index.mdx
@@ -20,7 +20,7 @@ AI Code Review helps you reviews your code changes, predicting errors and offeri
 
 To enable AI Code Review in your GitHub organization or on specific repositories:
 
-1.  Have the [Sentry Github integration](/organization/integrations/source-code-mgmt/github/) enabled.
+1.  Have the [Sentry GitHub integration](/organization/integrations/source-code-mgmt/github/) enabled.
 
 2. Enable these required settings in your Sentry [organization settings](https://sentry.io/orgredirect/settings/:orgslug/):
    - `Show Generative AI Features`


### PR DESCRIPTION
Hi, this is the casing police 

<img width="1420" height="946" alt="image" src="https://github.com/user-attachments/assets/88efefcd-a9f2-46d4-85ff-1605b90ee9cb" />
