### PR TITLE
Mobile docs encoding

### DIFF
--- a/docs/concepts/search/index.mdx
+++ b/docs/concepts/search/index.mdx
@@ -151,13 +151,13 @@ For ease of use, we recommend using the wildcard `*` character instead of these 
 # Note: the characters wrapping the operators are `\uf00d`.
 
 # contains, and does not contain
-browser:Containschrome, !browser:Containsfire
+browser:\uf00dContains\uf00dchrome, !browser:\uf00dContains\uf00dfire
 
 # starts with, and does not start with
-browser:StartsWithchrome, !browser:StartsWithchrome
+browser:\uf00dStartsWith\uf00dchrome, !browser:\uf00dStartsWith\uf00dchrome
 
 # ends with, and does not end with
-browser:EndsWithchrome, !browser:EndsWithfire
+browser:\uf00dEndsWith\uf00dchrome, !browser:\uf00dEndsWith\uf00dfire
 ```
 
 ## Page Filters


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## DESCRIBE YOUR PR
Fixes an encoding issue on the wildcard operators documentation page (`/docs/concepts/search/index.mdx`). The code block was using literal `\uf00d` characters, which displayed as boxes (□) on Mobile Safari due to font rendering issues. This PR replaces these literal characters with their escaped text representation `\uf00d` to ensure consistent display across all browsers and clearly communicate the correct characters to users.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

---
[Slack Thread](https://sentry.slack.com/archives/C8H0BQRDJ/p1772586328839519?thread_ts=1772586328.839519&cid=C8H0BQRDJ)

<p><a href="https://cursor.com/agents/bc-d8aed35e-26a1-5b68-bcf4-a276e4e227ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8aed35e-26a1-5b68-bcf4-a276e4e227ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->