### PR TITLE
docs(ai): Add iOS Swift setup skill to agent skills table

### DIFF
--- a/docs/ai/agent-skills.mdx
+++ b/docs/ai/agent-skills.mdx
@@ -100,6 +100,7 @@ Once installed, your AI assistant will automatically discover the skills. Simply
 | "Set up Sentry in React Native"            | `sentry-react-native-setup`  |
 | "Add Sentry to my Python/Django/Flask app" | `sentry-python-setup`        |
 | "Set up Sentry in my Ruby/Rails app"       | `sentry-ruby-setup`          |
+| "Add Sentry to my iOS app"                 | `sentry-ios-swift-setup`     |
 | "Add performance monitoring to my app"     | `sentry-setup-tracing`       |
 | "Enable Sentry logging"                    | `sentry-setup-logging`       |
 | "Track custom metrics with Sentry"         | `sentry-setup-metrics`       |


### PR DESCRIPTION
Add reference to the sentry-ios-swift-setup skill in the agent skills documentation. This skill helps users set up Sentry in iOS apps using the wizard CLI.

The skill was recently added to the available agent skills but was missing from the documentation table that lists all setup skills.

Refs https://github.com/getsentry/sentry-docs/blob/master/docs/ai/agent-skills.mdx