### PR TITLE
docs(sdk): Add skills page under ai-tools

### DIFF
--- a/develop-docs/sdk/getting-started/ai-tools/skills/index.mdx
+++ b/develop-docs/sdk/getting-started/ai-tools/skills/index.mdx
@@ -6,7 +6,7 @@ sidebar_order: 1
 
 ## Skills Package Manager (dotagents)
 
-We've launched a package manager for .agents directories that enables you to declare agent skill dependencies in `agents.toml`, lock versions for reproducibility, and allow every tool on your team to reliably discover skills from a unified location.
+A package manager for .agents directories that enables you to declare agent skill dependencies in `agents.toml`, lock versions for reproducibility, and allow every tool on your team to reliably discover skills from a unified location.
 
 https://github.com/getsentry/dotagents
 


### PR DESCRIPTION
Add a new skills page under `develop-docs/sdk/getting-started/ai-tools/skills/` that documents:

- The skills package manager (dotagents)
- Sentry Skills repository
- Sentry SDK Skills repository
- Sentry Reproduction Skill (repro) repository

Co-Authored-By: Claude <noreply@anthropic.com>