### PR TITLE
docs(dev/metrics): Add opt-in requirement for auto-emitted metrics

### DIFF
--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -240,7 +240,7 @@ However, metrics that are **automatically emitted by integrations or libraries**
 
 **Third-party metrics bindings** — An SDK feature that binds to an external library's metrics API and mirrors those metrics as Sentry metrics in the background (e.g., syncing from a framework's built-in metrics or an OpenTelemetry metrics pipeline) **MUST** also be opt-in. Users **MUST** explicitly enable the binding before any metrics are forwarded to Sentry.
 
-These rules exist because auto-emitted metrics can produce high cardinality and volume that directly impacts a user's quota. Unlike spans or errors — where users have prior intuition about volume — silently emitting metrics on their behalf could lead to unexpected costs. Requiring opt-in ensures users remain in control of their metrics volume.
+These rules exist because auto-emitted metrics can cause a high volume of telemetry that directly impacts a user's quota. Unlike spans or errors — where users have prior intuition about volume — silently emitting metrics on their behalf could lead to unexpected costs. Requiring opt-in ensures users remain in control of their metrics volume.
 
 </SpecSection>
 


### PR DESCRIPTION
Adds a new candidate section (v2.7.0) to the metrics spec requiring auto-emitted metrics to be opt-in.

- Integrations that auto-emit metrics MUST be opt-in (via integration option or explicit registration)                                                                                   
- Third-party metrics bindings (e.g., syncing from framework metrics) MUST be opt-in
