### PR TITLE
ref(python): Remove extras from installation instructions

### DIFF
--- a/docs/platforms/python/integrations/aiohttp/aiohttp-client.mdx
+++ b/docs/platforms/python/integrations/aiohttp/aiohttp-client.mdx
@@ -11,13 +11,13 @@ This integration also supports AIOHTTP servers. See <PlatformLink to="/integrati
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `aiohttp` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[aiohttp]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[aiohttp]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/aiohttp/index.mdx
+++ b/docs/platforms/python/integrations/aiohttp/index.mdx
@@ -9,13 +9,13 @@ If you use AIOHTTP as your HTTP client and want to instrument outgoing HTTP requ
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `aiohttp` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[aiohttp]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[aiohttp]"
+uv add sentry-sdk
 ```
 
 

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -11,14 +11,14 @@ Sentry AI Monitoring will automatically collect information about prompts, tools
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `anthropic` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[anthropic]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[anthropic]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/arq/index.mdx
+++ b/docs/platforms/python/integrations/arq/index.mdx
@@ -7,13 +7,13 @@ The arq integration adds support for the [arq job queue system](https://arq-docs
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `arq` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[arq]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[arq]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/asyncpg/index.mdx
+++ b/docs/platforms/python/integrations/asyncpg/index.mdx
@@ -8,13 +8,13 @@ The `AsyncPGIntegration` captures queries from
 
 ## Install
 
-To get started, install `sentry-sdk` from PyPI.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[asyncpg]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[asyncpg]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/bottle/index.mdx
+++ b/docs/platforms/python/integrations/bottle/index.mdx
@@ -9,13 +9,13 @@ However the integration with the development version (0.13) doesn't work properl
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `bottle` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[bottle]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[bottle]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/celery/index.mdx
+++ b/docs/platforms/python/integrations/celery/index.mdx
@@ -7,13 +7,13 @@ The Celery integration adds support for the [Celery Task Queue System](https://d
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `celery` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[celery]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[celery]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/chalice/index.mdx
+++ b/docs/platforms/python/integrations/chalice/index.mdx
@@ -5,13 +5,13 @@ description: "Learn about using Sentry with Chalice."
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `chalice` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[chalice]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[chalice]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/clickhouse-driver/index.mdx
+++ b/docs/platforms/python/integrations/clickhouse-driver/index.mdx
@@ -9,13 +9,13 @@ The integration is available for clickhouse-driver 0.2.0 or later.
 
 ## Install
 
-Install `sentry-sdk` with the `clickhouse-driver` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[clickhouse-driver]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[clickhouse-driver]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -15,13 +15,13 @@ If you're using Python 3.7, Django applications with `channels` 2.0 will be corr
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `django` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[django]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[django]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/falcon/index.mdx
+++ b/docs/platforms/python/integrations/falcon/index.mdx
@@ -8,13 +8,13 @@ The integration has been confirmed to work with Falcon 1.4 and 2.0.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `falcon` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[falcon]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[falcon]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -8,13 +8,13 @@ The FastAPI integration adds support for the [FastAPI Framework](https://fastapi
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `fastapi` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[fastapi]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[fastapi]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -7,13 +7,13 @@ The Flask integration adds support for the [Flask Web Framework](https://flask.p
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `flask` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[flask]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[flask]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/google-genai/index.mdx
+++ b/docs/platforms/python/integrations/google-genai/index.mdx
@@ -11,14 +11,14 @@ Sentry AI Monitoring will automatically collect information about prompts, tools
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `google-genai` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[google-genai]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[google-genai]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/grpc/index.mdx
+++ b/docs/platforms/python/integrations/grpc/index.mdx
@@ -10,13 +10,13 @@ and ensure traces are properly propagated to downstream services.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `grpcio` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[grpcio]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[grpcio]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/httpx/index.mdx
+++ b/docs/platforms/python/integrations/httpx/index.mdx
@@ -9,13 +9,13 @@ Use this integration to create spans for outgoing requests and ensure traces are
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `httpx` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[httpx]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[httpx]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -9,14 +9,14 @@ Once you've installed this SDK, you can use Sentry AI Agents Monitoring, a Sentr
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `huggingface_hub` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[huggingface_hub]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[huggingface_hub]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -9,14 +9,14 @@ Once you've installed this SDK, you can use Sentry AI Agents Monitoring, a Sentr
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `langchain` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[langchain]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[langchain]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/langgraph/index.mdx
+++ b/docs/platforms/python/integrations/langgraph/index.mdx
@@ -9,14 +9,14 @@ Once you've installed this SDK, you can use Sentry AI Agents Monitoring, a Sentr
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `langgraph` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[langgraph]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[langgraph]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/launchdarkly/index.mdx
+++ b/docs/platforms/python/integrations/launchdarkly/index.mdx
@@ -7,13 +7,13 @@ The [LaunchDarkly](https://launchdarkly.com/) integration tracks feature flag ev
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `launchdarkly` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[launchdarkly]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[launchdarkly]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/litellm/index.mdx
+++ b/docs/platforms/python/integrations/litellm/index.mdx
@@ -11,14 +11,14 @@ Sentry AI Monitoring will automatically collect information about prompts, tools
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `litellm` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[litellm]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[litellm]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/litestar/index.mdx
+++ b/docs/platforms/python/integrations/litestar/index.mdx
@@ -7,13 +7,13 @@ The Litestar integration adds support for the [Litestar framework](https://docs.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `litestar` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[litestar]" "uvicorn"
+pip install sentry-sdk uvicorn
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[litestar]" "uvicorn"
+uv add sentry-sdk uvicorn
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -16,14 +16,14 @@ Enable the Sentry Logs feature with `sentry_sdk.init(enable_logs=True)` to unloc
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `loguru` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[loguru]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[loguru]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/mcp/index.mdx
+++ b/docs/platforms/python/integrations/mcp/index.mdx
@@ -26,14 +26,14 @@ Sentry MCP monitoring will automatically collect information about:
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `mcp` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[mcp]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[mcp]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -17,14 +17,14 @@ AI frameworks are moving fast, and so are our integrations. To get the most out 
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `openai` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[openai]"
+pip install sentry-sdk
 ```
 
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[openai]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/openfeature/index.mdx
+++ b/docs/platforms/python/integrations/openfeature/index.mdx
@@ -9,13 +9,13 @@ The flag evaluations are held in memory and are sent to Sentry on error and tran
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `openfeature` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[openfeature]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[openfeature]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/pymongo/index.mdx
+++ b/docs/platforms/python/integrations/pymongo/index.mdx
@@ -10,13 +10,13 @@ The PyMongo integration adds support for [PyMongo](https://www.mongodb.com/docs/
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `pymongo` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[pymongo]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[pymongo]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/quart/index.mdx
+++ b/docs/platforms/python/integrations/quart/index.mdx
@@ -7,13 +7,13 @@ The Quart integration adds support for the [Quart Web Framework](https://gitlab.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `quart` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[quart]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[quart]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/rq/index.mdx
+++ b/docs/platforms/python/integrations/rq/index.mdx
@@ -7,13 +7,13 @@ The RQ integration adds support for the [RQ job queue system](https://python-rq.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `rq` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[rq]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[rq]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/sanic/index.mdx
+++ b/docs/platforms/python/integrations/sanic/index.mdx
@@ -7,13 +7,13 @@ The Sanic integration adds support for the [Sanic Web Framework](https://sanic.d
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `sanic` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[sanic]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[sanic]"
+uv add sentry-sdk
 ```
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:

--- a/docs/platforms/python/integrations/sqlalchemy/index.mdx
+++ b/docs/platforms/python/integrations/sqlalchemy/index.mdx
@@ -7,13 +7,13 @@ The SQLAlchemy integration captures queries from [SQLAlchemy](https://www.sqlalc
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `sqlalchemy` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[sqlalchemy]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[sqlalchemy]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -7,13 +7,13 @@ The Starlette integration adds support for the [Starlette Framework](https://www
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `starlette` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[starlette]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[starlette]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/starlite/index.mdx
+++ b/docs/platforms/python/integrations/starlite/index.mdx
@@ -7,13 +7,13 @@ The Starlite integration adds support for the [Starlite framework](https://docs.
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `starlite` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[starlite]" "uvicorn"
+pip install sentry-sdk uvicorn
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[starlite]" "uvicorn"
+uv add sentry-sdk uvicorn
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/statsig/index.mdx
+++ b/docs/platforms/python/integrations/statsig/index.mdx
@@ -7,13 +7,13 @@ The [Statsig](https://www.statsig.com/) integration tracks feature flag evaluati
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `statsig` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[statsig]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[statsig]"
+uv add sentry-sdk
 ```
 
 ## Configure

--- a/docs/platforms/python/integrations/tornado/index.mdx
+++ b/docs/platforms/python/integrations/tornado/index.mdx
@@ -7,13 +7,13 @@ The Tornado integration adds support for the [Tornado Web Framework](https://www
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `tornado` extra:
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[tornado]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[tornado]"
+uv add sentry-sdk
 ```
 
 If you're on Python 3.6, you also need the `aiocontextvars` package:

--- a/docs/platforms/python/integrations/unleash/index.mdx
+++ b/docs/platforms/python/integrations/unleash/index.mdx
@@ -7,13 +7,13 @@ The [Unleash](https://www.getunleash.io/) integration tracks feature flag evalua
 
 ## Install
 
-Install `sentry-sdk` from PyPI with the `unleash` extra.
+Install `sentry-sdk` from PyPI:
 
 ```bash {tabTitle:pip}
-pip install "sentry-sdk[unleash]"
+pip install sentry-sdk
 ```
 ```bash {tabTitle:uv}
-uv add "sentry-sdk[unleash]"
+uv add sentry-sdk
 ```
 
 ## Configure


### PR DESCRIPTION
The Python SDK has an extras system that's causing some headaches.

The only difference between `pip install sentry-sdk` and `pip install sentry-sdk[anthropic]` is that the latter also installs the `anthropic` package in addition to the Sentry SDK. There is no difference in behavior.

For most integrations, there is no need to install the extra, as it can be reasonably expected that the user already has the framework/library that they're using installed on their own. It makes no sense why an application monitoring SDK should in any way have ownership or be responsible for installing the framework that you want to write your app in.

Having the extras mostly leads to confused asks from people because in addition to them not doing anything important, we're also inconsistent in our installation instructions, sometimes using the extra, sometimes not.

Let's default to just not using it unless there's a good reason, like in the case of the `pure_eval` extra, which also installs some additional important packages to make sure the SDK will work correctly.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
