### PR TITLE
fix(mdx): Use /tmp for esbuild outdir on Vercel runtime

### DIFF
--- a/src/mdx.ts
+++ b/src/mdx.ts
@@ -639,9 +639,13 @@ export async function getFileBySlug(slug: string): Promise<SlugFile> {
   let cacheFile: string | null = null;
   let assetsCacheDir: string | null = null;
 
-  // Always use public/mdx-images during build
-  // During runtime (Lambda), this directory is read-only but images are already there from build
-  const outdir = path.join(root, 'public', 'mdx-images');
+  // Use public/mdx-images during build (CI or local dev)
+  // During Vercel runtime (Lambda), /var/task is read-only but /tmp is writable
+  // Note: Even with options.write=false, esbuild still attempts to create outdir internally
+  // See: DOCS-9K6 for the read-only filesystem error this prevents
+  const outdir = isVercelRuntime
+    ? path.join('/tmp', 'mdx-images')
+    : path.join(root, 'public', 'mdx-images');
 
   try {
     await mkdir(outdir, {recursive: true});


### PR DESCRIPTION
## Summary
- Fixes esbuild "read-only file system" errors on Vercel Lambda runtime (DOCS-9K6 - 330k+ events)
- Redirects esbuild's `outdir` to `/tmp/mdx-images` when running on Vercel runtime since `/var/task` is read-only
- esbuild internally creates the outdir even when `options.write=false`, bypassing the existing try-catch

## Root Cause
esbuild's internal directory creation fails on Vercel's read-only filesystem (`/var/task/public/mdx-images`) during MDX compilation, despite `options.write=false` being set. The only writable directory in AWS Lambda is `/tmp`.

## Related Issue
https://sentry.sentry.io/issues/DOCS-9K6