### PR TITLE
fix(ui): Re-enable product sidebar on platform redirect

### DIFF
--- a/src/components/sidebar/sidebarNavigation.tsx
+++ b/src/components/sidebar/sidebarNavigation.tsx
@@ -135,9 +135,11 @@ export async function SidebarNavigation({path}: {path: string[]}) {
     return <ul data-sidebar-tree />;
   }
 
-  // Platform redirect page - no sidebar needed
+  // Platform redirect page - show product sidebar
   if (path[0] === 'platform-redirect') {
-    return <ul data-sidebar-tree />;
+    return (
+      <ProductSidebar rootNode={rootNode} items={[{title: 'Product', root: 'product'}]} />
+    );
   }
 
   // This should never happen, all cases need to be handled above


### PR DESCRIPTION
The /platform-redirect page was explicitly returning an empty sidebar (<ul data-sidebar-tree />), causing the sidebar to disappear entirely. This replaces it with the Product sidebar to stay consistent with other docs pages, otherwise this looks like an UI bug.
