### PR TITLE
docs(api): add OAuth device authorization flow documentation

### DIFF
--- a/docs/api/auth.mdx
+++ b/docs/api/auth.mdx
@@ -124,7 +124,7 @@ The device authorization grant ([RFC 8628](https://datatracker.ietf.org/doc/html
 Request a device code from the device authorization endpoint:
 
 ```bash
-curl -X POST https://sentry.io/oauth/device_authorization/ \
+curl -X POST https://sentry.io/oauth/device/code/ \
   -d client_id={CLIENT_ID} \
   -d scope=org:read%20project:read
 ```
@@ -225,7 +225,7 @@ import time
 import requests
 
 CLIENT_ID = 'your-client-id'
-DEVICE_AUTH_URL = 'https://sentry.io/oauth/device_authorization/'
+DEVICE_AUTH_URL = 'https://sentry.io/oauth/device/code/'
 TOKEN_URL = 'https://sentry.io/oauth/token/'
 
 def authenticate():


### PR DESCRIPTION
Add documentation for the OAuth 2.0 Device Authorization Grant (RFC 8628) to the API authentication docs.

This documents the device code flow implemented in getsentry/sentry@d4e4b74becfb0f2d7f393ef5af5789d012b3b144, which enables headless clients (CLI tools, CI/CD pipelines, Docker containers) to authenticate without a browser on the device.

The new section covers:
- When to use the device flow vs standard OAuth
- Requesting device codes from `/oauth/device_authorization/`
- Displaying user codes and verification URLs
- Polling the token endpoint with proper interval handling
- Error responses (`authorization_pending`, `slow_down`, `access_denied`, `expired_token`)
- Complete Python example implementation