### PR TITLE
feat(tanstackstart-react)!: Export Vite plugin from @sentry/tanstackstart-react/vite subpath

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -25,7 +25,7 @@ and configure `sentryTanstackStart` in your vite.config.ts:
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";
-import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({

--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -178,7 +178,7 @@ and configure `sentryTanstackStart` in your `vite.config.ts`:
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";
-import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({

--- a/platform-includes/sourcemaps/overview/javascript.tanstackstart-react.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.tanstackstart-react.mdx
@@ -14,7 +14,7 @@ and configure `sentryTanstackStart` in your `vite.config.ts`:
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";
-import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({
@@ -44,7 +44,7 @@ Configure source map behavior using the [plugin options](/platforms/javascript/s
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";
-import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({


### PR DESCRIPTION
Updating the onboarding as we will have to change this to a subpath export: https://github.com/getsentry/sentry-javascript/pull/19182

Should be merged after the `10.40.0` release of the javascript SDKs
