### PR TITLE
chore(issues): Update supported code mapping languages

### DIFF
--- a/docs/organization/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/organization/integrations/source-code-mgmt/github/index.mdx
@@ -379,7 +379,7 @@ By default, this feature is automatically enabled once your GitHub integration h
 
 <Alert>
 
-Sentry will automatically try to set up code mappings on C#, Clojure, Go, Groovy, Java, JavaScript, PHP, Python, Ruby, and Scala for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually.
+Sentry will automatically try to set up code mappings on JavaScript, Python, Java, PHP, Ruby, Go, C#, and Kotlin for organizations with the GitHub integration installed. If your project uses a different SDK, you can add code mappings manually.
 
 </Alert>
 

--- a/docs/product/issues/suspect-commits/index.mdx
+++ b/docs/product/issues/suspect-commits/index.mdx
@@ -43,7 +43,7 @@ In [sentry.io](https://sentry.io):
 
 <Alert>
 
-Sentry will automatically try to set up code mappings on C#, Go, JavaScript, Node.js, PHP, Python, and Ruby projects for organizations with the GitHub integration installed. However, you can still manually add code mappings if you choose to do so. Support for other languages and other source code integrations are planned.
+Sentry will automatically try to set up code mappings on JavaScript, Python, Java, PHP, Ruby, Go, C#, and Kotlin projects for organizations with the GitHub integration installed. However, you can still manually add code mappings if you choose to do so. Support for other languages and other source code integrations are planned.
 
 </Alert>
 


### PR DESCRIPTION
Source of truth: https://github.com/getsentry/sentry/blob/master/src/sentry/issues/auto_source_code_config/constants.py#L15-L32

Removed Clojure/Groovy since they have _very_ low usage and also reranked languages by ~popularity.

Fixes ID-1212