### PR TITLE
docs(cli): Add vcs-provider parameter documentation

### DIFF
--- a/includes/size-analysis/upload-metadata.mdx
+++ b/includes/size-analysis/upload-metadata.mdx
@@ -7,6 +7,7 @@ We use build metadata to organize builds in the UI and ensure correct comparison
 | `build-configuration`\* | Build configuration describing how the app was built, for example `Release` or `Debug` or `Release-Bazel` |
 | `head-sha`              | Current commit SHA                                                                                        |
 | `base-sha`              | Base commit SHA (for comparisons, recommended to use the branch's merge-base)                             |
+| `vcs-provider`          | VCS provider name (for example `github`, `gitlab`, `bitbucket`, `azure`, `github_enterprise`). If not provided, the provider will be auto-detected from the git remote URL. Note: Only `github` and `github_enterprise` are supported for status checks. |
 | `head-repo-name`        | Repository name (`org/repo`)                                                                              |
 | `pr-number`             | Pull request number                                                                                       |
 | `head-ref`              | Branch or tag name                                                                                        |


### PR DESCRIPTION
Add documentation for the `vcs-provider` parameter used in `sentry-cli build upload` commands for size analysis and build distribution uploads.

This documentation will appear in both size analysis and build distribution pages for iOS, Android, React Native, and Flutter platforms.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Fixes EME-834