### PR TITLE
chore(android): Update Session Replay integration instructions

### DIFF
--- a/docs/platforms/android/session-replay/index.mdx
+++ b/docs/platforms/android/session-replay/index.mdx
@@ -37,13 +37,13 @@ If you have the SDK installed without the Sentry Gradle Plugin, you can update t
 
 ```groovy {filename:app/build.gradle}
 dependencies {
-    implementation 'io.sentry:sentry-android:{{@inject packages.version('sentry.java.android', '7.12.0') }}'
+  implementation 'io.sentry:sentry-android:{{@inject packages.version('sentry.java.android', '7.12.0') }}'
 }
 ```
 
 ```kotlin {filename:app/build.gradle.kts}
 dependencies {
-    implementation("io.sentry:sentry-android:{{@inject packages.version('sentry.java.android', '7.12.0') }}")
+  implementation("io.sentry:sentry-android:{{@inject packages.version('sentry.java.android', '7.12.0') }}")
 }
 ```
 
@@ -51,15 +51,15 @@ If you're not using the `sentry-android` dependency, you'd need to specify the S
 
 ```groovy {filename:app/build.gradle}
 dependencies {
-    implementation 'io.sentry:sentry-android-core:{{@inject packages.version('sentry.java.android', '7.12.0') }}'
-    implementation 'io.sentry:sentry-android-replay:{{@inject packages.version('sentry.java.android', '7.12.0') }}'
+  implementation 'io.sentry:sentry-android-core:{{@inject packages.version('sentry.java.android', '7.12.0') }}'
+  implementation 'io.sentry:sentry-android-replay:{{@inject packages.version('sentry.java.android', '7.12.0') }}'
 }
 ```
 
 ```kotlin {filename:app/build.gradle.kts}
 dependencies {
-    implementation("io.sentry:sentry-android-core:{{@inject packages.version('sentry.java.android', '7.12.0') }}")
-    implementation("io.sentry:sentry-android-replay:{{@inject packages.version('sentry.java.android', '7.12.0') }}")
+  implementation("io.sentry:sentry-android-core:{{@inject packages.version('sentry.java.android', '7.12.0') }}")
+  implementation("io.sentry:sentry-android-replay:{{@inject packages.version('sentry.java.android', '7.12.0') }}")
 }
 ```
 


### PR DESCRIPTION
Sometimes customers have only sentry-android-core specified and get confused as to why replay is not being captured even though they have specified the sample rates.