### PR TITLE
docs(dart): Fix user attributes gated behind `sendDefaultPii`

### DIFF
--- a/platform-includes/metrics/default-attributes/apple.mdx
+++ b/platform-includes/metrics/default-attributes/apple.mdx
@@ -10,8 +10,6 @@ By default the SDK will attach the following attributes to a metric:
 
 ### User Attributes
 
-User attributes are only added when `options.sendDefaultPii` is set to `true`:
-
 - `user.id`: The user ID from the current scope. Falls back to the installation ID if no user is set.
 - `user.name`: The username from the current scope.
 - `user.email`: The email address from the current scope.

--- a/platform-includes/metrics/default-attributes/dart.mdx
+++ b/platform-includes/metrics/default-attributes/dart.mdx
@@ -8,5 +8,5 @@ Sentry automatically attaches these attributes to every metric:
 | `sentry.sdk.version` | SDK version | Always |
 | `os.name` | Operating system name | If available |
 | `os.version` | Operating system version | If available |
-| `user.id`, `user.name`, `user.email` | User identifiers | If `sendDefaultPii` enabled |
+| `user.id`, `user.name`, `user.email` | User identifiers | If available |
 | `sentry.replay_id` | Session replay ID | If replay available |


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Related PR: https://github.com/getsentry/sentry-dart/pull/3524

This has been wrongly implemented in mobile. user attributes on logs and metrics should not be gated behind `sendDefaultPii` because they are manual APIs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
