### PR TITLE
Add the 0.0.0.0 address to the proxy configuration

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -143,7 +143,7 @@ By default Sentry sends anonymous usage statistics to the Sentry team. It helps 
     "default": {
       "httpProxy": "http://proxy:3128",
       "httpsProxy": "http://proxy:3128",
-      "noProxy": "localhost,smtp,memcached,redis,postgres,pgbouncer,kafka,clickhouse,seaweedfs,snuba-api,symbolicator,web,worker,nginx,relay,vroom,taskbroker,172.17.0.0/16,127.0.0.0/8"
+      "noProxy": "localhost,smtp,memcached,redis,postgres,pgbouncer,kafka,clickhouse,seaweedfs,snuba-api,symbolicator,web,worker,nginx,relay,vroom,taskbroker,0.0.0.0,172.17.0.0/16,127.0.0.0/8"
     }
   }
 }


### PR DESCRIPTION
## DESCRIBE YOUR PR

- `0.0.0.0` is the default socket bind address for multiple services (like relay, symbolicator, etc) in their template configuration files.
- When http(s)_proxy is set, health checks have issues for some people (errors like Backend Unreachable, etc).
- Health checks for those services are not integrated in the running service itself - they're separate processes (just executed from the same binary) that execute in the service container and connect to the running service over HTTP.
- Health checks defined in `docker-compose.yml` default to connecting to the service instance address from the service config.
- Which defaults to something like `0.0.0.0:3000`.
- Which is not in no_proxy.
- So the health check process tries to access the service via the proxy.
- Which fails.
- Which results in "Up 5 minutes (unhealthy)" despite the affected services working correctly.
- Except that `docker compose up --wait` waits for all services to be healthy. So that fails too.
- Also the `nginx` service depends on `web` (which works) and `relay` (which works, but reports itself as unhealthy), so the frontend never starts.

And to fix all that, just add `0.0.0.0` to `noProxy` here and we're gucci.

There are a couple of folks with weird health check issues on the self-hosted repo - it's likely they will benefit from this change too.


## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.