### PR TITLE
docs(dotnet): Format `SentryLog` type members to table for better readability

### DIFF
--- a/platform-includes/logs/options/dotnet.mdx
+++ b/platform-includes/logs/options/dotnet.mdx
@@ -47,12 +47,15 @@ options =>
 The `beforeSendLog` delegate receives a log object, and should return the log object if you want it to be sent to Sentry, or `null` if you want to discard it.
 
 The log object of type `SentryLog` has the following members:
-- `Timestamp` Property: (`DateTimeOffset`) The timestamp of the log.
-- `TraceId` Property: (`SentryId`) The trace id of the log.
-- `Level` Property: (`SentryLogLevel`) The severity level of the log. Either `Trace`, `Debug`, `Info`, `Warning`, `Error`, or `Fatal`.
-- `Message` Property: (`string`) The formatted log message.
-- `Template` Property: (`string?`) The parameterized template string.
-- `Parameters` Property: (`ImmutableArray<KeyValuePair<string, object>>`) The parameters to the template string.
-- `SpanId` Property: (`SpanId?`) The span id of the span that was active when the log was collected.
-- `TryGetAttribute(string key, out object value)` Method: Gets the attribute value associated with the specified key. Returns `true` if the log contains an attribute with the specified key and it's value is not `null`, otherwise `false`.
-- `SetAttribute(string key, object value)` Method: Sets a key-value pair of data attached to the log. Supported types are `string`, `bool`, integers up to a size of 64-bit signed, and floating-point numbers up to a size of 64-bit.
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `Timestamp` | `DateTimeOffset` | The timestamp of the log. |
+| `TraceId` | `SentryId` | The trace id of the log. |
+| `Level` | `SentryLogLevel` | The severity level of the log. Either `Trace`, `Debug`, `Info`, `Warning`, `Error`, or `Fatal`. |
+| `Message` | `string` | The formatted log message. |
+| `Template` | `string?` | The parameterized template string. |
+| `Parameters` | `ImmutableArray<KeyValuePair<string, object>>` | The parameters to the template string. |
+| `SpanId` | `SpanId?` | The span id of the span that was active when the log was collected. |
+| `TryGetAttribute(string key, out object value)` | Method | Gets the attribute value associated with the specified key. Returns `true` if the log contains an attribute with the specified key and it's value is not `null`, otherwise `false`. |
+| `SetAttribute(string key, object value)` | Method | Sets a key-value pair of data attached to the log. Supported types are `string`, `bool`, integers up to a size of 64-bit signed, and floating-point numbers up to a size of 64-bit. |


### PR DESCRIPTION
## DESCRIBE YOUR PR
Format `SentryLog` type members to table for better readability.
Equivalent to the `SentryMetric` type: see https://github.com/getsentry/sentry-docs/pull/16054/changes/5685ebdb22c824d462262c2e2f03a589664e6c3e

Preview: https://sentry-docs-git-docs-dotnet-logs-table-formatting.sentry.dev/platforms/dotnet/logs/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] ~PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)~