### PR TITLE
Fix missing explicit initializers for UObject-derived classes in Unreal Engine code examples

### DIFF
--- a/docs/platforms/unreal/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/unreal/enriching-events/identify-user/index.mdx
@@ -46,6 +46,7 @@ TMap<FString, FString> AdditionalData;
 AdditionalData.Add("DogName", "Spot");
 
 USentryUser* User = NewObject<USentryUser>();
+User->Initialize();
 User->SetEmail("user@sentry.io");
 User->SetId("123");
 User->SetUsername("AwesomeUser99");

--- a/docs/platforms/unreal/enriching-events/scopes/index.mdx
+++ b/docs/platforms/unreal/enriching-events/scopes/index.mdx
@@ -45,6 +45,7 @@ All data can be configured on the global scope using dedicated methods of `Sentr
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
 USentryUser* SentryUser = NewObject<USentryUser>();
+SentryUser->Initialize();
 SentryUser->SetEmail("john.doe@example.com");
 SentryUser->SetId(42);
 

--- a/platform-includes/capture-message/unreal.mdx
+++ b/platform-includes/capture-message/unreal.mdx
@@ -48,6 +48,7 @@ In a simplest case, it looks like this:
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
 USentryEvent* Event = NewObject<USentryEvent>();
+Event->Initialize();
 Event->SetMessage("Message");
 Event->SetLevel(ESentryLevel::Info);
 
@@ -60,6 +61,7 @@ You can also configure scope for some specific events:
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
 USentryEvent* Event = NewObject<USentryEvent>();
+Event->Initialize();
 Event->SetMessage("Message");
 Event->SetLevel(ESentryLevel::Info);
 

--- a/platform-includes/enriching-events/scopes/configure-scope/unreal.mdx
+++ b/platform-includes/enriching-events/scopes/configure-scope/unreal.mdx
@@ -5,6 +5,7 @@ ScopeDelegate.BindDynamic(this, &USomeClass::HandleScopeDelegate);
 void USomeClass::HandleScopeDelegate(USentryScope* Scope)
 {
     USentryUser* SentryUser = NewObject<USentryUser>();
+    SentryUser->Initialize();
     SentryUser->SetEmail("john.doe@example.com");
     SentryUser->SetId(42);
 
@@ -25,6 +26,7 @@ Alternatively, all data can be configured on the global scope using dedicated me
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
 USentryUser* SentryUser = NewObject<USentryUser>();
+SentryUser->Initialize();
 SentryUser->SetEmail("john.doe@example.com");
 SentryUser->SetId(42);
 

--- a/platform-includes/enriching-events/set-user/unreal.mdx
+++ b/platform-includes/enriching-events/set-user/unreal.mdx
@@ -5,6 +5,7 @@ TMap<FString, FString> AdditionalData;
 AdditionalData.Add("DogName", "Spot");
 
 USentryUser* User = NewObject<USentryUser>();
+User->Initialize();
 User->SetEmail("user@sentry.io");
 User->SetId("123");
 User->SetUsername("AwesomeUser99");


### PR DESCRIPTION
This PR adds missing explicit `Initialize()` method calls for some Sentry entities derived from Unreal’s default UObject class in C++ code examples. These calls became required during object instantiation starting with plugin version `1.0.0` (see [migration guide](https://docs.sentry.io/platforms/unreal/migration/#sentry-classes-instantiation))

Related to https://github.com/getsentry/sentry-unreal/issues/1185.