### PR TITLE
docs(unreal): Update Unreal docs to reflect callback reentrancy protection

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -215,6 +215,12 @@ If your callback handler class is part of another plugin, ensure that plugin is 
 
 </Alert>
 
+<Alert level="info">
+
+Avoid triggering the same hook from within its own handler (for example, adding a breadcrumb inside a <PlatformIdentifier name="BeforeBreadcrumb" /> handler). The SDK guards against this by skipping reentrant invocations of the same hook type — the data will still be captured, but your custom handler won't be called for the reentrant invocation.
+
+</Alert>
+
 <SdkOption name="BeforeSend" type="function">
 
 This function is called with an SDK-specific message or error event object, and can return a modified event object, or `null` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.

--- a/docs/platforms/unreal/enriching-events/breadcrumbs/index.mdx
+++ b/docs/platforms/unreal/enriching-events/breadcrumbs/index.mdx
@@ -47,7 +47,13 @@ The Unreal Engine SDK can capture certain types of breadcrumbs automatically. Th
 
 SDKs allow you to customize breadcrumbs through the <PlatformIdentifier name="before-breadcrumb" /> hook (the corresponding handler class can be set in the plugin settings).
 
-This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `nullptr`:
+This hook is passed an already assembled breadcrumb and, in some SDKs, an optional hint. The function can modify the breadcrumb or decide to discard it entirely by returning `nullptr`.
+
+<Alert level="info">
+
+Avoid adding breadcrumbs or logging (for example, via `UE_LOG`) inside the <PlatformIdentifier name="before-breadcrumb" /> handler. The SDK prevents recursive calls by skipping reentrant invocations — the breadcrumb will still be captured, but your custom handler won't be called for it.
+
+</Alert>
 
 ```cpp
 UCLASS()

--- a/platform-includes/logs/setup/unreal.mdx
+++ b/platform-includes/logs/setup/unreal.mdx
@@ -79,7 +79,9 @@ SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::Create
 To filter logs, or update them before they are sent to Sentry, you can create a custom before-log handler class.
 
 <Alert level="info">
-  Logging additional messages in the BeforeLog handler can cause recursive call of the handler, resulting in a stack overflow!
+
+Avoid logging additional messages (for example, via `UE_LOG`) inside the `BeforeLog` handler. The SDK prevents recursive calls by skipping reentrant invocations — the log will still be captured, but your custom handler won't be called for it.
+
 </Alert>
 
 ```cpp


### PR DESCRIPTION
This PR updates the Unreal Engine SDK documentation to reflect the addition of per-callback reentrancy guards:

- Added a general reentrancy notice to the `Hooks` section in the configuration options page, explaining that the SDK skips reentrant invocations while still capturing the data
- Updated the `BeforeLog` handler warning to replace the outdated "stack overflow" message with accurate behavior description
- Added a reentrancy notice to the `Customize Breadcrumbs` section, since `BeforeBreadcrumb` is the most common callback to  trigger recursion via `UE_LOG`

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1279