### PR TITLE
feat(javascript): `propagateTraceparent` for all SDKs + Logs fix

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -497,7 +497,7 @@ Sentry.init({
 
 </SdkOption>
 
-<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false' availableSince='10.10.0' categorySupported={['browser']}>
+<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false' availableSince='10.10.0'>
 
 If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/) to outgoing Http requests made via `fetch` or `XMLHttpRequest`.
 This header is attached in addition to the `sentry-trace` and `baggage` headers.
@@ -514,8 +514,6 @@ See <PlatformLink to="/tracing/distributed-tracing/dealing-with-cors-issues/">De
 
 </SdkOption>
 
-<PlatformCategorySection supported={['browser']}>
-
 ## Logs Options
 
 <SdkOption name="enableLogs" type='boolean' defaultValue='false'>
@@ -529,6 +527,8 @@ Set this option to `true` to enable log capturing in Sentry. Only when this is e
 This function is called with a log object, and can return a modified log object, or `null` to skip sending this log to Sentry. This can be used, for instance, for manual PII stripping before sending, or to add custom attributes to all logs.
 
 </SdkOption>
+
+<PlatformCategorySection supported={['browser']}>
 
 ## Session Replay Options
 


### PR DESCRIPTION
- Ref https://github.com/getsentry/sentry-javascript/issues/18263

This PR:
- Displays the `propagateTraceparent` option for all SDK rather than just the browser
- Moves `Logs Options` outside of browser only so it's now displayed for all SDKs too