### PR TITLE
docs(guides): Add user impact examples for viewing unique users

### DIFF
--- a/docs/guides/issues-errors.mdx
+++ b/docs/guides/issues-errors.mdx
@@ -183,13 +183,21 @@ Learn more about <PlatformLink to="/configuration/environments/">configuring env
 
 Some errors heavily affect power users. Others affect everyone, but rarely. Prioritize by unique user count, not just event count.
 
-**[In Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/):** Search for `is:unresolved` and use the sort dropdown to sort by **Users**
+**[In Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/):** Search for `is:unresolved` and sort by **Users** to see which issues affect the most unique users.
 
 **What to look for:**
 
 - Issues affecting many unique users (e.g., more than 10 users indicates widespread impact)
 - Issues affecting VIP or paying users (check user tags)
 - Issues blocking core workflows (login, checkout, data access)
+
+When you open an issue, the header shows the total number of unique users affected. For more detail, review the `user` tag distribution to see:
+
+- Unique user identifiers (user ID, email, or IP)
+- How many events each user triggered
+- Percentage breakdown across users
+
+This tells you if an issue affects many users equally or if one user is stuck in an error loop.
 
 Learn more about <PlatformLink to="/enriching-events/tags/">custom tags</PlatformLink> to mark user tiers, plans, or roles. Then search `is:unresolved user.tier:enterprise` to prioritize high-value users.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Expands the "Errors with High User Impact" section in the Issues & Errors guide with practical, accessible examples for viewing and analyzing user impact data:

- Sort issues by user count on the Issues page
- View total user count in issue header (high-level info)
- Review user tag distribution for detailed breakdown
- Set up user count alerts for widespread issues

Focuses on features available across all plan tiers. Uses clear language that is resilient to UI changes.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>