### PR TITLE
fix(envelopes): Document trace metric size limit

### DIFF
--- a/develop-docs/sdk/data-model/envelopes.mdx
+++ b/develop-docs/sdk/data-model/envelopes.mdx
@@ -348,6 +348,7 @@ These limits are subject to future change and defined currently as:
 - *1MB* for event (errors and transactions), span, log, and metric (statsd, buckets, meta) items.
 - *100KB* for monitor check-in items
 - *50MB* for profile items
+- *2KB* for trace metric items
 - *10MB* for compressed replay item
 - *100MB* for replay item after decompression
 - *100 sessions* per envelope


### PR DESCRIPTION
## DESCRIBE YOUR PR
This limit is defined in https://github.com/getsentry/relay/blob/5bde12fbcf7143097913a7a5ce83ebb3e157c622/relay-config/src/config.rs#L712.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
