### PR TITLE
php-sdk: standardize options type declarations

### DIFF
--- a/docs/platforms/php/common/configuration/options.mdx
+++ b/docs/platforms/php/common/configuration/options.mdx
@@ -22,7 +22,7 @@ Learn more about [DSN utilization](/product/sentry-basics/dsn-explainer/#dsn-uti
 
 </SdkOption>
 
-<SdkOption name="logger" type='LoggerInterface' defaultValue='null'>
+<SdkOption name="logger" type='\Psr\Log\LoggerInterface' defaultValue='null'>
 
 If enabled, the SDK prints out debug information about if something went wrong while sending events.
 It isn't recommended to use this in production.
@@ -111,7 +111,7 @@ For example, if your code is deployed in different locations across environments
 
 </SdkOption>
 
-<SdkOption name="max_request_body_size"type='string' defaultValue='medium'>
+<SdkOption name="max_request_body_size" type='string' defaultValue='medium'>
 
 This parameter controls whether integrations should capture HTTP request bodies. It can be set to one of the following values:
 
@@ -133,7 +133,7 @@ The number of characters after which the values containing text in the event pay
 
 </SdkOption>
 
-<SdkOption name="before_breadcrumb" type='function (Breadcrumb $breadcrumb): Breadcrumb'>
+<SdkOption name="before_breadcrumb" type='function (\Sentry\Breadcrumb $breadcrumb): \Sentry\Breadcrumb'>
 
 This function is called with a breadcrumb object before the breadcrumb is added to the scope. When nothing is returned from the function, the breadcrumb is dropped. To pass the breadcrumb through, return the breadcrumb itself.
 
@@ -147,7 +147,7 @@ Configures the sample rate for error events, in the range of `0.0` to `1.0`. The
 
 </SdkOption>
 
-<SdkOption name="before_send" type='function (Event $event): Event'>
+<SdkOption name="before_send" type='function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event'>
 
 This function is called with an event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
@@ -187,7 +187,7 @@ Either this or `traces_sampler` must be defined to enable tracing.
 
 </SdkOption>
 
-<SdkOption name="traces_sampler" type='function' defaultValue='null'>
+<SdkOption name="traces_sampler" type='function (\Sentry\Tracing\SamplingContext $context): float' defaultValue='null'>
 
 A function responsible for determining the percentage chance a given transaction will be sent to Sentry. It will automatically be passed information about the transaction and the context in which it's being created, and must return a number between `0` (0% chance of being sent) and `1` (100% chance of being sent). Can also be used for filtering transactions, by returning `0` for those that are unwanted.
 
@@ -201,7 +201,7 @@ A list of strings that match transaction names that shouldn't be sent to Sentry.
 
 </SdkOption>
 
-<SdkOption name="before_send_transaction" type='function (Event $transaction): Event'>
+<SdkOption name="before_send_transaction" type='function (\Sentry\Event $transaction, ?\Sentry\EventHint $hint): ?\Sentry\Event'>
 
 This function is called with a transaction event object, and can return a modified transaction event object, or `null` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 
@@ -221,7 +221,7 @@ To disable sending trace data to any downstream service, set this option to an e
 
 ## Cron Monitoring Options
 
-<SdkOption name="before_send_check_in" type='function (Event $checkIn): Event'>
+<SdkOption name="before_send_check_in" type='function (\Sentry\Event $checkIn, ?\Sentry\EventHint $hint): ?\Sentry\Event'>
 
 This function is called with a check-in event object, and can return a modified check-in event object, or `null` to skip reporting the event.
 
@@ -259,13 +259,13 @@ This function is called with a metric object, and can return a modified metric o
 
 Transports are used to send events to Sentry. Transports can be customized to some degree to better support highly specific deployments.
 
-<SdkOption name="transport" type="TransportInterface" defaultValue='null'>
+<SdkOption name="transport" type="\Sentry\Transport\TransportInterface" defaultValue='null'>
 
 Switches out the transport used to send events. It can, for instance, be used to capture events for unit testing.
 
 </SdkOption>
 
-<SdkOption name="http_client" type="HttpClientInterface" defaultValue="null">
+<SdkOption name="http_client" type="\Sentry\HttpClient\HttpClientInterface" defaultValue="null">
 
 Switches out the HTTP client used by the SDKs transport.
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Previously, the style of options types varied within the docs themselves and also did not fully match the types used in the actual implementation.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
