### PR TITLE
docs(size-analysis): Add dex size metrics explanation for Android (EME-578)

### DIFF
--- a/docs/platforms/android/size-analysis/insights.mdx
+++ b/docs/platforms/android/size-analysis/insights.mdx
@@ -9,11 +9,11 @@ Size Analysis Insights point out opportunities to reduce your Android app's size
 
 ## Understanding Dex Size Metrics
 
-One unique aspect of dex is the usage of shared data between different portions of bytecode. This allows dex to minimize its download/disk size as well as memory footprint, at the expense of being able to attribute all code to a single owner. See the [Dex executable format documentation](https://source.android.com/docs/core/runtime/dex-format) for more details on how dex shares constant information.
+One unique aspect of dex is the usage of shared data between different portions of bytecode. This allows dex to minimize its download/disk size as well as memory footprint, but it means that not all code can be attributed to a single owner. See the [Dex executable format documentation](https://source.android.com/docs/core/runtime/dex-format) for more details on how dex shares constant information.
 
-Due to this sharing, it's not possible to measure exactly how much size a specific package/class contributes to the overall dex. Therefore, Sentry shows only the "private size" of a class, which is equal to the size that we can attribute to a specific class with 100% certainty. This often means that the sum of the uncompressed size of all individual class nodes will be less than that of the overall Dex node, as we cannot fully account for shared dex elements.
+Due to this sharing, it's not possible to measure exactly how much size a specific package/class contributes to the overall dex. Therefore, Sentry shows only the "private size" of a class, which is the size that can be attributed to a specific class with 100% certainty. Sentry will show the full dex breakdown down to the class level of all code that can be attributed to a single owner. Because shared elements like string pools and constants cannot be fully attributed to individual classes, the sum of the uncompressed size of all individual class nodes will often be less than the overall Dex node size.
 
-Additionally, download sizes are an estimate of how much each dex class/package node will take in proportion to the uncompressed size. Occasionally, the sum of individual class download sizes might exceed that of the overall dex file, due to compression in the final APK format.
+Additionally, download sizes are an estimate of how much each dex class/package node will contribute in proportion to the uncompressed size. Occasionally, the sum of individual class download sizes might exceed that of the overall dex file, due to how compression works in the final APK format.
 
 ## Android Insights
 


### PR DESCRIPTION
Add "Understanding Dex Size Metrics" section to Android Size Analysis which is mostly taken [from the Emerge docs](https://docs.emergetools.com/docs/shared-dex-android) with minor changes to the sentences for clarity.

Fixes EME-578