### PR TITLE
docs(sdk): Add cross-reference to common telemetry processor spec

### DIFF
--- a/develop-docs/sdk/telemetry/telemetry-processor/backend-telemetry-processor.mdx
+++ b/develop-docs/sdk/telemetry/telemetry-processor/backend-telemetry-processor.mdx
@@ -8,6 +8,8 @@ sidebar_order: 1
   🚧 This document is work in progress.
 </Alert>
 
+For the common specification for the telemetry processor, refer to the [Telemetry Processor](/sdk/telemetry/telemetry-processor/) page. This page describes the backend-specific implementation of the telemetry processor.
+
 ## Telemetry Processor Layer: Prioritized, Bounded, Rate-Aware Envelope Delivery
 
 ### Overview


### PR DESCRIPTION
Add a link to the common Telemetry Processor page at the top of the backend-specific document.

This helps readers navigate between the common specification and the platform-specific implementation details, similar to how the Mobile Telemetry Processor page already references the common spec.