### PR TITLE
docs(sdk): Add two principles extracted from overview

### DIFF
--- a/develop-docs/sdk/getting-started/index.mdx
+++ b/develop-docs/sdk/getting-started/index.mdx
@@ -10,4 +10,4 @@ The [values](philosophy/) that shape what we build. Why SDKs exist, what makes a
 
 ## Principles
 
-Ten working [principles](principles/) for how we collaborate, review, and ship. They translate philosophy into daily decisions: who owns what, when to automate vs. judge, and why small PRs beat big ones.
+Working [principles](principles/) for how we collaborate, review, and ship. They translate philosophy into daily decisions: who owns what, when to automate vs. judge, and why small PRs beat big ones.

--- a/develop-docs/sdk/getting-started/principles/index.mdx
+++ b/develop-docs/sdk/getting-started/principles/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Principles
-description: These working principles govern how SDK teams collaborate, review, and ship. They build on the SDK philosophy, which governs what we build and how our SDKs should behave. Where a philosophy principle has direct implications for how we work, it is referenced below.
+description: These working principles govern how SDK teams collaborate, review, and ship. They build on the SDK philosophy, which governs what we build and how our SDKs should behave.
 sidebar_order: 2
 ---
 
@@ -43,3 +43,11 @@ Changes must solve a real problem. No speculative refactors, no "improvements" w
 ## If it's not written, it's not a rule
 
 If you expect engineers (or AI tools) to follow a practice, it must be in a document that's discoverable and machine-readable. Verbal norms and tribal knowledge don't scale, and AI tools can't read them at all. See [Write Down the Rules](/sdk/getting-started/philosophy/#write-down-the-rules) for more information.
+
+## Never capture your own exceptions
+
+SDKs must never capture Sentry events for exceptions happening within the SDK itself, including within user-defined callbacks and hooks such as `before_send` or `traces_sampler`. We are already in an event capturing flow where the scope has been applied - capturing another event at that point would lead to undefined behavior. In the worst case, it creates a busy loop of creating and sending events repeatedly until the system crashes. If the SDK throws, swallow gracefully and emit an error-level log. In mobile SDKs, unhandled crashes will still make it to Sentry via crash handlers. See [SDK Crash Detection](https://github.com/getsentry/sentry/tree/master/src/sentry/utils/sdk_crashes#sdk-crash-detection) for more details.
+
+## Integrate at the lowest level
+
+SDKs should integrate on the lowest level possible to capture as much of the runtime as they can. Hooking the runtime or a framework directly is preferred over requiring users to subclass specific base classes or mix in helpers. For example, the Python SDK monkey-patches core functionality in frameworks to automatically pick up on errors and integrate scope handling.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Extract two working principles from `sdk/overview.mdx` into `getting-started/principles/`:

- **Never capture your own exceptions** — from the "SDK Errors" section. SDKs must not capture internal exceptions to avoid busy loops.
- **Integrate at the lowest level** — from the "Layer of Integration" section. Hook runtimes/frameworks directly rather than requiring user subclassing.

Also drops "Ten" from the getting-started index description since the principle count is no longer fixed.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>