### PR TITLE
docs(nextjs): document the route manifest injection option

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/configuration/build/index.mdx
@@ -242,20 +242,32 @@ You can set this option to `false` to disable the route manifest injection.
 - You're experiencing build issues related to route scanning
 - You prefer raw URLs in transaction names
 
-You can also pass in an object with an `exclude` property to control which routes should be excluded from the route manifest:
+You can also pass in an object with an `exclude` property to control which routes should be excluded from the route manifest. The `exclude` property accepts an array of strings or regular expressions, or a function that returns `true` to exclude a route.
 
 ```javascript
-routeManifestInjection: {
-  exclude: ["/api/health", "/api/excluded/[parameter]", /^\/internal\//],
-  // or a function that returns `true` to exclude the route
-  exclude: (route) => route.includes("/excluded"),
-},
+withSentryConfig(nextConfig, {
+  // Exclude specific routes using an array of strings or RegExps
+  routeManifestInjection: {
+    exclude: ["/api/health", "/api/excluded/[parameter]", /^\/internal\//],
+  },
+});
 ```
 
-**Use this if:**
+```javascript
+withSentryConfig(nextConfig, {
+  // Or use a function for dynamic exclusion
+  routeManifestInjection: {
+    exclude: (route) => route.includes("/excluded"),
+  },
+});
+```
 
-- You want to exclude routes that are not yet released or should not be publicly accessible.
-- You want to reduce the size of the route manifest by excluding routes that do not require parameterized grouping.
+Excluded routes will appear as raw URLs in transaction names instead of parameterized routes.
+
+**Use `exclude` if:**
+
+- You want to hide internal or unreleased routes from appearing in the client bundle
+- You want to reduce bundle size by excluding routes that don't benefit from parameterized grouping (for example, static routes with no dynamic segments)
 
 </SdkOption>
 


### PR DESCRIPTION
This document outlines the new option introduced in https://github.com/getsentry/sentry-javascript/pull/18798, which was released in `10.34.0`.

This option replaces the `disableManifestinjection` option, providing users with the flexibility to either completely disable this behavior or selectively exclude specific routes from being included in the route manifest.

A common use case for this option is when some routes are private or contain unreleased features. Having these routes present in the route manifest posed challenges for certain users. To address this, an `exclude` option allows users to avoid the all-or-nothing compromise, ensuring that data quality is maintained and preventing the leakage of route information.