### PR TITLE
docs(js): Document "Sentry not part of build pipeline" error

### DIFF
--- a/includes/sourcemaps-not-part-of-build-pipeline.mdx
+++ b/includes/sourcemaps-not-part-of-build-pipeline.mdx
@@ -1,0 +1,16 @@
+<Expandable permalink title='"Sentry not part of build pipeline" error'>
+
+This error means your deployed JavaScript doesn't contain Debug IDs, so Sentry can't match it to uploaded source maps.
+
+**To fix:**
+
+1. Run the wizard to configure source map uploads for your bundler:
+   ```bash
+   npx @sentry/wizard@latest -i sourcemaps
+   ```
+
+2. Verify you're running a **production build** (not dev/watch mode)
+
+3. Check your [Source Maps](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/source-maps/) settings show uploaded artifacts
+
+</Expandable>

--- a/platform-includes/sourcemaps/overview/javascript.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.mdx
@@ -67,3 +67,12 @@ Though we strongly recommend uploading source maps as part of your build process
 </Alert>
 
 </PlatformSection>
+
+## Troubleshooting
+
+Having issues with source maps? Here are common problems:
+
+- **"Sentry not part of build pipeline"** - Your deployed code is missing Debug IDs. Run the wizard (`npx @sentry/wizard@latest -i sourcemaps`) and ensure you're running a production build.
+- **Source maps not applying** - Verify artifacts are uploaded before errors occur.
+
+For detailed troubleshooting steps, see <PlatformLink to="/sourcemaps/troubleshooting_js/">Troubleshooting Source Maps</PlatformLink>.

--- a/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -34,6 +34,8 @@ Setting up source maps can be tricky, but it's worth it to get it right. You can
 
 ## Troubleshooting Steps
 
+<Include name="sourcemaps-not-part-of-build-pipeline.mdx" />
+
 ### Verify Artifacts Are Uploaded
 
 Verify your artifacts are being uploaded to Sentry. You can find them at **[Settings] > Projects > Select your project > Source Maps**.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the "Sentry not part of build pipeline" error that users see on Sentry's issue page but couldn't find when visiting the sourcemaps documentation.

**Changes:**
- Add reusable include file with Expandable component for the error explanation and fix steps
- Add "Troubleshooting" section at the end of the sourcemaps overview page with searchable error text
- Include the Expandable in the troubleshooting page for detailed steps

This makes the error discoverable via search on the main sourcemaps page while keeping detailed troubleshooting in the appropriate location.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)