### PR TITLE
docs(godot): Update install instructions for separate demo package

### DIFF
--- a/platform-includes/getting-started-install/godot.mdx
+++ b/platform-includes/getting-started-install/godot.mdx
@@ -1,7 +1,9 @@
-Download the latest stable version `{{@inject packages.version('sentry.godot', '?') }}` from [GitHub Releases](https://github.com/getsentry/sentry-godot/releases/). The archive includes the Sentry SDK addon and a demo project. You can either extract the entire archive into a separate folder to open the demo in Godot Engine or extract only `addons/sentry` into existing project.
+Download the latest stable version `{{@inject packages.version('sentry.godot', '?') }}` from [GitHub Releases](https://github.com/getsentry/sentry-godot/releases/). Extract the `addons/sentry` folder from the archive into your project.
 
 <Alert>
 
-Ensure that the addon is placed exactly as it is in the demo project, in the `addons/sentry` folder, preserving the exact casing.
+Ensure that the addon is placed in the `addons/sentry` folder, preserving the exact casing.
 
 </Alert>
+
+A separate **demo project** archive is also available on the releases page. It contains a ready-to-run Godot project with examples of common features like error capturing, breadcrumbs, and user feedback. To use it, enter your DSN in **Project Settings > Sentry > Options**.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Update Godot install instructions to reflect the new packaging where the addon and demo project are shipped as separate archives.

- Refs https://github.com/getsentry/sentry-godot/pull/542

The main archive no longer includes the demo project. The install instructions now direct users to extract `addons/sentry` from the addon-only archive, and mention the separate demo project archive with a note to configure their DSN.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)