### PR TITLE
feat(docs): Add Next.js technical issue to OpenAI documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
@@ -111,34 +111,6 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.nextjs']}>
-
-## Edge Runtime
-
-For Next.js applications using the Edge runtime, you need to manually wrap your Anthropic client instance with the `instrumentAnthropicAiClient` helper:
-
-```javascript
-import Anthropic from "@anthropic-ai/sdk";
-
-const anthropic = new Anthropic({
-  apiKey: "your-api-key", // Warning: API key will be exposed in browser!
-});
-
-const client = Sentry.instrumentAnthropicAiClient(anthropic, {
-  recordInputs: true,
-  recordOutputs: true,
-});
-
-// Use the wrapped client instead of the original anthropic instance
-const response = await client.messages.create({
-  model: "claude-3-5-sonnet-20241022",
-  max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
-
-</PlatformSection>
-
 ## Configuration
 
 ### Options

--- a/docs/platforms/javascript/common/configuration/integrations/openai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openai.mdx
@@ -38,11 +38,23 @@ supported:
 
 ## Server-Side Usage
 
+<PlatformSection supported={["javascript.nextjs"]}>
+
+<Alert>
+
+For Next.js applications using all runtimes, you need to manually wrap your OpenAI client instance with `instrumentOpenAiClient`. See instructions in the [Browser-Side Usage](#browser-side-usage) section.
+
+</Alert>
+
+</PlatformSection>
+
+<PlatformSection notSupported={["javascript.nextjs"]}>
+
 _Import name: `Sentry.openAIIntegration`_
 
 The `openAIIntegration` adds instrumentation for the [`openai`](https://www.npmjs.com/package/openai) SDK to capture spans by wrapping OpenAI SDK calls and recording LLM interactions.
 
-<PlatformSection notSupported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
+<PlatformSection notSupported={["javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
 
 <Alert>
 
@@ -52,7 +64,7 @@ Enabled by default and automatically captures spans for OpenAI SDK calls. Requir
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
+<PlatformSection supported={["javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
 
 <Alert>
 
@@ -65,6 +77,8 @@ For other runtimes, like the Browser, the instrumentation needs to be manually e
 </PlatformSection>
 
 To customize what data is captured (such as inputs and outputs), see the [Options](#options) in the Configuration section.
+
+</PlatformSection>
 
 </PlatformSection>
 
@@ -98,34 +112,6 @@ const response = await client.chat.completions.create({
 ```
 
 To customize what data is captured (such as inputs and outputs), see the [Options](#options) in the Configuration section.
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.nextjs']}>
-
-## Edge Runtime
-
-For Next.js applications using the Edge runtime, you need to manually wrap your OpenAI client instance with the `instrumentOpenAiClient` helper:
-
-```javascript
-import OpenAI from "openai";
-
-const openai = new OpenAI({
-  // Warning: API key will be exposed in browser!
-  apiKey: 'your-api-key', 
-});
-
-const client = Sentry.instrumentOpenAiClient(openai, {
-  recordInputs: true,
-  recordOutputs: true,
-});
-
-// Use the wrapped client instead of the original openai instance
-const response = await client.chat.completions.create({
-  model: "gpt-4o",
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
 
 </PlatformSection>
 


### PR DESCRIPTION
Based on @RulaKhaled’s report and my own findings, when using Next.js with Sentry without adding any AI instrumentation to the Sentry initialization, AI spans are not generated. That is, even though Node.js is the server runtime, the Sentry integration does not work out of the box. Users must explicitly instrument the OpenAI client using the helper `Sentry.instrumentOpenAiClient`. This PR reflects that requirement.


<img width="1483" height="1152" alt="image" src="https://github.com/user-attachments/assets/2f9c8bbb-f472-4542-8387-91db077f649c" />


TODO: Update this in the agent monitoring onboarding too