### PR TITLE
Kotlin multiplatform user feedback sidebar

### DIFF
--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/user-feedback/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/user-feedback/index.mdx
@@ -2,7 +2,7 @@
 title: Set Up User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
 sidebar_order: 6000
-sidebar_section: configuration
+sidebar_section: features
 ---
 
 When a user experiences an error, Sentry provides the ability to collect additional feedback. You can collect feedback according to the method supported by the SDK.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Corrects the `sidebar_section` for the Kotlin Multiplatform user-feedback page from `configuration` to `features`. This change aligns its navigation categorization with all other platforms (Android, Apple, .NET, Java, Go, Elixir, Native), ensuring the page appears in the correct section of the sidebar.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b9a6d030-3d40-4151-a795-68c888306219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9a6d030-3d40-4151-a795-68c888306219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

