### PR TITLE
docs(sdk): add descriptions to telemetry pages for PageGrid

### DIFF
--- a/develop-docs/sdk/telemetry/check-ins.mdx
+++ b/develop-docs/sdk/telemetry/check-ins.mdx
@@ -1,5 +1,6 @@
 ---
 title: Check-Ins
+description: Cron monitoring protocol for reporting job start, success, and failure via check-in envelopes.
 spec_id: sdk/telemetry/check-ins
 spec_version: 1.6.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: Client Reports
+description: SDK self-reporting protocol for tracking discarded events and their discard reasons.
 spec_id: sdk/telemetry/client-reports
 spec_version: 1.19.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/feedbacks.mdx
+++ b/develop-docs/sdk/telemetry/feedbacks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Feedback
+description: Collecting qualitative user input with optional attachments, replay links, and error associations.
 spec_id: sdk/telemetry/feedbacks
 spec_version: 1.3.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logs
+description: Structured logging protocol with severity levels, trace context, and batched envelope delivery.
 spec_id: sdk/telemetry/logs
 spec_version: 1.15.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+description: Counter, gauge, and distribution metrics sent as batched trace_metric envelope items.
 spec_id: sdk/telemetry/metrics
 spec_version: 2.5.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/profiles/index.mdx
+++ b/develop-docs/sdk/telemetry/profiles/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Profiles
+description: Stack trace sampling at regular intervals for flamecharts and performance bottleneck analysis.
 spec_id: sdk/telemetry/profiles
 spec_version: 2.5.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/replays.mdx
+++ b/develop-docs/sdk/telemetry/replays.mdx
@@ -1,5 +1,6 @@
 ---
 title: Replay
+description: Session recording protocol for capturing and streaming browser or mobile user sessions to Sentry.
 spec_id: sdk/telemetry/replays
 spec_version: 1.2.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/sessions/index.mdx
+++ b/develop-docs/sdk/telemetry/sessions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sessions
+description: Release health tracking via session lifecycle updates and crash-free rate computation.
 spec_id: sdk/telemetry/sessions
 spec_version: 1.7.0
 spec_status: stable

--- a/develop-docs/sdk/telemetry/spans/index.mdx
+++ b/develop-docs/sdk/telemetry/spans/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Spans
+description: Span creation, sampling, filtering, and data scrubbing within traces.
 sidebar_order: 10
 ---
 

--- a/develop-docs/sdk/telemetry/traces/index.mdx
+++ b/develop-docs/sdk/telemetry/traces/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Traces
+description: Distributed tracing with span trees, sampling, and cross-service trace propagation.
 ---
 
 This document covers how SDKs should add support for Performance Monitoring with [Distributed

--- a/develop-docs/sdk/telemetry/user-reports.mdx
+++ b/develop-docs/sdk/telemetry/user-reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: "User Report (Deprecated)"
+description: Deprecated user feedback mechanism — use the Feedback spec instead.
 spec_id: sdk/telemetry/user-reports
 spec_version: 1.2.1
 spec_status: deprecated


### PR DESCRIPTION
Add frontmatter `description` fields to all child pages under `/sdk/telemetry/` so the PageGrid component shows a brief summary alongside each page title instead of just the title alone.

Co-Authored-By: Claude <noreply@anthropic.com>