### PR TITLE
ref(docs): Restructure LangGraph integration documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
@@ -136,7 +136,7 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 
 ## Edge runtime
 
-This integration is automatically instrumented in the Node.js runtime. For Next.js applications using the Edge runtime, you need to manually instrument LangGraph operations using the `instrumentLangGraph` helper:
+For Next.js applications using the Edge runtime, you need to manually instrument LangGraph operations using the `instrumentLangGraph` helper:
 
 ```javascript
 import { ChatOpenAI } from "@langchain/openai";


### PR DESCRIPTION
- Separate server-side and browser-side usage sections for clarity
- Document langGraphIntegration for Node.js platforms (auto-enabled by default)
- Document instrumentLangGraph for browser and edge runtimes
- Add special handling for Cloudflare Workers and Next.js Edge runtime
- Simplify code examples with placeholder comments
- Restructure Configuration section with options first, then usage examples
- Improve platform-specific visibility using PlatformSection components

closes https://linear.app/getsentry/issue/TET-1741/langgraph-ai-integration-restructure-and-improve-docs