### PR TITLE
docs(profiling): Fix missing `platform` item header for `profile_chunk`

### DIFF
--- a/develop-docs/sdk/data-model/envelope-items.mdx
+++ b/develop-docs/sdk/data-model/envelope-items.mdx
@@ -432,7 +432,7 @@ _None_
 
 `platform`
 
-: **String, required.** The platform of the profiled application. This item header is used for rate limiting and categorization. Examples: `"javascript"`, `"node"`, `"python"`, `"cocoa"`, etc.
+: **String, required.** The platform of the profiled application. This item header is used for rate limiting and categorization. It must match the `platform` in the payload. the Examples: `"javascript"`, `"node"`, `"python"`, `"cocoa"`, etc.
 
 ### Check-Ins
 

--- a/develop-docs/sdk/telemetry/profiles/sample-format-v2.mdx
+++ b/develop-docs/sdk/telemetry/profiles/sample-format-v2.mdx
@@ -280,11 +280,9 @@ It's suggested to remove unnecessary data like thread data without samples from
 
 ## Ingestion
 
-After this payload is generated, serialize it as JSON, pack it into an
+After this payload is generated, serialize it as JSON, pack it into an [Envelope](/sdk/data-model/envelopes/) with the item type [`profile_chunk`](/sdk/data-model/envelope-items/#profile-chunk) and send it to Relay.
 
-[Envelope](/sdk/data-model/envelopes/) with the item type [`profile_chunk`](/sdk/data-model/envelope-items/#profile-chunk) and send
-
-it to Relay. The `platform` item header is required for rate limiting and categorization of the profile chunk.
+The `platform` item header is required for rate limiting and categorization of the profile chunk and must match the `platform` in the payload.
 
 This envelope should look like this:
 


### PR DESCRIPTION

## DESCRIBE YOUR PR

Adds missing `platform` item header.

closes https://linear.app/getsentry/issue/JS-1539/document-platform-for-profile-chunk (internal Linear)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


