### PR TITLE
fix(reprocessing): Update warning re: which issues count

### DIFF
--- a/docs/product/issues/reprocessing/index.mdx
+++ b/docs/product/issues/reprocessing/index.mdx
@@ -8,7 +8,7 @@ og_image: /og-images/product-issues-reprocessing.png
 Sentry uses [debug information
 files](/platforms/native/data-management/debug-files/) only after they have been uploaded. _Reprocessing_ allows you to apply debug information files to error events that have already occurred.
 
-Note: This feature is only applicable for error issues with debug information files. (Note that this does not include JS events, which use source maps rather than DIFs.) Other categories of issues 
+Note: This feature is only applicable for error issues with debug information files. (Note that this does not include JavaScript events, which use source maps rather than DIFs.) Other categories of issues 
 (such as [performance issues](/product/issues/issue-details/performance-issues/) or [replay issues](/product/issues/issue-details/replay-issues/)) do not support this feature.
 
 You can find the following action when viewing an issue:


### PR DESCRIPTION
We're [removing the bit about DIFs and sourcemaps](https://github.com/getsentry/sentry-docs/pull/16621) from the more general "only error issues" include, so this replaces the include on the reprocessing page with a note which still includes that information (reworded a bit for clairity).