### PR TITLE
fix (API): Removed block on deprecated API endpoints so docs are created

### DIFF
--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -97,8 +97,14 @@ function slugify(s: string): string {
     .toLowerCase();
 }
 
+const DEPRECATED_PREFIX_REGEX = /^\(DEPRECATED\)\s*/;
+
+function isDeprecatedOperationId(operationId: string | undefined): boolean {
+  return operationId ? DEPRECATED_PREFIX_REGEX.test(operationId) : false;
+}
+
 function stripDeprecatedPrefix(operationId: string): string {
-  return operationId.replace(/^\(DEPRECATED\)\s*/, '');
+  return operationId.replace(DEPRECATED_PREFIX_REGEX, '');
 }
 
 let apiCategoriesCache: Promise<APICategory[]> | undefined;
@@ -126,7 +132,7 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
 
   Object.entries(data.paths).forEach(([apiPath, methods]) => {
     Object.entries(methods).forEach(([method, apiData]) => {
-      const isDeprecated = apiData.operationId?.includes('(DEPRECATED)') ?? false;
+      const isDeprecated = isDeprecatedOperationId(apiData.operationId);
       const cleanOperationId = stripDeprecatedPrefix(apiData.operationId ?? '');
 
       let server = 'https://sentry.io';


### PR DESCRIPTION
## DESCRIBE YOUR PR
A filter on deprecated API endpoints removed them from the docs entirely. Restoring them. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)