### PR TITLE
fix(nextjs): Use dynamic imports for API page components

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -1,11 +1,10 @@
 import {Fragment, useMemo} from 'react';
 import * as Sentry from '@sentry/nextjs';
 import {Metadata} from 'next';
+import nextDynamic from 'next/dynamic';
 import {notFound} from 'next/navigation';
 
 import {apiCategories} from 'sentry-docs/build/resolveOpenAPI';
-import {ApiCategoryPage} from 'sentry-docs/components/apiCategoryPage';
-import {ApiPage} from 'sentry-docs/components/apiPage';
 import {DocPage} from 'sentry-docs/components/docPage';
 import {Home} from 'sentry-docs/components/home';
 import {Include} from 'sentry-docs/components/include';
@@ -32,6 +31,17 @@ import {PageType} from 'sentry-docs/metrics';
 import {setServerContext} from 'sentry-docs/serverContext';
 import {PaginationNavNode} from 'sentry-docs/types/paginationNavNode';
 import {stripVersion} from 'sentry-docs/versioning';
+
+// Dynamic imports for API page components to avoid loading mdx-bundler at module load time.
+// mdx-bundler is excluded from serverless bundles, so we must only import it when actually needed.
+const ApiCategoryPage = nextDynamic(
+  () => import('sentry-docs/components/apiCategoryPage').then(mod => mod.ApiCategoryPage),
+  {ssr: true}
+);
+const ApiPage = nextDynamic(
+  () => import('sentry-docs/components/apiPage').then(mod => mod.ApiPage),
+  {ssr: true}
+);
 
 export async function generateStaticParams() {
   const docs = await (isDeveloperDocs ? getDevDocsFrontMatter() : getDocsFrontMatter());


### PR DESCRIPTION
## Summary

Fixes DOCS-A5B regression where pages fail to load at runtime because `mdx-bundler` cannot be found.

**Root cause:** PR #16232 excluded `mdx-bundler` from serverless bundles to fix CJS/ESM compatibility issues. However, the static import of `ApiPage` in `page.tsx` caused `mdx-bundler` to be loaded at module initialization time, even for non-API pages like `/changelog`.

**Fix:** Use `next/dynamic` to lazily import `ApiCategoryPage` and `ApiPage` only when actually rendering API routes, preventing the `mdx-bundler` import from executing for regular doc pages.

## Changes

- Replace static imports of `ApiCategoryPage` and `ApiPage` with dynamic imports using `next/dynamic`
- Use `{ssr: true}` to ensure server-side rendering still works for API pages
- Move dynamic import declarations after all static imports for better readability

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Verify non-API pages (like `/changelog`) load without errors
- [ ] Verify API pages still render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Made with [Cursor](https://cursor.com)