### PR TITLE
docs(android): Update Session Replay Network Details version requirements

### DIFF
--- a/docs/platforms/android/session-replay/configuration.mdx
+++ b/docs/platforms/android/session-replay/configuration.mdx
@@ -45,6 +45,7 @@ Body and header content will be PII-sanitized server-side, based on object keys 
 
 ### Requirements
 - SDK version >= [8.29.0](https://github.com/getsentry/sentry-java/releases/tag/8.29.0)
+- Android Gradle Plugin version >= [6.0.0-beta.3](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.0.0-beta.3)
 - OkHttp
 
 <Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

[ANDROID-250: Fix Network Body parsing logic for large JSON bodies](https://linear.app/getsentry/issue/ANDROID-250/fix-network-body-parsing-logic-for-large-json-bodies) will cause a RuntimeException when parsing certain large JSON payloads.

   _SentryReplayOptions.MAX_NETWORK_BODY_SIZE <= json payload size < 2*SentryReplayOptions.MAX_NETWORK_BODY_SIZE_

1. Fixed in [#4958](https://github.com/getsentry/sentry-java/pull/4958) so updating docs for minimum required sdk version.

2. Also adding reference to required gradle version.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: _ASAP - minor change, would like to share docs with potential adopters._
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
