### PR TITLE
docs(react): add CRA deprecation notice and Vite plugin placement guidance

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/create-react-app.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/create-react-app.mdx
@@ -6,6 +6,17 @@ supported:
   - javascript.react
 ---
 
+<Alert level="warning" title="Create React App Status">
+
+Create React App (CRA) is [no longer recommended](https://react.dev/learn/start-a-new-react-project) by the React team for new projects. For new React applications, consider:
+
+- **[Vite](/platforms/javascript/guides/react/sourcemaps/uploading/vite/)** — Fast, modern build tool (recommended for SPAs)
+- **[Next.js](/platforms/javascript/guides/nextjs/)** — Full-stack React framework
+
+This guide remains available for existing CRA projects.
+
+</Alert>
+
 In this guide, you'll learn how to upload source maps for Create React App using our `sentry-cli` tool.
 
 <Include name="debug-id-requirement.mdx" />

--- a/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
@@ -54,6 +54,12 @@ Learn more about configuring the plugin in our [Sentry Vite Plugin documentation
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Alert level="info" title="Plugin Order Matters">
+
+Place the Sentry Vite plugin **after all other plugins** in your `plugins` array. This ensures source maps are generated correctly and tree-shaking doesn't remove Sentry's instrumentation.
+
+</Alert>
+
 Example:
 
 ```javascript {filename:vite.config.js}


### PR DESCRIPTION
## Summary

Adds deprecation notice for Create React App and explicit plugin placement guidance for Vite to help developers avoid common issues.

Preview: 

## Changes

### Create React App Source Maps Page
- Added deprecation alert directing users to Vite (recommended for SPAs) or Next.js for new projects
- Clarifies the guide remains available for existing CRA projects

### Vite Source Maps Page
- Added explicit alert about plugin order: Sentry plugin should be placed **after all other plugins**
- Prevents tree-shaking issues that can remove Sentry's instrumentation

## Why

- CRA is [no longer recommended](https://react.dev/learn/start-a-new-react-project) by the React team
- Plugin placement in Vite was only mentioned in a code comment; making it an explicit alert helps prevent issues

## Related

Part of React SDK documentation modernization project (PR 3 of 7)

- PR 1: #16102
- PR 2: #16105

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)