### PR TITLE
feat(js): Document element timing option in browser tracing

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/browsertracing.mdx
@@ -39,4 +39,4 @@ Sentry.init({
 });
 ```
 
-See <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#configuration-options">Configuration Options</PlatformLink> for a full list of available options for `browserTracingIntegration` 
+See <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/##advanced-options">Configuration Options</PlatformLink> for a full list of available options for `browserTracingIntegration`

--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -25,6 +25,7 @@ Once you enable tracing, the SDK automatically captures performance data without
 | **HTTP requests** | All fetch/XHR calls | Duration, status, URL |
 | **User interactions** | Clicks, inputs that trigger work | INP (responsiveness) |
 | **Long tasks** | Main thread blocking > 50ms | Duration, attribution |
+| **Element timing** | Elements marked with `elementtiming` attribute | Render/load times for critical UI elements |
 
 <PlatformContent includePath="performance/what-instrumentation-provides" />
 
@@ -185,6 +186,24 @@ Enable/disable automatic spans for long tasks (main thread blocking > 50ms).
 <SdkOption name="enableLongAnimationFrame" type='boolean' defaultValue='true' availableSince='8.18.0'>
 
 Enable/disable spans for long animation frames. Falls back to long tasks if browser doesn't support long animation frames.
+
+</SdkOption>
+
+<SdkOption name="enableElementTiming" type='boolean' defaultValue='true'>
+
+Enable/disable automatic spans for [Element Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceElementTiming) entries. When enabled, Sentry captures performance data for elements marked with the `elementtiming` attribute.
+
+This is useful for tracking when critical UI elements (like hero images or important text) are rendered on the page:
+
+```html
+<img src="hero.jpg" elementtiming="hero-image" />
+<h1 elementtiming="main-heading">Welcome</h1>
+```
+
+Element timing spans will appear in your trace with names like `element[hero-image]` and include metrics such as:
+- Render time
+- Load time (for images)
+- Element size and type
 
 </SdkOption>
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -18,14 +18,14 @@ Capturing spans requires that you first <PlatformLink to="/tracing/">set up trac
 
 Once you enable tracing, the SDK automatically captures performance data without additional code:
 
-| What | Description | Metrics |
-|------|-------------|---------|
-| **Page loads** | Full page load performance | LCP, CLS, TTFB |
-| **Navigations** | Client-side route changes | Duration, Web Vitals |
-| **HTTP requests** | All fetch/XHR calls | Duration, status, URL |
-| **User interactions** | Clicks, inputs that trigger work | INP (responsiveness) |
-| **Long tasks** | Main thread blocking > 50ms | Duration, attribution |
-| **Element timing** | Elements marked with `elementtiming` attribute | Render/load times for critical UI elements |
+| What                  | Description                                    | Metrics                                    |
+| --------------------- | ---------------------------------------------- | ------------------------------------------ |
+| **Page loads**        | Full page load performance                     | LCP, CLS, TTFB                             |
+| **Navigations**       | Client-side route changes                      | Duration, Web Vitals                       |
+| **HTTP requests**     | All fetch/XHR calls                            | Duration, status, URL                      |
+| **User interactions** | Clicks, inputs that trigger work               | INP (responsiveness)                       |
+| **Long tasks**        | Main thread blocking > 50ms                    | Duration, attribution                      |
+| **Element timing**    | Elements marked with `elementtiming` attribute | Render/load times for critical UI elements |
 
 <PlatformContent includePath="performance/what-instrumentation-provides" />
 
@@ -189,7 +189,7 @@ Enable/disable spans for long animation frames. Falls back to long tasks if brow
 
 </SdkOption>
 
-<SdkOption name="enableElementTiming" type='boolean' defaultValue='true'>
+<SdkOption name="enableElementTiming" type='boolean' defaultValue='true' availableSince="9.35.0">
 
 Enable/disable automatic spans for [Element Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceElementTiming) entries. When enabled, Sentry captures performance data for elements marked with the `elementtiming` attribute.
 
@@ -201,6 +201,7 @@ This is useful for tracking when critical UI elements (like hero images or impor
 ```
 
 Element timing spans will appear in your trace with names like `element[hero-image]` and include metrics such as:
+
 - Render time
 - Load time (for images)
 - Element size and type
@@ -255,7 +256,7 @@ Ignore specific resource span categories by their `op` (e.g., `resource.script`,
 Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
-      ignoreResourceSpans: ['resource.css', 'resource.script'],
+      ignoreResourceSpans: ["resource.css", "resource.script"],
     }),
   ],
 });
@@ -271,7 +272,7 @@ Ignore spans created from `performance.mark()` and `performance.measure()`:
 Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
-      ignorePerformanceApiSpans: ['myMeasurement', /myMark/],
+      ignorePerformanceApiSpans: ["myMeasurement", /myMark/],
     }),
   ],
 });
@@ -304,7 +305,11 @@ Sentry.init({
     }),
   ],
   tracesSampleRate: 1.0,
-  tracePropagationTargets: ["localhost", /^\//,  /^https:\/\/yourserver\.io\/api/],
+  tracePropagationTargets: [
+    "localhost",
+    /^\//,
+    /^https:\/\/yourserver\.io\/api/,
+  ],
 });
 ```
 


### PR DESCRIPTION
This PR adds documentation for the `enableElementTiming` option in the browser tracing integration

This PR adds:

- Documentation in the "What's Captured Automatically" table
- A new configuration option section for `enableElementTiming` with examples and usage instructions
- Information about how element timing spans appear in traces

Closes #16334