### PR TITLE
ref(telemetry-processor): Migrate info from backend spec

### DIFF
--- a/develop-docs/sdk/foundations/processing/telemetry-processor/backend-telemetry-processor.mdx
+++ b/develop-docs/sdk/foundations/processing/telemetry-processor/backend-telemetry-processor.mdx
@@ -36,9 +36,7 @@ On the backend, use the same size limits as the [common requirements](/sdk/found
 
 ##### Span Buffer
 
-The span buffer must follow the common [telemetry span buffer requirements](/sdk/foundations/processing/telemetry-processor/#span-buffer). Further requirements for the bucketed-by-trace buffer are:
-
-1. The span buffer **MAY** use FIFO to prioritize forwarding spans: always forward spans from the oldest traceID. FIFO prevents spans from lingering in the buffer.
+The span buffer must follow the common [telemetry span buffer requirements](/sdk/foundations/processing/telemetry-processor/#span-buffer).
 
 ##### Trace Consistency Trade-offs
 

--- a/develop-docs/sdk/foundations/processing/telemetry-processor/index.mdx
+++ b/develop-docs/sdk/foundations/processing/telemetry-processor/index.mdx
@@ -135,6 +135,7 @@ For the telemetry span buffer, we recommend using a map of [traceID to span buck
 
 1. When forwarding spans, the span buffer **MUST** forward only spans from a single trace, since each envelope supports only one traceID. This means that the span buffer might forward spans multiple times.
 2. When the span buffer overflows and it drops data, it **SHOULD** drop all spans from a single traceID rather than individual spans. Dropping individual spans creates incomplete traces that are harder to debug, whereas dropping a complete trace preserves the integrity of the remaining traces.
+3. The span buffer **MAY** use FIFO to prioritize forwarding spans: always forward spans from the oldest traceID. FIFO prevents spans from lingering in the buffer.
 
 ### Buckets per TraceID
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

First step of https://github.com/getsentry/sentry-docs/issues/16189 to consolidate duplicate content between the backend and index telemetry processor pages. This PR moves the architecture overview and API definition to the index file and removes the duplicated parts from the backend file.

It also moves the span forwarding FIFO recommendation (oldest traceID first) from the backend page into the common span buffer requirements in the index spec.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>