### PR TITLE
chore(platform): Set auth token explicitly in `withSentryConfig`

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -148,6 +148,7 @@ const nextConfig = {
 module.exports = withSentryConfig(nextConfig, {
   org: 'sentry',
   project: process.env.NEXT_PUBLIC_DEVELOPER_DOCS ? 'develop-docs' : 'docs',
+  authToken: process.env.SENTRY_AUTH_TOKEN,
 
   // Suppresses source map uploading logs during build
   silent: !process.env.CI,


### PR DESCRIPTION
This makes the env var easier discoverable.