### PR TITLE
fix(apple): Use correct camelCase for enablePropagateTraceparent option

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -559,7 +559,7 @@ If <PlatformIdentifier name="tracePropagationTargets" /> is not provided, trace 
 </SdkOption>
 
 
-<SdkOption name="enable-propagate-trace-parent" type="bool" defaultValue="false" availableSince="9.0.0">
+<SdkOption name="enablePropagateTraceparent" type="bool" defaultValue="false" availableSince="9.0.0">
 
 This option is available as of [version 9.0.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9000).
 
@@ -567,7 +567,7 @@ If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org
 This header is attached in addition to the `sentry-trace` and `baggage` headers.
 Set this option to `true` if your backend services are instrumented with a W3C Trace Context compatible library such as OpenTelemetry and you want to continue traces from the client.
 
-Use <PlatformIdentifier name="trace-propagation-targets" /> to control which requests the `traceparent` header is attached to.
+Use <PlatformIdentifier name="tracePropagationTargets" /> to control which requests the `traceparent` header is attached to.
 
 </SdkOption>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fix incorrect option names in the Apple SDK configuration options docs.

The `enablePropagateTraceparent` option was documented as `enable-propagate-trace-parent` (kebab-case) but the actual Swift property in [sentry-cocoa Options.swift](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Swift/Options.swift) is `enablePropagateTraceparent` (camelCase, with "traceparent" as a single word per the W3C spec). The `tracePropagationTargets` PlatformIdentifier reference inside that section had the same kebab-case issue (`trace-propagation-targets`).

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)