### PR TITLE
fix(metrics): Clean up old metrics deprecation references and stale links

### DIFF
--- a/docs/platforms/android/metrics/index.mdx
+++ b/docs/platforms/android/metrics/index.mdx
@@ -10,7 +10,10 @@ beta: true
 With Sentry Metrics, you can send counters, gauges, distributions, and sets from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
 
 <Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/discussions/18055) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+  This feature is currently in open beta. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
+  feedback or questions. Features in beta are still in-progress and may have
+  bugs. We recognize the irony.
 </Alert>
 
 ## Requirements

--- a/docs/platforms/android/migration/index.mdx
+++ b/docs/platforms/android/migration/index.mdx
@@ -11,9 +11,9 @@ description: "Migrating between versions of Sentry's SDK for Android."
 
 - `Contexts` no longer extends `ConcurrentHashMap`, instead we offer a selected set of methods.
 - `sentry-android-okhttp` has been removed in favor of `sentry-okhttp`, making the module independent from Android ([#3510](https://github.com/getsentry/sentry-java/pull/3510))
-- Calling `Sentry.init()` on Android now throws a `IllegalArgumentException`, please use `SentryAndroid.init()` instead  ([#3596](https://github.com/getsentry/sentry-java/pull/3596))
-- Metrics have been removed from the SDK ([#3774](https://github.com/getsentry/sentry-java/pull/3774))
-  - Metrics will return but we don't know in what exact form yet
+- Calling `Sentry.init()` on Android now throws a `IllegalArgumentException`, please use `SentryAndroid.init()` instead ([#3596](https://github.com/getsentry/sentry-java/pull/3596))
+- The previous metrics API has been removed from the SDK ([#3774](https://github.com/getsentry/sentry-java/pull/3774))
+  - A new Metrics feature is now available. See the [Metrics documentation](/platforms/android/metrics/) for setup instructions.
 - `enableTracing` option (a.k.a `enable-tracing`) has been removed from the SDK ([#3776](https://github.com/getsentry/sentry-java/pull/3776))
   - Please set `tracesSampleRate` to a value >= 0.0 for enabling performance instead. The default value is `null` which means performance is disabled.
 - Change OkHttp sub-spans to span attributes ([#3556](https://github.com/getsentry/sentry-java/pull/3556))
@@ -22,7 +22,7 @@ description: "Migrating between versions of Sentry's SDK for Android."
   - If you are subclassing any Sentry classes, please check if the parent class used `synchronized` before. Please make sure to use the same lock object as the parent class in that case.
 - `traceOrigins` option (`io.sentry.traces.tracing-origins` in manifest) has been removed, please use `tracePropagationTargets` (`io.sentry.traces.trace-propagation-targets` in manifest`) instead ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
 - `profilingEnabled` option (`io.sentry.traces.profiling.enable` in manifest) has been removed, please use `profilesSampleRate` (`io.sentry.traces.profiling.sample-rate` in manifest) instead ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
-    - Please set `profileSampleRate` to a value >= 0.0 for enabling profiling instead. The default value is `null` which means profiling is disabled.
+  - Please set `profileSampleRate` to a value >= 0.0 for enabling profiling instead. The default value is `null` which means profiling is disabled.
 - `shutdownTimeout` option has been removed, please use `shutdownTimeoutMillis` instead ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
 - `profilingTracesIntervalMillis` option for Android has been removed ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
 - `io.sentry.session-tracking.enable` manifest option has been removed ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
@@ -60,7 +60,6 @@ try (final @NotNull ISentryLifecycleToken ignored = Sentry.pushScope()) {
 ```
 
 as well as:
-
 
 ```
 try (final @NotNull ISentryLifecycleToken ignored = Sentry.pushIsolationScope()) {
@@ -523,7 +522,6 @@ The file `sentry.properties` used by the previous version of the SDK has been di
 
 Example of the configuration in the Manifest:
 
-
 ```xml
 <application>
     <!-- Example of the Sentry DSN setting -->
@@ -552,7 +550,6 @@ To initialize the SDK manually:
   ```
 
 - Initialize the SDK directly in your application:
-
 
 ```java
 SentryAndroid.init(this, options -> {

--- a/docs/platforms/apple/common/metrics/index.mdx
+++ b/docs/platforms/apple/common/metrics/index.mdx
@@ -10,7 +10,10 @@ beta: true
 With Sentry Metrics, you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, traces, and logs, and searched using their individual attributes.
 
 <Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-cocoa/discussions) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+  This feature is currently in open beta. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
+  feedback or questions. Features in beta are still in-progress and may have
+  bugs. We recognize the irony.
 </Alert>
 
 ## Requirements

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -8,7 +8,10 @@ beta: true
 ---
 
 <Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-dotnet/discussions/4838) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+  This feature is currently in open beta. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
+  feedback or questions. Features in beta are still in-progress and may have
+  bugs. We recognize the irony.
 </Alert>
 
 Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.

--- a/docs/platforms/go/common/metrics/index.mdx
+++ b/docs/platforms/go/common/metrics/index.mdx
@@ -10,7 +10,10 @@ beta: true
 With [Sentry Metrics](/product/explore/metrics/), you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
 
 <Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-go/discussions) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+  This feature is currently in open beta. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
+  feedback or questions. Features in beta are still in-progress and may have
+  bugs. We recognize the irony.
 </Alert>
 
 ## Prerequisites

--- a/docs/platforms/java/common/migration/7.x-to-8.0.mdx
+++ b/docs/platforms/java/common/migration/7.x-to-8.0.mdx
@@ -13,8 +13,8 @@ Please make sure to use the same version for all Sentry dependencies, otherwise 
 - `Contexts` no longer extends `ConcurrentHashMap`, instead we offer a selected set of methods.
 - `sentry-android-okhttp` has been removed in favor of `sentry-okhttp`, making the module independent from android ([#3510](https://github.com/getsentry/sentry-java/pull/3510))
 - Throw IllegalArgumentException when calling Sentry.init on Android ([#3596](https://github.com/getsentry/sentry-java/pull/3596))
-- Metrics have been removed from the SDK ([#3774](https://github.com/getsentry/sentry-java/pull/3774))
-  - Metrics will return but we don't know in what exact form yet
+- The previous metrics API has been removed from the SDK ([#3774](https://github.com/getsentry/sentry-java/pull/3774))
+  - A new Metrics feature is now available. See the [Metrics documentation](/platforms/java/metrics/) for setup instructions.
 - `enableTracing` option (a.k.a `enable-tracing`) has been removed from the SDK ([#3776](https://github.com/getsentry/sentry-java/pull/3776))
   - Please set `tracesSampleRate` to a value >= 0.0 for enabling performance instead. The default value is `null` which means performance is disabled.
 - Change OkHttp sub-spans to span attributes ([#3556](https://github.com/getsentry/sentry-java/pull/3556))
@@ -23,7 +23,7 @@ Please make sure to use the same version for all Sentry dependencies, otherwise 
   - If you are subclassing any Sentry classes, please check if the parent class used `synchronized` before. Please make sure to use the same lock object as the parent class in that case.
 - `traceOrigins` option (`io.sentry.traces.tracing-origins` in manifest) has been removed, please use `tracePropagationTargets` (`io.sentry.traces.trace-propagation-targets` in manifest`) instead ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
 - `profilingEnabled` option (`io.sentry.traces.profiling.enable` in manifest) has been removed, please use `profilesSampleRate` (`io.sentry.traces.profiling.sample-rate` in manifest) instead ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
-    - Please set `profileSampleRate` to a value >= 0.0 for enabling profiling instead. The default value is `null` which means profiling is disabled.
+  - Please set `profileSampleRate` to a value >= 0.0 for enabling profiling instead. The default value is `null` which means profiling is disabled.
 - `shutdownTimeout` option has been removed, please use `shutdownTimeoutMillis` instead ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
 - `profilingTracesIntervalMillis` option for Android has been removed ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
 - `io.sentry.session-tracking.enable` manifest option has been removed ([#3780](https://github.com/getsentry/sentry-java/pull/3780))
@@ -63,7 +63,6 @@ try (final @NotNull ISentryLifecycleToken ignored = Sentry.pushScope()) {
 ```
 
 as well as:
-
 
 ```
 try (final @NotNull ISentryLifecycleToken ignored = Sentry.pushIsolationScope()) {
@@ -107,6 +106,7 @@ If you've been using the previous version of `sentry-opentelemetry-agent`, simpl
 #### New to the agent
 
 If you've not been using the Sentry OpenTelemetry agent before, you can add `sentry-opentelemetry-agent` to your setup by downloading the latest release and using it when starting up your application
+
 - `SENTRY_PROPERTIES_FILE=sentry.properties java -javaagent:sentry-opentelemetry-agent-x.x.x.jar -jar your-application.jar`
 - Please use `sentry.properties` or environment variables to configure the SDK as the agent is now in charge of initializing the SDK and options coming from things like logging integrations or our Spring Boot integration will not take effect.
 - You may find the <PlatformLink to="/opentelemetry/setup/agent/auto-init/">docs page</PlatformLink> useful.

--- a/docs/platforms/javascript/common/metrics/index.mdx
+++ b/docs/platforms/javascript/common/metrics/index.mdx
@@ -14,7 +14,10 @@ notSupported:
 With [Sentry Metrics](/product/explore/metrics/), you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
 
 <Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/discussions/18055) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+  This feature is currently in open beta. Please reach out on
+  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
+  feedback or questions. Features in beta are still in-progress and may have
+  bugs. We recognize the irony.
 </Alert>
 
 ## Prerequisites
@@ -37,6 +40,11 @@ This feature is currently in open beta. Please reach out on [GitHub](https://git
 
 ## Related Features
 
-- <PlatformLink to="/tracing/">Tracing</PlatformLink> — Drill down from metrics into related traces to understand performance patterns.
-- <PlatformSection notSupported={["javascript.deno", "javascript.cordova"]}><PlatformLink to="/logs/">Logs</PlatformLink> — Combine metrics with logs for full observability into your application's behavior.</PlatformSection>
-- <PlatformLink to="/usage/">Error Monitoring</PlatformLink> — Use metrics alongside error tracking to understand the impact of issues.
+- <PlatformLink to="/tracing/">Tracing</PlatformLink> — Drill down from metrics
+  into related traces to understand performance patterns.
+- <PlatformSection notSupported={["javascript.deno", "javascript.cordova"]}>
+    <PlatformLink to="/logs/">Logs</PlatformLink> — Combine metrics with logs
+    for full observability into your application's behavior.
+  </PlatformSection>
+- <PlatformLink to="/usage/">Error Monitoring</PlatformLink> — Use metrics
+  alongside error tracking to understand the impact of issues.

--- a/docs/platforms/javascript/common/migration/v8-to-v9.mdx
+++ b/docs/platforms/javascript/common/migration/v8-to-v9.mdx
@@ -281,9 +281,9 @@ All exports and APIs of `@sentry/utils` and `@sentry/types` (except for the ones
 
 The changes outlined in this section detail deprecated APIs that are now removed.
 
-- **The metrics API has been removed from the SDK.**
+- **The previous metrics API has been removed from the SDK.**
 
-  The Sentry metrics beta has ended and the metrics API has been removed from the SDK. Learn more in the Sentry [help center docs](https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Metrics-Beta-Ended-on-October-7th).
+  The previous Sentry metrics beta has ended and its API has been removed from the SDK. A new Metrics feature is now available in the latest SDK versions. See the [Metrics documentation](/platforms/javascript/metrics/) for setup instructions.
 
 - The `transactionContext` property on the `samplingContext` argument passed to the `tracesSampler` and `profilesSampler` options has been removed.
   All object attributes are available in the top-level of `samplingContext`:

--- a/docs/platforms/php/common/metrics/index.mdx
+++ b/docs/platforms/php/common/metrics/index.mdx
@@ -9,7 +9,7 @@ beta: true
 
 <Alert>
 
-  This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-php) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
 
 </Alert>
 

--- a/docs/platforms/python/metrics/index.mdx
+++ b/docs/platforms/python/metrics/index.mdx
@@ -9,7 +9,7 @@ beta: true
 
 <Alert>
 
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-python/discussions/5042) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
 
 </Alert>
 

--- a/includes/metrics-api-change.mdx
+++ b/includes/metrics-api-change.mdx
@@ -1,3 +1,0 @@
-<Alert level="warning" title="The Metrics beta has ended on October 7th">
-Thank you for participating in our Metrics beta program. After careful consideration, we have ended the beta program and retired the current Metrics solution. We're actively developing a new solution that will make tracking and debugging any issues in your application easier. [Learn more](https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics).
-</Alert>

--- a/platform-includes/metrics/requirements/ruby.mdx
+++ b/platform-includes/metrics/requirements/ruby.mdx
@@ -1,4 +1,4 @@
-Metrics for Python are supported in Sentry Ruby SDK version `6.3.0` and above.
+Metrics for Ruby are supported in Sentry Ruby SDK version `6.3.0` and above.
 
 ```bash
 gem install sentry-ruby


### PR DESCRIPTION
## DESCRIBE YOUR PR

Cleans up artifacts from the previous (sunset) metrics beta that conflict with the current, active metrics beta. Users migrating SDKs were seeing "metrics beta has ended" and "metrics have been removed" language with no mention that a new metrics system exists — causing confusion.

### Changes

**Removed:**
- Deleted orphaned `includes/metrics-api-change.mdx` — an unused sunset notice from the old metrics beta that was never wired up

**Updated migration guides (3 files):**
- `platforms/javascript/common/migration/v8-to-v9.mdx` — Clarified the *previous* metrics API was removed and linked to the new metrics docs
- `platforms/java/common/migration/7.x-to-8.0.mdx` — Replaced stale "Metrics will return but we don't know in what exact form yet" with a link to the new metrics docs
- `platforms/android/migration/index.mdx` — Same as Java

**Fixed GitHub discussion links (7 platform metrics pages):**
All platform SDK metrics pages were pointing to old per-SDK GitHub discussions from the previous beta. Updated them to point to the canonical new beta feedback discussion (`getsentry/sentry#102275`):
- JavaScript (`sentry-javascript#18055` → `sentry#102275`)
- Python (`sentry-python#5042` → `sentry#102275`)
- Android (`sentry-javascript#18055` → `sentry#102275` — was linking to the wrong SDK entirely)
- .NET (`sentry-dotnet#4838` → `sentry#102275`)
- Go (`sentry-go/discussions` → `sentry#102275`)
- Apple (`sentry-cocoa/discussions` → `sentry#102275`)
- PHP (`sentry-php` → `sentry#102275`)

**Fixed copy-paste bug:**
- `platform-includes/metrics/requirements/ruby.mdx` — Said "Metrics for **Python**" instead of "Metrics for **Ruby**"

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>