### PR TITLE
docs(dashboards): Add Categorical Bar widget documentation

### DIFF
--- a/docs/product/dashboards/widget-builder/index.mdx
+++ b/docs/product/dashboards/widget-builder/index.mdx
@@ -88,13 +88,9 @@ Each chart type allows you to solve different problems:
 
 ### Bar (Categorical)
 
-Bar (categorical) charts allow you to plot an aggregate function grouped by a categorical field such as browser, country, or transaction name. Unlike time series charts where the X-axis represents time, categorical bar charts use a field value as the X-axis.
+Categorical bar charts allow you to plot an aggregate function grouped by a categorical field such as browser, country, or transaction name. Unlike time series charts where the X-axis represents time, categorical bar charts use a field value as the X-axis.
 
-This visualization is useful when you want to compare values across different categories rather than over time. Some example uses include:
-
-- Count of errors by browser type
-- Average response time by endpoint
-- Transaction count by country
+This visualization is useful when you want to compare values across different categories rather than over time. Some example uses include showing a count of errors by browser type, or the average response time by endpoint.
 
 ### Table
 
@@ -126,7 +122,7 @@ You can also choose to construct an equation by clicking “Add Equation”. Doi
 
 ## X-Axis
 
-The X-axis option is only available for [bar (categorical)](/product/dashboards/widget-builder/#bar-categorical) charts. Use this to select the field that will be used to group data into categories along the X-axis. Only string-type fields are available, such as `browser.name`, `geo.country_code`, or `transaction`. Numeric fields are not available since they would create too many unique categories.
+The X-axis option is only available for [categorical bar charts](/product/dashboards/widget-builder/#bar-categorical) charts. Use this to select the field that will group the data into categories along the X-axis. Only string-type fields are available, such as `browser.name`, `geo.country_code`, or `transaction`.
 
 ## Filter
 


### PR DESCRIPTION
Adds documentation for the new categorical bar chart visualization type in Dashboards.

This chart type allows plotting aggregate functions grouped by categorical fields rather than over time.

Since there's already an existing "Bar" widget, we've disambiguated them by suffixing with "(Time Series)" or "(Categorical)"

**e.g.,**
<img width="315" height="330" alt="Screenshot 2026-02-05 at 11 45 38 AM" src="https://github.com/user-attachments/assets/ee7bd6ba-27f9-4b03-a0ce-c3bdccff8c36" />
<img width="849" height="428" alt="Screenshot 2026-02-05 at 11 51 33 AM" src="https://github.com/user-attachments/assets/7fd8b613-4eb5-4e2a-8e40-48da2f1d56e1" />

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## OPEN QUESTIONS

- [x] Does any other related documentation need to be updated?
- [x] Is adding "(Categorical)" and "(Time Series)" to every mention of the widget too awkward?

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)