### PR TITLE
docs(apple): Document NoUIFramework SPM package trait

### DIFF
--- a/docs/platforms/apple/common/install/swift-package-manager.mdx
+++ b/docs/platforms/apple/common/install/swift-package-manager.mdx
@@ -30,9 +30,7 @@ Alternatively, when your project uses a `Package.swift` file to manage dependenc
 
 ## Building Without UIKit or AppKit
 
-If you're building a command-line tool, a headless server app, or any other target where UIKit or AppKit isn't available, you can use the `NoUIFramework` package trait to strip out UI framework dependencies entirely. This requires **Swift 6.1+** and **Xcode 26.4+**.
-
-When enabled, the SDK compiles from source without linking UIKit, AppKit, or SwiftUI. UI-related features like UIViewController tracing and screenshot capture are excluded.
+If you're building a command-line tool, a headless server app, or any other target where UIKit or AppKit isn't available, you can use the `NoUIFramework` package trait to strip out UI framework dependencies entirely. This requires **Sentry SDK 9.7.0+**, **Swift 6.1+**, and **Xcode 26.4+**. When enabled, the SDK compiles from source without linking UIKit, AppKit, or SwiftUI. UI-related features like UIViewController tracing and screenshot capture are excluded.
 
 ### Xcode
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the new `NoUIFramework` Swift Package Manager trait added in getsentry/sentry-cocoa#7578. This trait lets compile-from-source users build the Sentry SDK without UIKit or AppKit linkage — useful for command-line tools, headless servers, and other non-UI contexts.

Adds a "Building Without UIKit or AppKit" section to the SPM install page covering:
- Requirements (Swift 6.1+, Xcode 26.4+)
- Xcode UI setup (selecting `SentrySPM` product, enabling the trait)
- `Package.swift` configuration with a runnable example
- Note explaining why `SentrySPM` (compile-from-source) is needed

Refs getsentry/sentry-cocoa#7578

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>