### PR TITLE
ref(self-hosted): Declare self-hosted sentry to be IOPS heavy due to various services

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -40,7 +40,7 @@ These are the minimum requirements:
 
 We recommend using 32 GB RAM, but it works with 16 GB RAM + 16 GB swap as well. You will not notice a downside if your 16 GB swap is on a high speed disk.
 
-Self-hosted Sentry relies heavily on disk I/O because it runs databases, message brokers, and other services on a single machine. If you're using a VPS provider that measures IOPS (Input/Output Operations Per Second), we recommend provisioning at least 3000 IOPS for your disk. A high-IOPS disk will significantly improve your Sentry installation's performance. Additionally, configuring a hard IOPS limit helps prevent noisy neighbors and disk saturation issues.
+Self-hosted Sentry relies heavily on disk I/O because it runs databases, message brokers, and other services on a single machine. If you're using a monitoring system that measures IOPS (Input/Output Operations Per Second) and `iowait`, we recommend monitoring `iowait` to see what number is fit for you, for Self-hosted Sentry, `iowait > 10%` of CPU time probably shows your system cannot handle the load. A high-IOPS disk will significantly improve your Sentry installation's performance. Additionally, configuring a hard IOPS limit helps prevent noisy neighbors and disk saturation issues.
 
 Depending on your traffic volume, you may want to increase your system specification to handle increased load. Although most of the times, this is not the case for self-hosted Sentry, since no matter how small or big the traffic is, you will most likely hover around the same used resources.
 


### PR DESCRIPTION

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Relevant Discord thread: https://discord.com/channels/621778831602221064/1465664194052620312

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
