### PR TITLE
docs(inbound-filters): Add health-check glob pattern to health check docs

### DIFF
--- a/docs/concepts/data-management/filtering/index.mdx
+++ b/docs/concepts/data-management/filtering/index.mdx
@@ -64,6 +64,7 @@ By applying this filter, you effectively bypass transactions that, while crucial
 We consider a transaction to be a health check if its name matches one of the following glob patterns:
 
 - `*healthcheck*`
+- `*health-check*`
 - `*heartbeat*`
 - `*/health`
 - `*/healthy`


### PR DESCRIPTION
Document the new *health-check* (hyphenated) glob pattern that was added to HEALTH_CHECK_GLOBS in sentry, alongside the existing *healthcheck* pattern.
