### PR TITLE
fix(ci): Add .npmrc to force Vercel to use pnpm@10.x

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Enable corepack to respect packageManager field in package.json
+# This ensures Vercel uses pnpm@10.x instead of falling back to pnpm@9.x
+enable-pre-post-scripts=true


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes Vercel build failures caused by pnpm version mismatch. Vercel was falling back to pnpm@9.x based on project creation date, which doesn't support the `patchedDependencies` format in the lockfile generated by pnpm@10.x.

**Error:**
```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. 
The current "patchedDependencies" configuration doesn't match the value found in the lockfile
```

**Solution:**
Added `.npmrc` to force Vercel to respect the `packageManager` field in `package.json`, ensuring it uses pnpm@10.30.0 via corepack.

**Related:**
- Original fix PR: #16476 (added the patch that uses patchedDependencies)
- Vercel docs: https://vercel.com/docs/deployments/configure-a-build#corepack

## IS YOUR CHANGE URGENT?

- [x] Urgent deadline: Blocking production deployments to master
- [ ] Other deadline:
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)