### PR TITLE
fix(ai-insights): polish agent monitoring JS docs

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -29,7 +29,7 @@ supported:
   - javascript.tanstackstart-react
 ---
 
-With <Link to="/product/insights/ai/agents/dashboard/">Sentry AI Agent Monitoring</Link>, you can monitor and debug your AI systems with full-stack context. You'll be able to track key insights like token usage, latency, tool usage, and error rates. AI Agent Monitoring data will be fully connected to your other Sentry data like logs, errors, and traces.
+With <Link to="/product/insights/ai/agents/dashboard/">Sentry AI Agent Monitoring</Link>, you can monitor and debug your AI systems with full-stack context. Track token usage, latency, tool usage, and error rates—all connected to your existing Sentry data like logs, errors, and traces.
 
 ## Prerequisites
 
@@ -78,6 +78,8 @@ Sentry.init({
 
 ## Options
 
+You can customize the behavior of AI integrations with the following options.
+
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>
@@ -113,7 +115,7 @@ Sentry.init({
 
 ## Manual Instrumentation
 
-If you're using a library that Sentry does not automatically instrument, you can manually instrument your code to capture spans. For your AI agents data to show up in Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/agents/), spans must have well-defined names and data attributes.
+If you're using a library without automatic instrumentation, you can manually instrument your code to capture spans. For your AI agents data to show up in Sentry [AI Agents Insights](https://sentry.io/orgredirect/organizations/:orgslug/insights/ai/agents/), spans must have well-defined names and data attributes.
 
 ### AI Request Span
 
@@ -169,7 +171,7 @@ await Sentry.startSpan(
 </SplitSection>
 </SplitLayout>
 
-<Expandable title="AI Request span attributes">
+<Expandable title="All AI Request span attributes">
   <Include name="tracing/ai-agents-module/ai-client-span" />
 </Expandable>
 
@@ -216,7 +218,7 @@ await Sentry.startSpan(
 </SplitSection>
 </SplitLayout>
 
-<Expandable title="Invoke Agent span attributes">
+<Expandable title="All Invoke Agent span attributes">
   <Include name="tracing/ai-agents-module/invoke-agent-span" />
 </Expandable>
 
@@ -259,7 +261,7 @@ await Sentry.startSpan(
 </SplitSection>
 </SplitLayout>
 
-<Expandable title="Execute Tool span attributes">
+<Expandable title="All Execute Tool span attributes">
   <Include name="tracing/ai-agents-module/execute-tool-span" />
 </Expandable>
 
@@ -274,9 +276,8 @@ This span marks the transition of control from one agent to another, typically w
 **Requirements:**
 - `op` must be `"gen_ai.handoff"`
 - `name` should follow the pattern `"handoff from {source} to {target}"`
-- All [Common Span Attributes](#common-span-attributes) should be set
 
-The handoff span itself has no body — it just marks the transition point before the target agent starts.
+The handoff span itself has no body—it just marks the transition point before the target agent starts.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -298,6 +299,10 @@ await Sentry.startSpan(
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+<Expandable title="All Handoff span attributes">
+  <Include name="tracing/ai-agents-module/handoff-span" />
+</Expandable>
 
 ## Common Span Attributes
 

--- a/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
@@ -42,7 +42,6 @@ _Import name: `Sentry.anthropicAIIntegration`_
 
 The `anthropicAIIntegration` adds instrumentation for the [`@anthropic-ai/sdk`](https://www.npmjs.com/package/@anthropic-ai/sdk) API to capture spans by wrapping Anthropic SDK calls and recording LLM interactions.
 
-
 <PlatformSection notSupported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
 
 <Alert>
@@ -59,7 +58,7 @@ Enabled by default and automatically captures spans for Anthropic SDK calls. Req
 
 Enabled by default and automatically captures spans for Anthropic SDK calls. Requires Sentry SDK version `10.28.0` or higher.
 
-For other runtimes, like the Browser, the instrumentation needs to be manually enabled. See the [setup instructions below](#browser-side-usage).
+For other runtimes, like the Browser, you need to manually enable the instrumentation. See the [setup instructions below](#browser-side-usage).
 
 </Alert>
 
@@ -113,6 +112,8 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 
 ## Configuration
 
+Configure the Anthropic integration using the options below.
+
 ### Options
 
 The following options control what data is captured from Anthropic SDK calls:
@@ -142,11 +143,13 @@ Using the `anthropicAIIntegration` integration:
 ```javascript
 Sentry.init({
   dsn: "____PUBLIC_DSN____",
-   // Tracing must be enabled for agent monitoring to work
-  tracesSampleRate: 1.0, 
+  // Tracing must be enabled for agent monitoring to work
+  tracesSampleRate: 1.0,
   integrations: [
     Sentry.anthropicAIIntegration({
-      // your options here
+      recordInputs: true,
+      recordOutputs: true,
+      // See Options section for all available options
     }),
   ],
 });
@@ -178,7 +181,7 @@ By default, tracing support is added to the following Anthropic SDK calls:
 - `models.retrieve()` - Retrieve model details
 - `beta.messages.create()` - Beta messages API
 
-Streaming and non-streaming requests are automatically detected and handled appropriately.
+The integration automatically detects and handles both streaming and non-streaming requests.
 
 ## Supported Versions
 

--- a/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
@@ -58,7 +58,7 @@ Enabled by default and automatically captures spans for Google Gen AI SDK calls.
 
 Enabled by default and automatically captures spans for Google Gen AI SDK calls. Requires Sentry SDK version `10.28.0` or higher.
 
-For other runtimes, like the Browser, the instrumentation needs to be manually enabled. See the [setup instructions below](#browser-side-usage).
+For other runtimes, like the Browser, you need to manually enable the instrumentation. See the [setup instructions below](#browser-side-usage).
 
 </Alert>
 
@@ -122,6 +122,8 @@ const result = await client.models.generateContent("Hello!");
 
 ## Configuration
 
+Configure the Google Gen AI integration using the options below.
+
 ### Options
 
 The following options control what data is captured from Google Gen AI SDK calls:
@@ -151,11 +153,13 @@ Using the `googleGenAIIntegration` integration:
 ```javascript
 Sentry.init({
   dsn: "____PUBLIC_DSN____",
-   // Tracing must be enabled for agent monitoring to work
+  // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
   integrations: [
     Sentry.googleGenAIIntegration({
-      // your options here
+      recordInputs: true,
+      recordOutputs: true,
+      // See Options section for all available options
     }),
   ],
 });
@@ -185,7 +189,7 @@ By default, tracing support is added to the following Google Gen AI SDK calls:
 - `sendMessage()` - Send messages in chat sessions
 - `sendMessageStream()` - Stream messages in chat sessions
 
-Streaming and non-streaming requests are automatically detected and handled appropriately.
+The integration automatically detects and handles both streaming and non-streaming requests.
 
 ## Supported Versions
 

--- a/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
@@ -42,7 +42,6 @@ _Import name: `Sentry.langChainIntegration`_
 
 The `langChainIntegration` adds instrumentation for [`langchain`](https://www.npmjs.com/package/langchain) to capture spans by automatically wrapping LangChain operations and recording AI agent interactions with configurable input/output recording.
 
-
 <PlatformSection notSupported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
 
 <Alert>
@@ -59,7 +58,7 @@ Enabled by default and automatically captures spans for LangChain SDK calls. Req
 
 Enabled by default and automatically captures spans for LangChain SDK calls. Requires Sentry SDK version `10.28.0` or higher.
 
-For other runtimes, like the Browser or Edge, the instrumentation needs to be manually enabled. See the [setup instructions below](#browser-side-usage).
+For other runtimes, like the Browser or Edge, you need to manually enable the instrumentation. See the [setup instructions below](#browser-side-usage).
 
 </Alert>
 
@@ -142,6 +141,8 @@ await model.invoke("Tell me a joke", {
 
 ## Configuration
 
+Configure the LangChain integration using the options below.
+
 ### Options
 
 The following options control what data is captured from LangChain operations:
@@ -175,7 +176,9 @@ Sentry.init({
   tracesSampleRate: 1.0,
   integrations: [
     Sentry.langChainIntegration({
-      // your options here
+      recordInputs: true,
+      recordOutputs: true,
+      // See Options section for all available options
     }),
   ],
 });

--- a/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
@@ -40,8 +40,7 @@ supported:
 
 _Import name: `Sentry.langGraphIntegration`_
 
-The `langGraphIntegration` adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) to capture spans by automatically wrapping LangGraph operations and recording AI agent interactions including agent invocations, graph executions, and node operations. 
-
+The `langGraphIntegration` adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) to capture spans by automatically wrapping LangGraph operations and recording AI agent interactions including agent invocations, graph executions, and node operations.
 
 <PlatformSection notSupported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react", "javascript.bun", "javascript.cloudflare"]}>
 
@@ -59,7 +58,7 @@ Enabled by default and automatically captures spans for LangGraph SDK calls. Req
 
 Enabled by default and automatically captures spans for LangGraph SDK calls. Requires Sentry SDK version `10.28.0` or higher.
 
-For other runtimes, like the Browser, the instrumentation needs to be manually enabled. See the [setup instructions below](#browser-side-usage).
+For other runtimes, like the Browser, you need to manually enable the instrumentation. See the [setup instructions below](#browser-side-usage).
 
 </Alert>
 
@@ -183,6 +182,8 @@ const result = await graph.invoke({
 
 ## Configuration
 
+Configure the LangGraph integration using the options below.
+
 ### Options
 
 The following options control what data is captured from LangGraph operations:
@@ -216,7 +217,9 @@ Sentry.init({
   tracesSampleRate: 1.0,
   integrations: [
     Sentry.langGraphIntegration({
-      // your options here
+      recordInputs: true,
+      recordOutputs: true,
+      // See Options section for all available options
     }),
   ],
 });

--- a/docs/platforms/javascript/common/configuration/integrations/openai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openai.mdx
@@ -58,7 +58,7 @@ Enabled by default and automatically captures spans for OpenAI SDK calls. Requir
 
 Enabled by default and automatically captures spans for OpenAI SDK calls. Requires Sentry SDK version `10.28.0` or higher.
 
-For other runtimes, like the Browser, the instrumentation needs to be manually enabled. See the [setup instructions below](#browser-side-usage).
+For other runtimes, like the Browser, you need to manually enable the instrumentation. See the [setup instructions below](#browser-side-usage).
 
 </Alert>
 
@@ -73,7 +73,6 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 ## Browser-Side Usage
 
 _Import name: `Sentry.instrumentOpenAiClient`_
-
 
 The `instrumentOpenAiClient` helper adds instrumentation for the [`openai`](https://www.npmjs.com/package/openai) SDK to capture spans by wrapping OpenAI SDK calls and recording LLM interactions with configurable input/output recording. You need to manually wrap your OpenAI client instance with this helper:
 
@@ -102,6 +101,8 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 </PlatformSection>
 
 ## Configuration
+
+Configure the OpenAI integration using the options below.
 
 ### Options
 
@@ -133,10 +134,12 @@ Using the `openAIIntegration` integration:
 Sentry.init({
   dsn: "____PUBLIC_DSN____",
   // Tracing must be enabled for agent monitoring to work
-  tracesSampleRate: 1.0, 
+  tracesSampleRate: 1.0,
   integrations: [
     Sentry.openAIIntegration({
-      // your options here
+      recordInputs: true,
+      recordOutputs: true,
+      // See Options section for all available options
     }),
   ],
 });
@@ -163,7 +166,7 @@ By default, tracing support is added to the following OpenAI SDK calls:
 - `chat.completions.create()` - Chat completion requests
 - `responses.create()` - Response SDK requests
 
-Streaming and non-streaming requests are automatically detected and handled appropriately.
+The integration automatically detects and handles both streaming and non-streaming requests.
 
 ## Supported Versions
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -102,6 +102,8 @@ const result = await generateText({
 <PlatformSection notSupported={['javascript.cloudflare']}>
 ## Options
 
+You can customize the behavior of the Vercel AI integration with the following options.
+
 ### `force`
 
 Requires SDK version `9.29.0` or higher.


### PR DESCRIPTION
- Part of [TET-1796: Do another pass on all AI docs in sentry-docs using claude skills](https://linear.app/getsentry/issue/TET-1796/do-another-pass-on-all-ai-docs-in-sentry-docs-using-claude-skills)
- Used `docs-review` skill
