### PR TITLE
docs(js): Add note for bundled bun code

### DIFF
--- a/docs/platforms/javascript/guides/bun/index.mdx
+++ b/docs/platforms/javascript/guides/bun/index.mdx
@@ -72,6 +72,12 @@ Start your app using:
 bun --preload ./instrument.js app.js
 ```
 
+<Alert level="warning" title="Bundled Code Limitation">
+
+Sentry's auto-instrumentation does not work with bundled code, including Bun's single-file executables. This is because auto-instrumentation relies on module loading hooks that are not available when code is bundled. If you need to bundle your application, you'll need to <PlatformLink to="/tracing/instrumentation/">manually instrument your code</PlatformLink> instead of relying on auto-instrumentation.
+
+</Alert>
+
 ## Step 3: Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />


### PR DESCRIPTION
Sentry's auto-instrumentation relies on module loading hooks that aren't available when code is bundled. This adds a caveat to the Bun setup docs noting that `--preload` won't work with bundled code (e.g., Bun's single-file executables), and points users to manual instrumentation as an alternative.

closes https://github.com/getsentry/sentry-javascript/issues/19339