### PR TITLE
ref(span-v2-sdk): Add `sentry.span.source` attribute to common attributes list

### DIFF
--- a/develop-docs/sdk/data-model/event-payloads/transaction.mdx
+++ b/develop-docs/sdk/data-model/event-payloads/transaction.mdx
@@ -181,6 +181,12 @@ _Optional_. An object containing standard/custom measurements with keys signifyi
 
 ## Transaction Annotations
 
+<Alert level="info">
+
+Span name source information MUST still be set for Span v2 segment spans, although via a span attribute. See [Span v2 Protocol](/sdk/telemetry/spans/span-protocol/#common-attribute-keys) for more information.
+
+</Alert>
+
 `transaction_info`
 
 _Recommended_. Additional information about the name of the transaction.

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -168,6 +168,7 @@ Empty attributes must be omitted.
 | `sentry.environment` | string | The environment name (e.g., "production", "staging", "development") |
 | `sentry.segment.name` | string | The segment name (e.g., "GET /users") |
 | `sentry.segment.id` | string | The segment span id |
+| `sentry.span.source` | string | The source of the span name. **MUST** be set on segment spans, **MAY** be set on child spans. <br/> See [Sentry Conventions](https://github.com/getsentry/sentry-conventions/attributes/sentry#sentry-span-source) for all supported sources. <br/>See [Transaction Annotations](/sdk/data-model/event-payloads/transaction/#transaction-annotations) and [Clustering](/backend/application-domains/transaction-clustering/#automatic-transaction-clustering) for more information.|
 | `os.name` | string | The operating system name (e.g., "Linux", "Windows", "macOS") |
 | `browser.name` | string | The browser name (e.g., "Chrome", "Firefox", "Safari") |
 | `user.id` | string | The user ID (gated by `sendDefaultPii`) |


### PR DESCRIPTION
Following an internal discussion about how (segment) span clustering/sanitization is working in span-first, we came to the conclusion that SDKs must send the [`sentry.span.source` attribute ](https://getsentry.github.io/sentry-conventions/generated/attributes/sentry.html#sentryspansource) analogously to [how they send `transaction_info.source`](https://develop.sentry.dev/sdk/data-model/event-payloads/transaction/#transaction-annotations) in Today's transaction events.

I chose to add this to common span attributes although technically, this only needs to be set on segment spans. My thinking here is, setting it on child spans doesn't hurt and we already do this in JS* since v8 on many occasions. If we ever choose to group or sanitize child spans, we're already sending this data along. So therefore I included the MUST/MAY requirement for segment and child spans respectively. Happy to change if anyone has concerns. 

side-note: We technically send `sentry.source`, not `sentry.span.source` today in JS. But we can easily alias this, send both for the time being and stop sending `sentry.source` in the next major. Not relevant for this PR though.