### PR TITLE
docs(client-reports): fix `reason` inconsistency

### DIFF
--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -165,7 +165,7 @@ an envelope item, for example, with the response 429, the client SDK must not re
 this as the server already does. Still, the SDK must record lost envelope items
 when dropping them itself, for example, caused by an active rate limit. SDKs can put
 a simple optional check for HTTP status codes in place where any code `>= 400` except
-`429` will be recorded as `network_error`. The client SDKs can assume that client
+`429` will be recorded as `send_error`. The client SDKs can assume that client
 reports never get rate limited. The server is minimizing the possibility of client
 reports getting rate limited, but the SDKs shouldn't worry about this edge case as
 this feature is best-effort.


### PR DESCRIPTION
## DESCRIBE YOUR PR
During
- https://github.com/getsentry/sentry-dotnet/issues/4861
- https://github.com/getsentry/sentry-unity/issues/2494

we noticed an inconsistency of `reason` for Client-Reports.

- https://develop.sentry.dev/sdk/expected-features/#dealing-with-network-failures mentions `send_error`
- https://develop.sentry.dev/sdk/client-reports/#sdk-side-recommendations mentions `network_error`

Changing the latter from `network_error` to `send_error`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
