### PR TITLE
docs(python): Add owner field examples to crons documentation

### DIFF
--- a/docs/platforms/python/integrations/celery/crons.mdx
+++ b/docs/platforms/python/integrations/celery/crons.mdx
@@ -155,17 +155,3 @@ def init_sentry(**kwargs):
 def tell_the_world(msg):
     print(msg)
 ```
-
-You can also pass additional monitor configuration, including ownership:
-
-```python {diff} {filename:tasks.py}
-+monitor_config = {
-+    "schedule": {"type": "crontab", "value": "0 0 * * *"},
-+    "owner": "team:6",
-+}
-
-@app.task
-+@sentry_sdk.monitor(monitor_slug='<monitor-slug>', monitor_config=monitor_config)
-def tell_the_world(msg):
-    print(msg)
-```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add documentation for the new `owner` field in Python cron monitor configuration. This field allows developers to assign monitor ownership to teams or users
(format: `"team:6"` or `"user:51"`) for improved discoverability and routing within Sentry organizations.

**Related SDK PR:** getsentry/sentry-python#5609

### Changes:
- Updated `docs/platforms/python/crons/index.mdx` to include `owner` field in monitor_config example
- Updated `docs/platforms/python/integrations/celery/crons.mdx` to show usage with Celery tasks

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## SLA

Reviewers: @getsentry/docs (or specific docs team member if you know them)

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
