### PR TITLE
docs(nextjs): Add workaround for multiple transactions inside after

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/tracing/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/tracing/index.mdx
@@ -375,7 +375,7 @@ Sentry.init({
 
 ### Detached spans with `after()`
 
-If you're using Next.js's [`after()`](https://nextjs.org/docs/app/api-reference/functions/after) and seeing many small transactions (like individual `db` spans) instead of one cohesive trace, your spans are becoming detached.
+If you're using Next.js's [`after()`](https://nextjs.org/docs/app/api-reference/functions/after) and you see multiple root spans (like individual `db` spans) instead of one cohesive trace, your spans are becoming detached.
 
 This happens when `after()` runs after the response is sent. By then, the request's root span has already ended.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

closes #16815
closes [DOCS-2548](https://linear.app/getsentry/issue/DOCS-2548/document-after-trace-context-behavior-for-nextjs)

I wasn't sure where to add this, but decided to move it into the Next.js specific troubleshootings inside the tracing section. I was also not sure how technical it should be, but was then going into a mix of being technical enough to use "transaction", but not going into much detail why this happens exactly.	

Would it make sense to link to the original discussion: https://github.com/getsentry/sentry-javascript/issues/19529#issuecomment-3973460550 ?

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
