### PR TITLE
feat(lambda-layers): make ARN easier to see & copy

### DIFF
--- a/src/components/lambdaLayerDetailClient.tsx
+++ b/src/components/lambdaLayerDetailClient.tsx
@@ -37,10 +37,13 @@ export function LambdaLayerDetailClient({
 
   const defaultOption = regions.length > 0 ? toOption(regions[0]) : undefined;
 
-  const [regionOption, setRegion] = useState<{
-    label: string;
-    value: string;
-  } | undefined>(defaultOption);
+  const [regionOption, setRegion] = useState<
+    | {
+        label: string;
+        value: string;
+      }
+    | undefined
+  >(defaultOption);
 
   let arn: string = '';
   if (regionOption) {


### PR DESCRIPTION
- Pre-select a region to show an ARN without user interaction
- Put the ARN into a code block instead of plain text to make it more obvious that there is something to copy here

**Before** 
<img width="958" height="233" alt="Screenshot 2025-12-15 at 09 58 52" src="https://github.com/user-attachments/assets/4ef1cb1d-69a4-41db-bdee-0759795c6737" />
<img width="955" height="284" alt="Screenshot 2025-12-15 at 09 58 57" src="https://github.com/user-attachments/assets/c6cc89a8-d755-47f1-bb09-eb77c2233d1f" />

**After**
<img width="946" height="264" alt="Screenshot 2025-12-15 at 09 59 05" src="https://github.com/user-attachments/assets/2bf48194-0549-4c0f-9038-48df3073e588" />

