### PR TITLE
fix(ui): Fix `CodeTabs` to show multiple tabs

### DIFF
--- a/src/components/codeTabs.tsx
+++ b/src/components/codeTabs.tsx
@@ -49,10 +49,30 @@ const showSigninNote = (children: ReactNode) => {
   });
 };
 
+// Resolve React lazy elements from RSC serialization (Next.js 15.5+).
+// Client component children serialized through RSC boundaries arrive as
+// lazy elements with _init/_payload instead of the usual type/props shape.
+function resolveElement(child: any): ReactElement<CodeBlockProps> | null {
+  if (child == null || typeof child !== 'object') {
+    return null;
+  }
+  if (child.props) {
+    return child;
+  }
+  if (child._init && child._payload) {
+    try {
+      return child._init(child._payload);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
 export function CodeTabs({children}: CodeTabProps) {
-  const codeBlocks = (Array.isArray(children) ? [...children] : [children]).filter(
-    child => child?.props
-  );
+  const codeBlocks = (Array.isArray(children) ? [...children] : [children])
+    .map(resolveElement)
+    .filter((child): child is ReactElement<CodeBlockProps> => child !== null);
 
   // The title is what we use for sorting and also for remembering the
   // selection. If there is no title fall back to the title cased language name


### PR DESCRIPTION
The existing child?.props filter in CodeTabs was silently dropping these, causing only the first tab to render (e.g. only "Client" visible instead of Client/Server/Edge on the NextJS manual setup page).

**Broken:**
<img width="1101" height="681" alt="Screenshot 2026-03-13 at 14 16 43" src="https://github.com/user-attachments/assets/b522158d-4dc1-42f2-9016-40450d41da12" />

**Fixed:**
<img width="1103" height="803" alt="Screenshot 2026-03-13 at 14 18 11" src="https://github.com/user-attachments/assets/59f2ce97-4956-441b-8b6e-5aba497e5b91" />

