### PR TITLE
ref: add text to prevent markdown auto grouping

### DIFF
--- a/docs/platforms/php/guides/laravel/configuration/laravel-options.mdx
+++ b/docs/platforms/php/guides/laravel/configuration/laravel-options.mdx
@@ -60,6 +60,8 @@ If you want more control over which requests are monitored, use the [`traces_sam
 'traces_sampler' => [App\Exceptions\Sentry::class, 'tracesSampler'],
 ```
 
+Then implement the sampler:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/configuration/before-send-check-in/php.laravel.mdx
+++ b/platform-includes/configuration/before-send-check-in/php.laravel.mdx
@@ -4,6 +4,8 @@ In Laravel, use a callable to modify the check-in event or return a completely n
 'before_send_check_in' => [App\Exceptions\Sentry::class, 'beforeSendCheckIn'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/configuration/before-send-fingerprint/php.laravel.mdx
+++ b/platform-includes/configuration/before-send-fingerprint/php.laravel.mdx
@@ -2,6 +2,8 @@
 'before_send' => [App\Exceptions\Sentry::class, 'beforeSend'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/configuration/before-send-hint/php.laravel.mdx
+++ b/platform-includes/configuration/before-send-hint/php.laravel.mdx
@@ -2,6 +2,8 @@
 'before_send' => [App\Exceptions\Sentry::class, 'beforeSend'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/configuration/before-send-transaction/php.laravel.mdx
+++ b/platform-includes/configuration/before-send-transaction/php.laravel.mdx
@@ -4,6 +4,8 @@ In Laravel, use a callable to modify the transaction event or return a completel
 'before_send_transaction' => [App\Exceptions\Sentry::class, 'beforeSendTransaction'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/configuration/before-send/php.laravel.mdx
+++ b/platform-includes/configuration/before-send/php.laravel.mdx
@@ -4,6 +4,8 @@ In Laravel, use a callable to modify the event or return a completely new one. I
 'before_send' => [App\Exceptions\Sentry::class, 'beforeSend'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/php.laravel.mdx
+++ b/platform-includes/enriching-events/breadcrumbs/before-breadcrumb/php.laravel.mdx
@@ -2,6 +2,8 @@
 'before_breadcrumb' => [App\Exceptions\Sentry::class, 'beforeBreadcrumb'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/logs/options/php.laravel.mdx
+++ b/platform-includes/logs/options/php.laravel.mdx
@@ -6,6 +6,8 @@ To filter logs, or update them before they are sent to Sentry, you can use the `
 'before_send_log' => [App\Exceptions\Sentry::class, 'beforeSendLog'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/metrics/options/php.laravel.mdx
+++ b/platform-includes/metrics/options/php.laravel.mdx
@@ -6,6 +6,8 @@ To filter metrics, or update them before they are sent to Sentry, you can use th
 'before_send_metric' => [App\Exceptions\Sentry::class, 'beforeSendMetric'],
 ```
 
+Then implement the callback:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/performance/always-inherit-sampling-decision/php.laravel.mdx
+++ b/platform-includes/performance/always-inherit-sampling-decision/php.laravel.mdx
@@ -2,6 +2,8 @@
 'traces_sampler' => [App\Exceptions\Sentry::class, 'tracesSampler'],
 ```
 
+Then implement the sampler:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/performance/configure-sample-rate/php.laravel.mdx
+++ b/platform-includes/performance/configure-sample-rate/php.laravel.mdx
@@ -5,6 +5,8 @@
 'traces_sampler' => [App\Exceptions\Sentry::class, 'tracesSampler'],
 ```
 
+Then implement the sampler:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {

--- a/platform-includes/performance/traces-sampler-as-filter/php.laravel.mdx
+++ b/platform-includes/performance/traces-sampler-as-filter/php.laravel.mdx
@@ -2,6 +2,8 @@
 'traces_sampler' => [App\Exceptions\Sentry::class, 'tracesSampler'],
 ```
 
+Then implement the sampler:
+
 ```php {filename:app/Exceptions/Sentry.php}
 class Sentry
 {


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR introduces a small text between two markdown blocks in order to prevent them from getting collapsed into one block with tabs, which is hard to spot especially if both markdown blocks describe the same language

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
