### PR TITLE
fix(godot): Correct default values in configuration options

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -192,7 +192,7 @@ This option is turned on by default.
 
 </SdkOption>
 
-<SdkOption name="logger_breadcrumb_mask" type="int" defaultValue="15">
+<SdkOption name="logger_breadcrumb_mask" type="int" defaultValue="15 (All)">
 
 Specifies the types of errors captured as breadcrumbs. Accepts a single value or a bitwise combination of `GodotErrorMask` masks. The default value captures native errors, warnings, script and shader errors (`MASK_ERROR | MASK_WARNING | MASK_SCRIPT | MASK_SHADER`).
 
@@ -210,7 +210,7 @@ options.logger_breadcrumb_mask = mask
 
 </SdkOption>
 
-<SdkOption name="logger_event_mask" type="int" defaultValue="13">
+<SdkOption name="logger_event_mask" type="int" defaultValue="13 (All except warnings)">
 
 Specifies the types of errors captured as events. Accepts a single value or a bitwise combination of `GodotErrorMask` masks. The default value captures native, script and shader errors (`MASK_ERROR | MASK_SCRIPT` | `MASK_SHADER`).
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fix incorrect documented defaults that don't match the SDK source code in `sentry_options.h`:

- `skip_auto_init_on_editor_play`: `true` -> `false`
- `logger_include_variables`: `true` -> `false`
- `logger_event_mask`: `5` -> `13` (MASK_ALL_EXCEPT_WARNING)
- `logger_breadcrumb_mask`: `7` -> `15` (MASK_ALL)
- `logger_limits.throttle_events`: `10` -> `20`

Also fixes typo "nativer" -> "native".

Co-Authored-By: Claude <noreply@anthropic.com>

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)