### PR TITLE
fix(feedback): Update docs on Feedback attachments

### DIFF
--- a/develop-docs/sdk/data-model/envelope-items.mdx
+++ b/develop-docs/sdk/data-model/envelope-items.mdx
@@ -260,12 +260,12 @@ Use this to explicitly link a related error in the feedback UI.
 : _UUID String, optional._ The identifier of a related Session Replay in the same
 project. Sentry uses this ID to render a Replay clip in the feedback UI.
 
-**Attaching Screenshots:**
+**Attaching Files:**
 
-You can associate screenshots with a feedback by sending image data as
+You can attach files of any type to a feedback (screenshots, logs, documents, etc.) by sending them as
 [attachment items](/sdk/data-model/envelope-items/#attachment), with `event_id`
-corresponding to the feedback item. We recommend sending the items in the same
-Envelope.
+corresponding to the feedback item. We recommend sending the attachment items in the same
+Envelope as the feedback item.
 
 **Constraints:**
 

--- a/develop-docs/sdk/telemetry/feedbacks.mdx
+++ b/develop-docs/sdk/telemetry/feedbacks.mdx
@@ -52,12 +52,12 @@ For the full list of attributes, see [Event Payloads](/sdk/data-model/event-payl
 }
 ```
 
-### Attaching Screenshots
+### Attaching Files
 
-You can associate screenshots with a feedback by sending image data as
+You can attach files of any type to a feedback (screenshots, logs, documents, etc.) by sending them as
 [attachment items](/sdk/data-model/envelope-items/#attachment), with `event_id`
-corresponding to the feedback item. We recommend sending the items in the same
-Envelope.
+corresponding to the feedback item. We recommend sending the attachment items in the same
+Envelope as the feedback item.
 
 ## Full Envelope Example
 
@@ -102,6 +102,10 @@ Envelope.
     "name": "John Smith"
   }
 }
+{"type":"attachment","length":1234,"filename":"screenshot.png"}
+<binary screenshot data>
+{"type":"attachment","length":567,"filename":"debug-logs.txt"}
+<text file content>
 ```
 
 ## Feedback SDK Pipeline


### PR DESCRIPTION
**Before**
- https://develop.sentry.dev/sdk/telemetry/feedbacks/#attaching-screenshots
- https://develop.sentry.dev/sdk/data-model/envelope-items/#user-feedback:~:text=Attaching%20Screenshots%3A

**After**
(awaiting vercel preview)

## DESCRIBE YOUR PR
With this PR in native https://github.com/getsentry/sentry-native/pull/1414 we noticed the docs are outdated, since Feedback can get more than just screenshots attached (see [this event](https://sentry-sdks.sentry.io/issues/feedback/?feedbackSlug=sentry-native%3A7227469676&mailbox=ignored&project=4506178389999616&referrer=feedback_list_page&statsPeriod=14d) for example).

I updated the docs to be more generic as to what someone can attach to Feedbacks.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)