### PR TITLE
docs(mcp): restructure MCP server page for actionability

### DIFF
--- a/docs/product/sentry-mcp/index.mdx
+++ b/docs/product/sentry-mcp/index.mdx
@@ -14,30 +14,86 @@ og_image: /og-images/product-sentry-mcp.png
   if you have any feedback or concerns.
 </Alert>
 
-## Overview
-
-The [Sentry MCP Server](https://mcp.sentry.dev) provides a secure way of bringing Sentry's full issue context into systems that are able to leverage the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction). Sentry hosts and manages a remote MCP server, which you can connect to and leverage centrally. With the MCP, you can:
-
-- Access Sentry issues and errors
-- Search for errors in specific files
-- Query projects and organizations
-- List and create Sentry DSN's for projects
-- Invoke Seer to automatically fix issues and retrieve the status and details of an issue fix
-
-The Sentry MCP Server includes support for modern MCP features:
-
-- **Remote hosted (preferred) or local STDIO mode** - The hosted version provides lower friction and always includes the latest functionality and stability
-- **OAuth support** - Authenticate using your existing Sentry organization for seamless access to your projects
-- **Streamable HTTP with graceful SSE fallback** - Automatic fallback ensures compatibility across different clients
-- **16+ tool calls and prompts** - Comprehensive toolset for bringing Sentry context into LLM interactions
-
-<VimeoEmbed id="1080588938?h=1e437d4874" />
+The [Sentry MCP Server](https://mcp.sentry.dev) connects your LLM client to Sentry using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction), giving your AI tools direct access to issues, errors, projects, and [Seer](/product/ai-in-sentry/seer/) analysis. Sentry hosts and manages a remote MCP server with OAuth authentication, so there's nothing to install.
 
 ## Getting Started
 
-### OAuth Configuration (Recommended)
+Add the Sentry MCP server to your client with this configuration:
 
-For clients that support OAuth, you can use the streamlined configuration that provides automatic authentication:
+```json {tabTitle: OAuth (Recommended)}
+{
+  "mcpServers": {
+    "Sentry": {
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}
+```
+
+```bash {tabTitle: Self-Hosted (STDIO)}
+npx @sentry/mcp-server@latest --access-token=YOUR_TOKEN --host=sentry.example.com
+```
+
+**Most clients support the OAuth configuration.** When you first connect, you'll be prompted to:
+
+1. Log in with your Sentry organization
+2. Accept the OAuth authorization
+3. Grant access to the necessary permissions
+
+Once authenticated, all 16+ tools become available in your client.
+
+![Available Sentry MCP Tools](./img/mcp-tools.png)
+
+<Alert>
+  If you've joined a new Sentry organization, log out of your LLM's MCP
+  integration and log back in to refresh access.
+</Alert>
+
+<Expandable title="Self-Hosted STDIO Setup Details">
+
+If you're running a self-hosted Sentry installation, use the STDIO transport instead. You'll need a Sentry User Auth Token with the following scopes:
+
+- `org:read`
+- `project:read`
+- `project:write`
+- `team:read`
+- `team:write`
+- `event:write`
+
+You can also set these as environment variables:
+
+```bash
+SENTRY_ACCESS_TOKEN=your-token
+SENTRY_HOST=your-sentry-host
+```
+
+</Expandable>
+
+## Set Up Your Client
+
+Select your client below for specific setup instructions. All clients use the remote OAuth server at `https://mcp.sentry.dev/mcp` unless noted otherwise.
+
+### Claude Code
+
+<Expandable title="Setup Instructions" group="clients">
+
+Run the following command in your terminal:
+
+```bash
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
+```
+
+Then launch Claude Code with `claude`. You'll be prompted to authenticate with OAuth to Sentry.
+
+</Expandable>
+
+### Cursor
+
+<Expandable title="Setup Instructions" group="clients">
+
+Go to `Cursor` → `Settings` → `Cursor Settings` → `MCP` and follow the prompts to add the Sentry MCP server. Cursor 1.0+ includes native OAuth and Streamable HTTP support.
+
+You can also add the server manually by editing your `mcp.json` file:
 
 ```json
 {
@@ -49,239 +105,206 @@ For clients that support OAuth, you can use the streamlined configuration that p
 }
 ```
 
-This configuration:
+</Expandable>
 
-- Enables OAuth authentication with your Sentry organization
-- Uses Streamable HTTP transport with automatic SSE fallback
-- Provides access to all 16+ available tools
-- Automatically handles authentication and session management
+### Claude for Desktop
 
-With OAuth configuration, you'll be prompted to:
+<Expandable title="Setup Instructions" group="clients">
 
-1. Accept the OAuth authorization
-2. Login via your existing Sentry organization
-3. Grant access to the necessary permissions
-
-<Alert>
-  If you've joined a new Sentry organization, log out of your LLM's MCP
-  integration and log back in to refresh access.
-</Alert>
-
-Once authenticated, you'll see the tools become available in your MCP client.
-
-![Available Sentry MCP Tools](./img/mcp-tools.png)
-
-### Remote MCP Configuration (Legacy)
-
-For clients that don't support OAuth, you can continue using the existing Remote MCP endpoint configuration:
+Open developer tools via `CMD + ,` → `Developer` → `Edit Config`, then add the Sentry server to your `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "Sentry": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://mcp.sentry.dev/mcp"]
+      "url": "https://mcp.sentry.dev/mcp"
     }
   }
 }
 ```
 
-### Local STDIO Mode
+Restart Claude Desktop to pick up the changes.
 
-Alternatively, if you don't want the Remote-MCP server, you can run the MCP Server locally in STDIO mode by following the instructions in the [README](https://github.com/getsentry/sentry-mcp). This is particularly useful for self-hosted Sentry installations.
+</Expandable>
 
-To use STDIO mode, you'll need a Sentry User Auth Token with the following scopes:
+### Claude.ai
 
-- `org:read`
-- `project:read`
-- `project:write`
-- `team:read`
-- `team:write`
-- `event:write`
+<Expandable title="Setup Instructions" group="clients">
 
-Launch the STDIO transport:
+Navigate to `Settings` → `Profile` → scroll to `Integrations`, select `Add More`, and add the Sentry MCP server URL:
 
-```bash
-npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.example.com
+```
+https://mcp.sentry.dev/mcp
 ```
 
-You can also use environment variables:
+</Expandable>
 
-```bash
-SENTRY_ACCESS_TOKEN=your-token
-SENTRY_HOST=your-sentry-host
+### VS Code and GitHub Copilot
+
+<Expandable title="Setup Instructions" group="clients">
+
+Open the Command Palette with `CMD+Shift+P` and select `MCP: Add Server`. Enter the Sentry MCP server URL:
+
+```
+https://mcp.sentry.dev/mcp
 ```
 
-### mcp.sentry.dev (live demo)
+</Expandable>
 
-The [Sentry MCP page](https://mcp.sentry.dev) provides a simple way to configure and test the MCP server. From this web client you can authenticate with your Sentry organization and access a hosted MCP server for testing.
+### Codex
+
+<Expandable title="Setup Instructions" group="clients">
+
+Run the following command in your terminal:
+
+```bash
+codex mcp add sentry --url https://mcp.sentry.dev/mcp
+```
+
+Then launch Codex with `codex`. You'll be prompted to authenticate with Sentry using OAuth.
+
+</Expandable>
+
+### Windsurf
+
+<Expandable title="Setup Instructions" group="clients">
+
+Configure via the `Configure MCP` option in Cascade (`CMD + L`). Add the Sentry MCP server URL:
+
+```
+https://mcp.sentry.dev/mcp
+```
+
+</Expandable>
+
+### Warp
+
+<Expandable title="Setup Instructions" group="clients">
+
+Go to `Settings` → `MCP Servers` → `+ Add` and select **Streamable HTTP or SSE Server (URL)**. Enter the following configuration:
+
+```json
+{
+  "Sentry": {
+    "url": "https://mcp.sentry.dev/mcp"
+  }
+}
+```
+
+Warp supports OAuth one-click installation and will open a browser window to authenticate with Sentry.
+
+</Expandable>
+
+### Amp
+
+<Expandable title="Setup Instructions" group="clients">
+
+**VS Code Extension:** Add the Sentry server via the Amp VS Code extension settings, or update your `settings.json`:
+
+```json
+"amp.mcpServers": {
+    "sentry": {
+        "url": "https://mcp.sentry.dev/mcp"
+    }
+}
+```
+
+**Amp CLI:** Add via the `amp mcp add` command:
+
+```bash
+amp mcp add sentry --url https://mcp.sentry.dev/mcp
+```
+
+</Expandable>
+
+### Factory Droid
+
+<Expandable title="Setup Instructions" group="clients">
+
+Launch Factory Droid CLI and open the MCP menu with `/mcp`. Select `Add MCP Server from Registry` and search for `sentry`.
+
+You can also add it manually using the Sentry MCP server URL `https://mcp.sentry.dev/mcp`.
+
+</Expandable>
+
+### Vercel v0
+
+<Expandable title="Setup Instructions" group="clients">
+
+Select `Prompt Tools` in the [v0.app](https://v0.app) UI, then select `Add MCP` and choose Sentry from the list.
+
+</Expandable>
+
+### Other Clients
+
+<Expandable title="Setup Instructions" group="clients">
+
+The Sentry MCP Server follows standard MCP protocols and works with any client that supports:
+
+- **OAuth authentication** (recommended)
+- **Streamable HTTP** with automatic SSE fallback
+
+Use the server URL `https://mcp.sentry.dev/mcp` in your client's MCP configuration.
+
+If your client doesn't yet support native OAuth or Streamable HTTP, you can use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge as a temporary workaround.
+
+</Expandable>
+
+### Test the Connection
+
+The [Sentry MCP page](https://mcp.sentry.dev) provides a web-based interface where you can authenticate with your Sentry organization and test the MCP server directly in your browser.
 
 ![Sentry MCP live demo](./img/mcpdev.png)
 
-## Available Tools
-
-The Sentry MCP Server provides comprehensive tools for interacting with Sentry data:
-
-### Core Tools
-
-- **Organizations**: List and query organization information
-- **Projects**: Find, list, and create projects
-- **Teams**: Manage and query team information
-- **Issues**: Access issue details, search, and analyze problems
-- **DSNs**: List and create Data Source Names for projects
-
-### Analysis Tools
-
-- **Error Searching**: Find errors in specific files or across projects
-- **Issue Analysis**: Detailed issue investigation with context
-- **Seer Integration**: Invoke Sentry's AI agent for root cause analysis and automated fixes
-
-### Advanced Features
-
-- **Release Management**: Query and analyze release information
-- **Performance Monitoring**: Access transaction and performance data
-- **Custom Queries**: Execute complex searches across Sentry data
+<VimeoEmbed id="1080588938?h=1e437d4874" />
 
 ## Example Usage
 
-Here are some example prompts you can use with the Sentry MCP:
+Once connected, try these prompts to start using Sentry context in your LLM:
 
 - Tell me about the issues in my `project-name`
 - Check Sentry for errors in `components/UserProfile.tsx` and propose solutions
 - Diagnose issue `PROJECT-123` and propose solutions
-- Create a new project in Sentry for `new-service-name` and setup local instrumentation
+- Create a new project in Sentry for `new-service-name` and set up local instrumentation
 - Use Sentry's Seer to analyze and propose a solution for issue `PROJECT-456`
 - Show me the most recent releases for my organization
 - Find all unresolved crashes in my React Native app
 
 ![Sentry MCP using Autofix](./img/mcp-autofix1.png)
 
-## Verified Clients
+## Available Tools
 
-The Sentry MCP Server has been verified to work in:
+The Sentry MCP Server provides 16+ tools for interacting with Sentry data:
 
-### Claude for Desktop
+**Core Tools** — Organizations, Projects, Teams, Issues, and DSN management
 
-Access developer tools via `CMD + ,` → `Developer` → `Edit Config` → edit the `claude_desktop_config.json` file
+**Analysis Tools** — Error searching across files and projects, detailed issue investigation, and Seer integration for AI-powered root cause analysis
 
-### Claude.ai
-
-Navigate to `Settings` → `Profile` → Scroll to `Integrations`, select `Add More`, and add the Sentry MCP server URL `https://mcp.sentry.dev/mcp`
-
-### Claude Code
-
-Since recently reaching 1.0, Claude Code has native support for remote hosted MCP servers. From your CLI enter `claude mcp add --transport http sentry https://mcp.sentry.dev/mcp` and then access Claude Code with `claude`.
-
-Once in, you'll be prompted to authenticate with OAuth to Sentry.
-
-### Codex
-
-From your CLI, enter `codex mcp add sentry --url https://mcp.sentry.dev/mcp` and then access Codex with `codex`.
-
-Once in, you'll be prompted to authenticate with Sentry using OAuth.
-
-### Cursor
-
-Available via `Cursor` → `Settings` → `Cursor Settings` → `MCP` following the prompts to configure Sentry MCP. Cursor 1.0+ includes enhanced MCP support with OAuth and Streamable HTTP.
-
-You can still edit the `mcp.json` file manually if you prefer.
-
-### Factory Droid
-
-When launching Factory Droid CLI, you can add the Sentry MCP server by selecting accessing the MCP menu with `/mcp`, selecting `Add MCP Server from Registry`, and searching for `sentry` in the list. 
-
-You can also add it manually by adding the Sentry MCP server URL `https://mcp.sentry.dev/mcp`. 
-
-### Amp
-
-Add via the Amp VS Code extension settings screen or by updating your settings.json file:
-
-```json
-"amp.mcpServers": {
-    "sentry": {
-        "command": "npx",
-        "args": [
-          "-y",
-          "mcp-remote@latest",
-          "https://mcp.sentry.dev/mcp"
-        ]
-      }
-}
-```
-
-**Amp CLI Setup:**
-
-Add via the `amp mcp add` command below
-
-```bash
-amp mcp add sentry -- npx -y mcp-remote@latest https://mcp.sentry.dev/mcp
-```
-
-### VS Code and GitHub Copilot
-
-Add the server using `CMD+Shift+P` and selecting `MCP: Add Server`
-
-### Vercel v0
-
-Select `Prompt Tools` in the https://v0.app UI and then select `Add MCP` and select Sentry from the list.
-
-### Warp
-
-Available via `Settings` -> `MCP Servers` -> `Manage MCP Servers` -> `Add MCP Server` -> `Sentry` -> `https://mcp.sentry.dev/mcp`.
-
-```json
-{
-  "Sentry": {
-    "command": "npx",
-    "args": ["-y", "mcp-remote@latest", "https://mcp.sentry.dev/mcp"],
-    "env": {},
-    "working_directory": null
-  }
-}
-```
-
-### Windsurf
-
-Configure via the `Configure MCP` option in Cascade (CMD + L)
-
-### Other Clients
-
-The Sentry MCP Server follows standard MCP protocols and should work with any client that supports:
-
-- OAuth authentication (recommended)
-- Remote MCP servers
-- SSE or Streamable HTTP transport
+**Advanced Features** — Release management, performance monitoring, and custom queries
 
 ## Integration with Seer
 
-The Sentry MCP Server provides seamless integration with [Seer](/product/ai-in-sentry/seer/), Sentry's AI agent. You can:
+The Sentry MCP Server provides seamless integration with [Seer](/product/ai-in-sentry/seer/), Sentry's AI agent. Through MCP, you can trigger Seer analysis, get AI-generated fix recommendations, and monitor fix status — all from within your LLM client.
 
-- **Trigger Seer Analysis**: Initiate automated root cause analysis for issues
-- **Get Fix Recommendations**: Receive AI-generated solutions for bugs and performance issues
-- **Monitor Fix Status**: Track the progress of Seer's analysis and implementation
-
-**Note**: MCP and Seer are complementary tools. MCP brings Sentry context into your LLM, while Seer is purpose-built for deep issue analysis and automated debugging. You can use MCP to invoke Seer for complex debugging workflows.
+MCP and Seer are complementary tools. MCP brings Sentry context into your LLM, while Seer is purpose-built for deep issue analysis and automated debugging. Use MCP to invoke Seer for complex debugging workflows.
 
 ## Troubleshooting
-
-### Common Issues
 
 **OAuth Authentication Problems**
 
 - Ensure your client supports OAuth authentication
-- Try the legacy Remote MCP configuration if OAuth isn't working
 - Check that you have the necessary permissions in your Sentry organization
+- Try logging out of the MCP integration and logging back in
 
 **Connection Issues**
 
 - Verify the MCP server URL is correct: `https://mcp.sentry.dev/mcp`
-- For legacy setups, use: `https://mcp.sentry.dev/sse`
 - Check your client's MCP configuration syntax
 
 **Missing Tools**
 
 - Ensure authentication completed successfully
 - Verify your Sentry organization access
-- Check for any error messages in your client's console
+- Check for error messages in your client's console
 
 For additional support, visit the [GitHub repository](https://github.com/getsentry/sentry-mcp) or contact Sentry support.


### PR DESCRIPTION
## Summary

Reorganizes the Sentry MCP Server documentation to be more actionable and get users set up faster.

- **Getting Started above the fold**: Tabbed code blocks (OAuth recommended + Self-Hosted STDIO) are now the first thing users see, before any overview or video content
- **Per-client setup with TOC navigation**: Each verified client gets an h3 heading (visible in right-side nav) with an Expandable accordion for setup instructions, keeping the page scannable while remaining navigable
- **Removed `npx mcp-remote` references**: All client configs updated to use native OAuth/Streamable HTTP URLs — Warp and Amp configs updated based on their current docs confirming native support
- **STDIO deprioritized**: Moved to last tab in Getting Started, labeled "Self-Hosted" to clarify its use case
- **Condensed overview**: Replaced verbose overview + duplicate feature lists with a single intro sentence
- **Video moved after setup sections**: Users see actionable setup first
- **Example Usage moved up**: Appears before the tools reference so users know what to try immediately after connecting
- **`mcp-remote` fallback**: Single mention in "Other Clients" section for edge cases only

## Before/After structure

**Before:** Overview → Video → Getting Started (OAuth / Legacy Remote / STDIO) → Tools → Examples → 12 client subsections → Seer → Troubleshooting

**After:** Intro → Getting Started (tabbed) → Client Setup (h3 + accordion per client) → Video → Examples → Tools → Seer → Troubleshooting