### PR TITLE
docs(nestjs): Isolate async background job scopes

### DIFF
--- a/docs/platforms/javascript/guides/nestjs/features/async-context.mdx
+++ b/docs/platforms/javascript/guides/nestjs/features/async-context.mdx
@@ -1,0 +1,32 @@
+---
+title: Isolate Background Job Scopes
+description: "Learn how to isolate Sentry scopes in NestJS background jobs to prevent breadcrumb leakage into HTTP request events."
+---
+
+In NestJS, background job handlers like `@Cron()`, `@Interval()`, `@OnEvent()`, or BullMQ `@Processor()` handlers share the default isolation scope with incoming HTTP requests. This means breadcrumbs and tags added inside background jobs can leak into error events from unrelated HTTP requests, making it harder to debug issues.
+
+To prevent this, wrap each background job handler with `Sentry.withIsolationScope()` to give it its own isolated scope. Here's an example using `@Cron()`:
+
+```typescript
+import * as Sentry from "@sentry/nestjs";
+import { Injectable } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+
+@Injectable()
+export class MyJobService {
+  @Cron(CronExpression.EVERY_HOUR)
+  handleCron() {
+    Sentry.withIsolationScope(() => {
+      // Breadcrumbs and tags added here won't leak into HTTP request events
+      Sentry.addBreadcrumb({ message: "Processing scheduled job" });
+      this.doWork();
+    });
+  }
+
+  private doWork() {
+    // your job logic
+  }
+}
+```
+
+Apply the same pattern to `@Interval()`, `@OnEvent()`, `@Processor()`, and any other background task that runs outside the context of a request lifecycle.

--- a/docs/platforms/javascript/guides/nestjs/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/index.mdx
@@ -78,7 +78,11 @@ export class AppModule {}
 
 <PlatformContent includePath="getting-started-capture-errors" />
 
-## Step 4: Add Readable Stack Traces With Source Maps (Optional)
+## Step 4: Isolate Async Context for Background Jobs (Optional)
+
+If your NestJS app uses background jobs (such as `@Cron()`, `@Interval()`, `@OnEvent()`, or BullMQ), breadcrumbs from those jobs can leak into unrelated HTTP request error events. Wrap your background job handlers with `Sentry.withIsolationScope()` to isolate them. See <PlatformLink to="/features/async-context">Isolate Background Job Scopes</PlatformLink> for details and code examples.
+
+## Step 5: Add Readable Stack Traces With Source Maps (Optional)
 
 The stack traces in your Sentry errors probably won't look like your actual code. To fix this, upload your source maps to Sentry.
 The easiest way to do this is by using the Sentry Wizard:
@@ -87,7 +91,7 @@ The easiest way to do this is by using the Sentry Wizard:
 npx @sentry/wizard@latest -i sourcemaps
 ```
 
-## Step 5: Verify Your Setup
+## Step 6: Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 


### PR DESCRIPTION
Async background jobs leak breadcrumbs into HTTP request scopes in the `nestjs` SDK. This can be fixed by wrapping async jobs with `withIsolationScope`. We will investigate a more holistic fix but for now we should document the workaround.

[Context](https://github.com/getsentry/sentry-javascript/issues/17742#issuecomment-3950424831)