### PR TITLE
Update sentry-android-gradle-plugin version to 6.0.0-rc.1

### DIFF
--- a/src/components/gradleUploadInstructions.tsx
+++ b/src/components/gradleUploadInstructions.tsx
@@ -27,7 +27,7 @@ export function GradleUploadInstructions({feature}: Props) {
           <a href="/platforms/android/configuration/gradle/">
             Sentry Android Gradle plugin
           </a>{' '}
-          with at least version <code>6.0.0-beta1</code>
+          with at least version <code>6.0.0-rc.1</code>
         </li>
 
         <li>


### PR DESCRIPTION
## Summary
Updated the minimum required version of sentry-android-gradle-plugin for build distribution and size analysis from `6.0.0-beta1` to `6.0.0-rc.1`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)