### PR TITLE
feat(tanstackstart-react): Add new feature page for wrapMiddlewaresWi…

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/features/wrapMiddlewaresWithSentry.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/wrapMiddlewaresWithSentry.mdx
@@ -36,8 +36,3 @@ export { wrappedAuth as authMiddleware, wrappedLogging as loggingMiddleware };
 ```
 
 The middleware name in Sentry is automatically assigned based on the object key (e.g., `authMiddleware`, `loggingMiddleware`).
-
-## Next Steps:
-
-- [Return to **Getting Started**](../../)
-- [Return to the main integrations page](../)


### PR DESCRIPTION
Documents the new `wrapMiddlewaresWithSentry` wrapper for the `tanstackstart-react` SDK as a new feature page. This wrapper allows users to get tracing for their middlewares.

Should go out after the `10.34.0` release of the javascript SDKs.


