### PR TITLE
fix(astro): Fix misleading documentation example

### DIFF
--- a/docs/platforms/javascript/guides/astro/index.mdx
+++ b/docs/platforms/javascript/guides/astro/index.mdx
@@ -294,6 +294,10 @@ To test tracing, create a custom span to measure the time it takes for the API r
 <script>
   import * as Sentry from "@sentry/astro";
 
+  const button = document.getElementById("one");
+
+  button.addEventListener("click", throwApiError);
+
   async function throwApiError() {
     await Sentry.startSpan(
       {
@@ -307,7 +311,7 @@ To test tracing, create a custom span to measure the time it takes for the API r
   }
 </script>
 
-<button type="button" onclick="throwApiError()">
+<button id="one" type="button">
   Throw an API error with a trace
 </button>
 ```


### PR DESCRIPTION
Astro won't compile if this is not present. It is essential to tell Astro compiler not to minify or manipulate this script to preserve names reference in the buttons onclick handlers.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
It fixes misleading code snippet that causes Astro builds to fail.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
