### PR TITLE
docs(search): Add comment about wildcard operators

### DIFF
--- a/docs/concepts/search/index.mdx
+++ b/docs/concepts/search/index.mdx
@@ -120,6 +120,10 @@ In the example above, the search query returns all Issues that are unresolved _a
 
 #### Wildcard Character
 
+{/* Internal note: Do not document wildcard operators on this page. Keep the
+query syntax docs limited to the supported public syntax we want customers to
+use. */}
+
 Search supports the wildcard character `*` as a placeholder for specific characters and strings.
 
 ```


### PR DESCRIPTION
Adding in a comment to not mention wildcard ops.