### PR TITLE
feat(js): Document missing options for http integration

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/http.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/http.mdx
@@ -67,6 +67,7 @@ _Type: `'none' | 'small' | 'medium' | 'always'`_ (Defaults to `'medium'`)
 Controls the maximum size of incoming HTTP request bodies attached to events.
 
 Available options:
+
 - 'none': No request bodies will be attached
 - 'small': Request bodies up to 1,000 bytes will be attached
 - 'medium': Request bodies up to 10,000 bytes will be attached (default)
@@ -126,9 +127,9 @@ _Type: `(number | [number, number])[]`_ (Defaults to `[[401, 404], [301, 303], [
 
 Do not capture spans for incoming HTTP requests with the given status codes.
 By default, spans with some 3xx and 4xx status codes are ignored.
-Expects an array of status codes or a range of status codes.
+Expects an array that can contain individual status codes (numbers) or ranges (2-element arrays of `[start, end]` where both start and end are inclusive).
 
-For example, `[[300, 399], 404]` would ignore all 3xx status codes and 404 status codes.
+For example, `[[300, 399], 404]` would ignore all 3xx status codes (300-399 inclusive) and 404 status codes.
 
 ### `trackIncomingRequestsAsSessions`
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds 3 missing options to the documentation:

1. spans - Controls whether spans are created for outgoing HTTP requests
2. disableIncomingRequestSpans - Disables spans for incoming requests
3. sessionFlushingDelayMS - Controls session flushing interval

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+


Related issue: https://github.com/getsentry/sentry-javascript/issues/18490