### PR TITLE
fix(alerts): Make metric alert scheduling docs more accurate

### DIFF
--- a/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -58,11 +58,17 @@ When creating new metric alerts, the `is:unresolved` filter is added by default.
 
 ### Time Interval
 
-Choose the time period over which to evaluate your metric. Your choices range between one minute and one day. Sentry evaluates the specified window each minute. For example, if you specify an hour time window, Sentry evaluates:
+Choose the time period over which to evaluate your metric. Your choices range between one minute and one day. Sentry evaluates the specified time interval as frequently as every minute, though longer intervals are scheduled less often. For example:
+
+- A **1-minute** interval is evaluated every minute.
+- A **1-hour** interval may be evaluated as infrequently as every 3 minutes.
+- A **24-hour** interval may be evaluated as infrequently as every 15 minutes.
+
+For a 1-hour interval, Sentry evaluates a rolling window, such as:
 
 - At 3:00pm: 2:00pm - 3:00pm
-- At 3:01pm: 2:01pm - 3:01pm
-- At 3:02pm: 2:02pm - 3:02pm
+- At 3:03pm: 2:03pm - 3:03pm
+- At 3:06pm: 2:06pm - 3:06pm
 - ...
 
 ## Filters


### PR DESCRIPTION
Every minute isn't quite accurate, and we don't want to mislead.
