### PR TITLE
docs(platforms): Clarify permissions for IP address storage setting

### DIFF
--- a/docs/platforms/android/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/android/enriching-events/identify-user/index.mdx
@@ -34,7 +34,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/apple/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/apple/common/enriching-events/identify-user/index.mdx
@@ -34,7 +34,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/dart/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/dart/common/enriching-events/identify-user/index.mdx
@@ -32,7 +32,7 @@ If the user's `ip_address` is set to `"\{\{auto}}"`, Sentry will infer the IP ad
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"\{\{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"\{\{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/dart/guides/flutter/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/dart/guides/flutter/enriching-events/identify-user/index.mdx
@@ -32,7 +32,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/dotnet/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/dotnet/common/enriching-events/identify-user/index.mdx
@@ -34,7 +34,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/elixir/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/elixir/enriching-events/identify-user/index.mdx
@@ -34,7 +34,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/go/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/go/common/enriching-events/identify-user/index.mdx
@@ -30,7 +30,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `null`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/godot/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/godot/enriching-events/identify-user/index.mdx
@@ -28,7 +28,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/java/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/java/common/enriching-events/identify-user/index.mdx
@@ -26,7 +26,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `null`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/kotlin/guides/kotlin-multiplatform/enriching-events/identify-user/index.mdx
@@ -28,7 +28,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/native/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/native/common/enriching-events/identify-user/index.mdx
@@ -33,7 +33,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/php/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/php/common/enriching-events/identify-user/index.mdx
@@ -34,7 +34,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the field is omitted, the default value is `null`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/php/guides/laravel/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/php/guides/laravel/enriching-events/identify-user/index.mdx
@@ -60,7 +60,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the field is omitted, the default value is `null`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/powershell/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/powershell/enriching-events/identify-user/index.mdx
@@ -34,7 +34,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/python/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/python/enriching-events/identify-user/index.mdx
@@ -26,7 +26,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `None`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/react-native/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/react-native/enriching-events/identify-user/index.mdx
@@ -28,7 +28,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/ruby/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/ruby/common/enriching-events/identify-user/index.mdx
@@ -26,7 +26,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `nil`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/rust/common/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/rust/common/enriching-events/identify-user/index.mdx
@@ -26,7 +26,7 @@ The SDK will attempt to pull the IP address from the HTTP request data on incomi
 
 If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP address from the connection between your app and Sentry's server. If the field is omitted, the default value is `null`.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/unity/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/unity/enriching-events/identify-user/index.mdx
@@ -28,7 +28,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 

--- a/docs/platforms/unreal/enriching-events/identify-user/index.mdx
+++ b/docs/platforms/unreal/enriching-events/identify-user/index.mdx
@@ -31,7 +31,7 @@ If the user's `ip_address` is set to `"{{auto}}"`, Sentry will infer the IP addr
 
 If the field is omitted, the default value is `null`. However, due to backwards compatibility concerns, certain platforms (in particular JavaScript) have a different default value for `"{{auto}}"`. SDKs and other clients should not rely on this behavior and should set IP addresses or `"{{auto}}"` explicitly.
 
-To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
+To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's [server-side data](/security-legal-pii/scrubbing/) scrubbing to remove `$user.ip_address`. Adding such a rule ultimately overrules any other logic.
 
 </DefinitionList>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

This PR clarifies who has permission to modify the "Prevent Storing of IP Addresses" setting in project Security & Privacy settings.

**Changes:**
- Added permission requirements to IP address opt-out documentation
- Specifies that users need project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin)
- Changed wording from "you can go to" to explicitly state permission requirements
- Updated "or use" to "Alternatively, use" for better flow

**Files updated:** 20 platform SDK identify-user pages:
- Android, Apple, Dart, Flutter, .NET, Elixir
- Go, Godot, Java, Kotlin, Native  
- PHP, Laravel, PowerShell, Python
- React Native, Ruby, Rust, Unity, Unreal

**Before:**
> To opt out of storing users' IP addresses in your event data, you can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses" or use Sentry's server-side data scrubbing...

**After:**
> To opt out of storing users' IP addresses in your event data, users with project admin permissions (Org Owner, Org Manager, Team Admin, or Org Admin) can go to your project settings, click on "Security & Privacy", and enable "Prevent Storing of IP Addresses". Alternatively, use Sentry's server-side data scrubbing...

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>