### PR TITLE
docs(js): Update profiling option in quick start guides

### DIFF
--- a/docs/platforms/javascript/guides/aws-lambda/install/npm.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/npm.mdx
@@ -116,8 +116,11 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 ```
@@ -148,8 +151,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 ```

--- a/docs/platforms/javascript/guides/azure-functions/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/index.mdx
@@ -58,8 +58,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 

--- a/docs/platforms/javascript/guides/gcp-functions/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/index.mdx
@@ -40,77 +40,7 @@ Run the command for your preferred package manager to add the Sentry SDK to your
 
 Make sure to initialize Sentry at the top of your function code and wrap each function with the appropriate helper. Select the tab that matches the kind of function you're using (HTTP, Background, or CloudEvent):
 
-```javascript {tabTitle:Http functions}
-const Sentry = require("@sentry/google-cloud-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // Adds request headers and IP for users, for more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/gcp-functions/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
-  // ___PRODUCT_OPTION_START___ performance
-
-  // Add Tracing by setting tracesSampleRate and adding integration
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions
-  // We recommend adjusting this value in production
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
-  tracesSampleRate: 1.0,
-  // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
-});
-
-exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
-  // your code
-});
-```
-
-```javascript {tabTitle:Background functions}
-const Sentry = require("@sentry/google-cloud-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  // ___PRODUCT_OPTION_START___ performance
-
-  // Add Tracing by setting tracesSampleRate and adding integration
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions
-  // We recommend adjusting this value in production
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
-  tracesSampleRate: 1.0,
-  // ___PRODUCT_OPTION_END___ performance
-});
-
-exports.helloEvents = Sentry.wrapEventFunction((data, context, callback) => {
-  // your code
-});
-```
-
-```javascript {tabTitle:CloudEvent functions}
-const Sentry = require("@sentry/google-cloud-serverless");
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  // ___PRODUCT_OPTION_START___ performance
-
-  // Add Tracing by setting tracesSampleRate and adding integration
-  // Set tracesSampleRate to 1.0 to capture 100% of transactions
-  // We recommend adjusting this value in production
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
-  tracesSampleRate: 1.0,
-  // ___PRODUCT_OPTION_END___ performance
-});
-
-exports.helloEvents = Sentry.wrapCloudEventFunction((context, callback) => {
-  // your code
-});
-```
+<PlatformContent includePath="getting-started-config" />
 
 ## Step 3: Add Readable Stack Traces With Source Maps (Optional)
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -215,12 +215,10 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 ```

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -275,12 +275,10 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 ```

--- a/platform-includes/getting-started-complete/javascript.remix.mdx
+++ b/platform-includes/getting-started-complete/javascript.remix.mdx
@@ -24,6 +24,8 @@ Choose the features you want to configure, and this guide will show you how:
 
 Run the command for your preferred package manager to add the Sentry SDK to your application:
 
+<OnboardingOption optionId="profiling" hideForThisOption>
+
 ```bash {tabTitle:npm}
 npm install @sentry/remix --save
 ```
@@ -35,6 +37,23 @@ yarn add @sentry/remix
 ```bash {tabTitle:pnpm}
 pnpm add @sentry/remix
 ```
+
+</OnboardingOption>
+
+<OnboardingOption optionId="profiling">
+```bash {tabTitle:npm}
+npm install @sentry/remix @sentry/profiling-node --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/remix @sentry/profiling-node
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/remix @sentry/profiling-node
+```
+
+</OnboardingOption>
 
 ## Step 2: Configure
 
@@ -164,6 +183,9 @@ Create an instrumentation file `instrument.server.mjs` in your project's root fo
 
 ```typescript {tabTitle:Server} {filename: instrument.server.mjs}
 import * as Sentry from "@sentry/remix";
+// ___PRODUCT_OPTION_START___ profiling
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+// ___PRODUCT_OPTION_END___ profiling
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -171,6 +193,11 @@ Sentry.init({
   // Adds request headers and IP for users, for more info visit: and captures action formData attributes
   // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+  // ___PRODUCT_OPTION_START___ profiling
+
+  // Add our Profiling integration
+  integrations: [nodeProfilingIntegration()],
+  // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -180,6 +207,13 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
+  // ___PRODUCT_OPTION_START___ profiling
+
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 
   // Enable logs to be sent to Sentry

--- a/platform-includes/getting-started-config/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-config/javascript.aws-lambda.mdx
@@ -6,15 +6,13 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  
+
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
   // ___PRODUCT_OPTION_START___ profiling
-  
-  integrations: [
-    nodeProfilingIntegration(),
-  ],
+
+  integrations: [nodeProfilingIntegration()],
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ performance
 
@@ -27,8 +25,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 
@@ -45,15 +45,13 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  
+
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
   // ___PRODUCT_OPTION_START___ profiling
-  
-  integrations: [
-    nodeProfilingIntegration(),
-  ],
+
+  integrations: [nodeProfilingIntegration()],
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ performance
 
@@ -66,8 +64,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
 
   // ___PRODUCT_OPTION_START___ profiling
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 

--- a/platform-includes/getting-started-config/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-config/javascript.gcp-functions.mdx
@@ -1,17 +1,21 @@
 ```javascript {tabTitle:Http functions}
 const Sentry = require("@sentry/google-cloud-serverless");
+// ___PRODUCT_OPTION_START___ profiling
 const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+// ___PRODUCT_OPTION_END___ profiling
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  
+
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/gcp-functions/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
-  
+  // ___PRODUCT_OPTION_START___ profiling
+
   integrations: [
     nodeProfilingIntegration(),
   ],
+  // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Performance Monitoring by setting tracesSampleRate
@@ -23,8 +27,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 
@@ -35,18 +41,18 @@ exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
 
 ```javascript {tabTitle:Background functions}
 const Sentry = require("@sentry/google-cloud-serverless");
+// ___PRODUCT_OPTION_START___ profiling
 const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+// ___PRODUCT_OPTION_END___ profiling
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  
-  // Adds request headers and IP for users, for more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/gcp-functions/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
-  
+  // ___PRODUCT_OPTION_START___ profiling
+
   integrations: [
     nodeProfilingIntegration(),
   ],
+  // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Performance Monitoring by setting tracesSampleRate
@@ -58,8 +64,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 
@@ -79,6 +87,7 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // ___PRODUCT_OPTION_START___ profiling
+
   integrations: [
     nodeProfilingIntegration(),
   ],
@@ -94,8 +103,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
 });
 

--- a/platform-includes/getting-started-config/javascript.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.hono.mdx
@@ -29,12 +29,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 
@@ -75,12 +73,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 

--- a/platform-includes/getting-started-config/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-config/javascript.nestjs.mdx
@@ -24,12 +24,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/nestjs/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 

--- a/platform-includes/getting-started-config/javascript.node.mdx
+++ b/platform-includes/getting-started-config/javascript.node.mdx
@@ -29,12 +29,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 
@@ -75,12 +73,10 @@ Sentry.init({
   // ___PRODUCT_OPTION_END___ performance
   // ___PRODUCT_OPTION_START___ profiling
 
-  // Set profilesSampleRate to 1.0 to profile 100%
-  // of sampled transactions.
-  // This is relative to tracesSampleRate
+  // Enable profiling for a percentage of sessions
   // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#profilesSampleRate
-  profilesSampleRate: 1.0,
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
   // ___PRODUCT_OPTION_START___ logs
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Updated all JS quick start guides to use `profileSessionSampleRate` instead of `profilesSampleRate`.

GCF and Remix were missing node profiling settings, although the pages have the Profiling onboarding option -> updated them accordingly

closes: #16169

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
