### PR TITLE
fix: Remove line about nonexistent limit

### DIFF
--- a/develop-docs/sdk/expected-features/data-handling.mdx
+++ b/develop-docs/sdk/expected-features/data-handling.mdx
@@ -132,7 +132,6 @@ https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions
 
 Fields in the event payload that allow user-specified or dynamic values are restricted in size. This applies to most meta data fields, such as variables in a stack trace, as well as contexts, tags and extra data:
 
-- Mappings of values (such as HTTP data, extra data, etc) are limited to 50 item pairs.
 - Event IDs are limited to 36 characters and must be valid UUIDs.
 - Flag keys are limited to 32 characters.
 - Flag values are limited to 200 characters.


### PR DESCRIPTION
## DESCRIBE YOUR PR
I can find no evidence that any collection is limited to 50 key/value pairs in Relay. Both in local testing and by sending an event to the `sentry-test` org, it seems that we handle events with 100 extra items just fine. I assume that this once existed in some form and the docs weren't updated when it was removed.
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
