### PR TITLE
fix: touch product/stats

### DIFF
--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -8,6 +8,7 @@ og_image: /og-images/product-stats.png
 ---
 
 The [**Stats**](https://sentry.io/orgredirect/organizations/:orgslug/stats/) page is an overview of the usage data that Sentry receives across your entire organization. It allows you to spot projects that have experienced recent spikes in activity or are showing more errors than others and may require a closer look. You can also adjust the displayed date range, enabling you to narrow down to a specific time period or zoom out for a broader view.
+
 ![Overview of Usage Stats page](./img/usage-stats-page-errors.png)
 
 With the dropdowns at the top of the page, you can set whether the page displays stats for errors, transactions, or attachments, as well as the date range. With the date selector, the time period can be set from an hour to a maximum of 90 days, and all of the page elements change dynamically when you update this setting.


### PR DESCRIPTION
https://github.com/getsentry/sentry-docs/pull/15929 updated the image but seems like the HTML rebuild was not triggered. This PR fixes it (not sure if this is correct approach tho).