### PR TITLE
Update url-state to show import

### DIFF
--- a/develop-docs/frontend/url-state.mdx
+++ b/develop-docs/frontend/url-state.mdx
@@ -23,11 +23,13 @@ Going forward, we will be using [nuqs](https://nuqs.dev/) to manage URL state in
 Per default, everything is parsed as `string`. It is recommended to use any of the built-in parsers or to write your own over doing type assertions or coercions in the component. Types can be inferred from what the parsers return, and it also handles serialization back to the URL.
 
 ```tsx
+import {parseAsInteger, useQueryState} from 'nuqs';
+
 // parsed as string per default
 const [cursor, setCursor] = useQueryState('cursor')
 
 // with a predefined parser
-const [page, setPage] = useQueryState('page', parseAsNumber)
+const [page, setPage] = useQueryState('page', parseAsInteger)
 
 // with a custom parser
 const [mailbox, setMailbox] = useQueryState('mailbox', parseAsMailbox);


### PR DESCRIPTION
Also change `parseAsNumber` to `parseAsInteger`,
`parseAsNumber` does not seem documented at:
https://nuqs.dev/docs/parsers/built-in