### PR TITLE
docs(dart): Update stacktrace info for the logging integration

### DIFF
--- a/includes/dart-integrations/logging.mdx
+++ b/includes/dart-integrations/logging.mdx
@@ -108,3 +108,39 @@ void testLogging() {
 - **Breadcrumbs**: All three log calls will appear as breadcrumbs on the error event
 - **Error Event**: The `severe` log creates a full error event with stack trace
 - **Structured Logs**: (if `enableLogs` is `true`) Navigate to **Logs** in your Sentry project to see all three entries as searchable structured logs
+
+## Stack Traces
+
+The Dart `logging` package only includes a stack trace in a `LogRecord` if one is explicitly provided. When no stack trace is available, Sentry falls back to calling `StackTrace.current` internally, which points to Sentry's own internals rather than the actual call site. This means error events may show inaccurate stack traces unless you take one of the following approaches.
+
+### Set `recordStackTraceAtLevel`
+
+Configure the `logging` package to automatically capture a stack trace at the call site for specific log levels:
+
+```dart
+import 'package:logging/logging.dart';
+
+// Automatically captures stack traces for SEVERE and above
+recordStackTraceAtLevel = Level.SEVERE;
+
+final log = Logger('MyLogger');
+
+// The logging framework will now call StackTrace.current at this call site
+log.severe('Something went wrong');
+```
+
+### Pass the Stack Trace Manually
+
+When catching exceptions, pass both the error and the stack trace directly:
+
+```dart
+final log = Logger('MyLogger');
+
+try {
+  // code that may throw
+} catch (error, stackTrace) {
+  log.severe('Something went wrong', error, stackTrace);
+}
+```
+
+This gives Sentry the most accurate stack trace since it's captured at the point where the exception occurred.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
As it causes some confusion add more info to how stacktraces are collected using the logging integration.

Closes https://github.com/getsentry/sentry-dart/issues/3499

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
