### PR TITLE
docs(develop): Add client discard reason `invalid`

### DIFF
--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -100,6 +100,7 @@ The following discard reasons are currently defined for `discarded_events`:
 - `insufficient_data`: an event was dropped due to a lack of data in the event (eg: not enough samples in a profile)
 - `backpressure`: an event was dropped due to downsampling caused by the system being under load
 - `ignored`: a telemetry item was ignored by the SDK (eg: a span was ignored by `ignore_spans`, can also be used by other deny-list mechanisms)
+- `invalid`: an event was dropped because it failed validation (eg: a replay session exceeded the maximum allowed length)
 
 In case a reason needs to be added,
 it also has to be added to the allowlist in [snuba](https://github.com/getsentry/snuba/blob/master/rust_snuba/src/processors/outcomes.rs#L15).


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/FE-689/document-invalid-client-discard-reason-in-dev-docs
ref https://github.com/getsentry/sentry-javascript/issues/18316