### PR TITLE
Clarify user fields in span protocol documentation

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -174,9 +174,9 @@ Empty attributes must be omitted.
 | `sentry.replay_id` | string | The id of the currently running replay (if available) |
 | `os.name` | string | The operating system name (e.g., "Linux", "Windows", "macOS") |
 | `browser.name` | string | The browser name (e.g., "Chrome", "Firefox", "Safari") |
-| `user.id` | string | The user ID
-| `user.email` | string | The user email
-| `user.ip_address` | string | The user IP
+| `user.id` | string | The user ID |
+| `user.email` | string | The user email |
+| `user.ip_address` | string | The user IP address |
 | `user.name` | string | The user username |
 | `thread.id` | string | The thread ID |
 | `thread.name` | string | The thread name |


### PR DESCRIPTION
Updated user-related fields to remove 'gated by sendDefaultPii' notes for clarity. SDKs gate any automatic `scope.setUser()` calls instead.
