### PR TITLE
fix: update MCP automatic instrumentation links to correct product docs URL

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/mcp-module.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/mcp-module.mdx
@@ -34,9 +34,7 @@ As a prerequisite to setting up MCP monitoring with JavaScript, you'll need to f
 
 The JavaScript SDK supports automatic instrumentation for MCP servers. We recommend adding the MCP integration to your Sentry configuration to automatically capture spans for MCP operations.
 
-- <PlatformLink to="/integrations/mcp/">
-    MCP (Model Context Protocol)
-  </PlatformLink>
+- [MCP (Model Context Protocol)](/product/insights/ai/mcp/getting-started/)
 
 ## Manual Instrumentation
 

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/mcp-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/mcp-module.mdx
@@ -12,9 +12,7 @@ As a prerequisite to setting up MCP monitoring with Python, you'll need to first
 
 The Python SDK supports automatic instrumentation for MCP servers. We recommend adding the MCP integration to your Sentry configuration to automatically capture spans for MCP operations.
 
-- <PlatformLink to="/integrations/mcp/">
-    MCP (Model Context Protocol)
-  </PlatformLink>
+- [MCP (Model Context Protocol)](/product/insights/ai/mcp/getting-started/)
 
 ## Manual Instrumentation
 


### PR DESCRIPTION
## Summary

Updates the MCP automatic instrumentation links in JavaScript and Python documentation to point to the correct product documentation URL.

## Changes

- Updated link in `docs/platforms/javascript/common/tracing/instrumentation/mcp-module.mdx`
- Updated link in `docs/platforms/python/tracing/instrumentation/custom-instrumentation/mcp-module.mdx`

**Before:** Links pointed to `/integrations/mcp/` (non-existent platform-specific path)
**After:** Links point to `/product/insights/ai/mcp/getting-started/`

## Testing

Verified links resolve to the correct MCP getting started documentation.