### PR TITLE
fix(issues): Remove confusion phrasing around merges

### DIFF
--- a/includes/only-error-issues-note.mdx
+++ b/includes/only-error-issues-note.mdx
@@ -1,5 +1,5 @@
 <Alert>
 
-This feature is only applicable for [error issues](/product/issues/issue-details/error-issues/) with debug information files, excluding source maps. Other categories of issues (such as [performance issues](/product/issues/issue-details/performance-issues/) or [replay issues](/product/issues/issue-details/replay-issues/)) do not support this feature.
+This feature is only applicable for [error issues](/product/issues/issue-details/error-issues/). Other categories of issues (such as [performance issues](/product/issues/issue-details/performance-issues/) or [replay issues](/product/issues/issue-details/replay-issues/)) do not support this feature.
 
 </Alert>


### PR DESCRIPTION
This phrasing is likely outdated or was confusingly worded - merging is supported for all error issues so let's just clean it up.