### PR TITLE
docs(metrics): Update metrics API documentation

### DIFF
--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -321,29 +321,23 @@ SentrySDK.metrics()
   .count(
     name: "button.clicks",
     value: 1,
-    options: [
-      "attributes": ["button_id": "submit", "page": "checkout"]
-    ]
+    attributes: ["button_id": "submit", "page": "checkout"]
   )
 
 SentrySDK.metrics()
   .gauge(
     name: "db.connection_pool.active",
     value: 42,
-    options: [
-      "unit": "connection",
-      "attributes": ["pool_name": "main_db", "database": "postgres"]
-    ]
+    unit: "connection",
+    attributes: ["pool_name": "main_db", "database": "postgres"]
   )
 
 SentrySDK.metrics()
   .distribution(
     name: "page.load_time",
     value: 245.7,
-    options: [
-      "unit": "millisecond",
-      "attributes": ["page": "/dashboard", "browser": "chrome"]
-    ]
+    unit: "millisecond",
+    attributes: ["page": "/dashboard", "browser": "chrome"]
   )
 ```
 


### PR DESCRIPTION
Fix Python code block formatting and update Cocoa metrics API examples

The Python metrics example was missing a closing code fence, causing incorrect rendering. 

Additionally, the Cocoa metrics API examples have been updated to use a cleaner parameter syntax, replacing the nested `options:` array with direct named parameters (`unit:` and `attributes:`). This matches the actual SDK API and improves code readability.