### PR TITLE
ref(span-first): Clarify application of scope data to spans

### DIFF
--- a/develop-docs/sdk/telemetry/spans/implementation.mdx
+++ b/develop-docs/sdk/telemetry/spans/implementation.mdx
@@ -77,7 +77,7 @@ Here's a rough overview of what `captureSpan` should do in which order:
 2. Obtain the current, isolation and global scopes and merge the scope data.
 3. Apply [common span attributes](../span-protocol/#common-attribute-keys) from the client and the merged scope data to every span.
 4. Apply [scope attributes](../../scopes/#setting-attributes) from the merged scope data to every span.
-5. Apply `contests` and `request` data from the merged scopes to the segment span only.
+5. Apply `contexts` and `request` data from the merged scopes to the segment span only.
 6. Apply any span processing hooks (i.e. event processor replacements) to the span.
 7. Apply the `before_send_span` callback to the span.
 8. Enqueue the span into the span buffer.


### PR DESCRIPTION
Clarifies which spans get which data from the scopes:
- scope attributes are applied to all spans
- scope contexts and request data is only applied to segment span
