### PR TITLE
Metrics SDKs documentation

### DIFF
--- a/docs/product/explore/metrics/getting-started/index.mdx
+++ b/docs/product/explore/metrics/getting-started/index.mdx
@@ -228,6 +228,11 @@ To set up Sentry Metrics, use the links below for supported SDKs. After it's bee
     label="Flutter"
     url="/platforms/dart/guides/flutter/metrics/"
   />
+- <LinkWithPlatformIcon
+    platform="react-native"
+    label="React Native"
+    url="/platforms/react-native/metrics/"
+  />
 
 ### Python
 
@@ -422,25 +427,11 @@ To set up Sentry Metrics, use the links below for supported SDKs. After it's bee
 
 ## Upcoming SDKs
 
-We're actively working on adding Metrics functionality to additional SDKs. Check out these GitHub issues for the latest updates:
+We're actively working on adding Metrics functionality to additional SDKs:
 
-- <LinkWithPlatformIcon
-    platform="rust"
-    label="Rust"
-    url="https://github.com/getsentry/sentry-rust/issues/938"
-  />
-
-- <LinkWithPlatformIcon
-    platform="react-native"
-    label="React Native"
-    url="https://github.com/getsentry/sentry-react-native/issues/5384"
-  />
-
-- <LinkWithPlatformIcon
-    platform="apple"
-    label="Apple"
-    url="https://github.com/getsentry/sentry-cocoa/issues/6815"
-  />
+- Rust
+- Elixir
+- Godot
 
 If you don't see your platform listed above, please reach out to us on [GitHub](https://github.com/getsentry/sentry/discussions/102275), [Discord](https://discord.gg/sentry) or contact us at [feedback-metrics@sentry.io](mailto:feedback-metrics@sentry.io), we'll get it prioritized!
 

--- a/docs/product/explore/metrics/index.mdx
+++ b/docs/product/explore/metrics/index.mdx
@@ -8,7 +8,7 @@ og_image: /og-images/product-explore-metrics.png
 ---
 
 <Alert level="info">
-  Metrics is currently in Open Beta for non-Enterprise plans customers that have JavaScript or Python SDK based projects. If you have any questions or feedback comment on this [GitHub discussion](https://github.com/getsentry/sentry/discussions/102275) or contact us at feedback-metrics@sentry.io . Features in beta are still in-progress and may have bugs. We recognize the irony.
+  Metrics is currently in Open Beta for non-Enterprise plans. Metrics are supported across a wide range of SDKs including JavaScript, Python, Ruby, Go, Java, PHP, .NET, Native (C/C++), Dart/Flutter, React Native, Android, Apple platforms, Unreal, and Unity. If you have any questions or feedback comment on this [GitHub discussion](https://github.com/getsentry/sentry/discussions/102275) or contact us at feedback-metrics@sentry.io . Features in beta are still in-progress and may have bugs. We recognize the irony.
 </Alert>
 
 ## Overview


### PR DESCRIPTION
## DESCRIBE YOUR PR
This PR updates the Sentry Metrics documentation to accurately reflect current SDK support.

The changes address two main issues:
1.  The main Metrics page (`docs/product/explore/metrics/index.mdx`) incorrectly stated support was limited to "JavaScript or Python SDK based projects." This has been updated to list all currently supported SDKs.
2.  The Getting Started page (`docs/product/explore/metrics/getting-started/index.mdx`) incorrectly listed React Native and Apple platforms as "Upcoming SDKs." These have been moved to their correct sections, and the "Upcoming SDKs" list has been updated.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/CDXAKMGTU/p1771457685269509?thread_ts=1771457685.269509&cid=CDXAKMGTU)

<p><a href="https://cursor.com/background-agent?bcId=bc-81e8eff8-4cbe-59c7-9dd6-bac4a189e618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81e8eff8-4cbe-59c7-9dd6-bac4a189e618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

