### PR TITLE
docs(sdk): migrate opening-a-pr playbook to spec format

### DIFF
--- a/develop-docs/sdk/getting-started/playbooks/opening-a-pr.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/opening-a-pr.mdx
@@ -1,0 +1,95 @@
+---
+title: Opening a Pull Request
+spec_id: sdk/playbooks/opening-a-pr
+spec_version: 1.0.0
+spec_status: candidate
+spec_depends_on:
+  - id: sdk/getting-started/standards/code-submission
+    version: ">=1.0.0"
+  - id: sdk/getting-started/standards/repository-docs
+    version: ">=1.0.0"
+  - id: sdk/getting-started/standards/review-ci
+    version: ">=1.0.0"
+  - id: sdk/getting-started/standards/code-quality
+    version: ">=1.0.0"
+spec_changelog:
+  - version: 1.0.0
+    date: 2026-02-21
+    summary: Initial playbook — standardized pull request creation workflow from branch to review
+---
+
+<SpecRfcAlert />
+
+<SpecMeta />
+
+## Overview
+
+This playbook guides contributors through creating a well-structured pull request for an SDK repository. It covers branch naming, commit formatting, local verification, draft PR workflow, and review assignment. By following these steps, PRs will have proper documentation, pass CI checks, and be ready for efficient review.
+
+Related resources:
+- [Code Submission Standards](/sdk/getting-started/standards/code-submission) — commit format, branch naming, and PR requirements
+- [Sentry Skills](https://github.com/getsentry/skills#available-skills) — automation tools for commits and PRs
+- [Repository Documentation Standards](/sdk/getting-started/standards/repository-docs) — documentation requirements
+
+---
+
+## Steps
+
+#### 1. Branch from the default branch
+
+You **MUST** use the naming convention `<type>/<short-description>` ([Branch naming](/sdk/getting-started/standards/code-submission#branch-naming)).
+
+Examples: `feat/add-user-auth`, `fix/rate-limit-parsing`.
+
+#### 2. Confirm a linked issue exists
+
+If there isn't one, create it first — even for internal work. Non-trivial changes **REQUIRE** an issue before a PR ([PR description quality](/sdk/getting-started/standards/code-submission#pr-description-quality)).
+
+#### 3. Write commits
+
+You **MUST** use [conventional format](/sdk/getting-started/standards/code-submission#commit-message-format). If AI-assisted, you **MUST** add `Co-Authored-By` in the commit footer ([AI attribution](/sdk/getting-started/standards/code-submission#ai-attribution)).
+
+You **SHOULD** use the [`sentry-skills:commit`](https://github.com/getsentry/skills#available-skills) skill to create properly formatted commits.
+
+#### 4. Verify locally
+
+Tests **MUST** pass, linter **MUST** pass, and the SDK **MUST** build cleanly before opening a PR.
+
+#### 5. Open the PR as a draft
+
+You **MUST** open PRs as drafts ([PR draft mode](/sdk/getting-started/standards/code-submission#pr-draft-mode)).
+
+You **SHOULD** use the [`sentry-skills:create-pr`](https://github.com/getsentry/skills#available-skills) skill to create the PR with proper formatting.
+
+#### 6. Write the description
+
+You **MUST** include: what changed, why, linked issue, and context for reviewers. No boilerplate, no test plan sections ([PR description quality](/sdk/getting-started/standards/code-submission#pr-description-quality)).
+
+#### 7. If the change is user-facing
+
+You **MUST** add a changelog entry ([Changelog entry](/sdk/getting-started/standards/code-submission#changelog-entry)) and open or link a docs PR ([Documentation-with-code](/sdk/getting-started/standards/repository-docs#documentation-with-code)).
+
+#### 8. Wait for CI to pass
+
+When green, mark the PR as ready for review.
+
+#### 9. Assign 1–2 reviewers
+
+If the PR touches public API, dependencies, or security-sensitive areas, you **MUST** assign an @sdk-leads reviewer ([Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers)).
+
+## Referenced Standards
+
+- [Branch naming](/sdk/getting-started/standards/code-submission#branch-naming) — branch naming convention format
+- [Commit message format](/sdk/getting-started/standards/code-submission#commit-message-format) — conventional commit structure
+- [AI attribution](/sdk/getting-started/standards/code-submission#ai-attribution) — Co-Authored-By footer requirement
+- [PR draft mode](/sdk/getting-started/standards/code-submission#pr-draft-mode) — draft PR workflow
+- [PR description quality](/sdk/getting-started/standards/code-submission#pr-description-quality) — description content requirements
+- [Changelog entry](/sdk/getting-started/standards/code-submission#changelog-entry) — user-facing change documentation
+- [One logical change per PR](/sdk/getting-started/standards/code-submission#one-logical-change-per-pr) — focused PR scope
+- [Documentation-with-code](/sdk/getting-started/standards/repository-docs#documentation-with-code) — docs PR requirements
+- [Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers) — @sdk-leads review triggers
+- [Test requirements by change type](/sdk/getting-started/standards/code-quality#test-requirements-by-change-type) — test coverage requirements
+
+---
+
+<SpecChangelog />


### PR DESCRIPTION
## DESCRIBE YOUR PR
- Added spec frontmatter with version tracking
- Added SpecRfcAlert, SpecMeta, and SpecChangelog components
- Added Overview section with related resources
- Applied RFC 2119 keywords to requirements
- Enhanced skill references with proper links
- Expanded Referenced Standards section with 10 standards
- Fixed principle reference to link to PR description quality standard
- Verified all referenced standard sections exist

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

 Co-Authored-By: Claude <noreply@anthropic.com>   