### PR TITLE
docs(vercelai): Add troubleshooting guide for force option on Vercel

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -201,3 +201,28 @@ const result = await generateText({
 ## Supported Versions
 
 - `ai`: `>=3.0.0 <=6`
+
+## Troubleshooting
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+<Expandable title="Why do my AI spans show 'ai.toolCall' instead of 'gen_ai.execute_tool' on Vercel?">
+
+When deploying to Vercel, you may notice that AI SDK spans have raw names like `ai.toolCall` or `ai.streamText` instead of the expected semantic names like `gen_ai.execute_tool` or `gen_ai.stream_text`.
+
+This happens because the `ai` package is bundled (not externalized) in Next.js production builds, which prevents the integration from automatically detecting and instrumenting the module.
+
+To fix this, explicitly enable the integration with `force: true` in your `sentry.server.config.ts`:
+
+```javascript
+Sentry.init({
+  dsn: "____PUBLIC_DSN____",
+  integrations: [Sentry.vercelAIIntegration({ force: true })],
+});
+```
+
+The `force` option ensures the integration registers its span processors regardless of module detection.
+
+</Expandable>
+
+</PlatformSection>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a troubleshooting section to the Vercel AI integration docs explaining why AI spans may show raw names like `ai.toolCall` instead of semantic `gen_ai.execute_tool` names when deploying Next.js apps to Vercel.

The issue occurs because the `ai` package is bundled (not externalized) in Next.js production builds, preventing the integration from automatically detecting and instrumenting the module. The solution is to use `force: true` in the `vercelAIIntegration` config.

This troubleshooting tip is scoped to Next.js using `<PlatformSection>` and uses the `<Expandable>` component pattern consistent with other troubleshooting sections in the docs.

## IS YOUR CHANGE URGENT?  

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)