### PR TITLE
feat(tanstackstart-react): Add guide for setup without `--import`

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -180,9 +180,9 @@ To capture server-side errors and tracing data, you need to explicitly define a 
 
 Follow the section below that matches your deployment setup:
 
-#### Node.js Server
+#### With `--import` Flag (e.g. Node.js Server)
 
-Use this setup when running your application as a long-lived Node.js process (e.g. a traditional server or container).
+Use this setup when you can configure Node.js CLI flags.
 
 Create a `src/server.ts` file in your project:
 
@@ -230,9 +230,9 @@ Add a `--import` flag directly or to the `NODE_OPTIONS` environment variable whe
 }
 ```
 
-#### Serverless (e.g. Vercel, Netlify)
+#### Without `--import` Flag (e.g. Vercel, Netlify)
 
-Use this setup when deploying to a serverless platform. Instead of using the `--import` flag, import the server instrumentation file directly at the top of your server entry point.
+If you can't configure Node.js CLI flags or environment variables at runtime (for example, when deploying to serverless platforms like Vercel or Netlify), you can import the server instrumentation file directly at the top of your server entry point instead.
 
 Create a `src/server.ts` file in your project:
 
@@ -256,7 +256,7 @@ This installation method has the fundamental restriction that only native Node.j
 
 As a result, the Sentry SDK will not capture data from database calls, queues, ORMs, third-party libraries, or other framework-specific data.
 
-We recommend using the [Node.js Server setup](#nodejs-server) if the `--import` flag is an option for you.
+We recommend using the [setup with the `--import` flag](#with---import-flag-eg-nodejs-server) if possible.
 
 </Alert>
 


### PR DESCRIPTION
For serverless environments where users can't set `--import` flag on startup we need a slightly different setup, where users need to import the `instrument.server.mjs` in the server entry file. So far we have no documentation for that, so I split the docs to set up server-side Sentry into two sections (one for normal node setup, one for serverless environments). The described setup should work starting from the next SDK release.