### PR TITLE
Enhance user feedback example with optional fields

### DIFF
--- a/docs/platforms/apple/common/user-feedback/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/index.mdx
@@ -173,9 +173,9 @@ The User Feedback API allows you to collect user feedback while using your own U
 ```swift
 SentrySDK.capture(feedback: .init(
     message: "I encountered a bug while using the app.",
-    name: "John Doe",
-    email: "john.doe@example.com",
+    name: "John Doe", // optional
+    email: "john.doe@example.com", // optional
     source: .custom,
-    screenshot: somePngImageData // optional
+    attachments: someSentryAttachmentData // optional, see SentryAttachment type
 ))
 ```


### PR DESCRIPTION
Updated the user feedback example in the documentation to include optional fields for name, email, and attachments.
