### PR TITLE
feat(logs,metrics,spans): Add `settings` object spec for envelope item container

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -361,7 +361,7 @@ An envelope **MUST** contain at most one `log` envelope item — all log entries
   "items": [{..log..}, {..log..}, {..log..}, {..log..}, {..log..}],
   "settings": {
     "infer_ip:": "auto",
-    "infer_useragent:": "auto",
+    "infer_useragent:": "auto"
   }
 }
 ```

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -10,6 +10,9 @@ spec_depends_on:
   - id: sdk/foundations/state-management/scopes/attributes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.17.0
+    date: 2026-03-05
+    summary: Added `settings` to log envelope item
   - version: 1.16.0
     date: 2026-03-04
     summary: Add sentry.timestamp.sequence attribute for deterministic log ordering
@@ -355,9 +358,28 @@ An envelope **MUST** contain at most one `log` envelope item — all log entries
   "content_type": "application/vnd.sentry.items.log+json"
 }
 {
-  "items": [{..log..}, {..log..}, {..log..}, {..log..}, {..log..}]
+  "items": [{..log..}, {..log..}, {..log..}, {..log..}, {..log..}],
+  "settings": {
+    "infer_ip:": "auto",
+    "infer_useragent:": "auto",
+  }
 }
 ```
+
+</SpecSection>
+
+<SpecSection id="log-envelope-item-settings" status="proposal" since="1.17.0">
+
+### Envelope Item `settings`
+
+The `log` envelope item `settings` property is an optional JSON object that contains ingestion settings for Relay to infer certain data from the incoming request.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
+| `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
+
+This can be used by SDKs like Browser or React Native to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the log as an attribute.
 
 </SpecSection>
 

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -382,7 +382,7 @@ The `log` envelope item `ingest_settings` property is an optional JSON object th
 
 SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the log as an attribute.
 
-For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher.
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher. If `version` is omitted, Relay treats the payload as version `1` and doesn't apply `ingest_settings`.
 
 </SpecSection>
 

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -339,7 +339,7 @@ SDKs **MUST** report count (`log_item`) and size in bytes (`log_byte`) of discar
 
 ### `log` Envelope Item
 
-The `log` envelope item contains an array of log payloads encoded as JSON, allowing multiple logs per envelope item.
+The `log` envelope item payload is a JSON object that **MUST** include an `items` array of log entries, allowing multiple logs per envelope item. The payload **MAY** also include top-level `version` and `ingest_settings` fields as specified in the next section.
 
 An envelope **MUST** contain at most one `log` envelope item — all log entries for a flush are batched into a single item's `items` array. Logs from different traces **MAY** be mixed into the same `log` item, but if they are, the envelope **MUST NOT** include a DSC (dynamic sampling context) header.
 

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -2,7 +2,7 @@
 title: Logs
 description: Structured logging protocol with severity levels, trace context, and batched envelope delivery.
 spec_id: sdk/telemetry/logs
-spec_version: 1.16.0
+spec_version: 1.17.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
@@ -12,7 +12,7 @@ spec_depends_on:
 spec_changelog:
   - version: 1.17.0
     date: 2026-03-05
-    summary: Added `settings` to log envelope item
+    summary: Added `ingest_settings` and `version` to log envelope item
   - version: 1.16.0
     date: 2026-03-04
     summary: Add sentry.timestamp.sequence attribute for deterministic log ordering
@@ -358,28 +358,31 @@ An envelope **MUST** contain at most one `log` envelope item — all log entries
   "content_type": "application/vnd.sentry.items.log+json"
 }
 {
-  "items": [{..log..}, {..log..}, {..log..}, {..log..}, {..log..}],
-  "settings": {
-    "infer_ip:": "auto",
-    "infer_useragent:": "auto"
-  }
+  "version": 2,
+  "ingest_settings": {
+    "infer_ip": "auto",
+    "infer_useragent": "auto"
+  },
+  "items": [{..log..}, {..log..}, {..log..}, {..log..}, {..log..}]
 }
 ```
 
 </SpecSection>
 
-<SpecSection id="log-envelope-item-settings" status="proposal" since="1.17.0">
+<SpecSection id="log-envelope-item-ingest-settings" status="candidate" since="1.17.0">
 
-### Envelope Item `settings`
+### `version` and `ingest_settings` properties
 
-The `log` envelope item `settings` property is an optional JSON object that contains ingestion settings for Relay to infer certain data from the incoming request.
+The `log` envelope item `ingest_settings` property is an optional JSON object that contains ingestion settings for Relay, for example, to infer certain data from the incoming request.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
 | `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
 
-This can be used by SDKs like Browser or React Native to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the log as an attribute.
+SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the log as an attribute.
+
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher.
 
 </SpecSection>
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -10,6 +10,9 @@ spec_depends_on:
   - id: sdk/foundations/state-management/scopes/attributes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 2.8.0
+    date: 2026-04-07
+    summary: Added `settings` to trace_metric envelope item
   - version: 2.7.0
     date: 2026-03-10
     summary: Auto-emitted metrics and third-party metrics bindings MUST be opt-in
@@ -274,8 +277,27 @@ An envelope **MUST** contain at most one `trace_metric` envelope item — all me
 }
 {
 	"items": [{..metric..}, {..metric..}, {..metric..}]
+	"settings": {
+		"infer_ip:": "auto",
+		"infer_useragent:": "auto",
+	}
 }
 ```
+
+</SpecSection>
+
+<SpecSection id="trace-metric-envelope-item-settings" status="proposal" since="2.7.0">
+
+### Envelope Item `settings`
+
+The `trace_metric` envelope item `settings` property is an optional JSON object that contains ingestion settings for Relay to infer certain data from the incoming request.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
+| `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
+
+This can be used by SDKs like Browser or React Native to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the metric as an attribute.
 
 </SpecSection>
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -300,7 +300,7 @@ The `trace_metric` envelope item `ingest_settings` property is an optional JSON 
 
 SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the metric as an attribute.
 
-For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher.
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher. If `version` is omitted, Relay treats the payload as version `1` and doesn't apply `ingest_settings`.
 
 </SpecSection>
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -257,7 +257,7 @@ These rules exist because auto-emitted metrics can cause a high volume of teleme
 
 ### `trace_metric` Envelope Item
 
-Metrics are sent as a `trace_metric` envelope item containing a JSON object with an `items` array. See the [Examples](#full-trace_metric-envelope) section for a complete envelope.
+The `trace_metric` envelope item payload is a JSON object that **MUST** include an `items` array of metric entries, allowing multiple metrics per envelope item. The payload **MAY** also include top-level `version` and `ingest_settings` fields as specified in the next section. See the [Examples](#full-trace_metric-envelope) section for a complete envelope.
 
 An envelope **MUST** contain at most one `trace_metric` envelope item — all metrics for a flush are batched into a single item's `items` array. Metrics from different traces **MAY** be mixed into the same `trace_metric` item, but if they are, the envelope **MUST NOT** include a DSC (dynamic sampling context) header.
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -2,7 +2,7 @@
 title: Metrics
 description: Counter, gauge, and distribution metrics sent as batched trace_metric envelope items.
 spec_id: sdk/telemetry/metrics
-spec_version: 2.7.0
+spec_version: 2.8.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
@@ -12,7 +12,7 @@ spec_depends_on:
 spec_changelog:
   - version: 2.8.0
     date: 2026-04-07
-    summary: Added `settings` to trace_metric envelope item
+    summary: Added `ingest_settings` and `version` to trace_metric envelope item
   - version: 2.7.0
     date: 2026-03-10
     summary: Auto-emitted metrics and third-party metrics bindings MUST be opt-in
@@ -276,28 +276,31 @@ An envelope **MUST** contain at most one `trace_metric` envelope item — all me
 	"content_type": "application/vnd.sentry.items.trace-metric+json"
 }
 {
-	"items": [{..metric..}, {..metric..}, {..metric..}],
-	"settings": {
-		"infer_ip:": "auto",
-		"infer_useragent:": "auto"
-	}
+	"version": 2,
+	"ingest_settings": {
+		"infer_ip": "auto",
+		"infer_useragent": "auto"
+	},
+	"items": [{..metric..}, {..metric..}, {..metric..}]
 }
 ```
 
 </SpecSection>
 
-<SpecSection id="trace-metric-envelope-item-settings" status="proposal" since="2.7.0">
+<SpecSection id="trace-metric-envelope-item-ingest-settings" status="candidate" since="2.8.0">
 
-### Envelope Item `settings`
+### `version` and `ingest_settings` properties
 
-The `trace_metric` envelope item `settings` property is an optional JSON object that contains ingestion settings for Relay to infer certain data from the incoming request.
+The `trace_metric` envelope item `ingest_settings` property is an optional JSON object that contains ingestion settings for Relay, for example, to infer certain data from the incoming request.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
 | `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
 
-This can be used by SDKs like Browser or React Native to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the metric as an attribute.
+SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the metric as an attribute.
+
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher.
 
 </SpecSection>
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -276,10 +276,10 @@ An envelope **MUST** contain at most one `trace_metric` envelope item — all me
 	"content_type": "application/vnd.sentry.items.trace-metric+json"
 }
 {
-	"items": [{..metric..}, {..metric..}, {..metric..}]
+	"items": [{..metric..}, {..metric..}, {..metric..}],
 	"settings": {
 		"infer_ip:": "auto",
-		"infer_useragent:": "auto",
+		"infer_useragent:": "auto"
 	}
 }
 ```

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -49,7 +49,7 @@ The span v2 envelope item container is defined as follows:
   "items": [{..span..}, {..span..}, {..span..}],
   "settings": {
     "infer_ip:": "auto",
-    "infer_useragent:": "auto",
+    "infer_useragent:": "auto"
   }
 }
 ```

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -42,6 +42,35 @@ The envelope item header must contain the following properties:
 
 ## Span v2 Envelope Item Payload
 
+The span v2 envelope item container is defined as follows:
+
+```json
+{
+  "items": [{..span..}, {..span..}, {..span..}],
+  "settings": {
+    "infer_ip:": "auto",
+    "infer_useragent:": "auto",
+  }
+}
+```
+
+<SpecSection id="span-envelope-item-settings" status="proposal" since="0.0.0">
+
+### Envelope Item `settings`
+
+The `span` envelope item `settings` property is an optional JSON object that contains ingestion settings for Relay to infer certain data from the incoming request.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
+| `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
+
+This can be used by SDKs like Browser or React Native to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the span as an attribute.
+
+</SpecSection>
+
+### `span` Item Payload
+
 The envelope item payload must contain an `items` array with span one and up to 1000 span objects:
 
 ```json

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -42,7 +42,9 @@ The envelope item header must contain the following properties:
 
 ## Span v2 Envelope Item Payload
 
-The span v2 envelope item container is defined as follows:
+The span v2 envelope item payload is a JSON object that **MUST** include an `items` array of span objects. The payload **MAY** also include top-level `version` and `ingest_settings` fields as specified in the next section.
+
+The container is defined as follows:
 
 ```json
 {
@@ -74,7 +76,7 @@ For ingestion settings to take effect, the SDK **MUST** also set the `version` p
 
 ### `items` property - `span` Item Payload
 
-The envelope item payload must contain an `items` array with span one and up to 1000 span objects:
+The `items` array **MUST** contain at least one and at most 1000 span objects:
 
 ```json
 {

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -46,30 +46,33 @@ The span v2 envelope item container is defined as follows:
 
 ```json
 {
-  "items": [{..span..}, {..span..}, {..span..}],
-  "settings": {
-    "infer_ip:": "auto",
-    "infer_useragent:": "auto"
-  }
+  "version": 2,
+  "ingest_settings": {
+    "infer_ip": "auto",
+    "infer_useragent": "auto"
+  },
+  "items": [{..span..}, {..span..}, {..span..}]
 }
 ```
 
-<SpecSection id="span-envelope-item-settings" status="proposal" since="0.0.0">
+<SpecSection id="span-envelope-item-ingest-settings" status="candidate" since="0.0.0">
 
-### Envelope Item `settings`
+### `version` and `ingest_settings` properties
 
-The `span` envelope item `settings` property is an optional JSON object that contains ingestion settings for Relay to infer certain data from the incoming request.
+The span envelope item `ingest_settings` property is an optional JSON object that contains ingestion settings for Relay, for example, to infer certain data from the incoming request.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
 | `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
 
-This can be used by SDKs like Browser or React Native to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the span as an attribute.
+SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the span as an attribute.
+
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher.
 
 </SpecSection>
 
-### `span` Item Payload
+### `items` property - `span` Item Payload
 
 The envelope item payload must contain an `items` array with span one and up to 1000 span objects:
 

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -70,7 +70,7 @@ The span envelope item `ingest_settings` property is an optional JSON object tha
 
 SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the span as an attribute.
 
-For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher.
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher. If `version` is omitted, Relay treats the payload as version `1` and doesn't apply `ingest_settings`. 
 
 </SpecSection>
 


### PR DESCRIPTION
This PR adds a specification for ingestion settings of what data Relay should infer from incoming requests. This object shall be the same across our new telemetry items (logs, metrics and spans (v2)) and it lives on the container object:

```json
{
  "version": 2,
  "items": [...],
  "ingest_settings": {
    "infer_ip:": "auto",
    "infer_useragent:": "auto",
  }
}
```

This shall serve as a replacement for the `settings` property on the `sdk` object on events as [defined here](https://develop.sentry.dev/sdk/foundations/transport/event-payloads/sdk/).
I went with the same `'auto'` and `'never'` values but omitted `'legacy'` since it doesn't seem like we need it. If reviewers prefer, we can also use a `boolean` instead, assuming we never need more than two states.

For backwards compatibility, this also introduces a `version` field which must be set to at least `2` for `ingest_settings` to take effect.

Prior to this PR, @cleptric @Dav1dde and I discussed this format. Happy to adjust as reviewers see fit!

ref https://linear.app/getsentry/issue/FE-714/how-to-send-sdksettings-infer-ip