### PR TITLE
docs(platforms): remove now obsolete metrics deprecation

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1840,16 +1840,6 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     from: '/platforms/javascript/guides/:guide/tracing/instrumentation/opentelemetry/',
     to: '/platforms/javascript/guides/:guide/opentelemetry/',
   },
-  // START redirecting deprecated generic metrics docs to concepts
-  {
-    from: '/platforms/apple/metrics/',
-    to: '/concepts/key-terms/tracing/span-metrics/',
-  },
-  {
-    from: '/platforms/unity/metrics/',
-    to: '/concepts/key-terms/tracing/span-metrics/',
-  },
-  // END redirecting deprecated generic metrics docs to concepts
   {
     from: '/learn/cli/configuration/',
     to: '/cli/configuration/',


### PR DESCRIPTION
## DESCRIBE YOUR PR
The final two redirects from the previously deprecated metrics, now reborn in Trace-connected Metrics.
They be gone.

Follow-ups to
- #15822
- #16356

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): ASAP
  - Metrics are in Open Beta, and available in the latest `sentry-cocoa` and `unity` SDKs
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
  - [x] Apple SDKs
  - [x] Unity SDK
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
