### PR TITLE
ref(docs): Restructure Google Gen AI integration documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
@@ -96,6 +96,30 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 
 </PlatformSection>
 
+<PlatformSection supported={['javascript.nextjs']}>
+
+## Edge runtime
+
+For Next.js applications using the Edge runtime, you need to manually wrap your Google Gen AI client instance with the `instrumentGoogleGenAIClient` helper:
+
+```javascript
+import { GoogleGenAI } from "@google/genai";
+
+const genAI = new GoogleGenAI({
+  apiKey: "your-api-key", // Warning: API key will be exposed in browser!
+});
+
+const client = Sentry.instrumentGoogleGenAIClient(genAI, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+// Use the wrapped client instead of the original genAI instance
+const result = await client.models.generateContent("Hello!");
+```
+
+</PlatformSection>
+
 ## Configuration
 
 ### Options


### PR DESCRIPTION
- Separate server-side and browser-side usage sections for clarity
- Document googleGenAIIntegration for Node.js platforms (auto-enabled by default)
- Document instrumentGoogleGenAIClient for browser and edge runtimes
- Add special handling for Cloudflare Workers and Next.js Edge runtime
- Simplify code examples with placeholder comments
- Restructure Configuration section with options first, then usage examples
- Improve platform-specific visibility using PlatformSection components

closes https://linear.app/getsentry/issue/TET-1739/google-gen-ai-integration-restructure-and-improve-docs