### PR TITLE
feat(python): Mark OpenAI Agents, Google Gen AI, MCP, and Pydantic AI as auto-enabled

### DIFF
--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -42,15 +42,15 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 |                                                                                                                                   | **Auto-enabled** |
 | --------------------------------------------------------------------------------------------------------------------------------- | :--------------: |
 | <LinkWithPlatformIcon platform="anthropic"       label="Anthropic" url="/platforms/python/integrations/anthropic" />              |        ✓         |
-| <LinkWithPlatformIcon platform="google-genai"    label="Google Gen AI" url="/platforms/python/integrations/google-genai" />       |                  |
+| <LinkWithPlatformIcon platform="google-genai"    label="Google Gen AI" url="/platforms/python/integrations/google-genai" />       |        ✓         |
 | <LinkWithPlatformIcon platform="huggingface_hub" label="Hugging Face Hub" url="/platforms/python/integrations/huggingface_hub" /> |        ✓         |
 | <LinkWithPlatformIcon platform="openai"          label="OpenAI" url="/platforms/python/integrations/openai" />                    |        ✓         |
-| <LinkWithPlatformIcon platform="openai-agents"   label="OpenAI Agents SDK" url="/platforms/python/integrations/openai-agents" />  |                  |
+| <LinkWithPlatformIcon platform="openai-agents"   label="OpenAI Agents SDK" url="/platforms/python/integrations/openai-agents" />  |        ✓         |
 | <LinkWithPlatformIcon platform="langchain"       label="LangChain" url="/platforms/python/integrations/langchain" />              |        ✓         |
 | <LinkWithPlatformIcon platform="langgraph"       label="LangGraph" url="/platforms/python/integrations/langgraph" />              |        ✓         |
 | <LinkWithPlatformIcon platform="litellm"         label="LiteLLM" url="/platforms/python/integrations/litellm" />                  |                  |
-| <LinkWithPlatformIcon platform="pydantic-ai"     label="Pydantic AI" url="/platforms/python/integrations/pydantic-ai" />          |                  |
-| <LinkWithPlatformIcon platform="mcp"             label="MCP (Model Context Protocol)" url="/platforms/python/integrations/mcp" /> |                  |
+| <LinkWithPlatformIcon platform="pydantic-ai"     label="Pydantic AI" url="/platforms/python/integrations/pydantic-ai" />          |        ✓         |
+| <LinkWithPlatformIcon platform="mcp"             label="MCP (Model Context Protocol)" url="/platforms/python/integrations/mcp" /> |        ✓         |
 
 
 ### Data Processing


### PR DESCRIPTION
Based on the [codebase](https://github.com/getsentry/sentry-python/blob/749d8e5dba904665015469d7729bab75f389e4dd/sentry_sdk/integrations/__init__.py#L67-L108)  OpenAI Agents, Google Gen AI, MCP, and Pydantic AI are auto enabled, but the documentation doesn't match. Updating it.

**Before**
<img width="641" height="610" alt="image" src="https://github.com/user-attachments/assets/a4ee7594-c666-4ba7-b366-9babbf79aa41" />



**After**

<img width="734" height="610" alt="image" src="https://github.com/user-attachments/assets/b3493b9a-1eb9-4537-87a6-3cdb01c01727" />
