### PR TITLE
fix(develop-docs): Wording for discarding envelope

### DIFF
--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -261,7 +261,7 @@ If Sentry returns an `HTTP 4xx` or `HTTP 5xx` status code, SDKs:
 For an `HTTP 429` response, SDKs:
 
 - **MUST** respect the [rate limiting rules](/sdk/expected-features/rate-limiting/), such as correctly parsing the retry-header.
-- **MUST** drop the envelope, but **MUST NOT** record a [client report](/sdk/telemetry/client-reports), because the backend already does this. Doing this would double-count dropped envelopes.
+- **MUST** discard the envelope, but **MUST NOT** record a [client report](/sdk/telemetry/client-reports), because the backend already does this. Doing this would double-count discarded envelopes.
 - **MUST NOT** retry sending the envelope.
 
 SDKs **MAY** retry sending the envelope when a network error occurs, such as:


### PR DESCRIPTION
Replace drop with discard, so we always use the term discard.

