### PR TITLE
fix(telemetry-buffer): Size limits

### DIFF
--- a/develop-docs/sdk/telemetry/telemetry-processor/index.mdx
+++ b/develop-docs/sdk/telemetry/telemetry-processor/index.mdx
@@ -96,17 +96,15 @@ The telemetry buffer batches high-volume data and forwards it to the telemetry s
 6. When the size limit is reached, the telemetry buffer **MUST** forward all items to the telemetry scheduler. The buffer **MAY** forward items in batches.
 
 
-## Size Limit Recommendations
+## Size Limits
 
-We recommend starting with 100 items for logs, metrics, and spans for `x`, which is the maximum number of items the buffer can hold. SDKs **MAY** choose different values based on their needs, but they **SHOULD** respect the max suggested `x` values:
+SDKs **SHOULD** use the following size limits for the telemetry buffer. SDKs **MAY** use lower values, but they **MUST NOT** exceed the following size limits:
 
-| Data type | Max suggested x |
-| --- | --- |
-| Logs | ~1150 |
-| Metrics |  ~1800 (Each metric **MUST** be `<= 2 KiB` or Relay drops the entire envelope) |
-| Spans | ~1300 |
+- 100 items for logs
+- 100 items for metrics
+- 1000 items for spans
 
-Here is the reasoning behind the max numbers. Using the example payloads in [Logs](/sdk/telemetry/logs/#appendix-a-example-log-envelope), [Metrics](/sdk/telemetry/metrics/#appendix-a-example-trace_metric-envelope), and the [Span Protocol](/sdk/telemetry/spans/span-protocol/#span-v2-envelope-item-payload), the average serialized item sizes are ~730 B (log), ~460 B (metric), and ~630 B (span). Applying a 20% safety buffer against the Relay [envelope size limits](/sdk/data-model/envelopes/#size-limits) yields the maximum suggested x values.
+While the [envelope size limits](/sdk/data-model/envelopes/#size-limits) would allow higher size limits for specific categories, these limits are optimized for Relay and exceeding them is absolutely discouraged.
 
 ## Data Forwarding Scenarios
 


### PR DESCRIPTION

## DESCRIBE YOUR PR

Remove that SDKs may choose larger size limits for the telemetry buffers.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

