### PR TITLE
feat(span-first): Remove `active` from `startSpan` options

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-api.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-api.mdx
@@ -117,7 +117,7 @@ SDKs MUST allow specifying the following options to be passed to `startSpan`:
 Behaviour:
 - Spans MUST be started as active by default. This means that any span started, while the initial span is active, MUST be attached as a child span of the active span.
 - Inactive span behaviour is possible if users pass the parent of the currently active span as `parentSpan` which will attach the started span as a sibling of the currently active span.
-- If a `Span` is passed via `parentSpan`, the span will be started as the child of the passed parent span. This has precedence over the currently active span. 
+- If a `Span` is passed via `parentSpan`, the span will be started as the child of the passed parent span. This has precedence over the currently active span.
 - If `null` is passed via `parentSpan`, the new span will be started as a root/segment span.
 - SDKs MUST NOT end the span automatically. This is the responsibility of the user.
 - `startSpan` MUST always return a span instance, even if the started span's trace is negatively sampled.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*
Removes `active` from `startSpan`

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
