### PR TITLE
feat(develop-docs): SDKs handling HTTP 413

### DIFF
--- a/develop-docs/sdk/expected-features/index.mdx
+++ b/develop-docs/sdk/expected-features/index.mdx
@@ -260,7 +260,7 @@ If Sentry returns an `HTTP 4xx` or `HTTP 5xx` status code, SDKs:
 
 For an [`HTTP 413 Content Too Large`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413) response, SDKs:
 
-* **MUST** discard the envelope, but **MUST NOT** record a [client report](/sdk/telemetry/client-reports), because the Relay already does this. Doing this would double-count client reports for discarded envelopes.
+* **MUST** discard the envelope, but **MUST NOT** record a [client report](/sdk/telemetry/client-reports), because the upstream already does this. Doing this would double-count client reports for discarded envelopes.
 * **MUST NOT** retry sending the envelope.
 * **SHOULD** log an error, informing users that the envelope was discarded due to size limits.
 * **MAY** add information from the response body to the logged error. If doing so, SDKs **MUST** be aware that Relay can change or remove information in the response body for an `HTTP 413` at any time without notice.


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

As decided in the DACI below, SDKs should now handle a 413 response to better inform users when envelopes get dropped due to size limits.

See:
https://www.notion.so/sentry/DACI-Relay-returns-413-for-too-large-envelopes-2c68b10e4b5d8034be83e524c855e73d

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

