### PR TITLE
docs(otlp): Simplify OTLPIntegration spec

### DIFF
--- a/develop-docs/sdk/telemetry/traces/otlp.mdx
+++ b/develop-docs/sdk/telemetry/traces/otlp.mdx
@@ -20,7 +20,7 @@ Concurrently to the above SDK work, we also shipped first-class support for inge
 
 ## Integration Spec
 
-The new integration **MUST** be called `OTLPIntegration` with the following signature:
+The new integration **SHOULD** be called `OTLPIntegration` with the following signature:
 
 ```python
 OTLPIntegration(setup_otlp_traces_exporter=True, collector_url=None)
@@ -34,7 +34,7 @@ It **MUST** set up the following:
 
 * An `external_propagation_context` that extracts the active `trace_id` and `span_id` from the OpenTelemetry SDK
 
-It **SHOULD** also set up:
+It **SHOULD** also set up or expose:
 
 * A `SpanExporter` that automatically configures the OTLP ingestion endpoint from the DSN or from the `collector_url` (controlled by `setup_otlp_traces_exporter`)
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Removed Propagator and Exception interceptor components from the integration. Cross-service propagation is handled by `propagateTraceparent` or user-configured OTel propagators. Exception interception via `Span.record_exception` is no longer part of the spec.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+