### PR TITLE
feat(llms.txt): add /llms.txt route

### DIFF
--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,120 @@
+import {type DocNode, getDocsRootNode} from 'sentry-docs/docTree';
+import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
+import {isVersioned} from 'sentry-docs/versioning';
+
+export const dynamic = 'force-static';
+
+// Slugs excluded from the doc tree walk. The product changelog
+// (sentry.io/changelog/) is appended manually for both site variants.
+const EXCLUDED_SLUGS = new Set([
+  'changelog', // docs variant: dashboard API returns empty data
+  'contributing', // not relevant for SDK/product usage
+]);
+
+const BASE_URL = isDeveloperDocs
+  ? 'https://develop.sentry.dev'
+  : 'https://docs.sentry.io';
+
+const SITE_TITLE = isDeveloperDocs
+  ? 'Sentry Developer Documentation'
+  : 'Sentry Documentation';
+
+const SITE_DESCRIPTION = isDeveloperDocs
+  ? 'Internal documentation for developing the Sentry application, SDKs, and related services.'
+  : 'Sentry is a developer-first application monitoring platform that helps developers identify and fix issues in real-time. It provides error tracking, performance monitoring, session replay, profiling, and more across all major platforms and frameworks.';
+
+// Mirrors filterVisibleSiblings from src/docTree.ts (not exported).
+function isVisible(node: DocNode): boolean {
+  return (
+    !node.missing &&
+    !node.frontmatter.sidebar_hidden &&
+    !node.frontmatter.draft &&
+    !!node.path &&
+    !isVersioned(node.path) &&
+    !!(node.frontmatter.sidebar_title || node.frontmatter.title)
+  );
+}
+
+// Mirrors sortBySidebarOrder from src/docTree.ts (not exported).
+function sortBySidebarOrder(a: DocNode, b: DocNode): number {
+  const orderDiff =
+    (a.frontmatter.sidebar_order ?? 10) - (b.frontmatter.sidebar_order ?? 10);
+  if (orderDiff !== 0) {
+    return orderDiff;
+  }
+  const titleA = a.frontmatter.sidebar_title || a.frontmatter.title || '';
+  const titleB = b.frontmatter.sidebar_title || b.frontmatter.title || '';
+  return titleA.localeCompare(titleB);
+}
+
+function getTitle(node: DocNode): string {
+  return node.frontmatter.sidebar_title || node.frontmatter.title || node.slug;
+}
+
+function formatEntry(node: DocNode, indent = ''): string {
+  const title = getTitle(node);
+  const url = `${BASE_URL}/${node.path}.md`;
+  const desc = node.frontmatter.description;
+  return desc ? `${indent}- [${title}](${url}): ${desc}` : `${indent}- [${title}](${url})`;
+}
+
+function getGuidesForPlatform(platformNode: DocNode): DocNode[] {
+  const guidesNode = platformNode.children.find(c => c.slug === 'guides');
+  if (!guidesNode) {
+    return [];
+  }
+  return guidesNode.children.filter(isVisible).sort(sortBySidebarOrder);
+}
+
+function generateLlmsTxt(rootNode: DocNode): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${SITE_TITLE}`);
+  lines.push('');
+  lines.push(`> ${SITE_DESCRIPTION}`);
+  lines.push('');
+
+  const topLevelSections = rootNode.children
+    .filter(node => isVisible(node) && !EXCLUDED_SLUGS.has(node.slug))
+    .sort(sortBySidebarOrder);
+
+  for (const section of topLevelSections) {
+    lines.push(`## ${getTitle(section)}`);
+    lines.push('');
+
+    // Depth: top-level sections (H2) -> their immediate children (2 levels).
+    // Platforms go one deeper to include framework guides (3 levels).
+    // Going deeper than 2 levels (3 for platform guides) roughly quadruples the file size to ~100KB.
+    const children = section.children.filter(isVisible).sort(sortBySidebarOrder);
+    if (children.length > 0) {
+      for (const child of children) {
+        lines.push(formatEntry(child));
+        if (section.slug === 'platforms') {
+          for (const guide of getGuidesForPlatform(child)) {
+            lines.push(formatEntry(guide, '  '));
+          }
+        }
+      }
+    } else {
+      lines.push(formatEntry(section));
+    }
+
+    lines.push('');
+  }
+
+  lines.push('## Changelog');
+  lines.push('');
+  lines.push('- [Sentry Changelog](https://sentry.io/changelog/): Product updates, SDK changes, and new features');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export const GET = async () => {
+  const rootNode = await getDocsRootNode();
+  const body = generateLlmsTxt(rootNode);
+
+  return new Response(body, {
+    headers: {'content-type': 'text/plain; charset=utf-8'},
+  });
+};


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a `/llms.txt` route that generates a structured index of documentation pages with links to their `.md` variants. This complements the existing `.md` exports and content negotiation middleware.

The route:
- Walks the top 2 levels of the doc tree, with an extra level for platform framework guides (e.g., Next.js under JavaScript, Laravel under PHP) as https://docs.sentry.io/ shows framework guides are most important to Sentry docs
- Uses the same visibility filtering and sidebar ordering as the rest of the site
- Serves both `docs.sentry.io/llms.txt` and `develop.sentry.dev/llms.txt` via the existing `isDeveloperDocs` branching
- Is statically rendered at build time (`force-static`)
- Size is reasonable, under 30 KB and 250 lines at time of this PR (spec suggests 50 KB max)
- Excludes the doc changelog (dashboard API returns no data) and contributing section (not relevant for SDK/product usage). https://sentry.io/changelog/ is linked instead. Exclusions are configurable via `EXCLUDED_SLUGS`

Note: The visibility filtering logic (`isVisible`, `sortBySidebarOrder`) is based on unexported functions from `src/docTree.ts`. Exporting these would eliminate the duplication but I want this PR simple. It's a candidate for future cleanup.

This addresses https://github.com/getsentry/sentry-docs/issues/12925

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] Confirm llms.txt content on the platform and developer sites is desirable
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
