### PR TITLE
Update span status to use SPANSTATUS constant

### DIFF
--- a/docs/platforms/python/tracing/span-metrics/examples.mdx
+++ b/docs/platforms/python/tracing/span-metrics/examples.mdx
@@ -75,7 +75,7 @@ with sentry_sdk.start_span(op="upload", name="Upload File") as span:
         span.set_data("upload.success", False)
         span.set_data("upload.error_type", error.__class__.__name__)
         span.set_data("upload.error_message", str(error))
-        span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+        span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
         raise
 ```
 
@@ -114,7 +114,7 @@ with sentry_sdk.start_span(
                          (time.time() - upload_start) * 1000)
     
     except Exception as e:
-        span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+        span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
         span.set_data("error.message", str(e))
         raise
 ```
@@ -183,7 +183,7 @@ def handle_llm_request():
             })
             
         except Exception as error:
-            span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+            span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
             span.set_data("error.type", error.__class__.__name__)
             span.set_data("error.message", str(error))
             return jsonify({"error": str(error)}), 500
@@ -248,7 +248,7 @@ def process_llm_request(request_data):
             # Check if it's a rate limit error
             is_rate_limit = "rate_limit" in str(error).lower()
             span.set_data("error.is_rate_limit", is_rate_limit)
-            span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+            span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
             
             raise
 ```
@@ -305,7 +305,7 @@ class CheckoutView(View):
                 return JsonResponse({"order_id": order_result["order_id"]})
                 
             except Exception as e:
-                span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+                span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
                 span.set_data("order.success", False)
                 span.set_data("error.message", str(e))
                 return JsonResponse({"error": str(e)}, status=500)
@@ -367,7 +367,7 @@ def process_order(order_data):
             }
             
         except Exception as e:
-            span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+            span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
             span.set_data("error.message", str(e))
             span.set_data("order.success", False)
             raise
@@ -421,7 +421,7 @@ def submit_processing_job(data_file_path, priority="medium"):
             }
             
         except Exception as e:
-            span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+            span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
             span.set_data("job.submission_success", False)
             span.set_data("error.message", str(e))
             raise
@@ -465,7 +465,7 @@ def process_data_file(file_path, priority="medium"):
             }
             
         except Exception as e:
-            span.set_status(sentry_sdk.SpanStatus.INTERNAL_ERROR)
+            span.set_status(sentry_sdk.consts.SPANSTATUS.INTERNAL_ERROR)
             span.set_data("outcome.status", "failed")
             span.set_data("error.message", str(e))
             span.set_data("error.stage", span.get_data("processing.current_stage"))


### PR DESCRIPTION
## DESCRIBE YOUR PR

`sentry_sdk.SpanStatus` does not exist anymore and the docs are confusing and they wasted a bunch of my time trying to understand what's going on. It also confuses coding agents.

The constants appear to have moved to `sentry_sdk.consts.SPANSTATUS` so this PR updates the docs accordingly.

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.