### PR TITLE
feat(dev/logs/metrics): Add `sentry.timestamp.sequence` definition to the logs and metrics specs

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -11,7 +11,7 @@ spec_depends_on:
     version: ">=1.0.0"
 spec_changelog:
   - version: 1.16.0
-    date: 2026-02-06
+    date: 2026-03-04
     summary: Add sentry.timestamp.sequence attribute for deterministic log ordering
   - version: 1.15.0
     date: 2026-02-03

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -11,7 +11,7 @@ spec_depends_on:
     version: ">=1.0.0"
 spec_changelog:
   - version: 2.6.0
-    date: 2026-02-06
+    date: 2026-03-04
     summary: Add sentry.timestamp.sequence attribute for deterministic metric ordering
   - version: 2.5.0
     date: 2026-02-12


### PR DESCRIPTION
This pull request updates the telemetry logs specification to introduce deterministic log ordering via a new attribute, `sentry.timestamp.sequence`. This change addresses issues in environments where multiple logs can share identical timestamps, ensuring logs can always be ordered correctly.

The attribute addresses an issue that came up in Cloudflare’s runtime which [freezes all timers and clock functions](https://developers.cloudflare.com/workers/reference/security-model/#step-1-disallow-timers-and-multi-threading), causing all timestamp calls to return the same value. This can lead to logs being displayed out of order if they don’t get sent in one request. Instead, they’ll appear in the order of arrival in ingest, which is subject to request latencies and out-of-order request completion.

This is a proposal as we have yet to see what product thinks about this.