### PR TITLE
fix(langgraph): Call instrumentLangGraph before .compile()

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
@@ -103,6 +103,7 @@ The `instrumentLangGraph` helper adds instrumentation for [`@langchain/langgraph
 ```javascript
 import { ChatOpenAI } from "@langchain/openai";
 import { StateGraph, MessagesAnnotation, START, END } from '@langchain/langgraph';
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
 
 // Create LLM call
 const llm = new ChatOpenAI({


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fix the `instrumentLangGraph` example in the Browser-Side Usage section to call the helper **before** `.compile()`, not after.

`instrumentLangGraph` works by wrapping the `.compile()` method on a `StateGraph` to intercept the compilation step and inject tracing. It must be called before `.compile()` is invoked. The previous example passed the already-compiled graph, meaning the compile step had already happened and there was no hook point for the SDK to instrument.

Also updates the surrounding description from "wrapping a compiled LangGraph graph" to "wrapping a StateGraph before compilation" to match the correct usage.

Related fix in the sentry repo: https://github.com/getsentry/sentry/pull/109551

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>