### PR TITLE
docs(threads): add note about desktop for Main/UI threads

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/threads.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/threads.mdx
@@ -37,7 +37,7 @@ Defaults to `false`.
 `main`
 
 : _Optional_. If applicable, a flag indicating whether the thread was responsible for rendering the user interface.
-On mobile platforms this is oftentimes referred to as the "main thread" or "ui thread".
+On mobile and desktop platforms this is oftentimes referred to as the "main thread" or "ui thread".
 
 `name`
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Extend a note on "Main Thread" and "UI Thread" from mobile platforms to desktop platforms,
as this is a concept that also applies to Desktop applications like WinForms, WPF, Uno, and more (with regards to .NET).
Noted via getsentry/sentry-dotnet#4807 and suggested a similar change: https://github.com/getsentry/sentry-dotnet/pull/4807#discussion_r2614408364.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
