### PR TITLE
fix(feedback): Include full URL with query parameters

### DIFF
--- a/src/components/docFeedback/index.tsx
+++ b/src/components/docFeedback/index.tsx
@@ -41,6 +41,7 @@ export function DocFeedback({pathname}: Props) {
       Sentry.captureFeedback(
         {
           message: comments,
+          url: window.location.href,
         },
         {captureContext: {tags: {page: pathname, type: feedbackType}}}
       );


### PR DESCRIPTION
## Summary
- `captureFeedback` doesn't auto-capture the URL like `sendFeedback` does
- This was causing feedback to show truncated URLs without query params

For example, feedback from `/platform-redirect/?next=/configuration/environments/` was showing as just `/platform-redirect/`

## Test plan
- [x] Submit feedback on a page with query parameters (e.g., `/platform-redirect/?next=/configuration/environments/`)
- [x] Verify the full URL including query params appears in Sentry feedback

| without url | with url |
|--------|--------|
| <img width="3578" height="2412" alt="CleanShot 2026-01-10 at 21 15 05@2x" src="https://github.com/user-attachments/assets/4b70832d-cb61-476f-b6bc-368723886267" /> | <img width="3580" height="1988" alt="CleanShot 2026-01-10 at 21 14 39@2x" src="https://github.com/user-attachments/assets/7b66a03e-5325-472c-ac66-ab0e938d14e9" /> |

🤖 Generated with [Claude Code](https://claude.ai/code)