### PR TITLE
fix(develop): Replace client outcomes Snuba permalink with `master` link

### DIFF
--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -102,7 +102,7 @@ The following discard reasons are currently defined for `discarded_events`:
 - `ignored`: a telemetry item was ignored by the SDK (eg: a span was ignored by `ignore_spans`, can also be used by other deny-list mechanisms)
 
 In case a reason needs to be added,
-it also has to be added to the allowlist in [snuba](https://github.com/getsentry/snuba/blob/1a2528dacaf7415f71866bf2602ce473832d938c/rust_snuba/src/processors/outcomes.rs#L15-L27).
+it also has to be added to the allowlist in [snuba](https://github.com/getsentry/snuba/blob/master/rust_snuba/src/processors/outcomes.rs#L15).
 
 Additionally the following discard reasons are reserved but there is no expectation
 that SDKs send these under normal operation:


### PR DESCRIPTION
The previous permalink to the Snuba Outcomes definition showed an outdated version of the definitions, missing recent changes like #16010.  Now we just link directly to the LoC on `master`. This might also diverge (in terms of position) but at least then it's more obvious 😅 