### PR TITLE
ref: Migrate agent skills URL from sentry.gg to sentry.dev

### DIFF
--- a/src/components/agentSkillsCallout/index.tsx
+++ b/src/components/agentSkillsCallout/index.tsx
@@ -12,7 +12,7 @@ import styles from './style.module.scss';
 import {CodeBlock} from '../codeBlock';
 import {CodeTabs} from '../codeTabs';
 
-const SKILLS_BASE_URL = 'https://skills.sentry.gg';
+const SKILLS_BASE_URL = 'https://skills.sentry.dev';
 const SKILLS_REPO = 'getsentry/sentry-for-ai';
 
 type Props = {


### PR DESCRIPTION
## DESCRIBE YOUR PR

Update the agent skills base URL from `sentry.gg` to `sentry.dev` in the `AgentSkillsCallout` component.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)