### PR TITLE
docs(releases): remove deprecated reference

### DIFF
--- a/docs/product/releases/setup/release-automation/github-actions/index.mdx
+++ b/docs/product/releases/setup/release-automation/github-actions/index.mdx
@@ -35,7 +35,7 @@ To set repository secrets, click on your repository **Settings ①**, select **S
 
 ## Releases
 
-You can create a new Sentry release by setting the `version` option. By default, the Sentry Release GitHub action will use the GitHub sha that triggered the GitHub workflow.
+You can create a new Sentry release by setting the `release` option. By default, the Sentry Release GitHub action will use the GitHub sha that triggered the GitHub workflow.
 
 ```yml
 - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ You can create a new Sentry release by setting the `version` option. By default,
     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
   with:
     environment: production
-    version: 'v1.3.4'
+    release: 'v1.3.4'
 ```
 
 ## Source Maps


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
The GitHub Action documentation for Sentry Releases refers to a `version` parameter which was deprecated in favour of `release`.
GitHub Action documentation: https://github.com/getsentry/action-release?tab=readme-ov-file#parameters

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.