### PR TITLE
feat(reactrouter): Add react router wizard instructions

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Router Framework
-description: Learn how to set up and configure Sentry in your React Router v7 application, capture your first errors, and view them in Sentry.
+description: Learn how to set up and configure Sentry in your React Router v7 application using the installation wizard, capture your first errors, and view them in Sentry.
 sdk: sentry.javascript.react-router
 categories:
   - javascript
@@ -24,46 +24,51 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <PlatformContent includePath="getting-started-prerequisites" />
 
-## Step 1: Install
+<StepComponent>
 
-### Install the Sentry SDK
+## Install
 
-Run the command for your preferred package manager to add the SDK package to your application:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
-<OnboardingOption optionId="profiling">
+To install Sentry using the installation wizard, run the command on the right within your project directory.
 
-```bash {tabTitle:npm}
-npm install @sentry/react-router @sentry/profiling-node
+The wizard guides you through the setup process, asking you to enable additional (optional) Sentry features for your application beyond error monitoring.
+
+This guide assumes that you enable all features and allow the wizard to create an example page and route. You can add or remove features at any time, but setting them up now will save you the effort of configuring them manually later.
+
+<Expandable title="What does the installation wizard change inside your application?">
+
+- Installs the `@sentry/react-router` package (and optionally `@sentry/profiling-node`)
+- Reveals React Router entry point files (`entry.client.tsx` and `entry.server.tsx`) if not already visible
+- Initializes Sentry in your client and server entry files with default configuration
+- Creates `instrument.server.mjs` for server-side instrumentation
+- Updates your `app/root.tsx` to capture errors in the error boundary
+- Configures source map upload in `vite.config.ts` and `react-router.config.ts`
+- Creates `.env.sentry-build-plugin` with an auth token to upload source maps (this file is automatically added to `.gitignore`)
+- Creates example page and API route to help verify your Sentry setup
+
+</Expandable>
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```bash
+npx @sentry/wizard@latest -i reactRouter
 ```
 
-```bash {tabTitle:yarn}
-yarn add @sentry/react-router @sentry/profiling-node
-```
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-```bash {tabTitle:pnpm}
-pnpm add @sentry/react-router @sentry/profiling-node
-```
+## Configure
 
-</OnboardingOption>
+If you prefer to configure Sentry manually, here are the configuration files the wizard would create:
 
-<OnboardingOption optionId="profiling" hideForThisOption>
-  ```bash {tabTitle:npm}
-  npm install @sentry/react-router
-  ```
+In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also get to the root of an error or performance issue faster, by watching a video-like reproduction of a user session with [session replay](/product/explore/session-replay/web/getting-started/).
 
-```bash {tabTitle:yarn}
-yarn add @sentry/react-router
-```
-
-```bash {tabTitle:pnpm}
-pnpm add @sentry/react-router
-```
-
-</OnboardingOption>
-
-## Step 2: Configure
-
-Choose the features you want to configure, and this guide will show you how:
+Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
 <OnboardingOptionButtons
   options={[
@@ -81,77 +86,78 @@ Choose the features you want to configure, and this guide will show you how:
 
 <PlatformContent includePath="getting-started-features-expandable" />
 
-### Expose Entry Point Files
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
-Before configuring Sentry, you need to make React Router's entry files (`entry.client.tsx` and `entry.server.tsx`) visible in your project. Run this command to expose them:
+### Client-Side Configuration
 
-```bash
-npx react-router reveal
-```
+The wizard creates a client configuration file that initializes the Sentry SDK in your browser.
 
-### Configure Client-side Sentry
+The configuration includes your DSN (Data Source Name), which connects your app to your Sentry project, and enables the features you selected during installation.
 
-Initialize Sentry in your `entry.client.tsx` file:
+</SplitSectionText>
+<SplitSectionCode>
 
-```tsx {diff} {filename: entry.client.tsx}
-+import * as Sentry from "@sentry/react-router";
- import { startTransition, StrictMode } from "react";
- import { hydrateRoot } from "react-dom/client";
- import { HydratedRouter } from "react-router/dom";
+```tsx {tabTitle:Client} {filename:entry.client.tsx}
+import * as Sentry from "@sentry/react-router";
+import { startTransition, StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { HydratedRouter } from "react-router/dom";
 
-+Sentry.init({
-+  dsn: "___PUBLIC_DSN___",
-+
-+  // Adds request headers and IP for users, for more info visit:
-+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#sendDefaultPii
-+  sendDefaultPii: true,
-+
-+  integrations: [
-+    // ___PRODUCT_OPTION_START___ performance
-+    // Registers and configures the Tracing integration,
-+    // which automatically instruments your application to monitor its
-+    // performance, including custom Angular routing instrumentation
-+    Sentry.reactRouterTracingIntegration(),
-+    // ___PRODUCT_OPTION_END___ performance
-+    // ___PRODUCT_OPTION_START___ session-replay
-+    // Registers the Replay integration,
-+    // which automatically captures Session Replays
-+    Sentry.replayIntegration(),
-+    // ___PRODUCT_OPTION_END___ session-replay
-+    // ___PRODUCT_OPTION_START___ user-feedback
-+    Sentry.feedbackIntegration({
-+      // Additional SDK configuration goes in here, for example:
-+      colorScheme: "system",
-+    }),
-+    // ___PRODUCT_OPTION_END___ user-feedback
-+  ],
-+  // ___PRODUCT_OPTION_START___ logs
-+
-+  // Enable logs to be sent to Sentry
-+  enableLogs: true,
-+  // ___PRODUCT_OPTION_END___ logs
-+  // ___PRODUCT_OPTION_START___ performance
-+
-+  // Set tracesSampleRate to 1.0 to capture 100%
-+  // of transactions for tracing.
-+  // We recommend adjusting this value in production
-+  // Learn more at
-+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#traces-sample-rate
-+  tracesSampleRate: 1.0, //  Capture 100% of the transactions
-+
-+  // Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled
-+  tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
-+  // ___PRODUCT_OPTION_END___ performance
-+  // ___PRODUCT_OPTION_START___ session-replay
-+
-+  // Capture Replay for 10% of all sessions,
-+  // plus 100% of sessions with an error
-+  // Learn more at
-+  // https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/configuration/#general-integration-configuration
-+  replaysSessionSampleRate: 0.1,
-+  replaysOnErrorSampleRate: 1.0,
-+  // ___PRODUCT_OPTION_END___ session-replay
-+});
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Adds request headers and IP for users, for more info visit:
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#sendDefaultPii
+  sendDefaultPii: true,
+
+  integrations: [
+    // ___PRODUCT_OPTION_START___ performance
+    // Registers and configures the Tracing integration,
+    // which automatically instruments your application to monitor its
+    // performance, including custom Angular routing instrumentation
+    Sentry.reactRouterTracingIntegration(),
+    // ___PRODUCT_OPTION_END___ performance
+    // ___PRODUCT_OPTION_START___ session-replay
+    // Registers the Replay integration,
+    // which automatically captures Session Replays
+    Sentry.replayIntegration(),
+    // ___PRODUCT_OPTION_END___ session-replay
+    // ___PRODUCT_OPTION_START___ user-feedback
+    Sentry.feedbackIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: "system",
+    }),
+    // ___PRODUCT_OPTION_END___ user-feedback
+  ],
+  // ___PRODUCT_OPTION_START___ logs
+
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+  // ___PRODUCT_OPTION_END___ logs
+  // ___PRODUCT_OPTION_START___ performance
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for tracing.
+  // We recommend adjusting this value in production
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#traces-sample-rate
+  tracesSampleRate: 1.0,
+
+  // Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled
+  tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
+  // ___PRODUCT_OPTION_END___ performance
+  // ___PRODUCT_OPTION_START___ session-replay
+
+  // Capture Replay for 10% of all sessions,
+  // plus 100% of sessions with an error
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/configuration/#general-integration-configuration
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ session-replay
+});
 
 startTransition(() => {
   hydrateRoot(
@@ -163,94 +169,22 @@ startTransition(() => {
 });
 ```
 
-#### Report Errors from Error Boundaries
+</SplitSectionCode>
+</SplitSection>
 
-Update your `app/root.tsx` file to capture unhandled errors in your error boundary:
+<SplitSection>
+<SplitSectionText>
 
-```tsx {diff} {filename: app/root.tsx}
-+import * as Sentry from "@sentry/react-router";
+### Server-Side Configuration
 
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "Oops!";
-  let details = "An unexpected error occurred.";
-  let stack: string | undefined;
+The wizard also creates a server configuration file for Node.js runtime.
 
-  if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error";
-    details =
-      error.status === 404
-        ? "The requested page could not be found."
-        : error.statusText || details;
-  } else if (error && error instanceof Error) {
-    // you only want to capture non 404-errors that reach the boundary
-+   Sentry.captureException(error);
-    if (import.meta.env.DEV) {
-      details = error.message;
-      stack = error.stack;
-    }
-  }
+For more advanced configuration options or to set up Sentry manually, check out our [manual setup guide](/platforms/javascript/guides/react-router/manual-setup/).
 
-  return (
-    <main>
-      <h1>{message}</h1>
-      <p>{details}</p>
-      {stack && (
-        <pre>
-          <code>{stack}</code>
-        </pre>
-      )}
-    </main>
-  );
-}
-// ...
-```
+</SplitSectionText>
+<SplitSectionCode>
 
-### Configure Server-side Sentry
-
-<Expandable level="warning" title="Limited Node support for auto-instrumentation" permalink>
-  Automatic server-side instrumentation is currently only supported on:
-    - **Node 20:** Version \<20.19
-    - **Node 22:** Version \<22.12
-
-If you're on a different version, use our manual server wrappers.
-
-For server loaders use `wrapServerLoader`:
-
-```ts
-import * as Sentry from "@sentry/react-router";
-
-export const loader = Sentry.wrapServerLoader(
-  {
-    name: "Load Some Data",
-    description: "Loads some data from the db",
-  },
-  async ({ params }) => {
-    // ... your loader logic
-  }
-);
-```
-
-For server actions use `wrapServerAction`:
-
-```ts
-import * as Sentry from "@sentry/react-router";
-
-export const action = Sentry.wrapServerAction(
-  {
-    name: "Submit Form Data",
-    description: "Processes form submission data",
-  },
-  async ({ request }) => {
-    // ... your action logic
-  }
-);
-```
-
-</Expandable>
-
-First, create a file called `instrument.server.mjs` in the root of your project to initialize Sentry:
-
-```js {filename: instrument.server.mjs}
+```js {tabTitle:Server} {filename:instrument.server.mjs}
 import * as Sentry from "@sentry/react-router";
 // ___PRODUCT_OPTION_START___ profiling
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
@@ -291,278 +225,30 @@ Sentry.init({
 });
 ```
 
-Next, replace the default `handleRequest` and `handleError` functions in your `entry.server.tsx` file with Sentry's wrapped versions:
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-```tsx {diff} {filename: entry.server.tsx}
-+import * as Sentry from '@sentry/react-router';
- import { createReadableStreamFromReadable } from '@react-router/node';
- import { renderToPipeableStream } from 'react-dom/server';
- import { ServerRouter } from 'react-router';
- import { type HandleErrorFunction } from 'react-router';
+## Verify Your Setup
 
-+const handleRequest = Sentry.createSentryHandleRequest({
-+  ServerRouter,
-+  renderToPipeableStream,
-+  createReadableStreamFromReadable,
-+});
+If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard:
 
- export default handleRequest;
+1. Open the example page `/sentry-example-page` in your browser. For most React Router applications, this will be at localhost.
+2. Observe the example page with a button that triggers test errors.
 
-+export const handleError = Sentry.createSentryHandleError({
-+  logErrors: false
-+});
+Clicking the button triggers an error that Sentry captures for you. The example also demonstrates how to test performance tracing.
 
-// ... rest of your server entry
-```
+<Alert level="success" title="Tip">
 
-<Expandable title="Do you need to customize your handleRequest function?">
-  If you need to customize the logic of your `handleRequest` function, you'll need to use Sentry's helper functions (`getMetaTagTransformer` and `wrapSentryHandleRequest`) manually:
-
-```tsx {1-4, 44-45, 69-70}
-import {
-  getMetaTagTransformer,
-  wrapSentryHandleRequest,
-} from "@sentry/react-router";
-// ... other imports
-
-const handleRequest = function handleRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  routerContext: EntryContext,
-  _loadContext: AppLoadContext
-): Promise<Response> {
-  return new Promise((resolve, reject) => {
-    let shellRendered = false;
-    const userAgent = request.headers.get("user-agent");
-
-    // Determine if we should use onAllReady or onShellReady
-    const isBot = typeof userAgent === "string" && botRegex.test(userAgent);
-    const isSpaMode = !!(routerContext as { isSpaMode?: boolean }).isSpaMode;
-
-    const readyOption = isBot || isSpaMode ? "onAllReady" : "onShellReady";
-
-    const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter context={routerContext} url={request.url} />,
-      {
-        [readyOption]() {
-          shellRendered = true;
-          const body = new PassThrough();
-
-          const stream = createReadableStreamFromReadable(body);
-
-          responseHeaders.set("Content-Type", "text/html");
-
-          resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
-          );
-
-          // this enables distributed tracing between client and server
-          pipe(getMetaTagTransformer(body));
-        },
-        onShellError(error: unknown) {
-          reject(error);
-        },
-        onError(error: unknown) {
-          // eslint-disable-next-line no-param-reassign
-          responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            // eslint-disable-next-line no-console
-            console.error(error);
-          }
-        },
-      }
-    );
-
-    // Abort the rendering stream after the `streamTimeout`
-    setTimeout(abort, streamTimeout);
-  });
-};
-
-// wrap the default export
-export default wrapSentryHandleRequest(handleRequest);
-
-// ... rest of your entry.server.ts file
-```
-
-</Expandable>
-
-<Expandable title="Do you need to customize your handleError function?">
-  If you have custom logic in your `handleError` function, you'll need to capture errors manually:
-
-```tsx {12}
-import {
-  getMetaTagTransformer,
-  wrapSentryHandleRequest,
-} from "@sentry/react-router";
-// ... other imports
-
-export function handleError(
-  error: unknown,
-  { request, params, context }: LoaderFunctionArgs | ActionFunctionArgs
-) {
-  if (!request.signal.aborted) {
-    Sentry.captureException(error);
-    console.error(formatErrorForJsonLogging(error));
-  }
-}
-
-// ... rest of your entry.server.ts file
-```
-
-</Expandable>
-
-#### Load Instrumentation on Startup
-
-React Router runs in ESM mode, which means you need to load the Sentry instrumentation file before the application starts. Update your `package.json` scripts:
-
-```json {filename: package.json}
-"scripts": {
-  "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router dev",
-  "start": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js",
-}
-```
-
-<PlatformContent includePath="node-options-windows" />
-
-**Deploying to Vercel, Netlify, and similar platforms**
-
-If you're deploying to platforms where you can't set the `NODE_OPTIONS` flag, import the instrumentation file directly at the top of your `entry.server.tsx`:
-
-```tsx {diff} {filename: entry.server.tsx}
-+import './instrument.server';
- import * as Sentry from '@sentry/react-router';
- import { createReadableStreamFromReadable } from '@react-router/node';
- import { renderToPipeableStream } from 'react-dom/server';
- // ... rest of your imports
-```
-
-<Alert title="Incomplete Auto-instrumentation" level="warning">
-
-When you import the instrumentation file directly instead of using the `--import` flag, automatic instrumentation will be incomplete. You'll miss automatically captured spans and traces for some server-side operations. Only use this approach when the `NODE_OPTIONS` method isn't available.
+Don't forget to explore the example files' code in your project to understand what's happening after your button click.
 
 </Alert>
-
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
-
-The stack traces in your Sentry errors probably won't look like your actual code without unminifying them. To fix this, upload your source maps to Sentry.
-
-First, update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it:
-
-```typescript {filename: vite.config.ts} {diff}
-import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
-import { defineConfig } from 'vite';
-
-const sentryConfig: SentryReactRouterBuildOptions = {
-  org: "___ORG_SLUG___",
-  project: "___PROJECT_SLUG___",
-
-  // An auth token is required for uploading source maps;
-  // store it in an environment variable to keep it secure.
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-  // ...
-};
-
-export default defineConfig(config => {
-  return {
-+   plugins: [reactRouter(),sentryReactRouter(sentryConfig, config)],
-  };
-});
-```
-
-To keep your auth token secure, always store it in an environment variable instead of directly in your files:
-
-<OrgAuthTokenNote />
-
-```bash {filename:.env}
-SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
-```
-
-Next, include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
-
-```typescript {filename: react-router.config.ts} {diff}
-import type { Config } from "@react-router/dev/config";
-import { sentryOnBuildEnd } from "@sentry/react-router";
-
-export default {
-  ssr: true,
-  buildEnd: async ({ viteConfig, reactRouterConfig, buildManifest }) => {
-    // ...
-    // Call this at the end of the hook
-    +(await sentryOnBuildEnd({ viteConfig, reactRouterConfig, buildManifest }));
-  },
-} satisfies Config;
-```
-
-## Step 4: Avoid Ad Blockers With Tunneling (Optional)
-
-<PlatformContent includePath="getting-started-tunneling" />
-
-## Step 5: Verify Your Setup
-
-Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
-
-### Issues
-
-To verify that Sentry captures errors and creates issues in your Sentry project, throw an error in a loader:
-
-```tsx {filename: error.tsx}
-import type { Route } from "./+types/example-page";
-
-export async function loader() {
-  throw new Error("My first Sentry error!");
-}
-
-export default function ExamplePage() {
-  return <div>Loading this page will throw an error</div>;
-}
-```
-
-<OnboardingOption optionId="performance" hideForThisOption>
-  Open the route in your browser and you should trigger an error.
-</OnboardingOption>
-
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
-
-<OnboardingOption optionId="performance">
-### Tracing
-To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
-
-```tsx {filename: error.tsx}
-import * as Sentry from "@sentry/react-router";
-import type { Route } from "./+types/example-page";
-
-export async function loader() {
-  return Sentry.startSpan(
-    {
-      op: "test",
-      name: "My First Test Transaction",
-    },
-    () => {
-      throw new Error("My first Sentry error!");
-    }
-  );
-}
-
-export default function ExamplePage() {
-  return <div>Loading this page will throw an error</div>;
-}
-```
-
-Open the route in your browser. You should start a trace and trigger an error.
-
-</OnboardingOption>
 
 ### View Captured Data in Sentry
 
 Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
+
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
 <PlatformContent includePath="getting-started-verify-locate-data" />
 
@@ -579,7 +265,10 @@ Our next recommended steps for you are:
 
 <Expandable permalink={false} title="Are you having problems setting up the SDK?">
 
+- If you encountered issues with our installation wizard, try [setting up Sentry manually](/platforms/javascript/guides/react-router/manual-setup/)
 - Find various topics in <PlatformLink to="/troubleshooting">Troubleshooting</PlatformLink>
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepComponent>

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -1,0 +1,579 @@
+---
+title: "Manual Setup"
+sidebar_order: 1
+description: "Learn how to manually set up Sentry in your React Router v7 app and capture your first errors."
+---
+
+<Alert level="warning" title="Important">
+  This SDK is currently in **beta**. Beta features are still in progress and may
+  have bugs. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if
+  you have any feedback or concerns.
+</Alert>
+
+<Alert type="info">
+  For the fastest setup, we recommend using the [wizard
+  installer](/platforms/javascript/guides/react-router).
+</Alert>
+
+<PlatformContent includePath="getting-started-prerequisites" />
+
+## Step 1: Install
+
+### Install the Sentry SDK
+
+Run the command for your preferred package manager to add the SDK package to your application:
+
+<OnboardingOption optionId="profiling">
+
+```bash {tabTitle:npm}
+npm install @sentry/react-router @sentry/profiling-node
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/react-router @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react-router @sentry/profiling-node
+```
+
+</OnboardingOption>
+
+<OnboardingOption optionId="profiling" hideForThisOption>
+  ```bash {tabTitle:npm}
+  npm install @sentry/react-router
+  ```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/react-router
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/react-router
+```
+
+</OnboardingOption>
+
+## Step 2: Configure
+
+Choose the features you want to configure, and this guide will show you how:
+
+<OnboardingOptionButtons
+  options={[
+    "error-monitoring",
+    "performance",
+    "session-replay",
+    "user-feedback",
+    "logs",
+    {
+      id: "profiling",
+      checked: false,
+    },
+  ]}
+/>
+
+<PlatformContent includePath="getting-started-features-expandable" />
+
+### Expose Entry Point Files
+
+Before configuring Sentry, you need to make React Router's entry files (`entry.client.tsx` and `entry.server.tsx`) visible in your project. Run this command to expose them:
+
+```bash
+npx react-router reveal
+```
+
+### Configure Client-side Sentry
+
+Initialize Sentry in your `entry.client.tsx` file:
+
+```tsx {diff} {filename: entry.client.tsx}
++import * as Sentry from "@sentry/react-router";
+ import { startTransition, StrictMode } from "react";
+ import { hydrateRoot } from "react-dom/client";
+ import { HydratedRouter } from "react-router/dom";
+
++Sentry.init({
++  dsn: "___PUBLIC_DSN___",
++
++  // Adds request headers and IP for users, for more info visit:
++  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#sendDefaultPii
++  sendDefaultPii: true,
++
++  integrations: [
++    // ___PRODUCT_OPTION_START___ performance
++    // Registers and configures the Tracing integration,
++    // which automatically instruments your application to monitor its
++    // performance, including custom Angular routing instrumentation
++    Sentry.reactRouterTracingIntegration(),
++    // ___PRODUCT_OPTION_END___ performance
++    // ___PRODUCT_OPTION_START___ session-replay
++    // Registers the Replay integration,
++    // which automatically captures Session Replays
++    Sentry.replayIntegration(),
++    // ___PRODUCT_OPTION_END___ session-replay
++    // ___PRODUCT_OPTION_START___ user-feedback
++    Sentry.feedbackIntegration({
++      // Additional SDK configuration goes in here, for example:
++      colorScheme: "system",
++    }),
++    // ___PRODUCT_OPTION_END___ user-feedback
++  ],
++  // ___PRODUCT_OPTION_START___ logs
++
++  // Enable logs to be sent to Sentry
++  enableLogs: true,
++  // ___PRODUCT_OPTION_END___ logs
++  // ___PRODUCT_OPTION_START___ performance
++
++  // Set tracesSampleRate to 1.0 to capture 100%
++  // of transactions for tracing.
++  // We recommend adjusting this value in production
++  // Learn more at
++  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#traces-sample-rate
++  tracesSampleRate: 1.0, //  Capture 100% of the transactions
++
++  // Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled
++  tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
++  // ___PRODUCT_OPTION_END___ performance
++  // ___PRODUCT_OPTION_START___ session-replay
++
++  // Capture Replay for 10% of all sessions,
++  // plus 100% of sessions with an error
++  // Learn more at
++  // https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/configuration/#general-integration-configuration
++  replaysSessionSampleRate: 0.1,
++  replaysOnErrorSampleRate: 1.0,
++  // ___PRODUCT_OPTION_END___ session-replay
++});
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <HydratedRouter />
+    </StrictMode>
+  );
+});
+```
+
+#### Report Errors from Error Boundaries
+
+Update your `app/root.tsx` file to capture unhandled errors in your error boundary:
+
+```tsx {diff} {filename: app/root.tsx}
++import * as Sentry from "@sentry/react-router";
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  let message = "Oops!";
+  let details = "An unexpected error occurred.";
+  let stack: string | undefined;
+
+  if (isRouteErrorResponse(error)) {
+    message = error.status === 404 ? "404" : "Error";
+    details =
+      error.status === 404
+        ? "The requested page could not be found."
+        : error.statusText || details;
+  } else if (error && error instanceof Error) {
+    // you only want to capture non 404-errors that reach the boundary
++   Sentry.captureException(error);
+    if (import.meta.env.DEV) {
+      details = error.message;
+      stack = error.stack;
+    }
+  }
+
+  return (
+    <main>
+      <h1>{message}</h1>
+      <p>{details}</p>
+      {stack && (
+        <pre>
+          <code>{stack}</code>
+        </pre>
+      )}
+    </main>
+  );
+}
+// ...
+```
+
+### Configure Server-side Sentry
+
+<Expandable level="warning" title="Limited Node support for auto-instrumentation" permalink>
+  Automatic server-side instrumentation is currently only supported on:
+    - **Node 20:** Version \<20.19
+    - **Node 22:** Version \<22.12
+
+If you're on a different version, use our manual server wrappers.
+
+For server loaders use `wrapServerLoader`:
+
+```ts
+import * as Sentry from "@sentry/react-router";
+
+export const loader = Sentry.wrapServerLoader(
+  {
+    name: "Load Some Data",
+    description: "Loads some data from the db",
+  },
+  async ({ params }) => {
+    // ... your loader logic
+  }
+);
+```
+
+For server actions use `wrapServerAction`:
+
+```ts
+import * as Sentry from "@sentry/react-router";
+
+export const action = Sentry.wrapServerAction(
+  {
+    name: "Submit Form Data",
+    description: "Processes form submission data",
+  },
+  async ({ request }) => {
+    // ... your action logic
+  }
+);
+```
+
+</Expandable>
+
+First, create a file called `instrument.server.mjs` in the root of your project to initialize Sentry:
+
+```js {filename: instrument.server.mjs}
+import * as Sentry from "@sentry/react-router";
+// ___PRODUCT_OPTION_START___ profiling
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+// ___PRODUCT_OPTION_END___ profiling
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // Adds request headers and IP for users, for more info visit:
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#sendDefaultPii
+  sendDefaultPii: true,
+  // ___PRODUCT_OPTION_START___ logs
+
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+  // ___PRODUCT_OPTION_END___ logs
+  // ___PRODUCT_OPTION_START___ profiling
+
+  // Add our Profiling integration
+  integrations: [nodeProfilingIntegration()],
+  // ___PRODUCT_OPTION_END___ profiling
+  // ___PRODUCT_OPTION_START___ performance
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for tracing.
+  // We recommend adjusting this value in production
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#tracesSampleRate
+  tracesSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ performance
+  // ___PRODUCT_OPTION_START___ profiling
+  // Set profilesSampleRate to 1.0 to profile 100%
+  // of sampled transactions.
+  // This is relative to tracesSampleRate
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#profilesSampleRate
+  profilesSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ profiling
+});
+```
+
+Next, replace the default `handleRequest` and `handleError` functions in your `entry.server.tsx` file with Sentry's wrapped versions:
+
+```tsx {diff} {filename: entry.server.tsx}
++import * as Sentry from '@sentry/react-router';
+ import { createReadableStreamFromReadable } from '@react-router/node';
+ import { renderToPipeableStream } from 'react-dom/server';
+ import { ServerRouter } from 'react-router';
+ import { type HandleErrorFunction } from 'react-router';
+
++const handleRequest = Sentry.createSentryHandleRequest({
++  ServerRouter,
++  renderToPipeableStream,
++  createReadableStreamFromReadable,
++});
+
+ export default handleRequest;
+
++export const handleError = Sentry.createSentryHandleError({
++  logErrors: false
++});
+
+// ... rest of your server entry
+```
+
+<Expandable title="Do you need to customize your handleRequest function?">
+  If you need to customize the logic of your `handleRequest` function, you'll need to use Sentry's helper functions (`getMetaTagTransformer` and `wrapSentryHandleRequest`) manually:
+
+```tsx {1-4, 44-45, 69-70}
+import {
+  getMetaTagTransformer,
+  wrapSentryHandleRequest,
+} from "@sentry/react-router";
+// ... other imports
+
+const handleRequest = function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: AppLoadContext
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const userAgent = request.headers.get("user-agent");
+
+    // Determine if we should use onAllReady or onShellReady
+    const isBot = typeof userAgent === "string" && botRegex.test(userAgent);
+    const isSpaMode = !!(routerContext as { isSpaMode?: boolean }).isSpaMode;
+
+    const readyOption = isBot || isSpaMode ? "onAllReady" : "onShellReady";
+
+    const { pipe, abort } = renderToPipeableStream(
+      <ServerRouter context={routerContext} url={request.url} />,
+      {
+        [readyOption]() {
+          shellRendered = true;
+          const body = new PassThrough();
+
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set("Content-Type", "text/html");
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            })
+          );
+
+          // this enables distributed tracing between client and server
+          pipe(getMetaTagTransformer(body));
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          // eslint-disable-next-line no-param-reassign
+          responseStatusCode = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            // eslint-disable-next-line no-console
+            console.error(error);
+          }
+        },
+      }
+    );
+
+    // Abort the rendering stream after the `streamTimeout`
+    setTimeout(abort, streamTimeout);
+  });
+};
+
+// wrap the default export
+export default wrapSentryHandleRequest(handleRequest);
+
+// ... rest of your entry.server.ts file
+```
+
+</Expandable>
+
+<Expandable title="Do you need to customize your handleError function?">
+  If you have custom logic in your `handleError` function, you'll need to capture errors manually:
+
+```tsx {12}
+import {
+  getMetaTagTransformer,
+  wrapSentryHandleRequest,
+} from "@sentry/react-router";
+// ... other imports
+
+export function handleError(
+  error: unknown,
+  { request, params, context }: LoaderFunctionArgs | ActionFunctionArgs
+) {
+  if (!request.signal.aborted) {
+    Sentry.captureException(error);
+    console.error(formatErrorForJsonLogging(error));
+  }
+}
+
+// ... rest of your entry.server.ts file
+```
+
+</Expandable>
+
+#### Load Instrumentation on Startup
+
+React Router runs in ESM mode, which means you need to load the Sentry instrumentation file before the application starts. Update your `package.json` scripts:
+
+```json {filename: package.json}
+"scripts": {
+  "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router dev",
+  "start": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js",
+}
+```
+
+<PlatformContent includePath="node-options-windows" />
+
+**Deploying to Vercel, Netlify, and similar platforms**
+
+If you're deploying to platforms where you can't set the `NODE_OPTIONS` flag, import the instrumentation file directly at the top of your `entry.server.tsx`:
+
+```tsx {diff} {filename: entry.server.tsx}
++import './instrument.server';
+ import * as Sentry from '@sentry/react-router';
+ import { createReadableStreamFromReadable } from '@react-router/node';
+ import { renderToPipeableStream } from 'react-dom/server';
+ // ... rest of your imports
+```
+
+<Alert title="Incomplete Auto-instrumentation" level="warning">
+
+When you import the instrumentation file directly instead of using the `--import` flag, automatic instrumentation will be incomplete. You'll miss automatically captured spans and traces for some server-side operations. Only use this approach when the `NODE_OPTIONS` method isn't available.
+
+</Alert>
+
+## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+
+The stack traces in your Sentry errors probably won't look like your actual code without unminifying them. To fix this, upload your source maps to Sentry.
+
+First, update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it:
+
+```typescript {filename: vite.config.ts} {diff}
+import { reactRouter } from '@react-router/dev/vite';
+import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
+import { defineConfig } from 'vite';
+
+const sentryConfig: SentryReactRouterBuildOptions = {
+  org: "___ORG_SLUG___",
+  project: "___PROJECT_SLUG___",
+
+  // An auth token is required for uploading source maps;
+  // store it in an environment variable to keep it secure.
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  // ...
+};
+
+export default defineConfig(config => {
+  return {
++   plugins: [reactRouter(),sentryReactRouter(sentryConfig, config)],
+  };
+});
+```
+
+To keep your auth token secure, always store it in an environment variable instead of directly in your files:
+
+<OrgAuthTokenNote />
+
+```bash {filename:.env}
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
+Next, include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
+
+```typescript {filename: react-router.config.ts} {diff}
+import type { Config } from "@react-router/dev/config";
+import { sentryOnBuildEnd } from "@sentry/react-router";
+
+export default {
+  ssr: true,
+  buildEnd: async ({ viteConfig, reactRouterConfig, buildManifest }) => {
+    // ...
+    // Call this at the end of the hook
+    +(await sentryOnBuildEnd({ viteConfig, reactRouterConfig, buildManifest }));
+  },
+} satisfies Config;
+```
+
+## Step 4: Avoid Ad Blockers With Tunneling (Optional)
+
+<PlatformContent includePath="getting-started-tunneling" />
+
+## Step 5: Verify Your Setup
+
+Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
+
+### Issues
+
+To verify that Sentry captures errors and creates issues in your Sentry project, throw an error in a loader:
+
+```tsx {filename: error.tsx}
+import type { Route } from "./+types/example-page";
+
+export async function loader() {
+  throw new Error("My first Sentry error!");
+}
+
+export default function ExamplePage() {
+  return <div>Loading this page will throw an error</div>;
+}
+```
+
+<OnboardingOption optionId="performance" hideForThisOption>
+  Open the route in your browser and you should trigger an error.
+</OnboardingOption>
+
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+
+<OnboardingOption optionId="performance">
+### Tracing
+To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+```tsx {filename: error.tsx}
+import * as Sentry from "@sentry/react-router";
+import type { Route } from "./+types/example-page";
+
+export async function loader() {
+  return Sentry.startSpan(
+    {
+      op: "test",
+      name: "My First Test Transaction",
+    },
+    () => {
+      throw new Error("My first Sentry error!");
+    }
+  );
+}
+
+export default function ExamplePage() {
+  return <div>Loading this page will throw an error</div>;
+}
+```
+
+Open the route in your browser. You should start a trace and trigger an error.
+
+</OnboardingOption>
+
+### View Captured Data in Sentry
+
+Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
+
+<PlatformContent includePath="getting-started-verify-locate-data" />
+
+## Next Steps
+
+At this point, you should have integrated Sentry into your React Router Framework application and should already be sending data to your Sentry project.
+
+Now's a good time to customize your setup and look into more advanced topics.
+Our next recommended steps for you are:
+
+- Learn how to <PlatformLink to="/usage">manually capture errors</PlatformLink>
+- Continue to <PlatformLink to="/configuration">customize your configuration</PlatformLink>
+- Get familiar with [Sentry's product features](/product/) like tracing, insights, and alerts
+
+<Expandable permalink={false} title="Are you having problems setting up the SDK?">
+
+- Find various topics in <PlatformLink to="/troubleshooting">Troubleshooting</PlatformLink>
+- [Get support](https://sentry.zendesk.com/hc/en-us/)
+
+</Expandable>


### PR DESCRIPTION
## DESCRIBE YOUR PR

We now have a wizard for setting up react-router applications.

I've aligned the quickstart guide with that of nextjs and moved the existing guide to manual setup.

Preview: https://sentry-docs-git-ab-react-router-wizard.sentry.dev/platforms/javascript/guides/react-router/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+
