### PR TITLE
docs: Add streaming token usage note to OpenAI integration docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/openai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openai.mdx
@@ -88,7 +88,6 @@ To customize what data is captured (such as inputs and outputs), see the [Option
 
 _Import name: `Sentry.instrumentOpenAiClient`_
 
-
 The `instrumentOpenAiClient` helper adds instrumentation for the [`openai`](https://www.npmjs.com/package/openai) SDK to capture spans by wrapping OpenAI SDK calls and recording LLM interactions with configurable input/output recording. You need to manually wrap your OpenAI client instance with this helper:
 
 ```javascript
@@ -96,7 +95,7 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({
   // Warning: API key will be exposed in browser!
-  apiKey: 'your-api-key', 
+  apiKey: "your-api-key",
 });
 
 const client = Sentry.instrumentOpenAiClient(openai, {
@@ -114,7 +113,6 @@ const response = await client.chat.completions.create({
 To customize what data is captured (such as inputs and outputs), see the [Options](#options) in the Configuration section.
 
 </PlatformSection>
-
 
 ## Configuration
 
@@ -148,7 +146,7 @@ Using the `openAIIntegration` integration:
 Sentry.init({
   dsn: "____PUBLIC_DSN____",
   // Tracing must be enabled for agent monitoring to work
-  tracesSampleRate: 1.0, 
+  tracesSampleRate: 1.0,
   integrations: [
     Sentry.openAIIntegration({
       // your options here
@@ -182,7 +180,7 @@ Streaming and non-streaming requests are automatically detected and handled appr
 
 <Alert>
 
-When using OpenAI's streaming API (`stream: true`), you must also pass `stream_options: { include_usage: true }` to receive token usage data. Without this option, OpenAI does not include `prompt_tokens` or `completion_tokens` in streamed responses, and Sentry will be unable to capture `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` on the resulting span. This is an OpenAI API behavior, not a Sentry limitation. See [OpenAI docs on stream options](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options).
+When using OpenAI's streaming API, you must also pass `stream_options: { include_usage: true }` to receive token usage data. Without this option, OpenAI does not include `prompt_tokens` or `completion_tokens` in streamed responses, and Sentry will be unable to capture `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` on the resulting span. This is an OpenAI API behavior, not a Sentry limitation. See [OpenAI docs on stream options](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options).
 
 </Alert>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Adds a note to the OpenAI integration documentation explaining that stream_options: { include_usage: true } must be passed when using streaming (stream: true) to capture token usage data (gen_ai.usage.input_tokens / gen_ai.usage.output_tokens). Without this option, OpenAI omits token counts from streamed responses, preventing Sentry from recording them. This is an OpenAI API behavior, not a Sentry limitation.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [X] Urgent deadline 
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
