### PR TITLE
fix(js): Replace non-existent wrapOpenAIWithSentry with instrumentOpenAiClient

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
@@ -77,10 +77,9 @@ Each integration page includes browser-specific examples with options like `reco
 
 ```javascript
 import * as Sentry from "___SDK_PACKAGE___";
-import { wrapOpenAIWithSentry } from "___SDK_PACKAGE___";
 import OpenAI from "openai";
 
-const client = wrapOpenAIWithSentry(
+const client = Sentry.instrumentOpenAiClient(
   new OpenAI({ apiKey: "...", dangerouslyAllowBrowser: true }),
   {
     recordInputs: true,


### PR DESCRIPTION
## DESCRIBE YOUR PR

The AI Agent Monitoring Browser docs referenced `wrapOpenAIWithSentry` which doesn't exist in the `sentry-javascript` codebase. The correct function is `Sentry.instrumentOpenAiClient`, which is already used correctly on the OpenAI integration page.

Introduced in #16117.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)