### PR TITLE
fix(web-vitals): Update supported browsers table

### DIFF
--- a/docs/product/insights/frontend/web-vitals/web-vitals-concepts.mdx
+++ b/docs/product/insights/frontend/web-vitals/web-vitals-concepts.mdx
@@ -95,8 +95,8 @@ Not all browsers fully support all web vitals. Sentry uses available web vitals 
 
 | Web Vital                                                         | Chrome | Edge | Opera | Firefox | Safari |
 | ----------------------------------------------------------------- | ------ | ---- | ----- | ------- | ------ |
-| [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP)   | ✓      | ✓    | ✓     | ✓       |        |
-| [Interaction to Next Paint](#interaction-to-next-paint-inp) (INP) | ✓      | ✓    | ✓     |         |        |
+| [Largest Contentful Paint](#largest-contentful-paint-lcp) (LCP)   | ✓      | ✓    | ✓     | ✓       | ✓      |
+| [Interaction to Next Paint](#interaction-to-next-paint-inp) (INP) | ✓      | ✓    | ✓     | ✓       | ✓      |
 | [Cumulative Layout Shift](#cumulative-layout-shift-cls) (CLS)     | ✓      | ✓    | ✓     |         |        |
 | [First Paint](#first-paint-fp) (FP)                               | ✓      | ✓    | ✓     |         |        |
 | [Time To First Byte](#time-to-first-byte-ttfb) (TTFB)             | ✓      | ✓    | ✓     | ✓       | ✓      |


### PR DESCRIPTION
- Safari [released](https://web.dev/blog/lcp-and-inp-are-now-baseline-newly-available?hl=en) support for INP and LCP with version `26.2` in December
- Firefox [released](https://blog.mozilla.org/performance/2025/10/15/firefox-144-ships-interactionid-for-inp/) support for INP in versino `144` in october

This PR updates the web vital browser support table accordingly