### PR TITLE
docs(mcp): add recordInputs/recordOutputs options documentation

### DIFF
--- a/docs/platforms/javascript/common/tracing/instrumentation/mcp-module.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/mcp-module.mdx
@@ -77,7 +77,7 @@ await Sentry.startSpan(
     span.setAttribute("mcp.transport", "stdio"); // or "http", "sse" for HTTP/WebSocket/SSE
     span.setAttribute("network.transport", "pipe"); // or "tcp" for HTTP/SSE
 
-    // Set tool arguments (optional, if send_default_pii=true)
+    // Set tool arguments (optional, requires recordInputs: true)
     for (const [key, value] of Object.entries(toolArguments)) {
       span.setAttribute(`mcp.request.argument.${key}`, value);
     }
@@ -141,7 +141,7 @@ await Sentry.startSpan(
     span.setAttribute("mcp.transport", "http");
     span.setAttribute("network.transport", "tcp");
 
-    // Set prompt arguments (optional, if send_default_pii=true)
+    // Set prompt arguments (optional, requires recordInputs: true)
     for (const [key, value] of Object.entries(promptArguments)) {
       span.setAttribute(`mcp.request.argument.${key}`, value);
     }
@@ -156,7 +156,7 @@ await Sentry.startSpan(
     // For single-message prompts, set role and content
     if (messages.length === 1) {
       span.setAttribute("mcp.prompt.result.message_role", messages[0].role);
-      // Content is PII, only set if send_default_pii=true
+      // Content may contain sensitive data, only set if recordOutputs: true
       span.setAttribute(
         "mcp.prompt.result.message_content",
         JSON.stringify(messages[0].content)

--- a/docs/product/insights/ai/mcp/getting-started.mdx
+++ b/docs/product/insights/ai/mcp/getting-started.mdx
@@ -30,18 +30,40 @@ import { McpServer } from "@modelcontextprotocol/sdk";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
-  // Optional: Enable to capture tool call arguments and results in Sentry, which may include PII
-  sendDefaultPii: true,
 });
 
-// Your MCP server
-const server = Sentry.wrapMcpServerWithSentry(new McpServer({
+// Your MCP server with optional input/output recording
+const server = Sentry.wrapMcpServerWithSentry(
+  new McpServer({
     name: "my-mcp-server",
     version: "1.0.0",
-}));
+  }),
+  {
+    recordInputs: true,
+    recordOutputs: true,
+  }
+);
 
 ...
 ```
+
+#### Options
+
+##### `recordInputs`
+
+_Type: `boolean`_
+
+Records inputs to MCP tool and prompt calls (such as tool arguments and prompt parameters).
+
+Defaults to `true` if `sendDefaultPii` is `true`.
+
+##### `recordOutputs`
+
+_Type: `boolean`_
+
+Records outputs from MCP tool and prompt calls (such as tool results and prompt messages).
+
+Defaults to `true` if `sendDefaultPii` is `true`.
 
 ### Python - MCP Server
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add documentation for the new `recordInputs` and `recordOutputs` options on `wrapMcpServerWithSentry()`. These options allow capturing MCP tool and prompt inputs/outputs without enabling `sendDefaultPii` globally.

Changes:
- Update JavaScript Quick Start example to show new options
- Add Options section documenting `recordInputs` and `recordOutputs`
- Update manual instrumentation comments to reference new options

Related to: https://github.com/getsentry/sentry-javascript/releases/tag/10.33.0

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the Sentry docs team