### PR TITLE
fix(kmp): Add a missing config to native platform init for KMP

### DIFF
--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/initialization-strategies.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/initialization-strategies.mdx
@@ -62,7 +62,15 @@ For example, if you configure your KMP application for Android, you will have ac
 
 ### Apple Target Requirements
 
-In order to be able to use the native platform options with Apple targets, you need to opt-in to `ExperimentalForeignApi`.
+In order to be able to use the native platform options with Apple targets, you need to opt-in to `ExperimentalForeignApi` and enable CInterop commonization.
+
+Add the following to your `gradle.properties`:
+
+```properties {filename:gradle.properties}
+kotlin.mpp.enableCInteropCommonization=true
+```
+
+And opt-in to `ExperimentalForeignApi` in your `build.gradle.kts`:
 
 ```kotlin {filename:build.gradle.kts}
 kotlin {


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adds a missing config to native platform init for KMP

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
