### PR TITLE
feat(docs): Enable logs page for Deno SDK

### DIFF
--- a/docs/platforms/javascript/common/logs/index.mdx
+++ b/docs/platforms/javascript/common/logs/index.mdx
@@ -6,7 +6,6 @@ sidebar_order: 4
 sidebar_section: features
 new: true
 notSupported:
-  - javascript.deno
   - javascript.cordova
 ---
 


### PR DESCRIPTION
## Summary
- Remove `javascript.deno` from the `notSupported` frontmatter in `docs/platforms/javascript/common/logs/index.mdx`
- This enables the `/platforms/javascript/guides/deno/logs/` docs page now that the Deno SDK exports the logs API

## Test plan
- [ ] Verify `/platforms/javascript/guides/deno/logs/` renders after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)