### PR TITLE
docs(js): Add import order troubleshooting to AI agent monitoring

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
@@ -414,3 +414,5 @@ if (result.handoffTo) {
 ## Common Span Attributes
 
 <Include name="tracing/ai-agents-module/common-span-attributes" />
+
+<Include name="tracing/ai-agents-module/import-order-troubleshooting" />

--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -314,3 +314,5 @@ If you're using an AI framework with a Sentry exporter, you can send traces to S
 ## MCP Server Monitoring
 
 If you're building MCP (Model Context Protocol) servers, Sentry can also track tool executions, prompt retrievals, and resource access. See <PlatformLink to="/tracing/instrumentation/mcp-module/">Instrument MCP Servers</PlatformLink> for setup instructions.
+
+<Include name="tracing/ai-agents-module/import-order-troubleshooting" />

--- a/includes/tracing/ai-agents-module/import-order-troubleshooting.mdx
+++ b/includes/tracing/ai-agents-module/import-order-troubleshooting.mdx
@@ -1,0 +1,140 @@
+## Troubleshooting: Missing AI Spans
+
+If you're not seeing AI agent monitoring spans in Sentry, verify that your Sentry import comes **before** the AI SDK imports. Sentry needs to be imported first to properly instrument the AI libraries.
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+### Incorrect Import Order
+
+When the AI SDK is imported before Sentry, the SDK cannot instrument the library and spans will not be captured.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```javascript
+// Wrong: AI SDK imported first
+import { openai } from "@ai-sdk/openai";
+import OpenAI from "openai";
+import * as Sentry from "___SDK_PACKAGE___"; // Too late to instrument
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+### Correct Import Order
+
+Import Sentry first so it can patch the AI libraries before they're used.
+
+This applies to all AI libraries: Vercel AI SDK, OpenAI, Anthropic, LangChain, Google GenAI, etc.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```javascript
+// Correct: Sentry imported first
+import * as Sentry from "___SDK_PACKAGE___";
+import { openai } from "@ai-sdk/openai";
+import OpenAI from "openai";
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+### Enforcing Import Order
+
+Configure your linter to automatically enforce Sentry imports first.
+
+<Expandable title="ESLint configuration">
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Using [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import), configure `pathGroups` to place `@sentry/*` imports before other external packages.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```json
+{
+  "plugins": ["import"],
+  "rules": {
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "@sentry/**",
+            "group": "external",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": [
+          "@sentry/**"
+        ]
+      }
+    ]
+  }
+}
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+</Expandable>
+
+<Expandable title="Biome configuration">
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+In your `biome.json`, configure import groups to place `@sentry/*` first. Then run `biome format --write .` to apply across your codebase.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```json
+{
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              ["@sentry/*"],
+              ["PACKAGES"],
+              ["ALIAS"],
+              ["RELATIVE"]
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+</Expandable>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds troubleshooting section to AI agent monitoring docs explaining that Sentry must be imported before AI SDK libraries (Vercel AI SDK, OpenAI, Anthropic, etc.) to properly instrument them.

**Changes:**
- Created new shared include: `includes/tracing/ai-agents-module/import-order-troubleshooting.mdx`
- Added include to server-side AI monitoring docs
- Added include to browser AI monitoring docs

Includes ESLint and Biome configuration snippets to help users enforce import order automatically.

## IS YOUR CHANGE URGENT?  

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)