### PR TITLE
docs(unreal): Sentry Crash Reporter customization

### DIFF
--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -204,7 +204,7 @@ EnableExternalCrashReporter=True
 
 ### Customizing the Crash Reporter
 
-You can customize the appearance of the Sentry Crash Reporter directly from the plugin settings. Navigate to **Project Settings > Plugins > Sentry > General > Native** and expand the **Crash reporter appearance** section. Each property has an override toggle - only properties you explicitly enable will be applied:
+You can customize the appearance of the Sentry Crash Reporter directly from the plugin settings. Navigate to **Project Settings > Plugins > Sentry > General > Native** and expand the **External crash reporter appearance** section. Each property has an override toggle - only properties you explicitly enable will be applied:
 
 - **Window title** - Custom title for the crash reporter window.
 - **Header text** - Header text shown in the crash reporter dialog.


### PR DESCRIPTION
This PR adds description for Sentry's external Crash Reporter customization options that can be edited via Unreal Engine plugin settings menu.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1286
- https://github.com/getsentry/sentry-unreal/issues/1275