### PR TITLE
fix(build): Enable esbuild write in local production builds

### DIFF
--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -783,9 +783,7 @@ export async function getFileBySlug(slug: string): Promise<SlugFile> {
       // We'll handle writing manually to gracefully handle read-only filesystems (e.g., Lambda runtime)
       // In local dev, we need write=true to avoid images being embedded as binary data
       options.write =
-        process.env.NODE_ENV === 'development' ||
-        !!process.env.CI ||
-        !process.env.VERCEL;
+        process.env.NODE_ENV === 'development' || !!process.env.CI || !process.env.VERCEL;
 
       return options;
     },


### PR DESCRIPTION
`yarn build` was failing with a weird MDX syntax error.

Upon closer inspection it was coming from the `esbuild` write option.

