### PR TITLE
docs(apple): update link to Watchdog Termination Logic implementation

### DIFF
--- a/docs/platforms/apple/common/configuration/watchdog-terminations.mdx
+++ b/docs/platforms/apple/common/configuration/watchdog-terminations.mdx
@@ -36,7 +36,7 @@ When a user launches the app, the SDK checks the following statements and report
 - The user didn't update the OS of their device.
 - The user didn't terminate the app manually, and neither did the OS.
 
-If you're interested in the implementation details, you can check out [the code](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Sentry/SentryWatchdogTerminationLogic.m) to find out more.
+If you're interested in the implementation details, you can check out [the code](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Swift/Integrations/WatchdogTerminations/SentryWatchdogTerminationLogic.swift) to find out more.
 
 If you'd like to opt out of this feature, you can do so using the <PlatformLink to="/configuration/options/#enableWatchdogTerminationTracking">`enableWatchdogTerminationTracking`</PlatformLink> option:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes a link to iOS's WatchdogTerminationLogic after Swift conversion.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
