### PR TITLE
docs(java): Add scope attributes docs for logs and metrics

### DIFF
--- a/platform-includes/logs/default-attributes/java.mdx
+++ b/platform-includes/logs/default-attributes/java.mdx
@@ -11,3 +11,7 @@ The Java SDK automatically sets several default attributes on all log entries to
 <Include name="logs/default-attributes/user" />
 
 <Include name="logs/default-attributes/integration" />
+
+### Scope Attributes
+
+Any attributes set on the current scope via `Sentry.setAttribute()` or `Sentry.setAttributes()` are automatically included on all log entries. See [Usage](#usage) above for details.

--- a/platform-includes/logs/usage/android.mdx
+++ b/platform-includes/logs/usage/android.mdx
@@ -65,3 +65,59 @@ Sentry.logger().log(
     "param1"
 )
 ```
+
+### Scope Attributes
+
+You can set attributes on the scope that will be automatically included in all log entries captured within that scope. This is useful for attaching contextual information like request IDs or user properties that should appear on every log.
+
+```java {tabTitle: Java}
+import io.sentry.Sentry;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123");
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150));
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("tenant", "acme-corp"),
+    SentryAttribute.booleanAttribute("is_admin", true)
+));
+
+// All subsequent logs will include these attributes
+Sentry.logger().info("Processing request");
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("request.id");
+```
+
+```kotlin {tabTitle: Kotlin}
+import io.sentry.Sentry
+import io.sentry.SentryAttribute
+import io.sentry.SentryAttributes
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123")
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150))
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("tenant", "acme-corp"),
+    SentryAttribute.booleanAttribute("is_admin", true)
+))
+
+// All subsequent logs will include these attributes
+Sentry.logger().info("Processing request")
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("request.id")
+```
+
+Attribute types are inferred automatically from the value: `String` maps to `string`, `Boolean` to `boolean`, integer types (`Integer`, `Long`, `Short`, `Byte`, `BigInteger`, `AtomicInteger`, `AtomicLong`) to `integer`, floating-point types (`Float`, `Double`, `BigDecimal`) to `double`, and `Collection` or array types to `array`. You can also use typed factory methods like `SentryAttribute.stringAttribute()` to set the type explicitly.
+
+Attributes passed directly to a log call override scope attributes with the same key.

--- a/platform-includes/logs/usage/java.mdx
+++ b/platform-includes/logs/usage/java.mdx
@@ -66,6 +66,74 @@ Sentry.logger().log(
 )
 ```
 
+### Scope Attributes
+
+You can set attributes on the scope that will be automatically included in all log entries captured within that scope. This is useful for attaching contextual information like request IDs or user properties that should appear on every log.
+
+```java {tabTitle: Java}
+import io.sentry.Sentry;
+import io.sentry.ScopeType;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
+
+// Set an attribute on the global scope so it applies to all logs
+Sentry.configureScope(ScopeType.GLOBAL, scope -> {
+    scope.setAttribute("region", "us-east-1");
+});
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123");
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150));
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("tenant", "acme-corp"),
+    SentryAttribute.booleanAttribute("is_admin", true)
+));
+
+// All subsequent logs will include these attributes
+Sentry.logger().info("Processing request");
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("request.id");
+```
+
+```kotlin {tabTitle: Kotlin}
+import io.sentry.Sentry
+import io.sentry.ScopeType
+import io.sentry.SentryAttribute
+import io.sentry.SentryAttributes
+
+// Set an attribute on the global scope so it applies to all logs
+Sentry.configureScope(ScopeType.GLOBAL) { scope ->
+    scope.setAttribute("region", "us-east-1")
+}
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123")
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150))
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("tenant", "acme-corp"),
+    SentryAttribute.booleanAttribute("is_admin", true)
+))
+
+// All subsequent logs will include these attributes
+Sentry.logger().info("Processing request")
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("request.id")
+```
+
+Attribute types are inferred automatically from the value: `String` maps to `string`, `Boolean` to `boolean`, integer types (`Integer`, `Long`, `Short`, `Byte`, `BigInteger`, `AtomicInteger`, `AtomicLong`) to `integer`, floating-point types (`Float`, `Double`, `BigDecimal`) to `double`, and `Collection` or array types to `array`. You can also use typed factory methods like `SentryAttribute.stringAttribute()` to set the type explicitly.
+
+Attributes passed directly to a log call override scope attributes with the same key.
+
 <PlatformSection supported={["java.spring-boot"]}>
 It is also possible to use Logback and Spring Boot together to have logs going through Logback sent to Sentry. Take a look at the <PlatformLink to="/logging-frameworks/">Logging Framework Integrations</PlatformLink> page.
 </PlatformSection>

--- a/platform-includes/metrics/default-attributes/android.mdx
+++ b/platform-includes/metrics/default-attributes/android.mdx
@@ -18,3 +18,7 @@ If user information is available in the current scope, the following attributes 
 If replay information is available in the current scope, the following attributes are added to the log:
 
 - `sentry.replay_id`: The ID of the replay.
+
+### Scope Attributes
+
+Any attributes set on the current scope via `Sentry.setAttribute()` or `Sentry.setAttributes()` are automatically included on all metrics. See [Usage](#usage) above for details.

--- a/platform-includes/metrics/default-attributes/java.mdx
+++ b/platform-includes/metrics/default-attributes/java.mdx
@@ -18,3 +18,7 @@ If user information is available in the current scope, the following attributes 
 The SDK will attach the following:
 
 - `server.address`: The address of the server that sent the metric. Equivalent to `server_name` that gets attached to Sentry errors.
+
+### Scope Attributes
+
+Any attributes set on the current scope via `Sentry.setAttribute()` or `Sentry.setAttributes()` are automatically included on all metrics. See [Usage](#usage) above for details.

--- a/platform-includes/metrics/usage/android.mdx
+++ b/platform-includes/metrics/usage/android.mdx
@@ -108,6 +108,60 @@ Sentry.metrics().distribution(
 )
 ```
 
+### Scope Attributes
+
+You can set attributes on the scope that will be automatically included in all metrics captured within that scope. This is useful for attaching contextual information that should appear on every metric.
+
+```java {tabTitle: Java}
+import io.sentry.Sentry;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123");
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150));
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("service", "checkout"),
+    SentryAttribute.booleanAttribute("canary", false)
+));
+
+// All subsequent metrics will include these attributes
+Sentry.metrics().count("order_placed", 1.0);
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("canary");
+```
+
+```kotlin {tabTitle: Kotlin}
+import io.sentry.Sentry
+import io.sentry.SentryAttribute
+import io.sentry.SentryAttributes
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123")
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150))
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("service", "checkout"),
+    SentryAttribute.booleanAttribute("canary", false)
+))
+
+// All subsequent metrics will include these attributes
+Sentry.metrics().count("order_placed", 1.0)
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("canary")
+```
+
+Attributes passed directly to a metric call override scope attributes with the same key.
+
 ### Specifying Units
 
 For `gauge` and `distribution` metrics, you can specify a unit using the `unit` option. This helps Sentry display the metric value in a human-readable format. `MetricsUnit` offers constants for units supported by Sentry. Sending in custom units is not supported.

--- a/platform-includes/metrics/usage/java.mdx
+++ b/platform-includes/metrics/usage/java.mdx
@@ -108,6 +108,72 @@ Sentry.metrics().distribution(
 )
 ```
 
+### Scope Attributes
+
+You can set attributes on the scope that will be automatically included in all metrics captured within that scope. This is useful for attaching contextual information that should appear on every metric.
+
+```java {tabTitle: Java}
+import io.sentry.Sentry;
+import io.sentry.ScopeType;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
+
+// Set an attribute on the global scope so it applies to all metrics
+Sentry.configureScope(ScopeType.GLOBAL, scope -> {
+    scope.setAttribute("region", "us-east-1");
+});
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123");
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150));
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("service", "checkout"),
+    SentryAttribute.booleanAttribute("canary", false)
+));
+
+// All subsequent metrics will include these attributes
+Sentry.metrics().count("order_placed", 1.0);
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("canary");
+```
+
+```kotlin {tabTitle: Kotlin}
+import io.sentry.Sentry
+import io.sentry.ScopeType
+import io.sentry.SentryAttribute
+import io.sentry.SentryAttributes
+
+// Set an attribute on the global scope so it applies to all metrics
+Sentry.configureScope(ScopeType.GLOBAL) { scope ->
+    scope.setAttribute("region", "us-east-1")
+}
+
+// Set a single attribute with automatic type inference
+Sentry.setAttribute("request.id", "abc-123")
+
+// Or use a factory method to set the type explicitly
+Sentry.setAttribute(SentryAttribute.integerAttribute("request.duration_ms", 150))
+
+// Set multiple attributes at once
+Sentry.setAttributes(SentryAttributes.of(
+    SentryAttribute.stringAttribute("service", "checkout"),
+    SentryAttribute.booleanAttribute("canary", false)
+))
+
+// All subsequent metrics will include these attributes
+Sentry.metrics().count("order_placed", 1.0)
+
+// Remove an attribute when it's no longer relevant
+Sentry.removeAttribute("canary")
+```
+
+Attributes passed directly to a metric call override scope attributes with the same key.
+
 ### Specifying Units
 
 For `gauge` and `distribution` metrics, you can specify a unit using the `unit` option. This helps Sentry display the metric value in a human-readable format. `MetricsUnit` offers constants for units supported by Sentry. Sending in custom units is not supported.


### PR DESCRIPTION
Add scope attributes sections to Java and Android logs/metrics usage docs, showing how to set attributes on the scope that are automatically included in all logs/metrics.

Covers `setAttribute` (with auto type inference), `SentryAttribute` factory methods (for explicit typing), `setAttributes` (for multiple at once), and `removeAttribute`. Examples are consistent across all four platform-includes files (logs/metrics x java/android).

Also adds scope attributes references in the default-attributes docs for Java logs and Android/Java metrics.

Co-Authored-By: Claude <noreply@anthropic.com>

PR Stack in SDK repo: https://github.com/getsentry/sentry-java/pull/5118#issuecomment-3966761742