### PR TITLE
feat(godot): Clarify environment option default

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -54,11 +54,11 @@ Sets the distribution of the application. Distributions are used to disambiguate
 
 </SdkOption>
 
-<SdkOption name="environment" type="string" envVar="SENTRY_ENVIRONMENT">
+<SdkOption name="environment" type="string" envVar="SENTRY_ENVIRONMENT" defaultValue="{auto}">
 
 Sets the environment. Environments indicate where an error occurred, such as in a release export, headless server, QA build, or another deployment. A release can be associated with more than one environment to separate them in the UI (think `staging` vs `production` or similar).
 
-The SDK automatically detects Godot-specific environments, such as `headless_server` and `export_release`, but you can also set it to your own value [programmatically](#programmatic-configuration).
+This option defaults to `{auto}`, which automatically detects the environment based on the current runtime context and sets it to one of the following values: `editor_dev`, `editor_dev_run`, `export_debug`, `export_release`, or `dedicated_server`.
 
 </SdkOption>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Clarify environment option default in the Godot SDK, according to changes in:
- https://github.com/getsentry/sentry-godot/pull/469

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

