### PR TITLE
docs(java): Add sampling note to OTLP setup

### DIFF
--- a/docs/platforms/java/common/opentelemetry/setup/otlp.mdx
+++ b/docs/platforms/java/common/opentelemetry/setup/otlp.mdx
@@ -121,3 +121,13 @@ public class SentryConfig {
 ```
 
 </PlatformSection>
+
+## Sampling
+
+The Sentry propagator inherits the sampling decision from the incoming `sentry-trace` header. When no sampling flag is present (deferred decision), it defaults to sampled.
+
+<Alert level="warning" title="Deferred Sampling">
+
+If you need to control sampling for deferred traces, you have to implement a custom OpenTelemetry `Sampler`.
+
+</Alert>


### PR DESCRIPTION
## Summary
- Follow-up to https://github.com/getsentry/sentry-docs/pull/16551
- Documents that the Sentry OTLP propagator inherits the sampling decision from the incoming `sentry-trace` header, defaulting to sampled when no flag is present
- Adds a warning that customers may need a custom OTel `Sampler` to control sampling for deferred traces

## Test plan
- [ ] Verify page renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)