### PR TITLE
docs(unreal): add missing features to landing page and options

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -167,6 +167,20 @@ This feature is supported only for Crashpad backend on Windows and Linux (defaul
 
 </SdkOption>
 
+<SdkOption name="EnableExternalCrashReporter" type="bool" defaultValue="false">
+
+When enabled, a standalone crash reporter dialog is shown to the user after a crash, allowing them to review crash details and provide feedback before the report is submitted to Sentry.
+
+See <PlatformLink to="/configuration/setup-crashreporter/#sentry-crash-reporter">Sentry Crash Reporter</PlatformLink> for setup details and customization options.
+
+<Alert>
+
+This feature is supported on Windows and Linux only.
+
+</Alert>
+
+</SdkOption>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
@@ -197,6 +211,38 @@ The callback typically gets a second argument (called a "hint") which contains t
 Currently, hints are supported only on Android.
 
 </Alert>
+
+</SdkOption>
+
+## Offline Caching
+
+<SdkOption name="EnableOfflineCaching" type="bool" defaultValue="false">
+
+Enables persistent caching of envelopes to disk. When enabled, envelopes are stored in a cache directory and retained regardless of send success or failure. The cache is cleaned up on startup based on the limits configured below.
+
+<Alert>
+
+This feature is available on Windows, Linux, and Xbox only. On Android and Apple, caching is enabled by default.
+
+</Alert>
+
+</SdkOption>
+
+<SdkOption name="CacheMaxItems" type="int" defaultValue="0">
+
+Maximum number of items in the cache directory. On startup, oldest entries are removed until the count is within this limit. Set to `0` for no limit.
+
+</SdkOption>
+
+<SdkOption name="CacheMaxSize" type="int" defaultValue="0">
+
+Maximum total size in bytes for the cache directory. On startup, oldest entries are removed until the size is within this limit. Set to `0` for no limit.
+
+</SdkOption>
+
+<SdkOption name="CacheMaxAge" type="int" defaultValue="0">
+
+Maximum age in seconds for cache entries. On startup, entries exceeding this age are removed. Set to `0` for no limit.
 
 </SdkOption>
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -41,7 +41,7 @@ to the user:
 
 ### Using the UE Crash Reporter on Windows
 
-The UE Crash Reporter works if the Sentry SDK is installed. Sentry SDK can help with configuring the UE Crash Reporter, uploading debug symbols, and enriching crash reports with custom data. **Starting from UE 5.2** users have to choose between the two available crash capturing mechanisms - the UE Crash Reporter or the `sentry-native` library that's integrated into the Sentry plugin. By default, the `sentry-native` library is used instead of the UE Crash Reporter. (See "Enable automatic crash capturing (Windows, UE 5.2+)" in the plugin settings.) The two solutions are mutually exclusive and can't be used simultaneously.
+The UE Crash Reporter works if the Sentry SDK is installed. Sentry SDK can help with configuring the UE Crash Reporter, uploading debug symbols, and enriching crash reports with custom data. **Starting from UE 5.2** users have to choose between the two available crash capturing mechanisms - the UE Crash Reporter or the `sentry-native` library that's integrated into the Sentry plugin. By default, the `sentry-native` library is used instead of the UE Crash Reporter (see "Enable automatic crash capturing (Windows, UE 5.2+)" in the plugin settings). The two solutions are mutually exclusive and can't be used simultaneously.
 
 ## Sentry SDK and UE Crash Reporter feature comparison
 
@@ -187,7 +187,7 @@ Available starting from Sentry Unreal SDK version 1.8.0. Supported on Windows an
 
 Starting from version 1.8.0, the Sentry Unreal plugin ships with an optional **Sentry Crash Reporter** - a standalone application that can be used instead of the default UE Crash Reporter. When enabled, it displays a dialog to users after a crash, allowing them to review crash details and provide feedback before the report is submitted to Sentry.
 
-Unlike the built-in UE Crash Reporter, the Sentry Crash Reporter works through the Sentry SDK pipeline and doesn't require modifying engine configuration files.
+Unlike the built-in UE Crash Reporter, the Sentry Crash Reporter works through the Sentry SDK pipeline and doesn't require modifying engine configuration files. This also means it requires Sentry's own crash capturing to be enabled (see "Enable automatic crash capturing (Windows, UE 5.2+)" in the plugin settings).
 
 ![Sentry Crash Reporter](./img/sentry-crash-reporter.png)
 

--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -20,10 +20,13 @@ Unreal Engine SDK builds on top of other Sentry SDKs and extends them with Unrea
   - macOS by using the [macOS SDK](/platforms/apple/guides/macos/) to support Objective-C, Swift, C and C++
   - iOS by using the [iOS SDK](/platforms/apple/guides/ios/) to support Objective-C, Swift, C and C++
   - Android by using the [Android SDK](/platforms/android/) to support Java, Kotlin, C and C++
-- Compatible with [Crash Reporter Client](/platforms/unreal/configuration/setup-crashreporter/) provided along with Unreal Engine
+- Compatible with default [Crash Reporter Client](/platforms/unreal/configuration/setup-crashreporter/) provided along with Unreal Engine
+- [Sentry Crash Reporter](/platforms/unreal/configuration/setup-crashreporter/#sentry-crash-reporter) dialog for collecting user feedback on crashes
 - [PlayStation](/platforms/playstation/), [Xbox](/platforms/xbox/) and [Nintendo Switch](/platforms/nintendo-switch/) support
 - [Release health](/platforms/unreal/configuration/releases/) to keep track of crash free users and sessions
 - [Structured Logging](/platforms/unreal/logs/) to capture and send log messages with additional context
+- [Metrics](/platforms/unreal/metrics/) to track counters, gauges, and distributions
+- [Offline Caching](/platforms/unreal/configuration/options/#EnableOfflineCaching) stores event data to disk in case the device is not online
 
 <Alert level="warning">
 


### PR DESCRIPTION
This PR adds metrics, offline caching and Sentry Crash Reporter to the Unreal Engine landing page feature list. 

Also, it documents the corresponding configuration options (`EnableOfflineCaching`, `CacheMaxItems`, `CacheMaxSize`, `CacheMaxAge`, `EnableExternalCrashReporter`) on the options page and clarifies that the Sentry Crash Reporter requires Sentry's own crash capturing to be enabled.