### PR TITLE
fix: remove unnecessary backticks in upgrade-policies link

### DIFF
--- a/develop-docs/frontend/upgrade-policies.mdx
+++ b/develop-docs/frontend/upgrade-policies.mdx
@@ -187,7 +187,7 @@ It has two primary modes of operation
 
 <Alert level="warning">
 
-We try and use dependabot to stay on top of dependency upgrades! These PRs happen relatively often, so there is a dedicated GitHub team `[@owners-js-deps](https://github.com/orgs/getsentry/teams/owners-js-deps)` which dependabot assigns the PRs for review.
+We try and use dependabot to stay on top of dependency upgrades! These PRs happen relatively often, so there is a dedicated GitHub team [@owners-js-deps](https://github.com/orgs/getsentry/teams/owners-js-deps) which dependabot assigns the PRs for review.
 
 </Alert>
 


### PR DESCRIPTION
Found while onboarding. Other org links don't use backticks.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="745" height="172" alt="Screenshot of production https://develop.sentry.dev/frontend/upgrade-policies/#take-advantage-of-tooling showing backticks around plaintext markdown link" src="https://github.com/user-attachments/assets/f4401d9c-dc8a-405f-98bf-d6f4031c585f" />
</td>
<td>
<img width="745" height="172" alt="Screenshot of updated https://develop.sentry.dev/frontend/upgrade-policies/#take-advantage-of-tooling showing properly formatted link" src="https://github.com/user-attachments/assets/ed604de4-23de-425e-a754-47c0a3741bef" />
</td>
</tr>
</tbody>
</table>