### PR TITLE
docs(sdk): migrate reviewing-a-pr playbook to spec format

### DIFF
--- a/develop-docs/sdk/getting-started/playbooks/reviewing-a-pr.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/reviewing-a-pr.mdx
@@ -1,0 +1,84 @@
+---
+title: Reviewing a Pull Request
+spec_id: sdk/playbooks/reviewing-a-pr
+spec_version: 1.0.0
+spec_status: candidate
+spec_depends_on:
+  - id: sdk/getting-started/standards/review-ci
+    version: ">=1.0.0"
+  - id: sdk/getting-started/standards/code-quality
+    version: ">=1.0.0"
+  - id: sdk/getting-started/standards/code-submission
+    version: ">=1.0.0"
+spec_changelog:
+  - version: 1.0.0
+    date: 2026-02-21
+    summary: Initial playbook — standardized code review process with LOGAF feedback conventions
+---
+
+<SpecRfcAlert />
+
+<SpecMeta />
+
+## Overview
+
+This playbook guides reviewers through conducting effective code reviews for SDK pull requests. It covers PR description validation, CI verification, code quality assessment, and feedback conventions using the LOGAF scale. By following these steps, reviews will focus on risk reduction, maintain consistent quality standards, and provide actionable feedback.
+
+Related resources:
+- [Review and CI Standards](/sdk/getting-started/standards/review-ci) — review requirements and feedback conventions
+- [Code Quality Standards](/sdk/getting-started/standards/code-quality) — test requirements and quality criteria
+- [Sentry code review checklist](https://develop.sentry.dev/engineering-practices/code-review/) — detailed review criteria
+- [Sentry Skills](https://github.com/getsentry/skills#available-skills) — code-review skill for automated checks
+
+---
+
+## Steps
+
+#### 1. Check the PR description
+
+Does it explain what and why? Is there a linked issue? If either is missing, request it before reviewing code.
+
+#### 2. Check CI status
+
+If checks are failing, comment on what's broken and wait. You **MUST NOT** review code that doesn't build or pass tests.
+
+#### 3. Review the code
+
+Use the [code review checklist](https://develop.sentry.dev/engineering-practices/code-review/). You **MUST** focus on:
+- Runtime errors and potential crashes
+- Performance concerns (N+1 queries, unbounded operations)
+- Unintended side effects or behavior changes
+- Backwards compatibility
+- Security vulnerabilities
+- Test coverage appropriate for the change type ([Test requirements by change type](/sdk/getting-started/standards/code-quality#test-requirements-by-change-type))
+- Test quality — do assertions verify real behavior? ([Test quality](/sdk/getting-started/standards/code-quality#test-quality))
+
+You **SHOULD** use the [`sentry-skills:code-review`](https://github.com/getsentry/skills#available-skills) skill to systematically check for issues.
+
+#### 4. Check for @sdk-leads review triggers
+
+([Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers)): public API changes, new dependencies, schema changes, security-sensitive code, new frameworks. If any apply and no @sdk-leads reviewer is assigned, flag it.
+
+#### 5. Use LOGAF prefixes on all feedback
+
+You **MUST** use LOGAF prefixes on all feedback ([Review feedback conventions](/sdk/getting-started/standards/review-ci#review-feedback-conventions)):
+- `h:` (high) — must fix before merge. Bugs, security issues, breakage, data loss.
+- `m:` (medium) — should fix. Design concerns, missing tests, unclear code.
+- `l:` (low) — optional nit. Style preferences, minor suggestions.
+
+#### 6. Approve when only `l:` items remain
+
+You **MUST NOT** block for style preferences. The goal is risk reduction, not perfection.
+
+## Referenced Standards
+
+- [Review feedback conventions](/sdk/getting-started/standards/review-ci#review-feedback-conventions) — LOGAF scale and blocking criteria
+- [Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers) — @sdk-leads review triggers
+- [Required CI checks baseline](/sdk/getting-started/standards/review-ci#required-ci-checks-baseline) — minimum CI requirements
+- [Test requirements by change type](/sdk/getting-started/standards/code-quality#test-requirements-by-change-type) — test coverage expectations
+- [Test quality](/sdk/getting-started/standards/code-quality#test-quality) — meaningful assertion requirements
+- [PR description quality](/sdk/getting-started/standards/code-submission#pr-description-quality) — description content requirements
+
+---
+
+<SpecChangelog />


### PR DESCRIPTION
## DESCRIBE YOUR PR
- Added spec frontmatter with version tracking
- Added SpecRfcAlert, SpecMeta, and SpecChangelog components
- Added Overview section with related resources
- Applied RFC 2119 keywords to requirements
- Enhanced skill references with proper links
- Expanded Referenced Standards section with 6 standards
- Changed "senior reviewer" to "@sdk-leads" for consistency
- Verified all referenced standard sections exist

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

 Co-Authored-By: Claude <noreply@anthropic.com>   