### PR TITLE
docs(guides): improve title and next steps links

### DIFF
--- a/docs/guides/custom-spans.mdx
+++ b/docs/guides/custom-spans.mdx
@@ -763,4 +763,4 @@ transaction.finish()
 
 ## Next Steps
 
-Explore the [product walkthrough guides](/product/) to learn more about the Sentry interface and discover additional tips.
+Explore the [Trace Explorer product walkthrough guides](/product/explore/trace-explorer/) to learn more about the Sentry interface and discover additional tips.

--- a/docs/guides/issues-errors.mdx
+++ b/docs/guides/issues-errors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "What to Watch"
+title: "What to Prioritize"
 sidebar_order: 5
 description: "Practical guidance on what errors to catch, how to search issues, and when to set alerts."
 ---
@@ -640,4 +640,4 @@ SentryAndroid.init(context) { options ->
 
 ## Next Steps
 
-Explore the [product walkthrough guides](/product/) to learn more about the Sentry interface and discover additional tips.
+Explore the [Issues product walkthrough guides](/product/issues/) to learn more about the Sentry interface and discover additional tips.

--- a/docs/guides/logs.mdx
+++ b/docs/guides/logs.mdx
@@ -1078,4 +1078,4 @@ If you can't install the Sentry SDK or need platform-level logs (CDN, database, 
 
 ## Next Steps
 
-Explore the [product walkthrough guides](/product/) to learn more about the Sentry interface and discover additional tips.
+Explore the [Logs product walkthrough guides](/product/explore/logs/) to learn more about the Sentry interface and discover additional tips.

--- a/docs/guides/metrics.mdx
+++ b/docs/guides/metrics.mdx
@@ -634,3 +634,5 @@ You'll soon be able to:
 | **Logs**    | Detailed context, debugging           | "What happened right before this error?" |
 
 All three are trace-connected. Start wherever makes sense and navigate to the others.
+
+Explore the [Metrics product walkthrough guides](/product/explore/metrics/) to learn more about the Sentry interface and discover additional tips.

--- a/docs/guides/querying-traces.mdx
+++ b/docs/guides/querying-traces.mdx
@@ -88,4 +88,4 @@ Learn about [creating alerts](/product/new-monitors-and-alerts/alerts/) and best
 
 ## Next Steps
 
-Explore the [product walkthrough guides](/product/) to learn more about the Sentry interface and discover additional tips.
+Explore the [Trace Explorer product walkthrough guides](/product/explore/trace-explorer/) to learn more about the Sentry interface and discover additional tips.

--- a/docs/guides/session-replay.mdx
+++ b/docs/guides/session-replay.mdx
@@ -4,7 +4,7 @@ sidebar_order: 40
 description: "Practical guidance on debugging errors and finding UX issues with Session Replay."
 ---
 
-You've set up [Sentry Session Replay](/product/explore/session-replay/). Now what? Stack traces tell you _what_ broke. Replay shows you _why_. This guide covers how to use replay to debug errors and spot UX problems before users report them.
+You've set up [Sentry Session Replay](/product/explore/session-replay/). Now what? Stack traces tell you _what_ broke. Replay shows you _how_ it broke. This guide covers how to use replay to debug errors and spot UX problems before users report them.
 
 ## What Replay Captures
 
@@ -46,7 +46,7 @@ When an error spikes, the stack trace shows the line of code. Replay shows the u
 - **Edge case data** — Empty arrays, null values, unexpected formats your code didn't handle.
 - **Browser/device context** — Errors on slow connections or older browsers reveal assumptions in your code.
 
-**Search in Sentry:** Go to **Replays** and filter by `count_errors:>0` to see all sessions with errors. Click into a replay to watch it, or check the AI Summary tab to quickly jump to key moments.
+**Search in Sentry:** Go to [**Replays**](https://sentry.io/orgredirect/organizations/:orgslug/explore/replays) and filter by `count_errors:>0` to see all sessions with errors. Click into a replay to watch it, or check the AI Summary tab to quickly jump to key moments.
 
 ### 2. Reproducing User-Reported Bugs
 
@@ -59,7 +59,7 @@ User says it's broken, but you can't reproduce it locally. Replay shows you exac
 - Browser console errors they didn't mention
 - Network failures or slow responses that affected behavior
 
-**Search in Sentry:** Go to **Replays** and filter by `user.email:jane@example.com` or `user.id:123` to find sessions around the time they reported the issue.
+**Search in Sentry:** Go to [**Replays**](https://sentry.io/orgredirect/organizations/:orgslug/explore/replays) and filter by `user.email:jane@example.com` or `user.id:123` to find sessions around the time they reported the issue.
 
 ### 3. Finding Error Patterns Across Users
 
@@ -72,7 +72,7 @@ When multiple users hit the same error, patterns emerge that point to the root c
 - Do they share the same browser, device, or region?
 - Did a specific API endpoint fail for all of them?
 
-**Search in Sentry:** Go to **Replays** and filter by `count_errors:>0 release:1.2.3` to see if errors cluster by release, or use `count_errors:>0 browser.name:Chrome` to compare by browser.
+**Search in Sentry:** Go to [**Replays**](https://sentry.io/orgredirect/organizations/:orgslug/explore/replays) and filter by `count_errors:>0 release:1.2.3` to see if errors cluster by release, or use `count_errors:>0 browser.name:Chrome` to compare by browser.
 
 ### 4. Spotting Rage Clicks and Dead Clicks
 
@@ -89,7 +89,7 @@ Clicks that don't work create silent frustration. Replay catches these before us
 - Element is covered by an invisible overlay (z-index issue)
 - JavaScript error preventing the handler from running
 
-**Search in Sentry:** Go to **Replays** and check the "Most Rage Clicks" and "Most Dead Clicks" widgets at the top* to see the worst offenders. Or filter by `count_rage_clicks:>0` or `count_dead_clicks:>0`. *If you don't see the widgets, toggle "Show Widgets" at the top.
+**Search in Sentry:** Go to [**Replays**](https://sentry.io/orgredirect/organizations/:orgslug/explore/replays) and check the "Most Rage Clicks" and "Most Dead Clicks" widgets at the top* to see the worst offenders. Or filter by `count_rage_clicks:>0` or `count_dead_clicks:>0`. *If you don't see the widgets, toggle "Show Widgets" at the top.
 
 ### 5. Identifying Slow Interactions
 
@@ -102,7 +102,7 @@ Users waiting too long for responses creates perceived sluggishness even if the 
 - Form submissions with no feedback
 - Navigation that feels frozen
 
-**Search in Sentry:** Go to **Replays** and filter by `url:*/checkout*` to focus on critical flows, then watch replays to spot slow interactions.
+**Search in Sentry:** Go to [**Replays**](https://sentry.io/orgredirect/organizations/:orgslug/explore/replays) and filter by `url:*/checkout*` to focus on critical flows, then watch replays to spot slow interactions.
 
 ## Privacy Considerations
 
@@ -130,4 +130,4 @@ Be selective. Never unmask form inputs, and review your [privacy configuration](
 
 ## Next Steps
 
-Explore the [product walkthrough guides](/product/) to learn more about the Sentry interface and discover additional tips.
+Explore the [Session Replay product walkthrough guides](/product/explore/session-replay/) to learn more about the Sentry interface and discover additional tips.


### PR DESCRIPTION
Improves the new practical guides with better titles, wording, and links.

**Changes:**
- Rename "What to Watch" to "What to Prioritize" for the issues/errors guide (clearer focus on triage)
- Fix session-replay intro: "why" → "how" (replay shows sequence of actions, not root cause reasoning)
- Add deep links to Replays page throughout session-replay guide
- Update all "Next Steps" links to point to specific product pages instead of generic `/product/`