### PR TITLE
feat(spans): Add common `sentry.op` attribute key

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -164,6 +164,7 @@ Empty attributes must be omitted.
 
 | Attribute Key | Type | Description |
 |---------------|------|-------------|
+| `sentry.op` | string | The [span op](../../traces/span-operations/) (e.g., "http.client", "db.query") of the span |
 | `sentry.release` | string | The release version of the application |
 | `sentry.environment` | string | The environment name (e.g., "production", "staging", "development") |
 | `sentry.segment.name` | string | The segment name (e.g., "GET /users") |


### PR DESCRIPTION
Just saw that we never specified that we should continue to send the op via `sentry.op`.