### PR TITLE
chore(integrations): callout for adding repos that might have permissions problem

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -54,6 +54,12 @@ Sentry owner, manager, or admin permissions, and GitHub owner permissions are re
 
 9. You can now [configure](#configure) the integration.
 
+<Alert>
+
+If you are not seeing your repository show up in Sentry, double check that the [Sentry Github app](https://github.com/apps/sentry) has permissions to access the repository.
+
+</Alert>
+
 The GitHub integration is available for all projects under your Sentry organization. You can connect multiple GitHub organizations to one Sentry organization. Connecting a GitHub organisation to multiple Sentry organisations is supported on Sentry organisations on a Business or Enterprise plans (not supported for GitHub Enterprise Server).
 
 While you can install the GitHub integration from [GitHub](https://github.com/apps/sentry), we recommend installing it from Sentry for a more streamlined process.


### PR DESCRIPTION
I ran into this and it took me awhile to figure out. This call out would have saved me lots of time

<img width="2456" height="416" alt="CleanShot 2025-12-09 at 16 23 25@2x" src="https://github.com/user-attachments/assets/b64082db-5ac2-474e-92c3-2c9e55c113f8" />


## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
