### PR TITLE
docs(sdk): Rename @sdk-leads to @sdk-seniors

### DIFF
--- a/develop-docs/sdk/getting-started/playbooks/development/opening-a-pr.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/development/opening-a-pr.mdx
@@ -75,7 +75,7 @@ When green, mark the PR as ready for review.
 
 #### 9. Assign 1–2 reviewers
 
-If the PR touches public API, dependencies, or security-sensitive areas, you **MUST** assign an @sdk-leads reviewer ([Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers)).
+If the PR touches public API, dependencies, or security-sensitive areas, you **MUST** assign an @sdk-seniors reviewer ([Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers)).
 
 ## Referenced Standards
 
@@ -87,7 +87,7 @@ If the PR touches public API, dependencies, or security-sensitive areas, you **M
 - [Changelog entry](/sdk/getting-started/standards/code-submission#changelog-entry) — user-facing change documentation
 - [One logical change per PR](/sdk/getting-started/standards/code-submission#one-logical-change-per-pr) — focused PR scope
 - [Documentation-with-code](/sdk/getting-started/standards/repository-docs#documentation-with-code) — docs PR requirements
-- [Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers) — @sdk-leads review triggers
+- [Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers) — @sdk-seniors review triggers
 - [Test requirements by change type](/sdk/getting-started/standards/code-quality#test-requirements-by-change-type) — test coverage requirements
 
 ---

--- a/develop-docs/sdk/getting-started/playbooks/development/reviewing-a-pr.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/development/reviewing-a-pr.mdx
@@ -61,9 +61,9 @@ Use the [code review checklist](/engineering-practices/code-review/). You **MUST
 
 You **SHOULD** use the [`sentry-skills:code-review`](https://github.com/getsentry/skills#available-skills) skill to systematically check for issues.
 
-#### 4. Check for @sdk-leads review triggers
+#### 4. Check for @sdk-seniors review triggers
 
-([Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers)): public API changes, new dependencies, schema changes, security-sensitive code, new frameworks. If any apply and no @sdk-leads reviewer is assigned, flag it.
+([Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers)): public API changes, new dependencies, schema changes, security-sensitive code, new frameworks. If any apply and no @sdk-seniors reviewer is assigned, flag it.
 
 #### 5. Use LOGAF prefixes on all feedback
 
@@ -79,7 +79,7 @@ You **MUST NOT** block for style preferences. The goal is risk reduction, not pe
 ## Referenced Standards
 
 - [Review feedback conventions](/sdk/getting-started/standards/review-ci#review-feedback-conventions) — LOGAF scale and blocking criteria
-- [Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers) — @sdk-leads review triggers
+- [Required reviewers](/sdk/getting-started/standards/review-ci#required-reviewers) — @sdk-seniors review triggers
 - [Required CI checks baseline](/sdk/getting-started/standards/review-ci#required-ci-checks-baseline) — minimum CI requirements
 - [Test requirements by change type](/sdk/getting-started/standards/code-quality#test-requirements-by-change-type) — test coverage expectations
 - [Test quality](/sdk/getting-started/standards/code-quality#test-quality) — meaningful assertion requirements

--- a/develop-docs/sdk/getting-started/playbooks/development/reviewing-ai-generated-code.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/development/reviewing-ai-generated-code.mdx
@@ -47,7 +47,7 @@ You **MUST NOT** review failing code.
 
 Runtime errors, performance, side effects, backwards compatibility, security, test coverage ([Test requirements by change type](/sdk/getting-started/standards/code-quality#test-requirements-by-change-type)), test quality ([Test quality](/sdk/getting-started/standards/code-quality#test-quality)).
 
-#### 4. Check @sdk-leads review triggers
+#### 4. Check @sdk-seniors review triggers
 
 Public API, dependencies, schema changes, security-sensitive code, frameworks.
 

--- a/develop-docs/sdk/getting-started/playbooks/sdk-lifecycle/breaking-changes.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/sdk-lifecycle/breaking-changes.mdx
@@ -114,7 +114,7 @@ Use internal data tools to estimate how many users rely on an attribute or featu
 - [Redash](https://redash.getsentry.net)
 - [Hex](https://app.hex.tech)
 
-If you do not have access, reach out to @sdk-leads, the Data team or request access through the IT helpdesk.
+If you do not have access, reach out to @sdk-seniors, the Data team or request access through the IT helpdesk.
 
 ---
 

--- a/develop-docs/sdk/getting-started/standards/api-architecture.mdx
+++ b/develop-docs/sdk/getting-started/standards/api-architecture.mdx
@@ -83,12 +83,12 @@ They **MUST NOT** fail due to additive changes. Unknown fields, categories, or d
 
 #### Rule
 
-Any change to public API (add, change, deprecate, remove) **REQUIRES** @sdk-leads approval. Public API includes anything a user can call, import, configure, subclass, or otherwise reference. If there is any doubt whether something is public, check for usage in public repositories using the SDK. When still unsure, treat it as public.
+Any change to public API (add, change, deprecate, remove) **REQUIRES** @sdk-seniors approval. Public API includes anything a user can call, import, configure, subclass, or otherwise reference. If there is any doubt whether something is public, check for usage in public repositories using the SDK. When still unsure, treat it as public.
 
 #### Enforcement
 
 - CI API snapshot diffs (where feasible)
-- Human review gate (@sdk-leads approval)
+- Human review gate (@sdk-seniors approval)
 
 #### Suggested skill(s)
 

--- a/develop-docs/sdk/getting-started/standards/review-ci.mdx
+++ b/develop-docs/sdk/getting-started/standards/review-ci.mdx
@@ -26,7 +26,7 @@ sidebar_order: 4
 #### Rule
 
 Every PR **REQUIRES** at least one approving review.
-@sdk-leads review **REQUIRED** for:
+@sdk-seniors review **REQUIRED** for:
 
 - Public API ([Public API change approval gate](/sdk/getting-started/standards/api-architecture#public-api-change-approval-gate))
 - New dependencies ([Dependency management](/sdk/getting-started/standards/code-quality#dependency-management))


### PR DESCRIPTION
## DESCRIBE YOUR PR
Rename @sdk-leads to @sdk-seniors across SDK developer documentation.

The group represents SE3+ engineers. The previous name (@sdk-leads) didn't accurately reflect the seniority-based criterion for membership, which caused confusion about who qualifies. @sdk-seniors is more precise and self-explanatory.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
