### PR TITLE
fix(dsn): Hide double scrollbar in dsn picker

### DIFF
--- a/src/components/codeKeywords/styles.ts
+++ b/src/components/codeKeywords/styles.ts
@@ -63,7 +63,7 @@ export const Dropdown = styled('div')<{dark: boolean}>`
 `;
 
 export const Selections = styled('div')`
-  overflow: scroll;
+  overflow: auto;
   overscroll-behavior: contain;
   max-height: 210px;
   min-width: 300px;


### PR DESCRIPTION
scroll always displays scroll bars when using windows or a mouse on mac. We can use auto and not display the bottom scroll bar.

<img width="319" height="302" alt="Screenshot 2026-01-14 at 10 30 51 AM" src="https://github.com/user-attachments/assets/137e03f7-ba4e-44c8-874c-4c5b00c39c92" />
