### PR TITLE
fix(apple): Fix slightly confusing app start docs

### DIFF
--- a/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -166,7 +166,6 @@ The Cocoa SDK creates the following app start spans:
 ![App Start Transaction](./img/app-start-transaction.png)
 
 Cold and warm start are Mobile Vitals, which you can learn about in the [full documentation](/product/insights/mobile/mobile-vitals).
-gi
 ### Prewarmed App Start Tracing
 
 Starting with iOS 15, the operating system might [prewarm](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence#3894431) your app by creating the process before the user opens it. Starting with SDK version [9.0.0](https://github.com/getsentry/sentry-cocoa/releases/tag/9.0.0), the `enablePreWarmedAppStartTracing` is enabled by default.


### PR DESCRIPTION
## DESCRIBE YOUR PR

The app start tracing docs mentioned how to enable app start tracing even though this feature is enabled by default. Instead, the docs now explain how to disable it.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

