### PR TITLE
fix(theme-toggle): show moon in light mode, sun in dark mode

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -13,12 +13,12 @@ export function ThemeToggle({
     <Fragment>
       <style>{`
      :root, .light, .light-theme {
-       --theme-toggle-sun-icon-display: block;
-       --theme-toggle-moon-icon-display: none;
-     }
-     .dark, .dark-theme {
        --theme-toggle-sun-icon-display: none;
        --theme-toggle-moon-icon-display: block;
+     }
+     .dark, .dark-theme {
+       --theme-toggle-sun-icon-display: block;
+       --theme-toggle-moon-icon-display: none;
      }
    `}</style>
 


### PR DESCRIPTION
The icon should represent the action (what you switch TO), not the current state. In light mode, show the moon to switch to dark. In dark mode, show the sun to switch to light.
