### PR TITLE
docs(replay): Add `traces_by_timestamp` field to replay event spec

### DIFF
--- a/develop-docs/sdk/telemetry/replays.mdx
+++ b/develop-docs/sdk/telemetry/replays.mdx
@@ -2,7 +2,7 @@
 title: Replay
 description: Session recording protocol for capturing and streaming browser or mobile user sessions to Sentry.
 spec_id: sdk/telemetry/replays
-spec_version: 1.2.0
+spec_version: 1.3.0
 spec_status: stable
 spec_platforms:
   - browser
@@ -11,6 +11,9 @@ spec_depends_on:
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.3.0
+    date: 2026-02-26
+    summary: Added traces_by_timestamp field for timestamped trace association
   - version: 1.2.0
     date: 2025-07-30
     summary: Added session mode hard limit behavior (stop recording, clear replay_id, remove from scope)
@@ -103,7 +106,8 @@ A `replay_event` envelope item **MUST** always be sent together with a `replay_r
 | `segment_id` | Number | **REQUIRED** | 1.0.0 | The segment identifier, starting at 0. |
 | `replay_start_timestamp` | Number | **REQUIRED** (first segment) | 1.0.0 | UNIX timestamp of the start of the replay (in seconds). Only required on the first segment. |
 | `urls` | List[String] | **OPTIONAL** | 1.0.0 | List of URLs in order of visitation. |
-| `trace_ids` | List[String] | **OPTIONAL** | 1.0.0 | List of trace IDs that occurred during the replay. |
+| `trace_ids` | List[String] | **OPTIONAL** | 1.0.0 | List of unique trace IDs that occurred during the segment. |
+| `traces_by_timestamp` | List[[Number, String]] | **OPTIONAL** | 1.3.0 | List of `[timestamp, trace_id]` pairs. Each entry is a tuple of the transaction's start timestamp (UNIX seconds) and its trace ID. Provides temporal ordering so Sentry can associate replay events with the correct trace. SDKs **SHOULD** send this alongside `trace_ids` for backwards compatibility. |
 | `error_ids` | List[String] | **DEPRECATED** | 1.0.0 | Deprecated. Do not use. |
 
 #### Event Attributes
@@ -323,6 +327,7 @@ sentry_sdk.init(
   "replay_type": "session",
   "segment_id": 0,
   "trace_ids": ["905aef2282af5fe2ab2c93aa7a340521"],
+  "traces_by_timestamp": [[1710861501.234, "905aef2282af5fe2ab2c93aa7a340521"]],
   "urls": [
     "https://sentry.io/issues/",
     "https://sentry.io/issues/?project=0&statsPeriod=7d&utc=true"
@@ -376,6 +381,7 @@ sentry_sdk.init(
   "replay_type": "session",
   "segment_id": 0,
   "trace_ids": ["905aef2282af5fe2ab2c93aa7a340521"],
+  "traces_by_timestamp": [[1710861501.234, "905aef2282af5fe2ab2c93aa7a340521"]],
   "urls": [
     "https://sentry.io/issues/",
     "https://sentry.io/issues/?project=0&statsPeriod=7d&utc=true"


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the new `traces_by_timestamp` field added to the replay event payload in [getsentry/sentry-javascript#18048](https://github.com/getsentry/sentry-javascript/pull/18048).

This field sends `[timestamp, trace_id]` pairs alongside the existing `trace_ids` list, enabling Sentry to associate replay custom events with the correct trace using temporal ordering (needed for migrating custom rrweb events to EAP).

- Added `traces_by_timestamp` to the Replay Attributes table (type `List[[Number, String]]`, optional, since 1.3.0)
- Updated `trace_ids` description for clarity
- Added field to both example JSON blocks (Replay Event and Full Envelope)
- Bumped spec version to 1.3.0 with changelog entry

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>