### PR TITLE
feat(js): Document scope attributes on metrics

### DIFF
--- a/platform-includes/metrics/usage/javascript.mdx
+++ b/platform-includes/metrics/usage/javascript.mdx
@@ -43,6 +43,24 @@ Sentry.metrics.count(
 );
 ```
 
+With version `10.33.0` and above, you can use scope APIs to set attributes on the SDK's scopes which will be applied to all metrics as long as the respective scopes are active. For the time being, only `string`, `number` and `boolean` attribute values are supported.
+
+
+```js
+Sentry.getGlobalScope().setAttributes({ is_admin: true, auth_provider: 'google' });
+
+Sentry.withScope(scope => {
+  scope.setAttribute('step', 'authentication');
+
+  // scope attributes `is_admin`, `auth_provider` and `step` are added
+  Sentry.metrics.count('clicks', 1, { attributes: { activeSince: 100 } });
+  Sentry.metrics.gauge('time_since_refresh', 4, { unit: 'hour' });
+});
+
+// scope attributes `is_admin` and `auth_provider` are added
+Sentry.metrics.distribution('response_time', 283.33, { unit: 'millisecond' });
+```
+
 ### Specifying Units
 
 For `gauge` and `distribution` metrics, you can specify a unit using the `unit` option. This helps Sentry display the metric value in a human-readable format.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Documents `scope.setAttribute(s)` which will be applied to metrics once https://github.com/getsentry/sentry-javascript/pull/18738 is merged and released.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
