### PR TITLE
docs(otel): Emphasize that `skipOpenTelemetrySetup: true` requires manual setup

### DIFF
--- a/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
+++ b/docs/platforms/javascript/common/opentelemetry/custom-setup.mdx
@@ -31,7 +31,7 @@ sidebar_order: 0
 
 Use this guide when you already have a completely custom OpenTelemetry setup or when you intend to add a custom OpenTelemetry setup next to the Sentry SDK.
 
-Setting `skipOpenTelemetrySetup: true` disables the Sentry SDK's automatic OpenTelemetry configuration, **requiring** you perform the setup manually. For example, to ensure errors are correctly associated with their scope, you must add the `SentryContextManager` to your OpenTelemetry setup. Details on the required manual setup are available further down on this page.
+Setting `skipOpenTelemetrySetup: true` disables the Sentry SDK's automatic OpenTelemetry configuration, **requiring** you to perform the setup manually. For example, to ensure errors are correctly associated with their scope, you must add the `SentryContextManager` to your OpenTelemetry setup. You can find details on the required manual setup further down on this page.
 
 If you are looking to simply add individual OpenTelemetry instrumentation to your Sentry setup, you should read <PlatformLink to="/opentelemetry/using-opentelemetry-apis/#adding-additional-opentelemetry-instrumentation">Adding Additional OpenTelemetry Instrumentation</PlatformLink> instead.
 


### PR DESCRIPTION

## DESCRIBE YOUR PR


closes https://github.com/getsentry/sentry-javascript/issues/18517
