### PR TITLE
ref(ai-agents-sdks): Remove `gen_ai.operation.type` and narrow operation names for requests

### DIFF
--- a/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
+++ b/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
@@ -24,7 +24,6 @@ Describes AI agent invocation.
 - Span `op` SHOULD be `"gen_ai.create_agent"`.
 - Span `name` SHOULD be `"create_agent {gen_ai.agent.name}"`. (e.g. `"create_agent Weather Agent"`)
 - Attribute `gen_ai.operation.name` MUST be `"create_agent"`.
-- Attribute `gen_ai.operation.type` MUST be `"agent"`.
 - Attribute `gen_ai.agent.name` SHOULD be set to the agents name. (e.g. `"Weather Agent"`)
 - All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
 
@@ -35,7 +34,6 @@ Describes AI agent invocation.
 - Span `op` SHOULD be `"gen_ai.invoke_agent"`.
 - Span `name` SHOULD be `"invoke_agent {gen_ai.agent.name}"`. (e.g. `"invoke_agent Weather Agent"`)
 - Attribute `gen_ai.operation.name` MUST be `"invoke_agent"`.
-- Attribute `gen_ai.operation.type` MUST be `"agent"`.
 - Attribute `gen_ai.agent.name` SHOULD be set to the agents name. (e.g. `"Weather Agent"`)
 - All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
 
@@ -102,7 +100,6 @@ This span represents a request to an AI model or service that generates a respon
 - Span `op` SHOULD be `"gen_ai.{gen_ai.operation.name}"`. (e.g. `"gen_ai.chat"`)
 - Span `name` SHOULD be `{gen_ai.operation.name} {gen_ai.request.model}"`. (e.g. `"chat o3-mini"`)
 - Attribute `gen_ai.operation.name` MUST be `"chat"`, `"embeddings"`, `"generate_content"` or `"text_completion"`. **[4]**
-- Attribute `gen_ai.operation.type` MUST be `"ai_client"`.
 - All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
 
 Additional attributes on the span:
@@ -168,7 +165,6 @@ Describes a tool execution.
 - Span `op` SHOULD be `"gen_ai.execute_tool"`.
 - Span `name` SHOULD be `"execute_tool {gen_ai.tool.name}"`. (e.g. `"execute_tool query_database"`)
 - Attribute `gen_ai.operation.name` MUST be `"execute_tool"`.
-- Attribute `gen_ai.operation.type` MUST be `"tool"`.
 - Attribute `gen_ai.tool.name` SHOULD be set to the name of the tool. (e.g. `"query_database"`)
 - All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
 
@@ -194,7 +190,6 @@ A span that describes the handoff from one agent to another agent.
 - Span `op` SHOULD be `"gen_ai.handoff"`.
 - Span `name` SHOULD be `"handoff from {from_agent} to {to_agent}"`.
 - Attribute `gen_ai.operation.name` MUST be `"handoff"`.
-- Attribute `gen_ai.operation.type` MUST be `"handoff"`.
 - All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
 
 ## Common Span Attributes
@@ -204,7 +199,6 @@ Some attributes are common to all AI Agents spans:
 | Attribute               | Type   | Requirement Level | Description                                                                              | Example               |
 | :---------------------- | :----- | :---------------- | :--------------------------------------------------------------------------------------- | :-------------------- |
 | `gen_ai.operation.name` | string | required          | The name of the operation being performed. **[4]**                                       | `"chat"`              |
-| `gen_ai.operation.type` | string | optional          | Type of AI operation: `"agent"`, `"ai_client"`, `"tool"`, `"handoff"`, `"guardrail"`.    | `"agent"`             |
 | `gen_ai.request.model`  | string | required          | The name of the AI model a request is being made to.                                     | `"gpt-4o"`            |
 | `gen_ai.response.model` | string | optional          | The name of the AI model the response was created with.                                  | `"gpt-4o-2024-08-06"` |
 | `gen_ai.agent.name`     | string | optional          | The name of the agent this span belongs to.                                              | `"Weather Agent"`     |


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The attribute `gen_ai.operation.type` is populated by Relay, so it does not need to be set by the SDK.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
