### PR TITLE
docs(flutter): Remove Flutter from upcoming to supported metrics

### DIFF
--- a/docs/product/explore/metrics/getting-started/index.mdx
+++ b/docs/product/explore/metrics/getting-started/index.mdx
@@ -223,6 +223,11 @@ To set up Sentry Metrics, use the links below for supported SDKs. After it's bee
     label="visionOS"
     url="/platforms/apple/guides/visionos/metrics/"
   />
+- <LinkWithPlatformIcon
+    platform="dart.flutter"
+    label="Flutter"
+    url="/platforms/dart/guides/flutter/metrics/"
+  />
 
 ### Python
 
@@ -327,12 +332,6 @@ We're actively working on adding Metrics functionality to additional SDKs. Check
     platform="apple"
     label="Apple"
     url="https://github.com/getsentry/sentry-cocoa/issues/6815"
-  />
-
-- <LinkWithPlatformIcon
-    platform="dart.flutter"
-    label="Flutter"
-    url="https://github.com/getsentry/sentry-dart/issues/3350"
   />
 
 If you don't see your platform listed above, please reach out to us on [GitHub](https://github.com/getsentry/sentry/discussions/102275), [Discord](https://discord.gg/sentry) or contact us at [feedback-metrics@sentry.io](mailto:feedback-metrics@sentry.io), we'll get it prioritized!


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Metrics support in Flutter has been released in `9.11.0`

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
