### PR TITLE
fix(nuxt): Fix file include in quick start guide

### DIFF
--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -261,7 +261,7 @@ The `hidden` option enables source map generation while preventing source map re
 
 <PlatformContent
   includePath="getting-started-tunneling"
-  platform="javascript.nuxt"
+  platform="javascript"
 />
 </PlatformSection>
 


### PR DESCRIPTION
Fixed the include for "## Step 4: Avoid Ad Blockers With Tunneling (Optional)" in the Nuxt manual quick start guide so the content gets displayed.


closes: #15985 
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
