### PR TITLE
docs(build-distribution,size-analysis): Move processing filters below upload guides

### DIFF
--- a/docs/product/build-distribution/index.mdx
+++ b/docs/product/build-distribution/index.mdx
@@ -12,16 +12,6 @@ Build Distribution enables you to securely distribute app builds to your interna
 
 Integrate Build Distribution into your CI pipeline to automatically distribute builds to your teams.
 
-### Configuring Processing Filters in Sentry Settings
-
-You can control which uploaded builds are processed for Build Distribution in Sentry Settings. Go to your project's [Mobile Builds](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/mobile-builds/) settings.
-
-![Mobile Builds Settings Page](../size-analysis/images/settings-mobile-builds.png)
-
-By default, Build Distribution processes all uploaded builds. You can configure filters to only distribute builds matching specific criteria, such as `git_head_ref: main`, `build_configuration_name: Release`, or `app_id: com.example.app`.
-
-![Example filter configuration](./images/settings-config.png)
-
 ## Upload Guides
 
 You can follow the platform guides to learn how to upload builds for distribution:
@@ -34,6 +24,16 @@ You can follow the platform guides to learn how to upload builds for distributio
 Below is the metadata included in your build, regardless of the platform.
 
 <Include name="size-analysis/upload-metadata" />
+
+### Configuring Processing Filters in Sentry Settings
+
+You can control which uploaded builds are processed for Build Distribution in Sentry Settings. Go to your project's [Mobile Builds](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/mobile-builds/) settings.
+
+![Mobile Builds Settings Page](../size-analysis/images/settings-mobile-builds.png)
+
+By default, Build Distribution processes all uploaded builds. You can configure filters to only distribute builds matching specific criteria, such as `git_head_ref: main`, `build_configuration_name: Release`, or `app_id: com.example.app`.
+
+![Example filter configuration](./images/settings-config.png)
 
 ## Install Groups
 

--- a/docs/product/size-analysis/index.mdx
+++ b/docs/product/size-analysis/index.mdx
@@ -36,16 +36,6 @@ jobs:
 
 See [Integrating Into CI](/product/size-analysis/integrating-into-ci/) for end-to-end setup, and our sample GitHub actions for [Android](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_emerge_upload.yml) and [iOS](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_emerge_upload_pr.yml). Platform-specific upload steps are covered in the [Upload Guides](#upload-guides) below.
 
-### Configuring Processing Filters in Sentry Settings
-
-You can further tune your builds for Size Analysis in Sentry Settings. Go to your project's [Mobile Builds](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/mobile-builds/) settings.
-
-![Mobile Builds Settings Page](./images/settings-mobile-builds.png)
-
-By default, Size Analysis processes all uploaded builds. You can configure filters to only process builds for specific criteria, e.g. `git_head_ref: main`, `build_configuration_name: Release`, etc. Below is an example filter for a specific bundle (`com.emergetools.hackernews`) and branch (`main`).
-
-![Example Filter for specific bundle + branch](./images/settings-config-1.png)
-
 ## Features
 
 ### Build Details
@@ -118,5 +108,15 @@ You can follow the platform guides to learn how to upload builds for Size Analys
 Below is the metadata included in your build, regardless of the platform.
 
 <Include name="size-analysis/upload-metadata" />
+
+### Configuring Processing Filters in Sentry Settings
+
+You can further tune your builds for Size Analysis in Sentry Settings. Go to your project's [Mobile Builds](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/mobile-builds/) settings.
+
+![Mobile Builds Settings Page](./images/settings-mobile-builds.png)
+
+By default, Size Analysis processes all uploaded builds. You can configure filters to only process builds for specific criteria, e.g. `git_head_ref: main`, `build_configuration_name: Release`, etc. Below is an example filter for a specific bundle (`com.emergetools.hackernews`) and branch (`main`).
+
+![Example Filter for specific bundle + branch](./images/settings-config-1.png)
 
 <PageGrid />


### PR DESCRIPTION
## DESCRIBE YOUR PR

Move the "Configuring Processing Filters" sections below the upload guides on both the Size Analysis and Build Distribution pages. Filters can only be configured after builds are uploaded, so the page flow now matches the logical order: intro → upload → filter.

- Size Analysis: moved filters below Upload Metadata
- Build Distribution: moved filters below Upload Metadata

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>