### PR TITLE
docs(sdk): Review agents-md

### DIFF
--- a/develop-docs/sdk/getting-started/templates/agents-md.mdx
+++ b/develop-docs/sdk/getting-started/templates/agents-md.mdx
@@ -13,7 +13,7 @@ Keep it focused on what the agent **cannot easily discover by reading the code**
 - **Commands** — exact invocations for test, lint, format, and build. Especially non-obvious ones like tox environments, specific flags, or required env setup.
 - **Non-obvious conventions** — things that look wrong but are intentional, or constraints that aren't visible in the code (e.g. "all migrations must be backward-compatible, we run blue-green deploys").
 - **Changelog and commit format** — agents will guess the wrong format without explicit instruction.
-- **Links to specs and standards** — the SDK spec, platform docs, and cross-SDK alignment references the agent can't find on its own.
+- **Links to specs and standards** — the SDK spec and platform docs the agent can't find on its own.
 
 **Keep it short.** Every line costs reasoning tokens. Prefer automated enforcement (linters, type checkers, CI) over written rules — tooling catches mistakes reliably; instructions don't always.
 
@@ -65,7 +65,6 @@ Remove sections that don't apply and replace all `[placeholder]` values with rea
 
 ## References
 
-- SDK spec: https://develop.sentry.dev/sdk/
+- SDK specs: https://develop.sentry.dev/sdk/
 - Platform docs: https://docs.sentry.io/platforms/[platform]/
-- Cross-SDK standards: https://develop.sentry.dev/sdk/getting-started/
 ```

--- a/redirects.js
+++ b/redirects.js
@@ -19,6 +19,10 @@ const developerDocsRedirects = [
     source: '/sdk/features/mcp-instrumentation/:path*',
     destination: '/sdk/foundations/client/integrations/mcp/:path*',
   },
+  {
+    source: '/sdk/getting-started/templates/agents-md-template/',
+    destination: '/sdk/getting-started/templates/agents-md/',
+  },
   // Playbook reorganization: flat → grouped subfolders
   {
     source: '/sdk/getting-started/playbooks/adding-a-dependency/',


### PR DESCRIPTION
Rename the AGENTS.md template file from `agents-md-template.mdx` to `agents-md.mdx` for a cleaner URL, add a redirect from the old path, and simplify the references section in the template.