### PR TITLE
chore: Remove "insights" codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 # /docs/platforms/rust/ @getsentry/team-web-sdk-backend
 
 # /docs/product/explore/discover-queries/ @getsentry/data-browsing
-# /docs/product/insights/ @getsentry/insights
+# /docs/product/insights/ @getsentry/dashboards
 
 # /docs/cli/ @getsentry/team-web-sdk-backend
 


### PR DESCRIPTION
That team doesn't really exist anymore, all of that UI is owned by the Dashboards team!