### PR TITLE
feat(mobile): Add enableTombstone option for Flutter and React Native

### DIFF
--- a/docs/platforms/dart/guides/flutter/configuration/options.mdx
+++ b/docs/platforms/dart/guides/flutter/configuration/options.mdx
@@ -316,6 +316,14 @@ Set this boolean to `false` to disable the scope sync from Java to NDK on Androi
 
 </SdkOption>
 
+<SdkOption name="enableTombstone" type="bool" defaultValue="false">
+
+Set this boolean to `true` to enable [Tombstone-based native crash reporting](/platforms/android/configuration/tombstones/) on Android 12+ (API level 30+). When enabled, uses Android's `ApplicationExitInfo.REASON_CRASH_NATIVE` to capture native crashes with more detailed thread information.
+
+This provides improved stack traces and richer crash context compared to the standard NDK integration alone. The SDK will merge reports from both integrations when applicable.
+
+</SdkOption>
+
 <SdkOption name="attachThreads" type="bool" defaultValue="false">
 
 Set this boolean to `true` to automatically attach all threads to all logged events on Android.

--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -363,6 +363,14 @@ Set this boolean to `false` to disable the scope sync from Java to NDK on Androi
 
 </SdkOption>
 
+<SdkOption name="enableTombstone" type="boolean" defaultValue="false">
+
+Set this boolean to `true` to enable [Tombstone-based native crash reporting](/platforms/android/configuration/tombstones/) on Android 12+ (API level 30+). When enabled, uses Android's `ApplicationExitInfo.REASON_CRASH_NATIVE` to capture native crashes with more detailed thread information.
+
+This provides improved stack traces and richer crash context compared to the standard NDK integration alone. The SDK will merge reports from both integrations when applicable.
+
+</SdkOption>
+
 <SdkOption name="attachThreads" type="boolean" defaultValue="false">
 
 Set this boolean to `true` to automatically attach all threads to all logged events on Android.


### PR DESCRIPTION
Document the new enableTombstone option in the Hybrid SDK Options section for both Flutter and React Native platforms. This option enables Tombstone-based native crash reporting on Android 12+ using ApplicationExitInfo.REASON_CRASH_NATIVE for improved crash context.

Slack thread: https://sentry.slack.com/archives/CP4UUUF1S/p1771404873687599?thread_ts=1769055443.846779&cid=CP4UUUF1S

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01UPWvt4rsCBnMjtAQ717h8o

