### PR TITLE
chore(ai): remove unnecessary import from code snippet

### DIFF
--- a/docs/platforms/python/integrations/langgraph/index.mdx
+++ b/docs/platforms/python/integrations/langgraph/index.mdx
@@ -24,7 +24,6 @@ uv add "sentry-sdk[langgraph]"
 If you have the `langgraph` package in your dependencies, the LangGraph integration will be enabled automatically when you initialize the Sentry SDK. 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.openai import OpenAIIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",


### PR DESCRIPTION
We used to need this, to deactive it, but now that we auto-activate and auto-deactivate, this is useless