### PR TITLE
feat(Seer): Updated RCA doc to include new RCA in Slack UX

### DIFF
--- a/docs/product/ai-in-sentry/seer/root-cause-analysis/index.mdx
+++ b/docs/product/ai-in-sentry/seer/root-cause-analysis/index.mdx
@@ -64,6 +64,20 @@ You can disable code generation for your organization [here](https://sentry.io/o
 
 ![Screenshot of Seer showing code it generated =800x](../img/coding-step.png)
 
+## Root Cause Analysis in Slack [Beta]
+
+<Alert>
+This feature is currently in <strong>beta</strong>. Beta features are still a work in progress and may have bugs. We recognize the irony.
+</Alert>
+
+If you have the [Slack integration](/organization/integrations/notification-incidents/slack/) enabled, you can trigger Root Cause Analysis from a Slack message. 
+
+1. Invite Sentry to your Slack channel (@Sentry)
+2. Make sure you have [Issue Alerts](/organization/integrations/notification-incidents/slack/#issue-alerts) configured to send alerts to the Slack channel
+3. When a new issue is shown on the channel, it will include an option to *Fix with Seer*
+
+Clicking *Fix with Seer* will trigger Root Cause Analysis for the issue. You can wait to see the result posted in the issue thread, or go to Sentry to see the process. Seer will prompt you to take next steps once it has finished running, including planning a solution, generating code, and pushing it to your codebase.
+
 ## What Root Cause Analysis Uses
 
 Seer handles access to a wide variety of data sources and tools. While debugging issues, it may examine:


### PR DESCRIPTION
## DESCRIBE YOUR PR
Updated RCA doc to include new RCA in Slack UX. 

Preview: https://sentry-docs-git-feat-seer-rca-in-slack-ea.sentry.dev/product/ai-in-sentry/seer/root-cause-analysis/#root-cause-analysis-in-slack-beta

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: Whenever I get a +1
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
