### PR TITLE
chore: add alpha notice to setConversationId/set_conversation_id

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -113,6 +113,10 @@ Sentry.init({
 
 ## Tracking Conversations
 
+<Alert level="info">
+  Tracking Conversations has **alpha** stability. Configuration options and behavior may change.
+</Alert>
+
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -130,14 +130,18 @@ with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Travel A
 
 ## Tracking Conversations
 
+<Alert level="info">
+  Tracking Conversations has **alpha** stability. Configuration options and behavior may change.
+</Alert>
+
 For AI applications that involve multi-turn conversations, you can use `sentry_sdk.ai.set_conversation_id()` to associate all AI spans from the same conversation. This enables you to track and analyze complete conversation flows within Sentry.
 
 The conversation ID is set as the `gen_ai.conversation.id` attribute on all AI-related spans in the current scope. To remove the conversation ID, use the `remove_conversation_id()` method on the `Scope`.
 
 ```python
-import sentry_sdk
+import sentry_sdk.ai
 
-sentry_sdk.set_conversation_id("conv_abc123")
+sentry_sdk.ai.set_conversation_id("conv_abc123")
 
 # All subsequent AI calls will be linked to this conversation
 ```


### PR DESCRIPTION
fix: import path for set_conversation_id

Closes https://linear.app/getsentry/issue/TET-1978/add-alpha-notice-for-set-conversation-id

