### PR TITLE
docs(nextjs): Add isolation scope guidance for logs

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/logs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/logs/index.mdx
@@ -132,25 +132,37 @@ Sentry.logger.info(Sentry.logger.fmt`User ${userId} purchased ${productName}`);
 
 ### Scope Attributes
 
-Set attributes on the scope to automatically include them in all logs within that context.
+Set attributes on a scope to automatically include them in all logs within that context.
+
+<Alert>
+
+Scopes don't propagate between Next.js runtimes. To include attributes on logs from all three runtimes, call `getIsolationScope().setAttribute()` in each (client, edge, server). Use isolation scope (not global) to prevent data leaking between concurrent requests. For server-side code, set context before any try/catch blocks so errors include it.
+
+</Alert>
+
+See <PlatformLink to="/enriching-events/scopes/#different-kinds-of-scopes">Different Kinds of Scopes</PlatformLink> to learn more.
 
 </SplitSectionText>
 <SplitSectionCode>
 
 ```typescript
-// Global attributes (all logs)
+// setAttribute() or setAttributes()
+// Global scope - shared across entire app
 Sentry.getGlobalScope().setAttributes({
   service: "checkout",
   version: "2.1.0",
 });
 
-// Scoped attributes (logs within scope)
-Sentry.withScope((scope) => {
-  scope.setAttribute("requestId", req.id);
+// Isolation scope - unique per request
+Sentry.getIsolationScope().setAttributes({
+  org_id: user.orgId,
+  user_tier: user.tier,
+});
 
-  // Both logs include requestId
+// Current scope - single operation
+Sentry.withScope((scope) => {
+  scope.setAttribute("request_id", req.id);
   Sentry.logger.info("Processing order");
-  Sentry.logger.info("Order complete");
 });
 ```
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
 Adds documentation for using `getIsolationScope()` to set custom attributes on logs in Next.js applications.

 Changes to docs/platforms/javascript/guides/nextjs/logs/index.mdx:
  - Updated the "Scope Attributes" section with an alert explaining that scopes don't propagate between Next.js runtimes (client, edge, server)
  - Added guidance to use isolation scope (not global) to prevent data leaking between concurrent requests
  - Added note about setting context before try/catch blocks on server-side code
  - Added link to "Different Kinds of Scopes" documentation for background reading
  - Updated code example to show getIsolationScope().setAttributes() for per-request data

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
