### PR TITLE
fix(ACI): Fix links to new alerts page

### DIFF
--- a/docs/product/new-monitors-and-alerts/alerts/index.mdx
+++ b/docs/product/new-monitors-and-alerts/alerts/index.mdx
@@ -20,7 +20,7 @@ Sentry's Alerts help you take action on issues in your projects. When an issue c
 
 ## Creating an Alert
 
-To create an Alert, navigate to the [Alerts](https://sentry.io/issues/alerts/new/) page and click **Create Alert**.
+To create an Alert, navigate to the [Alerts](https://sentry.io/monitors/alerts) page and click **Create Alert**.
 
 {/* <Arcade src="https://demo.arcade.software/YOUR_ARCADE_ID?embed" /> */}
 
@@ -30,9 +30,9 @@ The source of an Alert can come from either one or more projects, or one or more
 
 ### Set Triggers
 
-A trigger is an action that must occur for the Alert to run. All trigger actions are issue state based. For example, you may want to send a notification to your team's Slack channel _when an issue is created_. You can select multiple triggers in a single Alert. They will run under an `ANY` condition, meaning that if any one of the triggers happen, the Alert will run. 
+A trigger is an action that must occur for the Alert to run. All trigger actions are issue state based. For example, you may want to send a notification to your team's Slack channel _when an issue is created_. You can select multiple triggers in a single Alert. They will run under an `ANY` condition, meaning that if any one of the triggers happen, the Alert will run.
 
-### Set Filters 
+### Set Filters
 
 Filters are conditions that must be met for the Alert to run. For example, you may want to create a ticket _only for issues that are assigned to a specific team_ and _at a certain severity_. You can create multiple filters in a single Alert, and group them under either `ANY` or `ALL` conditions. For `ANY` conditions, if any one of the filters are true, the Alert will run. For `ALL` conditions, only if all of the filters are true, the Alert will run.
 
@@ -44,7 +44,7 @@ Actions are the events that will be executed when the Alert is run. You can send
 
 ## Managing Alerts
 
-You can see a list of all your Alerts on the [Alerts](https://sentry.io/issues/alerts/) page. By default, Alerts are filtered down to your projects. 
+You can see a list of all your Alerts on the [Alerts](https://sentry.io/monitors/alerts) page. By default, Alerts are filtered down to your projects.
 
 <Alert>
 
@@ -54,7 +54,7 @@ Alerts are an Organization-level feature. By default, all team members can creat
 
 By clicking on an Alert, you can view the details, edit the Alert, or turn it on or off.
 
-The details page will show a high level chart of how often the Alert has run, a list of the most recent runs, the configuration, and connected monitors. 
+The details page will show a high level chart of how often the Alert has run, a list of the most recent runs, the configuration, and connected monitors.
 
 ## Notifications
 


### PR DESCRIPTION
Fix the links on the new monitors and alerts page to go to the new alerts page instead of the legacy alerts page.