### PR TITLE
docs(sdk): Fix telemetry processor diagram inconsistency

### DIFF
--- a/develop-docs/sdk/telemetry/telemetry-processor/index.mdx
+++ b/develop-docs/sdk/telemetry/telemetry-processor/index.mdx
@@ -43,16 +43,15 @@ subgraph TelemetryProcessorSubgraph["TelemetryProcessor"]
 
       TelemetryBuffer -- add Span --> SpanBuffer
       TelemetryBuffer -- add Log or Metric --> GenericBuffer
-      TelemetryBuffer -- add Error, Check-In, Session, etc. --> OneItemBuffer
 
       SpanBuffer --> SendData
       GenericBuffer --> SendData
-      OneItemBuffer --> SendData
 
       SendData@{ shape: fork, label: "Fork or Join" }
 
     end
 
+    TelemetryBuffer -- "add low-volume data (Error, Check-In, Session, etc.)" --> TelemetryScheduler
     SendData -- when full or time out, flush buffered data --> TelemetryScheduler
 
     subgraph TelemetrySchedulerSubGraph["TelemetryScheduler"]


### PR DESCRIPTION
## DESCRIBE YOUR PR

The diagram showed low-volume data (errors, check-ins, sessions) going through OneItemBuffer, but requirement #3 states they must forward "directly to the telemetry scheduler". Remove OneItemBuffer and add direct arrow to match the documented requirement.

| Before | Now |
|--------|--------|
| <img width="2026" height="2010" alt="Screenshot 2026-01-09 at 10 49 04" src="https://github.com/user-attachments/assets/11e1b207-2fbc-4e2e-8da1-4446d8924d3d" /> | <img width="1800" height="2102" alt="Screenshot 2026-01-09 at 10 48 20" src="https://github.com/user-attachments/assets/b94b857a-a239-46a6-baa6-3605e8c7ff12" /> | 



