### PR TITLE
fix(metrics): Remove docs for non-existent feature

### DIFF
--- a/docs/product/explore/metrics/index.mdx
+++ b/docs/product/explore/metrics/index.mdx
@@ -155,7 +155,6 @@ Metrics are best for **application and code-based health signals** — numeric i
 
 Your Sentry metrics can be leveraged with AI agents and tooling for debugging and automated analysis:
 
-- **[Sentry CLI](/cli/)**: Provides command-line access to your metrics data for feeding into AI tools and scripts
 - **[Sentry MCP Server](/product/sentry-mcp/)**: Enables natural language queries and deep integration with AI tools like Claude, Cursor, and VS Code using the Model Context Protocol
 - **[Seer](/product/ai-in-sentry/seer/)**: Sentry's AI debugging agent can use metrics alongside traces, logs, and errors to provide intelligent issue analysis
 


### PR DESCRIPTION
Sentry CLI does not, and nor has it ever provided, a way to query metrics data from Sentry. I don't know how this line ended up in this document, but we should remove it.