### PR TITLE
docs(otlp): Update Ruby integration link to actual docs page

### DIFF
--- a/docs/concepts/otlp/sentry-with-otel.mdx
+++ b/docs/concepts/otlp/sentry-with-otel.mdx
@@ -69,12 +69,12 @@ If you're running both a Sentry SDK and OTel instrumentation in the same backend
     label="Python"
     url="/platforms/python/integrations/otlp"
   />
-Coming Soon:
 - <LinkWithPlatformIcon
     platform="ruby"
     label="Ruby"
-    url="#otlp-integration"
+    url="/platforms/ruby/integrations/otlp/"
   />
+Coming Soon:
 - <LinkWithPlatformIcon
     platform="go"
     label="Go"


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates the Ruby OTLP integration link from a placeholder (`#otlp-integration`) to the actual documentation page (`/platforms/ruby/integrations/otlp/`).

This follows up on #16579 which added the Ruby OTLP integration docs.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

---

Co-Authored-By: Claude <noreply@anthropic.com>