### PR TITLE
docs(seer): Rename "Background Agents" to "Coding Agents"

### DIFF
--- a/docs/organization/integrations/cursor/index.mdx
+++ b/docs/organization/integrations/cursor/index.mdx
@@ -33,6 +33,6 @@ Once installed, you can trigger Cursor Cloud Agents from the Seer Root Cause Ana
 
 You can trigger Cursor Cloud Agents automatically via Seer Automation.
 
-Go to your [Seer settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/), select your project, and configure Cursor Cloud Agent as the target in the "Where should Seer stop?" section or hit the "Set Seer to hand off to Cursor" button below.
+Go to your [Seer settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/), select your project, and configure Cursor Cloud Agent as the coding agent in the "Coding Agent" section.
 
 ![Launching Cursor Agent from Seer =1080x](./img/cursor-agent-stopping-point.png)

--- a/docs/product/ai-in-sentry/seer/index.mdx
+++ b/docs/product/ai-in-sentry/seer/index.mdx
@@ -13,7 +13,7 @@ Seer provides end-to-end debugging tools to help you troubleshoot and fix errors
 - [**AI Code Review**](#ai-code-review): Have Seer review your code changes in GitHub, catching bugs before merging pull requests.
 - [**Root Cause Analysis**](#root-cause-analysis): Automatically scans issues as they come into Sentry, feeding additional context to your alerts and automating triage
 - [**PR Creation**](#pr-creation): A collaborative agent, skilled at root cause analysis and solving issues
-- [**Delegate to Background Agents**](#background-agents): Send Seer's analysis to Cursor's background agent to debug directly in your IDE
+- [**Coding Agents**](#coding-agents): Delegate Seer's analysis to an external coding agent for further debugging and fixes
 
 <Arcade src="https://demo.arcade.software/Qv2KLty5r2aC6jCXkyWN?embed" />
 
@@ -53,9 +53,9 @@ Once the Root Cause Analysis has run, Seer will provide remediatiion recommendat
 
 You can prompt Seer to generate PRs to fix your issue, and push it to GitHub. You can add more context in natural language, or any external supporting information, to help Seer generate a better PR. **Note:** You must install the [Seer GitHub app](/organization/integrations/source-code-mgmt/github/#installing-the-seer-github-app) to use this feature.
 
-### Background Agents
+### Coding Agents
 
-You can send Seer's root cause analysis to Cursor for further debugging directly in your IDE. 
+You can delegate Seer's root cause analysis to an external coding agent, such as [Cursor](/organization/integrations/cursor/), for further debugging and fixes.
 
 ## What Seer Uses
 


### PR DESCRIPTION
## Summary

- Renames "Background Agents" → "Coding Agents" across Seer docs to match the UI rename in getsentry/sentry#107813
- Generalizes Cursor-specific copy in the Seer overview to support future coding agent integrations
- Updates the Cursor integration page to reference the new "Coding Agent" section name

## Files Changed

- `docs/product/ai-in-sentry/seer/index.mdx` — Renamed section heading, updated bullet and body text
- `docs/organization/integrations/cursor/index.mdx` — Updated automation section to reference new UI label