### PR TITLE
feat(tanstackstart-react): Add global sentry exception middlewares

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -231,7 +231,7 @@ Add a `--import` flag directly or to the `NODE_OPTIONS` environment variable whe
 
 ### Capturing Server-Side Errors
 
-To capture server-side errors from HTTP requests and server function invocations, add Sentry's global middlewares to `createStart()` in your `src/start.ts` file:
+To capture server-side errors from HTTP requests and server function calls, add Sentry's global middlewares to `createStart()` in your `src/start.ts` file:
 
 ```tsx {filename:src/start.ts}
 import {


### PR DESCRIPTION
We added global sentry middlewares to capture server-side errors in the Tanstack Start SDK. [PR](https://github.com/getsentry/sentry-javascript/pull/19330)

This will ship with the `10.40.0` release of the javascript SDKs. Updating the docs accordingly.