### PR TITLE
feat(develop/spans): Add common `sentry.replay_id` attribute

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -170,7 +170,7 @@ Empty attributes must be omitted.
 | `sentry.segment.name` | string | The segment name (e.g., "GET /users") |
 | `sentry.segment.id` | string | The segment span id |
 | `sentry.span.source` | string | The source of the span name. **MUST** be set on segment spans, **MAY** be set on child spans. <br/> See [Sentry Conventions](https://github.com/getsentry/sentry-conventions/attributes/sentry#sentry-span-source) for all supported sources. <br/>See [Transaction Annotations](/sdk/data-model/event-payloads/transaction/#transaction-annotations) and [Clustering](/backend/application-domains/transaction-clustering/#automatic-transaction-clustering) for more information.|
-| `sentry.replay_id` | string | The id of the currently running replay (if a replay is active) |
+| `sentry.replay_id` | string | The id of the currently running replay (if available) |
 | `os.name` | string | The operating system name (e.g., "Linux", "Windows", "macOS") |
 | `browser.name` | string | The browser name (e.g., "Chrome", "Firefox", "Safari") |
 | `user.id` | string | The user ID (gated by `sendDefaultPii`) |


### PR DESCRIPTION
Adds the [`sentry.replay_id` attribute](https://getsentry.github.io/sentry-conventions/generated/attributes/sentry.html#sentryreplay_id) to the list of attributes required on every span.

(Extracted from https://github.com/getsentry/sentry-docs/pull/16051, because we still need to clarify what to send where for profiling)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
