### PR TITLE
docs(android): Update build distribution to check SENTRY_AUTH_TOKEN

### DIFF
--- a/docs/platforms/android/build-distribution/auto-update.mdx
+++ b/docs/platforms/android/build-distribution/auto-update.mdx
@@ -33,7 +33,7 @@ Add the auto-update SDK configuration to your app's `build.gradle` or `build.gra
 sentry {
   distribution {
     // Enable build distribution uploads
-    enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent
+    enabled = providers.environmentVariable("SENTRY_AUTH_TOKEN").isPresent
 
     // Specify which build variants should include the auto-update SDK
     // These must be variants where the Sentry SDK is enabled (not in ignoredVariants)
@@ -49,7 +49,7 @@ sentry {
 sentry {
   distribution {
     // Enable build distribution uploads
-    enabled = providers.environmentVariable("GITHUB_ACTIONS").present
+    enabled = providers.environmentVariable("SENTRY_AUTH_TOKEN").present
 
     // Specify which build variants should include the auto-update SDK
     // These must be variants where the Sentry SDK is enabled (not in ignoredVariants)


### PR DESCRIPTION
## Summary

- Changed environment variable check from `GITHUB_ACTIONS` to `SENTRY_AUTH_TOKEN` in Android build distribution auto-update documentation
- Updated both Kotlin and Groovy code examples

This makes the check more universal across CI environments, as `SENTRY_AUTH_TOKEN` is the standard environment variable used for Sentry authentication rather than being GitHub Actions specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)