### PR TITLE
Update 'unit' property description in metrics documentation

### DIFF
--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -206,7 +206,8 @@ The parameters for these methods should be the following, or an equivalent form 
 - `name` **String, required**: The name of the metric
 - `value` **Number, required**: The value of the metric
 - `options` **Object, optional**: An object containing the following properties:
-  - `unit` **String, optional**: The unit of measurement (only used for `distribution` and `gauge`). SDKs must not restrict what can be sent in (e.g. by using an enum) but should offer constants or similar that help customers send in units we support.
+  - `unit` **String, optional**: The unit of measurement (only used for `distribution` and `gauge`). SDKs must not restrict what can be sent in (e.g. by using an enum) but should offer constants or similar that help customers send in <Link
+to="/sdk/telemetry/attributes/#units">units we support</Link>.
   - `attributes` **Object, optional**: A dictionary of attributes (key-value pairs with type information)
   - `scope` **Scope, optional**: The scope to capture the metric with.
 


### PR DESCRIPTION
Clarified the 'unit' property description for metrics.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
