### PR TITLE
chore: Remove unrestricted gh api permission

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,6 @@
       "Bash(gh run list:*)",
       "Bash(gh run logs:*)",
       "Bash(gh repo view:*)",
-      "Bash(gh api:*)",
       "Bash(node --version:*)",
       "Bash(yarn list:*)",
       "Bash(yarn info:*)",


### PR DESCRIPTION
Remove gh api:* wildcard permission, which allowed any GitHub API call,
including destructive operations. This permission could be exploited to:

- Delete repositories: gh api repos/:owner/:repo -X DELETE
- Make private repos public: gh api repos/:owner/:repo -X PATCH -f private=false
- Remove branch protection: gh api repos/:owner/:repo/branches/:branch/protection -X DELETE
- Add unauthorized collaborators: gh api repos/:owner/:repo/collaborators/:user -X PUT
- Access secrets: gh api repos/:owner/:repo/actions/secrets
- Add webhooks: gh api repos/:owner/:repo/hooks -X POST

Specific read-only gh commands remain allowed via existing allowlist entries.

This is a follow up on https://github.com/getsentry/sentry-docs/pull/15978, and came up here https://github.com/getsentry/sentry-cocoa/pull/7163#discussion_r2686020781.