### PR TITLE
docs(develop): Fix JSON examples in logs and metrics telemetry docs

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -327,8 +327,8 @@ SDKs may optionally attach user information as attributes (guarded by `sendDefau
 ```json
 {
   "attributes": {
-    "user.id": { "value": "123", "type": "string" }
-    "user.name": { "value": "john.doe", "type": "string" }
+    "user.id": { "value": "123", "type": "string" },
+    "user.name": { "value": "john.doe", "type": "string" },
     "user.email": { "value": "john.doe@example.com", "type": "string" }
   }
 }
@@ -343,8 +343,10 @@ By default, Relay should parse the user agent attached to an incoming log envelo
 
 ```json
 {
-  "browser.name": "Chrome",
-  "browser.version": "120.0"
+  "attributes": {
+    "browser.name": { "value": "Chrome", "type": "string" },
+    "browser.version": { "value": "120.0", "type": "string" }
+  }
 }
 ```
 
@@ -356,7 +358,9 @@ For backend SDKs (Node.js, Python, PHP, etc.), the SDKs should attach the follow
 
 ```json
 {
-  "server.address": "foo.example.com"
+  "attributes": {
+    "server.address": { "value": "foo.example.com", "type": "string" }
+  }
 }
 ```
 
@@ -372,11 +376,13 @@ For mobile, desktop, and native SDKs (Android, Apple, Electron, etc.), the SDKs 
 
 ```json
 {
-  "os.name": "iOS",
-  "os.version": "17.0",
-  "device.brand": "Apple",
-  "device.model": "iPhone 15 Pro Max",
-  "device.family": "iPhone"
+  "attributes": {
+    "os.name": { "value": "iOS", "type": "string" },
+    "os.version": { "value": "17.0", "type": "string" },
+    "device.brand": { "value": "Apple", "type": "string" },
+    "device.model": { "value": "iPhone 15 Pro Max", "type": "string" },
+    "device.family": { "value": "iPhone", "type": "string" }
+  }
 }
 ```
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -401,7 +401,9 @@ SDKs may optionally attach user information as attributes (guarded by `sendDefau
 ```json
 {
   "attributes": {
-    "user.id": { "value": "123", "type": "string" }
+    "user.id": { "value": "123", "type": "string" },
+    "user.name": { "value": "john.doe", "type": "string" },
+    "user.email": { "value": "john.doe@example.com", "type": "string" }
   }
 }
 ```
@@ -415,8 +417,10 @@ By default, Relay should parse the user agent attached to an incoming metric env
 
 ```json
 {
-  "browser.name": "Chrome",
-  "browser.version": "120.0"
+  "attributes": {
+    "browser.name": { "value": "Chrome", "type": "string" },
+    "browser.version": { "value": "120.0", "type": "string" }
+  }
 }
 ```
 
@@ -424,11 +428,13 @@ By default, Relay should parse the user agent attached to an incoming metric env
 
 For backend SDKs (Node.js, Python, PHP, etc.), the SDKs should attach the following:
 
-1. `server.address`: The address of the server that sent the log. Equivalent to [`server_name`](/sdk/data-model/event-payloads/#optional-attributes) we attach to errors and transactions.
+1. `server.address`: The address of the server that sent the metric. Equivalent to [`server_name`](/sdk/data-model/event-payloads/#optional-attributes) we attach to errors and transactions.
 
 ```json
 {
-  "server.address": "foo.example.com"
+  "attributes": {
+    "server.address": { "value": "foo.example.com", "type": "string" }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Fix JSON syntax errors (missing commas) in attribute examples
- Wrap attributes in proper `attributes` object structure for browser, server, and device examples
- Add missing user attributes to metrics docs for consistency with logs
- Fix typo: "log" → "metric" in server.address description

## Test plan
- [ ] Verify JSON examples render correctly in documentation
- [ ] Confirm attribute structure matches expected format

🤖 Generated with [Claude Code](https://claude.ai/code)