### PR TITLE
fix(ruby): Fix migration links to archived repo

### DIFF
--- a/docs/platforms/ruby/common/migration.mdx
+++ b/docs/platforms/ruby/common/migration.mdx
@@ -284,11 +284,11 @@ Sentry.get_current_scope.set_transaction_name("NewTransaction")
 
 ## Example Apps
 
-- [Rails example](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails/examples/rails-6.0)
-- [Sinatra example](https://github.com/getsentry/sentry-ruby/tree/master/sentry-ruby/examples/sinatra)
+- [Rails example](https://github.com/getsentry/examples/tree/master/ruby/sentry-rails/rails-6.0)
+- [Sinatra example](https://github.com/getsentry/examples/tree/master/ruby/sentry-ruby/sinatra)
 - Sidekiq examples:
-  - [with Rails](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails/examples/rails-6.0)
-  - [without Rails](https://github.com/getsentry/sentry-ruby/tree/master/sentry-sidekiq/example)
+  - [with Rails](https://github.com/getsentry/examples/tree/master/ruby/sentry-rails/rails-6.0)
+  - [without Rails](https://github.com/getsentry/examples/tree/master/ruby/sentry-sidekiq)
 
 ## Community Fork
 


### PR DESCRIPTION
* resolves: https://github.com/getsentry/sentry-ruby/issues/2811
* resolves: RUBY-127
