### PR TITLE
docs: Remove color references from error level descriptions

### DIFF
--- a/docs/product/issues/issue-details/error-issues/index.mdx
+++ b/docs/product/issues/issue-details/error-issues/index.mdx
@@ -21,12 +21,12 @@ The event description is displayed just below the issue title along with an icon
 
 The level can be:
 
-- Error - orange
-- Info - blue
-- Warning - yellow
-- Fatal - red
-- Debug - gray
-- Sample - purple
+- Error
+- Info
+- Warning
+- Fatal
+- Debug
+- Sample
 
 In the right hand sidebar, [sentry.io](https://sentry.io) reflects a summary that includes information such as how often the error <SandboxLink scenario="oneIssue" projectSlug="react">issue</SandboxLink> has occurred in the last 24 hours and the last 30 days, as well as the last time and the first time the issue was seen. If the issue is linked to any GitHub or Jira issues, that's displayed here as well. You can also use this section to link to existing GitHub or Jira issues. Learn more about linking issues in [Integrations](/organization/integrations/). Lastly, there is a facet map, which shows the distribution of values for the tags for all events included in the error issue. All of these values are based on the environment that you've selected in the environment dropdown.
 


### PR DESCRIPTION
There is no need in referencing the actual colors - the design should be good enough to where we don't have to explain that.