### PR TITLE
docs(flutter,react-native): Add Fastlane to size analysis and build distribution (EME-683)

### DIFF
--- a/docs/platforms/dart/guides/flutter/size-analysis/index.mdx
+++ b/docs/platforms/dart/guides/flutter/size-analysis/index.mdx
@@ -14,7 +14,11 @@ description: Upload Flutter builds to Sentry for size analysis.
 
 **Accepted Upload Formats**: XCArchive (preferred) | IPA
 
-**Upload Mechanisms**: [Sentry CLI](#uploading-ios-builds-with-the-sentry-cli)
+**Upload Mechanisms**: [Fastlane Plugin](#uploading-ios-builds-with-fastlane) _or_ [Sentry CLI](#uploading-ios-builds-with-the-sentry-cli)
+
+### Uploading iOS Builds With Fastlane
+
+<Include name="size-analysis/upload-fastlane" />
 
 ### Uploading iOS Builds With the Sentry CLI
 

--- a/docs/platforms/react-native/size-analysis/index.mdx
+++ b/docs/platforms/react-native/size-analysis/index.mdx
@@ -15,7 +15,11 @@ description: Upload React Native iOS and Android builds to Sentry for size analy
 
 **Accepted Upload Formats**: XCArchive (preferred) | IPA
 
-**Upload Mechanisms**: [Sentry CLI](#uploading-ios-builds-with-the-sentry-cli)
+**Upload Mechanisms**: [Fastlane Plugin](#uploading-ios-builds-with-fastlane) _or_ [Sentry CLI](#uploading-ios-builds-with-the-sentry-cli)
+
+### Uploading iOS Builds With Fastlane
+
+<Include name="size-analysis/upload-fastlane" />
 
 ### Uploading iOS Builds With the Sentry CLI
 

--- a/includes/build-distribution/getting-started-ios.mdx
+++ b/includes/build-distribution/getting-started-ios.mdx
@@ -1,6 +1,10 @@
 **Accepted Formats**: XCArchive
 
-**Upload Mechanism**: [Sentry CLI](#uploading-ios-builds-with-the-sentry-cli)
+**Upload Mechanisms**: [Fastlane Plugin](#uploading-ios-builds-with-fastlane) _or_ [Sentry CLI](#uploading-ios-builds-with-the-sentry-cli)
+
+### Uploading iOS Builds With Fastlane
+
+<Include name="size-analysis/upload-fastlane" />
 
 ### Uploading iOS Builds With the Sentry CLI
 


### PR DESCRIPTION
## Summary

- Adds Fastlane as an upload mechanism for iOS builds in Flutter size analysis documentation
- Adds Fastlane as an upload mechanism for iOS builds in React Native size analysis documentation  
- Adds Fastlane as an upload mechanism for iOS builds in Flutter and React Native build distribution documentation

Direct links to the previews:
RN Size Analysis: https://sentry-docs-git-no-eme-683-add-fastlane-to-flutter-and-r-ad0880.sentry.dev/platforms/react-native/size-analysis/
RN Build Distribution: https://sentry-docs-git-no-eme-683-add-fastlane-to-flutter-and-r-ad0880.sentry.dev/platforms/react-native/build-distribution/
Flutter Size Analysis: https://sentry-docs-git-no-eme-683-add-fastlane-to-flutter-and-r-ad0880.sentry.dev/platforms/dart/guides/flutter/size-analysis/
Flutter Build Distribution: https://sentry-docs-git-no-eme-683-add-fastlane-to-flutter-and-r-ad0880.sentry.dev/platforms/dart/guides/flutter/build-distribution/

Fixes EME-683