### PR TITLE
fix: Sidebar scroll position jumping on navigation

### DIFF
--- a/src/components/sidebar/developDocsSidebar.tsx
+++ b/src/components/sidebar/developDocsSidebar.tsx
@@ -2,10 +2,14 @@ import {DocNode, nodeForPath} from 'sentry-docs/docTree';
 
 import styles from './style.module.scss';
 
+import {ScrollActiveLink} from '../focus-active-link';
+
 import {DynamicNav, toTree} from './dynamicNav';
 import {SidebarLink, SidebarSeparator} from './sidebarLink';
 import {NavNode} from './types';
 import {docNodeToNavNode, getNavNodes} from './utils';
+
+const activeLinkSelector = `.${styles.sidebar} .toc-item .active`;
 
 const devDocsMenuItems: {root: string; title: string}[] = [
   {root: 'getting-started', title: 'Getting Started'},
@@ -42,6 +46,7 @@ export function DevelopDocsSidebar({
       <style>{':root { --sidebar-width: 300px; }'}</style>
       <div className="md:flex flex-col items-stretch">
         <div className={styles.toc}>
+          <ScrollActiveLink activeLinkSelector={activeLinkSelector} />
           <ul data-sidebar-tree>
             {devDocsMenuItems.map(({root, title}) => (
               <DynamicNav


### PR DESCRIPTION
Fix sidebar scroll position not being preserved when navigating between pages. Particularly noticeable on smaller screens (e.g. MacBook Pro 14") when navigating within a section like `/development-infrastructure/`.

Three bugs fixed:
- **Missing ScrollActiveLink in develop-docs sidebar** — the product sidebar had scroll persistence but the develop-docs sidebar did not
- **Click handler never fired** — used `target.hasAttribute('data-sidebar-link')` but click targets are always child `<span>`/`<div>` elements inside the link; fixed to use `target.closest()`
- **Fragile scroll restoration** — replaced `getBoundingClientRect` math with direct `scrollContainer.scrollTop` save/restore, and removed a scroll handler that was overwriting click data with stale positions

Co-Authored-By: Claude <noreply@anthropic.com>