### PR TITLE
Revert "Add size and distro to self-hosted delta"

### DIFF
--- a/develop-docs/self-hosted/index.mdx
+++ b/develop-docs/self-hosted/index.mdx
@@ -18,7 +18,6 @@ The difference only resides on a few things that are impossible to be hosted by 
 - [Spike protection](https://docs.sentry.io/pricing/quotas/spike-protection/), as it is tightly coupled with Billing Quotas.
 - [Spend Allocation](https://docs.sentry.io/pricing/quotas/spend-allocation/), as it is tightly coupled with Billing Quotas.
 - Seer and other AI & ML features, as these are currently closed source.
-- [Size Analysis](https://docs.sentry.io/product/size-analysis/) and [Build Distribution](https://docs.sentry.io/product/build-distribution/).
 - [Data Storage Location](https://docs.sentry.io/organization/data-storage-location/), because you own your data.
 - Limited stack-trace resolution for mobile platforms, but all other features are available:
   - [iOS Symbolication](https://docs.sentry.io/platforms/apple/data-management/debug-files/symbol-servers#built-in-repositories), because Apple does not provide a public symbol server, nor do they allow us to distribute the Debug Information Files (DIFs) ourselves.


### PR DESCRIPTION
Reverts getsentry/sentry-docs#16139

This is actually *available* on self-hosted, but it's not enabled by default.