### PR TITLE
fix(page): Use pre-computed tree for version extraction

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -17,6 +17,7 @@ import {
   getDocsRootNode,
   getNextNode,
   getPreviousNode,
+  getVersionsFromTree,
   nodeForPath,
 } from 'sentry-docs/docTree';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
@@ -24,7 +25,6 @@ import {
   getDevDocsFrontMatter,
   getDocsFrontMatter,
   getFileBySlugWithCache,
-  getVersionsFromDoc,
 } from 'sentry-docs/mdx';
 import {mdxComponents} from 'sentry-docs/mdxComponents';
 import {PageType} from 'sentry-docs/metrics';
@@ -192,9 +192,9 @@ export default async function Page(props: {params: Promise<{path?: string[]}>}) 
   }
   const {mdxSource, frontMatter} = doc;
 
-  // collect versioned files
-  const allFm = await getDocsFrontMatter();
-  const versions = getVersionsFromDoc(allFm, pageNode.path);
+  // collect versioned files from pre-computed tree (avoids filesystem scanning)
+  // See: DOCS-9RT
+  const versions = getVersionsFromTree(rootNode, pageNode.path);
 
   // pass frontmatter tree into sidebar, rendered page + fm into middle, headers into toc.
   const pageType = (params.path?.[0] as PageType) || 'unknown';


### PR DESCRIPTION
## Summary
- Fixes ENOENT errors when scanning `/vercel/path0/docs` (DOCS-9RT - 6.5k events)
- Replaces `getDocsFrontMatter()` call with new `getVersionsFromTree()` function that extracts version info from the pre-computed doc tree

## Changes
- **src/docTree.ts**: Add `getVersionsFromTree()` function that collects version info by traversing the doc tree
- **app/[[...path]]/page.tsx**: Use `getVersionsFromTree(rootNode, pageNode.path)` instead of `getDocsFrontMatter()` + `getVersionsFromDoc()`

## Root Cause
The `Page` component was calling `getDocsFrontMatter()` which attempts to scan the filesystem recursively. On Vercel, the docs directory path (`/vercel/path0/docs`) may not exist during certain build/runtime states, causing ENOENT errors.

The doc tree (`doctree.json`) is pre-computed during build and always available, making it a reliable source for version information.

## Related Issue
https://sentry.sentry.io/issues/DOCS-9RT