### PR TITLE
fix(rust-sdk): Correct the criteria for sending request body

### DIFF
--- a/docs/platforms/rust/common/data-management/data-collected.mdx
+++ b/docs/platforms/rust/common/data-management/data-collected.mdx
@@ -44,17 +44,18 @@ Depending on your application, this could contain PII data.
 
 ## Request Body
 
-The request body of incoming HTTP requests is not sent to Sentry by default.
-When using `sentry-actix`, the Sentry SDK can capture the request body. A prerequisite for this is to set `send_default_pii` to `true` in your `sentry::init` options.
-Then, whether the request body is sent or not, depends on the type and size of request body as described below:
+Whether the Rust SDK automatically captures request bodies depends on the HTTP integration and configuration.
 
-- **The type of the request body:**
-  - JSON and form bodies are sent
-  - Raw request bodies are always removed
-  - Uploaded files in the request bodies are never sent to Sentry
-- **The size of the request body:** There's a [`max_request_body_size`](/platforms/rust/configuration/options/#max_request_body_size) option that's set to `MaxRequestBodySize::Medium` by default, which governs the maximum size of request bodies that are sent to Sentry.
+When using `sentry-actix`, a request body is attached to events only if **all** of the following are true:
 
-If you want to prevent request bodies from being sent to Sentry altogether, set `max_request_body_size` to `MaxRequestBodySize::None`.
+- The request is **not** chunked (`Transfer-Encoding: chunked` bodies are not captured).
+- The request has a valid `Content-Length` header.
+- `Content-Length` is within the configured [`max_request_body_size`](/platforms/rust/configuration/options/#max_request_body_size) limit (default: `MaxRequestBodySize::Medium`, 10kB).
+- `send_default_pii` is `true`, **or** `Content-Type` is one of `application/json` and `application/x-www-form-urlencoded`.
+
+When using `sentry-tower` (with `http` feature enabled), request bodies are currently not captured automatically.
+
+To prevent request bodies from being captured automatically, set `max_request_body_size` to `MaxRequestBodySize::None`.
 
 ## Debug Images
 


### PR DESCRIPTION
This PR corrects the Rust Actix request-body documentation, which previously incorrectly stated that `send_default_pii = false` prevents request bodies from being sent. In fact, `send_default_pii` only restricts the captured content types, but does not fully prevent request bodies from being sent.

### Explanation

`send_default_pii` is read in middleware via [`client.options().send_default_pii`](https://github.com/getsentry/sentry-rust/blob/c3339e82e9249bdf2431da6f15b7dd882044db2e/sentry-actix/src/lib.rs#L305-L307), stored in a local `with_pii`, and then passed as the `with_pii` parameter to [`should_capture_request_body`](https://github.com/getsentry/sentry-rust/blob/c3339e82e9249bdf2431da6f15b7dd882044db2e/sentry-actix/src/lib.rs#L335-L337). Inside that function, the parameter is used in the [`is_valid_content_type`](https://github.com/getsentry/sentry-rust/blob/c3339e82e9249bdf2431da6f15b7dd882044db2e/sentry-actix/src/lib.rs#L225-L233) branch, where `send_default_pii = false` restricts body capture to exact `application/json` and `application/x-www-form-urlencoded`, while `send_default_pii = true` allows any content type.

[`should_capture_request_body`](https://github.com/getsentry/sentry-rust/blob/c3339e82e9249bdf2431da6f15b7dd882044db2e/sentry-actix/src/lib.rs#L214-L244) also checks transfer encoding, `Content-Length`, and `max_request_body_size`; `SentryMiddleware::call` then [checks `should_capture_request_body`'s return value](https://github.com/getsentry/sentry-rust/blob/c3339e82e9249bdf2431da6f15b7dd882044db2e/sentry-actix/src/lib.rs#L335-L337) to determine whether to capture the request body. So `send_default_pii` affects content-type eligibility, but is not a hard on/off switch for request body capture.
