### PR TITLE
ref(docs): Restructure LangChain integration documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
@@ -115,7 +115,7 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 
 ## Edge runtime
 
-This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument LangChain operations using the callback handler:
+For Next.js applications using the Edge runtime, you need to manually instrument LangChain operations using the callback handler:
 
 ```javascript
 import * as Sentry from "@sentry/nextjs";


### PR DESCRIPTION
- Separate server-side and browser-side usage sections for clarity
- Document langChainIntegration for Node.js platforms (auto-enabled by default)
- Document createLangChainCallbackHandler for browser and edge runtimes
- Add special handling for Cloudflare Workers and Next.js Edge runtime
- Simplify code examples with placeholder comments
- Restructure Configuration section with options first, then usage examples
- Improve platform-specific visibility using PlatformSection components

closes https://linear.app/getsentry/issue/TET-1740/langchain-integration-restructure-and-improve-docs