### PR TITLE
docs(nextjs): Add Next.js-specific tracing documentation

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/tracing/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/tracing/index.mdx
@@ -103,6 +103,8 @@ export default async function Page() {
 </SplitSection>
 </SplitLayout>
 
+For configuration options like timeouts, INP settings, and filtering spans, see <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/">Automatic Instrumentation</PlatformLink>.
+
 ## Server Actions
 
 <SplitLayout>
@@ -202,6 +204,8 @@ Add custom spans when you want to measure:
 - Database operations not auto-captured
 - Expensive computations
 
+For the full span API including `startSpanManual` and `startInactiveSpan`, see <PlatformLink to="/tracing/instrumentation/">Custom Instrumentation</PlatformLink>.
+
 </SplitSectionText>
 <SplitSectionCode>
 
@@ -297,6 +301,8 @@ Sentry.init({
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+For CORS configuration and manual trace propagation (WebSockets, etc.), see <PlatformLink to="/tracing/distributed-tracing/">Distributed Tracing</PlatformLink>.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary
- Creates dedicated tracing guide for Next.js addressing framework-specific concerns
- Covers Server Actions (require manual `withServerActionInstrumentation`)
- Documents auto-instrumentation by runtime (client/server/edge)
- Includes Web Vitals, custom instrumentation, and distributed tracing

## Why Override?
The common tracing doc doesn't address Next.js-specific needs:
- Server Actions are NOT auto-instrumented (critical gap)
- Three runtimes have different auto-instrumentation
- Need to show headers pattern for trace propagation

## Test plan
- [ ] Verify page renders at `/platforms/javascript/guides/nextjs/tracing/`
- [ ] Check links resolve correctly
- [ ] Review on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)