### PR TITLE
docs(backend): add explanation to serializers & get_attrs

### DIFF
--- a/develop-docs/backend/api/serializers.mdx
+++ b/develop-docs/backend/api/serializers.mdx
@@ -161,7 +161,7 @@ class ModelSerializer(Serializer):
 ...
 ```
 
-**Using get_attrs to avoid N+1 queries in bulk queries**
+**Using get_attrs to avoid N+1 queries**
 
 For API calls that involve serializing multiple objects (for example, several Organization instances), the top-level [`serialize` function](https://github.com/getsentry/sentry/blob/f5bb22601361802007d628a0b3652256c812c7b5/src/sentry/api/serializers/base.py#L30-L80) is designed to optimize database access and avoid N+1 query problems. The process works in two steps:
 


### PR DESCRIPTION
- Add some more flavor to the docs about the `get_attrs` method in the context of serializers, and how it can be used to prevent N+1 queries