### PR TITLE
fix(home): Increase spacing between SDK tile icon and label

### DIFF
--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -119,20 +119,20 @@ export async function Home() {
                     <a
                       key={platform.key}
                       href={platform.url}
-                      className="sdk-tile flex flex-col items-center justify-center bg-white dark:bg-[var(--gray-2)]"
+                      className="sdk-tile flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-[var(--gray-2)]"
                       style={{
                         textDecoration: 'none',
                         padding: '6px',
                         borderRadius: '6px',
                         width: '70px',
-                        height: '70px',
+                        height: '76px',
                       }}
                     >
                       <PlatformIcon
                         platform={platform.key}
                         size={36}
                         format="lg"
-                        style={{margin: 0, display: 'block', marginBottom: '3px'}}
+                        style={{margin: 0, display: 'block'}}
                       />
                       <span
                         className="text-[var(--gray-12)] whitespace-nowrap"


### PR DESCRIPTION
Add flex gap and increase tile height to improve visual separation between platform icons and their text labels on the homepage.

Before:
<img width="561" height="241" alt="Screenshot 2026-03-02 at 09 18 44" src="https://github.com/user-attachments/assets/9040f24a-5127-48b9-9090-48a7c7059924" />

After:
<img width="554" height="254" alt="Screenshot 2026-03-02 at 10 42 08" src="https://github.com/user-attachments/assets/f7d12341-23e0-4d22-8ed8-77fd1c3daac2" />
