### PR TITLE
fix(python-sdk-docs): correct minimum version requirements for 11 integrations

### DIFF
--- a/docs/platforms/python/integrations/aiohttp/index.mdx
+++ b/docs/platforms/python/integrations/aiohttp/index.mdx
@@ -109,5 +109,5 @@ Regardless of how `failed_request_status_codes` is set, any exceptions raised by
 
 ## Supported Versions
 
-- AIOHTTP: 3.5+
+- AIOHTTP: 3.4+
 - Python: 3.7+

--- a/docs/platforms/python/integrations/celery/index.mdx
+++ b/docs/platforms/python/integrations/celery/index.mdx
@@ -246,7 +246,7 @@ my_task_b.apply_async(
 
 ## Supported Versions
 
-- Celery: 4.0+
+- Celery: 4.4.7+
 - Python: 3.6+
 
 <Include name="python-use-older-sdk-for-legacy-support.mdx" />

--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -187,7 +187,7 @@ You can pass the following keyword arguments to `DjangoIntegration()`:
 
 ## Supported Versions
 
-- Django 1.11+
+- Django 1.8+
 - Python 3.6+
 
 <Include name="python-use-older-sdk-for-legacy-support.mdx" />

--- a/docs/platforms/python/integrations/flask/index.mdx
+++ b/docs/platforms/python/integrations/flask/index.mdx
@@ -121,7 +121,7 @@ You can pass the following keyword arguments to `FlaskIntegration()`:
 
 ## Supported Versions
 
-- Flask: 1.0+
+- Flask: 1.1.4+
 - Python: 3.6+
 
 <Include name="python-use-older-sdk-for-legacy-support.mdx" />

--- a/docs/platforms/python/integrations/google-genai/index.mdx
+++ b/docs/platforms/python/integrations/google-genai/index.mdx
@@ -110,5 +110,5 @@ You can pass the following keyword arguments to `GoogleGenAIIntegration()`:
 
 ## Supported Versions
 
-- google-genai: 1.4.0+
+- google-genai: 1.29.0+
 - Python: 3.9+

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -131,4 +131,4 @@ You can pass the following keyword arguments to `HuggingfaceHubIntegration()`:
 ## Supported Versions
 
 - Python: 3.8+
-- huggingface_hub: 0.22+
+- huggingface_hub: 0.24.7+

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -194,5 +194,5 @@ You can pass the following keyword arguments to `LangchainIntegration()`:
 
 - OpenAI: 1.0+
 - Python: 3.9+
-- langchain: 0.1.11+
+- langchain: 0.1.0+
     

--- a/docs/platforms/python/integrations/langgraph/index.mdx
+++ b/docs/platforms/python/integrations/langgraph/index.mdx
@@ -125,4 +125,4 @@ You can pass the following keyword arguments to `LanggraphIntegration()`:
 
 - OpenAI: 1.0+
 - Python: 3.9+
-- LangGraph: 0.6+
+- LangGraph: 0.6.6+

--- a/docs/platforms/python/integrations/litellm/index.mdx
+++ b/docs/platforms/python/integrations/litellm/index.mdx
@@ -114,5 +114,5 @@ You can pass the following keyword arguments to `LiteLLMIntegration()`:
 
 ## Supported Versions
 
-- LiteLLM: 1.77.0+
+- LiteLLM: 1.77.5+
 - Python: 3.8+

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -116,6 +116,6 @@ You can pass the following keyword arguments to `OpenAIIntegration()`:
 ## Supported Versions
 
 - OpenAI: 1.0+
-- tiktoken: 0.6.0+
+- tiktoken: 0.3.0+
 - Python: 3.9+
 - Sentry Python SDK 2.41.0+

--- a/docs/platforms/python/integrations/starlette/index.mdx
+++ b/docs/platforms/python/integrations/starlette/index.mdx
@@ -126,5 +126,5 @@ You can pass the following keyword arguments to `StarletteIntegration()`:
 
 ## Supported Versions
 
-- Starlette: 0.19.1+
+- Starlette: 0.16+
 - Python: 3.7+


### PR DESCRIPTION
Cross-referenced documented minimum versions against the SDK's _MIN_VERSIONS dict and setup.py. All versions below are sourced from: https://github.com/getsentry/sentry-python/blob/1566e628131c5a375a0853050f7b5c9a118fc43d/sentry_sdk/integrations/__init__.py#L118-L166

- google-genai: 1.4.0 → 1.29.0 (L138) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L138
- huggingface_hub: 0.22 → 0.24.7 (L141) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L141
- LiteLLM: 1.77.0 → 1.77.5 (L145) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L145
- LangGraph: 0.6 → 0.6.6 (L143) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L143
- Django: 1.11 → 1.8 (L131) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L131
- Flask: 1.0 → 1.1.4 (L135) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L135
- Celery: 4.0 → 4.4.7 (L127) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L127
- AIOHTTP: 3.5 → 3.4 (L119) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L119
- Starlette: 0.19.1 → 0.16 (L159) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L159
- tiktoken: 0.6.0 → 0.3.0 (from setup.py L72) https://github.com/getsentry/sentry-python/blob/1566e628/setup.py#L72
- langchain: 0.1.11 → 0.1.0 (L142) https://github.com/getsentry/sentry-python/blob/1566e628/sentry_sdk/integrations/__init__.py#L142
