### PR TITLE
ci: Fix bump-api-schema workflow to merge PRs immediately

### DIFF
--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -39,6 +39,11 @@ jobs:
           sed -i -e "s|^const SENTRY_API_SCHEMA_SHA =.*$|const SENTRY_API_SCHEMA_SHA = '$sha';|g" "$filepath"
           echo "Updated $filepath"
 
+          if git diff --quiet "$filepath"; then
+            echo "No changes to $filepath, skipping."
+            exit 0
+          fi
+
           branch="bot/bump-api-schema-to-${sha:0:8}"
           git checkout -b "$branch"
           git add "$filepath"
@@ -46,4 +51,4 @@ jobs:
           git push --set-upstream origin "$branch"
 
           gh pr create --fill
-          gh pr merge --squash --auto
+          gh pr merge --squash --admin


### PR DESCRIPTION
## DESCRIBE YOUR PR

The `bump-api-schema-sha.yml` workflow creates PRs with `--auto` merge, but checks never pass — causing a pile-up of open "Bump API schema" PRs. Since getsentry bot has been added to bypass PR requirements, we can use `--admin` to merge immediately.

Changes:
- Add no-op guard after `sed` to skip when the SHA is unchanged (prevents duplicate PRs)
- Switch `gh pr merge --squash --auto` → `gh pr merge --squash --admin` (bypass branch protections, merge immediately)

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)