### PR TITLE
fix(header): Align Docs logo vertically with nav links

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -156,10 +156,10 @@ export function Header({
           <Link
             href="/"
             title="Sentry error monitoring"
-            className="logo-slot flex flex-shrink-0 items-center text-lg font-medium text-[var(--foreground)] mr-1"
+            className="logo-slot flex flex-shrink-0 items-center text-lg font-medium text-[var(--foreground)] mr-1 py-2 border-b-2 border-transparent -translate-y-[1px]"
             style={{minWidth: 0}}
           >
-            <div className="h-full pb-[2px] mr-2">
+            <div className="mr-2">
               <Image
                 src={SentryLogoSVG}
                 alt="Sentry's logo"


### PR DESCRIPTION
Before: 
<img width="658" height="210" alt="Screenshot 2026-03-02 at 12 25 59" src="https://github.com/user-attachments/assets/ec18f4dc-b7d2-4322-8679-bbb3ff27d695" />

After:
<img width="642" height="222" alt="Screenshot 2026-03-02 at 12 26 03" src="https://github.com/user-attachments/assets/6a80b3ca-6916-498f-8f6e-707c4032f1e6" />
