### PR TITLE
docs(develop-docs): Reference sdk-feature-implementation skill in cro…

### DIFF
--- a/develop-docs/sdk/getting-started/playbooks/coordination/aligning-cross-sdk-changes.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/coordination/aligning-cross-sdk-changes.mdx
@@ -102,6 +102,10 @@ This public issue **MAY** be omitted for changes that are:
 
 Each team **MUST** follow their own PR process ([Opening a PR](/sdk/getting-started/playbooks/development/opening-a-pr), [Reviewing a PR](/sdk/getting-started/playbooks/development/reviewing-a-pr)). The Linear projects provide visibility, but each SDK maintains its own standards and timeline.
 
+You **SHOULD** use the [`sentry-sdk-skills:sdk-feature-implementation`](https://github.com/getsentry/sdk-skills?tab=readme-ov-file#available-skills) skill to spawn parallel agents that create draft PRs across all target SDK repos. The skill uses the Linear context gathered in step 5 and handles CI monitoring across repos.
+
+If not using the skill, each SDK team implements independently.
+
 #### 7. Coordinate documentation
 
 Documentation PRs **SHOULD** ship together or in clear sequence — not piecemeal. Users **MUST NOT** see docs for a change that hasn't reached their SDK yet.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Step 6 of the Aligning Cross-SDK Changes playbook ("Implement in each SDK independently") now points to the `sentry-sdk-skills:sdk-feature-implementation` skill, which automates parallel draft PR creation across SDK repos and handles CI monitoring.

This mirrors how step 5 already references the `linear-initiative` skill — the two skills are meant to be used in sequence for cross-SDK rollouts, so surfacing the implementation skill in the relevant step makes the workflow more discoverable.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
