### PR TITLE
docs(langgraph/langchain): Bump langgraph/langchain versions to <2.0.0

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
@@ -203,4 +203,4 @@ await model.invoke("Tell me a joke", {
 
 ## Supported Versions
 
-- `langchain`: `>=0.1.0 <1.0.0`
+- `langchain`: `>=0.1.0 <2.0.0`

--- a/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
@@ -228,4 +228,4 @@ By default this integration adds tracing support for LangGraph operations includ
 
 ## Supported Versions
 
-- `@langchain/langgraph`: `>=0.2.0 <1.0.0`
+- `@langchain/langgraph`: `>=0.2.0 <2.0.0`


### PR DESCRIPTION
## DESCRIBE YOUR PR
Maximal supported version for langgraph/langchain is 2.0.0

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

