### PR TITLE
docs(develop): add docs for how to start and access local dev admin ui

### DIFF
--- a/develop-docs/development-infrastructure/frontend-development-server.mdx
+++ b/develop-docs/development-infrastructure/frontend-development-server.mdx
@@ -29,7 +29,7 @@ To access the admin UI (files under `gsAdmin`), you can run:
 pnpm dev-ui-admin
 ```
 
-The admin interface will be available at [https://localhost:7999/_admin](https://localhost:7999/_admin).
+The admin interface will be available at [https://dev.getsentry.net:7999/_admin](https://dev.getsentry.net:7999/_admin).
 
 Make sure you have cookies synced (see above), as authentication is required to access the admin interface.
 


### PR DESCRIPTION
- Add section to the frontend development server about the Admin UI

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
