### PR TITLE
docs(godot): Add clear_attachments() to attachments page

### DIFF
--- a/docs/platforms/godot/enriching-events/attachments/index.mdx
+++ b/docs/platforms/godot/enriching-events/attachments/index.mdx
@@ -49,6 +49,12 @@ You can add attachments that will be sent with every event using <PlatformIdenti
 
 <PlatformContent includePath="enriching-events/attachment-upload" />
 
+To clear all user-added attachments, use <PlatformIdentifier name="SentrySDK.clear-attachments()" />. Built-in attachments such as log files, screenshots, and view hierarchy are preserved.
+
+```GDScript
+SentrySDK.clear_attachments()
+```
+
 <Alert>
 
 Sentry allows at most 40MB for a compressed request, and at most 200MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the new `SentrySDK.clear_attachments()` method on the Godot attachments page. This method removes all user-added attachments while preserving built-in ones (log files, screenshots, view hierarchy).

- Godot SDK PR: https://github.com/getsentry/sentry-godot/pull/565

Co-Authored-By: Claude <noreply@anthropic.com>

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)