### PR TITLE
fix: Add example of `array` attribute to telemetry attributes

### DIFF
--- a/develop-docs/sdk/telemetry/attributes.mdx
+++ b/develop-docs/sdk/telemetry/attributes.mdx
@@ -27,6 +27,10 @@ Attributes are stored as key-value pairs where each value is an object with type
 }
 ```
 
+<Alert>
+Sentry only supports <strong>non-mixed arrays</strong> as attribute values (e.g., all elements must be of the same type). Attributes with the 'array' type are not yet visible in the Sentry UI.
+</Alert>
+
 ### Properties
 
 | Property | Type | Required | Description |
@@ -90,4 +94,3 @@ The following units are [supported by Relay](https://getsentry.github.io/relay/r
 ## Semantic Conventions
 
 See [Sentry Conventions](https://github.com/getsentry/sentry-conventions/) for a full list of supported attributes.
-


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Original:
https://develop.sentry.dev/sdk/telemetry/attributes/
Vercel preview:


## DESCRIBE YOUR PR
Adds an example of the `array` type attribute, to avoid confusion about needing to send `integer[]` as the type.

Defined in Relay: https://github.com/getsentry/relay/blob/master/relay-event-schema/src/protocol/attributes.rs#L158 (added in https://github.com/getsentry/relay/pull/5394 with [examples here](https://github.com/getsentry/relay/pull/5394/changes#diff-59db6f882cc2165a2f15dccf0fb5600c27bccbd508620327834b62f6dd1499a4R683))

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
