### PR TITLE
docs(godot): Document adding attachments in config callback

### DIFF
--- a/docs/platforms/godot/enriching-events/attachments/index.mdx
+++ b/docs/platforms/godot/enriching-events/attachments/index.mdx
@@ -49,6 +49,17 @@ You can add attachments that will be sent with every event using <PlatformIdenti
 
 <PlatformContent includePath="enriching-events/attachment-upload" />
 
+You can also add attachments inside the `SentrySDK.init()` configuration callback. This is useful when you want to register attachments as part of SDK setup:
+
+```GDScript
+SentrySDK.init(func(options: SentryOptions) -> void:
+	# Add attachment during initialization.
+	var att := SentryAttachment.create_with_path("user://logs/godot.log")
+	att.content_type = "text/plain"
+	SentrySDK.add_attachment(att)
+)
+```
+
 To clear all user-added attachments, use <PlatformIdentifier name="SentrySDK.clear-attachments()" />. Built-in attachments such as log files, screenshots, and view hierarchy are preserved.
 
 ```GDScript


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document that `SentrySDK.add_attachment()` can be called inside the `SentrySDK.init()` configuration callback, with a code example.

- Godot SDK PR: https://github.com/getsentry/sentry-godot/pull/573

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)