### PR TITLE
fix(unity): correct lifecycle breadcrumbs docs

### DIFF
--- a/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/unity.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/automatic-breadcrumbs/unity.mdx
@@ -1,26 +1,26 @@
 The Unity SDK captures breadcrumbs automatically for:
 
-- **Unity Logs** 
+- **Unity Logs**
   -  Unity logs from the built-in logging system are captured when using the default `UnityApplicationLoggingIntegration`:
   - `Debug.Log` (captured at `Info` level)
   - `Debug.LogWarning` (captured at `Warning` level)
   - `Debug.LogError` and `Debug.LogAssert` (captured at `Error` level)
 
-- **Scene Events** 
+- **Scene Events**
 -   Scene events are captured when using `SceneManagerIntegration`:
   - Scene loaded
   - Scene unloaded
   - Active scene changed
 
-- **Application Lifecycle Events** 
+- **Application Lifecycle Events**
   - These are captured when `AutoSessionTracking` is enabled (default):
-  - Application focus gained/lost
-  - Application paused/resumed
+  - Application entering foreground (triggered by focus gain or unpause)
+  - Application entering background (triggered by focus loss or pause)
 
-- **Low Memory Warnings** 
+- **Low Memory Warnings**
   - Low memory warnings from Unity's system events are captured automatically when using `LowMemoryIntegration`.
 
-- **Native Platform Breadcrumbs** 
+- **Native Platform Breadcrumbs**
   -  Captured when native support is enabled (default for Android, iOS, macOS, and other platforms):
   - **Android**: Activity lifecycle, system events, user interactions, and HTTP requests via the Sentry Android SDK
   - **iOS/macOS**: Application lifecycle, UIControl events, system events (battery, memory, orientation), and HTTP requests via the Sentry Cocoa SDK


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-docs/pull/16330/