### PR TITLE
docs(metrics): align headings of Metrics usage

### DIFF
--- a/platform-includes/metrics/usage/php.laravel.mdx
+++ b/platform-includes/metrics/usage/php.laravel.mdx
@@ -2,7 +2,7 @@ Metrics are enabled by default in the PHP SDK. After the SDK is initialized, you
 
 The SDK buffers up to 1000 metric entries at a time. Once that limit is reached, it keeps only the most recent 1000. If you need to retain more than that, flush the metrics periodically before you exceed the buffer.
 
-## Emit a Counter
+### Emit a Counter
 
 Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
 
@@ -13,7 +13,7 @@ To emit a counter, do the following:
 \Sentry\trace_metrics()->count('button-click', 5, ['browser' => 'Firefox', 'app_version' => '1.0.0']);
 ```
 
-## Emit a Distribution
+### Emit a Distribution
 
 Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
 
@@ -26,7 +26,7 @@ use \Sentry\Metrics\Unit;
 \Sentry\trace_metrics()->distribution('page-load', 15.0, ['page' => '/home'], Unit::millisecond());
 ```
 
-## Emit a Gauge
+### Emit a Gauge
 
 Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. Gauges can not be used to represent percentiles. If percentiles aren't important to you, we recommend using gauges.
 
@@ -39,7 +39,7 @@ use \Sentry\Metrics\Unit;
 \Sentry\trace_metrics()->gauge('page-load', 15.0, ['page' => '/home'], Unit::millisecond());
 ```
 
-## Flush
+### Flush
 
 Metrics are flushed and sent to Sentry at the end of each request or command.
 

--- a/platform-includes/metrics/usage/php.mdx
+++ b/platform-includes/metrics/usage/php.mdx
@@ -2,7 +2,7 @@ Metrics are enabled by default in the PHP SDK. After the SDK is initialized, you
 
 The SDK buffers up to 1000 metric entries at a time. Once that limit is reached, it keeps only the most recent 1000. If you need to retain more than that, flush the metrics periodically before you exceed the buffer.
 
-## Emit a Counter
+### Emit a Counter
 
 Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
 
@@ -13,7 +13,7 @@ To emit a counter, do the following:
 \Sentry\trace_metrics()->count('button-click', 5, ['browser' => 'Firefox', 'app_version' => '1.0.0']);
 ```
 
-## Emit a Distribution
+### Emit a Distribution
 
 Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
 
@@ -26,7 +26,7 @@ use \Sentry\Metrics\Unit;
 \Sentry\trace_metrics()->distribution('page-load', 15.0, ['page' => '/home'], Unit::millisecond());
 ```
 
-## Emit a Gauge
+### Emit a Gauge
 
 Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. Gauges can not be used to represent percentiles. If percentiles aren't important to you, we recommend using gauges.
 
@@ -39,7 +39,7 @@ use \Sentry\Metrics\Unit;
 \Sentry\trace_metrics()->gauge('page-load', 15.0, ['page' => '/home'], Unit::millisecond());
 ```
 
-## Flush
+### Flush
 
 Make sure to flush collected metrics at the end.
 

--- a/platform-includes/metrics/usage/php.symfony.mdx
+++ b/platform-includes/metrics/usage/php.symfony.mdx
@@ -2,7 +2,7 @@ Metrics are enabled by default in the Symfony SDK. After the SDK is initialized,
 
 The SDK buffers up to 1000 metric entries at a time. Once that limit is reached, it keeps only the most recent 1000. If you need to retain more than that, flush the metrics periodically before you exceed the buffer.
 
-## Emit a Counter
+### Emit a Counter
 
 Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
 
@@ -13,7 +13,7 @@ To emit a counter, do the following:
 \Sentry\trace_metrics()->count('button-click', 5, ['browser' => 'Firefox', 'app_version' => '1.0.0']);
 ```
 
-## Emit a Distribution
+### Emit a Distribution
 
 Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
 
@@ -26,7 +26,7 @@ use \Sentry\Metrics\Unit;
 \Sentry\trace_metrics()->distribution('page-load', 15.0, ['page' => '/home'], Unit::millisecond());
 ```
 
-## Emit a Gauge
+### Emit a Gauge
 
 Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. Gauges can not be used to represent percentiles. If percentiles aren't important to you, we recommend using gauges.
 
@@ -39,7 +39,7 @@ use \Sentry\Metrics\Unit;
 \Sentry\trace_metrics()->gauge('page-load', 15.0, ['page' => '/home'], Unit::millisecond());
 ```
 
-## Flush
+### Flush
 
 Metrics are flushed and sent to Sentry at the end of each request or command.
 

--- a/platform-includes/metrics/usage/python.mdx
+++ b/platform-includes/metrics/usage/python.mdx
@@ -2,7 +2,7 @@ Metrics are enabled by default. Once you initialize the SDK, you can send metric
 
 The `metrics` namespace exposes three methods that you can use to capture different types of metric information: `count`, `gauge`, and `distribution`.
 
-## Emit a Counter
+### Emit a Counter
 
 Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
 
@@ -22,7 +22,7 @@ sentry_sdk.metrics.count(
 )
 ```
 
-## Emit a Distribution
+### Emit a Distribution
 
 Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
 
@@ -42,7 +42,7 @@ sentry_sdk.metrics.distribution(
 )
 ```
 
-## Emit a Gauge
+### Emit a Gauge
 
 Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. They can be represented in a more space-efficient way than distributions, but they can't be used to get percentiles. If percentiles aren't important to you, we recommend using gauges.
 

--- a/platform-includes/metrics/usage/ruby.mdx
+++ b/platform-includes/metrics/usage/ruby.mdx
@@ -2,7 +2,7 @@ Metrics are enabled by default. Once you initialize the SDK, you can send metric
 
 The `metrics` namespace exposes three methods that you can use to capture different types of metric information: `count`, `gauge`, and `distribution`.
 
-## Emit a Counter
+### Emit a Counter
 
 Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
 
@@ -17,7 +17,7 @@ Sentry.metrics.count(
 )
 ```
 
-## Emit a Distribution
+### Emit a Distribution
 
 Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
 
@@ -33,7 +33,7 @@ Sentry.metrics.distribution(
 )
 ```
 
-## Emit a Gauge
+### Emit a Gauge
 
 Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. They can be represented in a more space-efficient way than distributions, but they can't be used to get percentiles. If percentiles aren't important to you, we recommend using gauges.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
During #16054, I notice that the headings of `platform-includes/metrics/usage/*` are not aligned across all platforms:
- H3: JavaScript, Java (#16032)
- H2: PHP, Python, Ruby

Question: Do we want to do this?
Alternatively, we could change it to H4, so that they don't show up in the hierarchy like for "Options".

from -> to
<img width="156" height="290" alt="image" src="https://github.com/user-attachments/assets/1b5b5d58-29d1-4f08-a393-21ee6ebf2db1" />
<img width="164" height="297" alt="image" src="https://github.com/user-attachments/assets/13fb2def-d0b0-4ff6-bf37-641037f347a4" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
