### PR TITLE
fix(metrics): Skip sampling middleware spans that lack request context

### DIFF
--- a/src/tracesSampler.ts
+++ b/src/tracesSampler.ts
@@ -70,6 +70,15 @@ function getMiddlewareClassification(headers?: Record<string, string>): {
  * AI agents are checked first; if something matches both AI and bot patterns, we sample it.
  */
 export function tracesSampler(samplingContext: SamplingContext): number {
+  const spanName = samplingContext.name || '';
+
+  // Middleware spans don't receive normalizedRequest in Sentry's Edge runtime instrumentation,
+  // so they can't be classified. Skip sampling them entirely - the corresponding page span
+  // (e.g., "GET /path") will capture the same request with full classification data.
+  if (spanName.startsWith('middleware ')) {
+    return 0;
+  }
+
   const headers = samplingContext.normalizedRequest?.headers;
 
   // Check for middleware classification headers first (most reliable)


### PR DESCRIPTION
## DESCRIBE YOUR PR

Middleware spans in Sentry's Edge runtime instrumentation don't receive `normalizedRequest`, making traffic classification impossible. These spans were being classified as "unknown", inflating that metric significantly (~50% of all spans).

Since every middleware span has a corresponding page span (e.g., "middleware GET /path" → "GET /path") that does receive full request context, we can safely skip sampling middleware spans without losing any classification data.

**Root cause:** Discovered via local debugging that `samplingContext.normalizedRequest` is always `undefined` for spans named `middleware GET /...`, while the corresponding `GET /...` spans have full headers including user-agent.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)