### PR TITLE
docs: Introducing a new gen_ai.output_chunk span type

### DIFF
--- a/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
+++ b/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
@@ -162,6 +162,51 @@ Additional attributes on the span:
 - **[2]:** Cached tokens are a subset of input tokens; `gen_ai.usage.input_tokens` includes `gen_ai.usage.input_tokens.cached`.
 - **[3]:** Reasoning tokens are a subset of output tokens; `gen_ai.usage.output_tokens` includes `gen_ai.usage.output_tokens.reasoning`.
 
+## Output Chunk Span
+
+Describes a single output chunk from an AI agent's streaming response. When an agent produces output as a stream of messages (e.g., assistant messages, tool use messages, user messages), each logical message is represented as an output chunk span. For streamed assistant messages that arrive as incremental events (start, delta, stop), all events are accumulated into a single chunk span.
+
+Output chunk spans are always children of an [Invoke Agent Span](#invoke-agent-span).
+
+- Span `op` SHOULD be `"gen_ai.output_chunk"`.
+- Span `name` SHOULD be `"output_chunk {gen_ai.agent.name}"`. (e.g. `"output_chunk Weather Agent"`)
+- Attribute `gen_ai.operation.name` MUST be `"output_chunk"`.
+- Attribute `gen_ai.agent.name` SHOULD be set to the name of the agent that produced the chunk. (e.g. `"Weather Agent"`)
+- If provided, the attribute `gen_ai.request.model` SHOULD be set to the model used.
+- If relevant, the `gen_ai.pipeline.name` attribute SHOULD be set to the name of the AI workflow, pipeline or chain within which the agent operates. (e.g. `"weather-pipeline"`)
+- All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
+
+Additional attributes on the span:
+
+### Response Data
+
+| Attribute                    | Type    | Requirement Level | Description                                                                                    | Example                                                                      |
+| :--------------------------- | :------ | :---------------- | :--------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------- |
+| `gen_ai.output.messages`     | string  | optional          | Stringified array of message objects representing the chunk's content. **[0]**, **[1]**        | `'[{"role": "assistant", "parts": [{"type": "text", "content": "..."}]}]'`   |
+| `gen_ai.response.model`      | string  | optional          | The concrete response model.                                                                   | `"claude-sonnet-4-20250514"`                                            |
+| `gen_ai.response.id`         | string  | optional          | Unique identifier for the message.                                                             | `"msg_abc123"`                                                               |
+| `gen_ai.response.streaming`  | boolean | optional          | Whether this chunk was part of a streamed response.                                            | `true`                                                                       |
+| `gen_ai.response.text`       | string  | optional          | **Deprecated.** Use `gen_ai.output.messages` instead. The accumulated text of the chunk.       | `"The weather in Paris is rainy"`                                            |
+| `gen_ai.response.tool_calls` | string  | optional          | **Deprecated.** Use `gen_ai.output.messages` instead. Tool calls from the chunk. **[0]**       | `'[{"name": "get_weather", "type": "function_call", "arguments": "..."}]'`   |
+
+### Token Usage Data
+
+| Attribute                               | Type | Requirement Level | Description                                                                         | Example |
+| :-------------------------------------- | :--- | :---------------- | :---------------------------------------------------------------------------------- | :------ |
+| `gen_ai.usage.input_tokens`             | int  | optional          | The number of input tokens used for this chunk. **[2]**                  | `60`    |
+| `gen_ai.usage.input_tokens.cached`      | int  | optional          | The number of cached input tokens.                                       | `50`    |
+| `gen_ai.usage.input_tokens.cache_write` | int  | optional          | Tokens written to cache when processing input.                           | `20`    |
+| `gen_ai.usage.output_tokens`            | int  | optional          | The number of output tokens used for this chunk. **[3]**                 | `130`   |
+| `gen_ai.usage.output_tokens.reasoning`  | int  | optional          | The number of tokens used for reasoning.                                 | `30`    |
+| `gen_ai.usage.total_tokens`             | int  | optional          | The sum of `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`. | `190`   |
+
+**Note:** Cost attributes (`gen_ai.cost.*`) SHOULD NOT be set on output chunk spans. Cost is only set on the parent [Invoke Agent Span](#invoke-agent-span) using the final aggregated token counts.
+
+- **[0]:** Span attributes only allow primitive data types (like `int`, `float`, `boolean`, `string`). This means you need to use a stringified version of a list of dictionaries. Do NOT set the object/array `[{"foo": "bar"}]` but rather the string `'[{"foo": "bar"}]'` (must be parsable JSON).
+- **[1]:** Messages use the format `{role, parts}` where `parts` is an array of typed objects: `[{"role": "user", "parts": [{"type": "text", "content": "..."}]}]`. The `role` must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For backwards compatibility, the legacy format `{role, content}` (e.g. `[{"role": "user", "content": "..."}]`) is also accepted.
+- **[2]:** Cached tokens are a subset of input tokens; `gen_ai.usage.input_tokens` includes `gen_ai.usage.input_tokens.cached`.
+- **[3]:** Reasoning tokens are a subset of output tokens; `gen_ai.usage.output_tokens` includes `gen_ai.usage.output_tokens.reasoning`.
+
 ## Execute Tool Span
 
 Describes a tool execution.
@@ -217,6 +262,7 @@ Some attributes are common to all AI Agents spans:
 | `"execute_tool"`     | Execute a tool                                               |
 | `"generate_content"` | Multimodal content generation (e.g. Gemini Generate Content) |
 | `"invoke_agent"`     | Invoke GenAI agent                                           |
+| `"output_chunk"`     | A single output chunk from an agent's streaming response     |
 | `"text_completion"`  | Text completion operation                                    |
 
 **[5]** Well defined values for data attribute `gen_ai.system`:

--- a/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
+++ b/develop-docs/sdk/telemetry/traces/modules/ai-agents.mdx
@@ -185,9 +185,10 @@ Additional attributes on the span:
 | `gen_ai.output.messages`     | string  | optional          | Stringified array of message objects representing the chunk's content. **[0]**, **[1]**        | `'[{"role": "assistant", "parts": [{"type": "text", "content": "..."}]}]'`   |
 | `gen_ai.response.model`      | string  | optional          | The concrete response model.                                                                   | `"claude-sonnet-4-20250514"`                                            |
 | `gen_ai.response.id`         | string  | optional          | Unique identifier for the message.                                                             | `"msg_abc123"`                                                               |
-| `gen_ai.response.streaming`  | boolean | optional          | Whether this chunk was part of a streamed response.                                            | `true`                                                                       |
-| `gen_ai.response.text`       | string  | optional          | **Deprecated.** Use `gen_ai.output.messages` instead. The accumulated text of the chunk.       | `"The weather in Paris is rainy"`                                            |
-| `gen_ai.response.tool_calls` | string  | optional          | **Deprecated.** Use `gen_ai.output.messages` instead. Tool calls from the chunk. **[0]**       | `'[{"name": "get_weather", "type": "function_call", "arguments": "..."}]'`   |
+| `gen_ai.response.streaming`      | boolean | optional          | Whether this chunk was part of a streamed response.                                            | `true`                                                                       |
+| `gen_ai.response.finish_reasons` | string  | optional          | The reason why the model stopped generating. Only present on streamed chunks.                  | `"end_turn"`                                                                 |
+| `gen_ai.response.text`           | string  | optional          | **Deprecated.** Use `gen_ai.output.messages` instead. The accumulated text of the chunk.       | `"The weather in Paris is rainy"`                                            |
+| `gen_ai.response.tool_calls`     | string  | optional          | **Deprecated.** Use `gen_ai.output.messages` instead. Tool calls from the chunk. **[0]**       | `'[{"name": "get_weather", "type": "function_call", "arguments": "..."}]'`   |
 
 ### Token Usage Data
 
@@ -206,6 +207,27 @@ Additional attributes on the span:
 - **[1]:** Messages use the format `{role, parts}` where `parts` is an array of typed objects: `[{"role": "user", "parts": [{"type": "text", "content": "..."}]}]`. The `role` must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For backwards compatibility, the legacy format `{role, content}` (e.g. `[{"role": "user", "content": "..."}]`) is also accepted.
 - **[2]:** Cached tokens are a subset of input tokens; `gen_ai.usage.input_tokens` includes `gen_ai.usage.input_tokens.cached`.
 - **[3]:** Reasoning tokens are a subset of output tokens; `gen_ai.usage.output_tokens` includes `gen_ai.usage.output_tokens.reasoning`.
+
+### Attribute Availability
+
+Not all attributes appear on every output chunk span. Which attributes are present depends on the message type and the integration's streaming configuration:
+
+**Streamed chunks** (from partial/incremental messages, e.g. `SDKPartialAssistantMessage` in the Claude Agent SDK):
+- `gen_ai.response.streaming`: `true`
+- `gen_ai.usage.*`: Per-chunk token usage from stream events
+- `gen_ai.response.text` / `gen_ai.response.tool_calls`: Accumulated content deltas
+- `gen_ai.response.finish_reasons`: Why the model stopped generating
+
+**Complete message chunks** (e.g. `SDKAssistantMessage`, `SDKUserMessage`):
+- `gen_ai.output.messages`: Full message content
+- `gen_ai.response.model`: Model used
+- `gen_ai.response.streaming`: `false` or absent
+- Token usage (`gen_ai.usage.*`) MAY be absent; in this case, token usage is only available on the parent `gen_ai.invoke_agent` span (aggregated from the final result)
+
+**Result messages** (e.g. `SDKResultMessage` in the Claude Agent SDK):
+- These SHOULD NOT create a chunk span. Instead, their data (total token usage, cost, duration) SHOULD be set on the parent `gen_ai.invoke_agent` span.
+
+SDK implementations SHOULD document which streaming modes they support and how attribute availability changes based on configuration.
 
 ## Execute Tool Span
 

--- a/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
@@ -323,6 +323,12 @@ Sentry.startSpan(
   <Include name="tracing/ai-agents-module/output-chunk-span" />
 </Expandable>
 
+<Alert level="info" title="Attribute availability varies by message type">
+
+Not all attributes appear on every chunk span. Streamed chunks include per-chunk token usage and streaming indicators, while complete message chunks may only have message content and model info. When per-chunk token usage is absent, total token usage is still available on the parent `gen_ai.invoke_agent` span.
+
+</Alert>
+
 ### Execute Tool Span
 
 <SplitLayout>

--- a/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring-browser/index.mdx
@@ -251,6 +251,78 @@ Sentry.startSpan(
   <Include name="tracing/ai-agents-module/ai-client-span" />
 </Expandable>
 
+### Output Chunk Span
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+This span represents a single output chunk from an AI agent's streaming response. When an agent produces output as a stream of messages, each logical message becomes one output chunk span. For streamed messages that arrive incrementally, all events are accumulated into a single chunk span.
+
+Output chunk spans are always children of an Invoke Agent span.
+
+**Key attributes:**
+- `gen_ai.agent.name` — The agent's name
+- `gen_ai.response.model` — The model that produced the chunk
+- `gen_ai.response.streaming` — Whether the chunk was streamed
+- `gen_ai.usage.input_tokens` / `output_tokens` — Token counts for this chunk
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```javascript
+Sentry.startSpan(
+  {
+    op: "gen_ai.invoke_agent",
+    name: "invoke_agent Weather Agent",
+    attributes: {
+      "gen_ai.request.model": "claude-sonnet-4-20250514",
+      "gen_ai.agent.name": "Weather Agent",
+    },
+  },
+  async (parentSpan) => {
+    const stream = myAgent.stream();
+
+    for await (const message of stream) {
+      Sentry.startSpan(
+        {
+          op: "gen_ai.output_chunk",
+          name: "output_chunk Weather Agent",
+          attributes: {
+            "gen_ai.operation.name": "output_chunk",
+            "gen_ai.agent.name": "Weather Agent",
+            "gen_ai.response.model": message.model,
+            "gen_ai.response.streaming": true,
+          },
+        },
+        (chunkSpan) => {
+          chunkSpan.setAttribute(
+            "gen_ai.output.messages",
+            JSON.stringify([{ role: message.role, parts: [{ type: "text", content: message.content }] }])
+          );
+          if (message.usage) {
+            chunkSpan.setAttribute("gen_ai.usage.input_tokens", message.usage.inputTokens);
+            chunkSpan.setAttribute("gen_ai.usage.output_tokens", message.usage.outputTokens);
+          }
+        }
+      );
+    }
+
+    // Set aggregated token usage on the parent span (not on chunks)
+    parentSpan.setAttribute("gen_ai.usage.input_tokens", totalInputTokens);
+    parentSpan.setAttribute("gen_ai.usage.output_tokens", totalOutputTokens);
+  }
+);
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+<Expandable title="All Output Chunk span attributes">
+  <Include name="tracing/ai-agents-module/output-chunk-span" />
+</Expandable>
+
 ### Execute Tool Span
 
 <SplitLayout>

--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -269,6 +269,78 @@ await Sentry.startSpan(
   <Include name="tracing/ai-agents-module/invoke-agent-span" />
 </Expandable>
 
+### Output Chunk Span
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+This span represents a single output chunk from an AI agent's streaming response. When an agent produces output as a stream of messages, each logical message becomes one output chunk span. For streamed messages that arrive incrementally, all events are accumulated into a single chunk span.
+
+Output chunk spans are always children of an Invoke Agent span.
+
+**Key attributes:**
+- `gen_ai.agent.name` — The agent's name
+- `gen_ai.response.model` — The model that produced the chunk
+- `gen_ai.response.streaming` — Whether the chunk was streamed
+- `gen_ai.usage.input_tokens` / `output_tokens` — Token counts for this chunk
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```javascript
+await Sentry.startSpan(
+  {
+    op: "gen_ai.invoke_agent",
+    name: "invoke_agent Weather Agent",
+    attributes: {
+      "gen_ai.request.model": "claude-sonnet-4-20250514",
+      "gen_ai.agent.name": "Weather Agent",
+    },
+  },
+  async (parentSpan) => {
+    const stream = myAgent.stream();
+
+    for await (const message of stream) {
+      await Sentry.startSpan(
+        {
+          op: "gen_ai.output_chunk",
+          name: "output_chunk Weather Agent",
+          attributes: {
+            "gen_ai.operation.name": "output_chunk",
+            "gen_ai.agent.name": "Weather Agent",
+            "gen_ai.response.model": message.model,
+            "gen_ai.response.streaming": true,
+          },
+        },
+        (chunkSpan) => {
+          chunkSpan.setAttribute(
+            "gen_ai.output.messages",
+            JSON.stringify([{ role: message.role, parts: [{ type: "text", content: message.content }] }])
+          );
+          if (message.usage) {
+            chunkSpan.setAttribute("gen_ai.usage.input_tokens", message.usage.inputTokens);
+            chunkSpan.setAttribute("gen_ai.usage.output_tokens", message.usage.outputTokens);
+          }
+        }
+      );
+    }
+
+    // Set aggregated token usage on the parent span (not on chunks)
+    parentSpan.setAttribute("gen_ai.usage.input_tokens", totalInputTokens);
+    parentSpan.setAttribute("gen_ai.usage.output_tokens", totalOutputTokens);
+  }
+);
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+<Expandable title="Output Chunk span attributes">
+  <Include name="tracing/ai-agents-module/output-chunk-span" />
+</Expandable>
+
 ### Execute Tool Span
 
 <SplitLayout>

--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -341,6 +341,12 @@ await Sentry.startSpan(
   <Include name="tracing/ai-agents-module/output-chunk-span" />
 </Expandable>
 
+<Alert level="info" title="Attribute availability varies by message type">
+
+Not all attributes appear on every chunk span. Streamed chunks include per-chunk token usage and streaming indicators, while complete message chunks may only have message content and model info. When per-chunk token usage is absent, total token usage is still available on the parent `gen_ai.invoke_agent` span.
+
+</Alert>
+
 ### Execute Tool Span
 
 <SplitLayout>

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -122,6 +122,12 @@ with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather 
     parent_span.set_data("gen_ai.usage.output_tokens", total_output_tokens)
 ```
 
+<Alert level="info" title="Attribute availability varies by message type">
+
+Not all attributes appear on every chunk span. Streamed chunks include per-chunk token usage and streaming indicators, while complete message chunks may only have message content and model info. When per-chunk token usage is absent, total token usage is still available on the parent `gen_ai.invoke_agent` span.
+
+</Alert>
+
 ### Execute Tool Span
 
 This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -84,6 +84,44 @@ with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather 
     span.set_data("gen_ai.usage.output_tokens", result.usage.output_tokens)
 ```
 
+### Output Chunk Span
+
+This span represents a single output chunk from an AI agent's streaming response. Each logical message produced by the agent (assistant message, tool use message, etc.) becomes one output chunk span. For streamed messages that arrive incrementally, all events are accumulated into a single chunk span.
+
+Output chunk spans are always children of an [Invoke Agent Span](#invoke-agent-span).
+
+<Expandable title="Output Chunk span attributes">
+  <Include name="tracing/ai-agents-module/output-chunk-span" />
+</Expandable>
+
+#### Example Output Chunk Span
+
+```python
+import json
+import sentry_sdk
+
+with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as parent_span:
+    parent_span.set_data("gen_ai.request.model", "claude-sonnet-4-20250514")
+    parent_span.set_data("gen_ai.agent.name", "Weather Agent")
+
+    for message in my_agent.stream():
+        with sentry_sdk.start_span(op="gen_ai.output_chunk", name="output_chunk Weather Agent") as chunk_span:
+            chunk_span.set_data("gen_ai.operation.name", "output_chunk")
+            chunk_span.set_data("gen_ai.agent.name", "Weather Agent")
+            chunk_span.set_data("gen_ai.response.model", message.model)
+            chunk_span.set_data("gen_ai.response.streaming", True)
+            chunk_span.set_data("gen_ai.output.messages", json.dumps(
+                [{"role": message.role, "parts": [{"type": "text", "content": message.content}]}]
+            ))
+            if hasattr(message, "usage"):
+                chunk_span.set_data("gen_ai.usage.input_tokens", message.usage.input_tokens)
+                chunk_span.set_data("gen_ai.usage.output_tokens", message.usage.output_tokens)
+
+    # Set aggregated token usage on the parent span
+    parent_span.set_data("gen_ai.usage.input_tokens", total_input_tokens)
+    parent_span.set_data("gen_ai.usage.output_tokens", total_output_tokens)
+```
+
 ### Execute Tool Span
 
 This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.

--- a/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -71,6 +71,47 @@ Sentry.with_child_span(op: 'gen_ai.invoke_agent', description: 'invoke_agent Wea
 end
 ```
 
+### Output Chunk Span
+
+This span represents a single output chunk from an AI agent's streaming response. Each logical message produced by the agent (assistant message, tool use message, etc.) becomes one output chunk span. For streamed messages that arrive incrementally, all events are accumulated into a single chunk span.
+
+Output chunk spans are always children of an [Invoke Agent Span](#invoke-agent-span).
+
+<Expandable title="Output Chunk span attributes">
+  <Include name="tracing/ai-agents-module/output-chunk-span" />
+</Expandable>
+
+#### Example Output Chunk Span
+
+```ruby
+require 'json'
+
+Sentry.with_child_span(op: 'gen_ai.invoke_agent', description: 'invoke_agent Weather Agent') do |parent_span|
+  parent_span.set_data('gen_ai.request.model', 'claude-sonnet-4-20250514')
+  parent_span.set_data('gen_ai.agent.name', 'Weather Agent')
+
+  my_agent.stream.each do |message|
+    Sentry.with_child_span(op: 'gen_ai.output_chunk', description: 'output_chunk Weather Agent') do |chunk_span|
+      chunk_span.set_data('gen_ai.operation.name', 'output_chunk')
+      chunk_span.set_data('gen_ai.agent.name', 'Weather Agent')
+      chunk_span.set_data('gen_ai.response.model', message.model)
+      chunk_span.set_data('gen_ai.response.streaming', true)
+      chunk_span.set_data('gen_ai.output.messages', [
+        { role: message.role, parts: [{ type: 'text', content: message.content }] }
+      ].to_json)
+      if message.respond_to?(:usage)
+        chunk_span.set_data('gen_ai.usage.input_tokens', message.usage.input_tokens)
+        chunk_span.set_data('gen_ai.usage.output_tokens', message.usage.output_tokens)
+      end
+    end
+  end
+
+  # Set aggregated token usage on the parent span
+  parent_span.set_data('gen_ai.usage.input_tokens', total_input_tokens)
+  parent_span.set_data('gen_ai.usage.output_tokens', total_output_tokens)
+end
+```
+
 ### Execute Tool Span
 
 This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.

--- a/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -112,6 +112,12 @@ Sentry.with_child_span(op: 'gen_ai.invoke_agent', description: 'invoke_agent Wea
 end
 ```
 
+<Alert level="info" title="Attribute availability varies by message type">
+
+Not all attributes appear on every chunk span. Streamed chunks include per-chunk token usage and streaming indicators, while complete message chunks may only have message content and model info. When per-chunk token usage is absent, total token usage is still available on the parent `gen_ai.invoke_agent` span.
+
+</Alert>
+
 ### Execute Tool Span
 
 This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.

--- a/includes/tracing/ai-agents-module/output-chunk-span.mdx
+++ b/includes/tracing/ai-agents-module/output-chunk-span.mdx
@@ -16,6 +16,7 @@ Additional attributes on the span:
 | `gen_ai.response.model`               | string  | optional          | The concrete response model.                                                         | `"claude-sonnet-4-20250514"`                                                                  |
 | `gen_ai.response.id`                  | string  | optional          | Unique identifier for the message.                                                   | `"msg_abc123"`                                                                                     |
 | `gen_ai.response.streaming`           | boolean | optional          | Whether this chunk was part of a streamed response.                                  | `true`                                                                                             |
+| `gen_ai.response.finish_reasons`      | string  | optional          | The reason why the model stopped generating.                                         | `"end_turn"`                                                                                       |
 | `gen_ai.usage.input_tokens`           | int     | optional          | The number of input tokens used for this chunk.                                      | `60`                                                                                               |
 | `gen_ai.usage.output_tokens`          | int     | optional          | The number of output tokens used for this chunk.                                     | `130`                                                                                              |
 | `gen_ai.usage.total_tokens`           | int     | optional          | The sum of input and output tokens.                                                  | `190`                                                                                              |
@@ -24,3 +25,14 @@ Additional attributes on the span:
 - **[1]:** Each message item uses the format `{role:"", parts:[...]}`. The `role` can be `"user"`, `"assistant"`, `"tool"`, or `"system"`.
 
 **Note:** Cost attributes (`gen_ai.cost.*`) should NOT be set on output chunk spans. Cost is only tracked on the parent Invoke Agent span.
+
+<Alert level="info" title="Not all attributes appear on every chunk span">
+
+The attributes present on an output chunk span depend on the message type and the integration's streaming configuration:
+
+- **Streamed chunks** (e.g., from partial/incremental messages) include `gen_ai.response.streaming: true`, per-chunk token usage (`gen_ai.usage.*`), accumulated content deltas, and `gen_ai.response.finish_reasons`.
+- **Complete message chunks** (e.g., full assistant or user messages) include `gen_ai.output.messages` with the full message content and `gen_ai.response.model`, but may not have per-chunk token usage or streaming attributes. In this case, token usage is only available on the parent `gen_ai.invoke_agent` span.
+
+Check your integration's documentation for details on how to enable streaming events for richer per-chunk data.
+
+</Alert>

--- a/includes/tracing/ai-agents-module/output-chunk-span.mdx
+++ b/includes/tracing/ai-agents-module/output-chunk-span.mdx
@@ -1,0 +1,26 @@
+Describes a single output chunk from an AI agent's streaming response. Each logical message produced by the agent (assistant message, tool use message, etc.) becomes one output chunk span. For streamed assistant messages that arrive as incremental events (start, delta, stop), all events are accumulated into a single chunk span.
+
+Output chunk spans are always children of an [Invoke Agent Span](#invoke-agent-span).
+
+- The span `op` MUST be `"gen_ai.output_chunk"`.
+- The span `name` SHOULD be `"output_chunk {gen_ai.agent.name}"`. (e.g. `"output_chunk Weather Agent"`)
+- The `gen_ai.operation.name` attribute MUST be `"output_chunk"`.
+- The `gen_ai.agent.name` attribute SHOULD be set to the agent's name. (e.g. `"Weather Agent"`)
+- All [Common Span Attributes](#common-span-attributes) SHOULD be set (all `required` common attributes MUST be set).
+
+Additional attributes on the span:
+
+| Data Attribute                         | Type    | Requirement Level | Description                                                                          | Example                                                                                            |
+| :------------------------------------- | :------ | :---------------- | :----------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- |
+| `gen_ai.output.messages`               | string  | optional          | Stringified array of message objects representing the chunk's content. **[0]**, **[1]** | `"[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"...\"}]}]"` |
+| `gen_ai.response.model`               | string  | optional          | The concrete response model.                                                         | `"claude-sonnet-4-20250514"`                                                                  |
+| `gen_ai.response.id`                  | string  | optional          | Unique identifier for the message.                                                   | `"msg_abc123"`                                                                                     |
+| `gen_ai.response.streaming`           | boolean | optional          | Whether this chunk was part of a streamed response.                                  | `true`                                                                                             |
+| `gen_ai.usage.input_tokens`           | int     | optional          | The number of input tokens used for this chunk.                                      | `60`                                                                                               |
+| `gen_ai.usage.output_tokens`          | int     | optional          | The number of output tokens used for this chunk.                                     | `130`                                                                                              |
+| `gen_ai.usage.total_tokens`           | int     | optional          | The sum of input and output tokens.                                                  | `190`                                                                                              |
+
+- **[0]:** Span attributes only allow primitive data types. This means you need to use a stringified version of a list of dictionaries. Do NOT set `[{"foo": "bar"}]` but rather the string `"[{\"foo\": \"bar\"}]"`.
+- **[1]:** Each message item uses the format `{role:"", parts:[...]}`. The `role` can be `"user"`, `"assistant"`, `"tool"`, or `"system"`.
+
+**Note:** Cost attributes (`gen_ai.cost.*`) should NOT be set on output chunk spans. Cost is only tracked on the parent Invoke Agent span.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Introduces documentation for the new gen_ai.output_chunk span type, which represents individual output chunks from an AI agent's streaming response. This span type is needed ahead of the upcoming @anthropic-ai/claude-agent-sdk instrumentation, where an agent's query() call produces a stream of messages that each get their own child span under a parent gen_ai.invoke_agent span.

<img width="1134" height="535" alt="Screenshot 2026-02-23 at 9 56 37 AM" src="https://github.com/user-attachments/assets/83047fc1-d2a3-43fb-97cb-bdbca7180bf5" />



## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
