### PR TITLE
feat(python): Document AsyncioIntegration's new task_spans option

### DIFF
--- a/docs/platforms/python/integrations/asyncio/index.mdx
+++ b/docs/platforms/python/integrations/asyncio/index.mdx
@@ -122,9 +122,21 @@ asyncio.run(main())
 
 ## Behavior
 
-- All unhandled exceptions in tasks will be captured
-- Every executed Task will be instrumented and show up in the performance waterfall on Sentry.io
+- All unhandled exceptions in tasks will be captured.
+- By default, every executed task will be instrumented and show up in the performance waterfall on Sentry.io. This behavior can be disabled by providing the `task_spans=False` flag to the `AsyncioIntegration()` or to the `enable_asyncio_integration()` helper:
 
+```python
+import sentry_sdk
+from sentry_sdk.integrations.asyncio import AsyncioIntegration, enable_asyncio_integration
+
+sentry_sdk.init(
+    integrations=[AsyncioIntegration(task_spans=False)],
+)
+
+# Or:
+
+enable_asyncio_integration(task_spans=False)
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adding a new feature in https://github.com/getsentry/sentry-python/pull/5367, documenting it here

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
