### PR TITLE
docs(apple): add cacheDirectoryPath option documentation

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -850,7 +850,10 @@ Learn more in the <PlatformLink to="/features/experimental-features/">Experiment
 
 <SdkOption name="cacheDirectoryPath" type="string">
 
-The path where the SDK stores data before sending it to Sentry. By default, the SDK uses `NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)`, which resolves to `~/Library/Caches/` for non-sandboxed macOS apps.
+The path where the SDK stores data before sending it to Sentry. By default, the SDK uses `NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)`, which resolves to:
+- `~/Library/Caches/` for non-sandboxed macOS apps
+- `~/Library/Containers/{BundleID}/Data/Library/Caches/` for sandboxed macOS apps
+- `~/Library/Caches/` (within the app's sandbox) for iOS apps
 
 The data is persisted locally and sent to Sentry when network connectivity is available.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add documentation for the cacheDirectoryPath configuration option for Apple platforms. Documents the default path resolution to ~/Library/Caches/ for non-sandboxed macOS apps and explains that data is persisted locally before being sent to Sentry.

Related to getsentry/sentry-cocoa#5145

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
