### PR TITLE
fix(telemetry-processor): Clarify backend telemetry processor scope and limitations

### DIFF
--- a/develop-docs/sdk/foundations/processing/telemetry-processor/backend-telemetry-processor.mdx
+++ b/develop-docs/sdk/foundations/processing/telemetry-processor/backend-telemetry-processor.mdx
@@ -8,6 +8,12 @@ sidebar_order: 1
   🚧 This document is work in progress.
 </Alert>
 
+<Alert>
+  This document uses key words such as "MUST", "SHOULD", and "MAY" as defined
+  in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement
+  levels.
+</Alert>
+
 For the common specification, refer to the [Telemetry Processor](/sdk/foundations/processing/telemetry-processor/) page. This page describes a backend-specific approach, which is optimized for high load. The key difference is that the telemetry scheduler pulls telemetry data from the telemetry buffers using **weighted round-robin scheduling**.
 
 It's worth noting that this approach may not be suitable for SDKs needing to support multiple platforms, such as Java, because this approach doesn't work well with offline caching. Offline caches also need a priority based sending strategy and a priority based overflow strategy to avoid dropping critical data over high volume data. If the telemetry scheduler pulls data from the telemetry buffer and it supports an offline cache, it needs to balance items in the offline cache with items from the telemetry buffer. Each SDK should evaluate its requirements and decide whether to adopt the backend-specific pull-based approach or continue using a push-based model as defined in the [Telemetry Processor](/sdk/foundations/processing/telemetry-processor/) page, depending on its platform constraints and architectural needs.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarifies that the backend telemetry processor's pull-based approach is optimized for high load but may not suit SDKs needing offline caching support (e.g., Java). Each SDK should evaluate whether to adopt the pull-based or push-based model based on its platform constraints.

- Reworded intro to focus on the pull-based scheduling model
- Added paragraph explaining trade-offs with offline caching

Part of https://github.com/getsentry/sentry-docs/issues/16189.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>