### PR TITLE
fix(telemtry-processor): Add RFC 2119 alert to backend spec

### DIFF
--- a/develop-docs/sdk/foundations/processing/telemetry-processor/backend-telemetry-processor.mdx
+++ b/develop-docs/sdk/foundations/processing/telemetry-processor/backend-telemetry-processor.mdx
@@ -8,6 +8,12 @@ sidebar_order: 1
   🚧 This document is work in progress.
 </Alert>
 
+<Alert>
+  This document uses key words such as "MUST", "SHOULD", and "MAY" as defined
+  in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement
+  levels.
+</Alert>
+
 For the common specification, refer to the [Telemetry Processor](/sdk/foundations/processing/telemetry-processor/) page. This page describes the backend-specific implementation. The key difference is that backend SDKs use **weighted round-robin scheduling** to ensure critical telemetry (like errors) gets priority over high-volume data (like logs) when the application is under heavy load.
 
 ## Backend-Specific Design Decisions


### PR DESCRIPTION
## DESCRIBE YOUR PR
Adds the RFC 2119 requirements alert to the backend telemetry processor spec so normative keywords are explicitly defined in this file.

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA
- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.

## PRE-MERGE CHECKLIST
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Co-Authored-By: Claude <noreply@anthropic.com>
