### PR TITLE
docs(sdk): Note that triage may be bypassed for team-created issues

### DIFF
--- a/develop-docs/sdk/getting-started/playbooks/coordination/triaging.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/coordination/triaging.mdx
@@ -24,6 +24,8 @@ Each repository **MUST** have a triage rotation in place that includes all maint
 
 Triage **SHOULD** prioritise acknowledgement and categorization over immediate fixes.
 
+Triage **MAY** be bypassed if the issue was created by a team member.
+
 Related resources:
 - [Triaging SLA](/sdk/getting-started/standards/coordination-maintenance#triaging-sla) — 2 business day first response requirement
 - [GitHub Saved Replies](/sdk/getting-started/templates/saved-replies) — team-approved response templates for common scenarios


### PR DESCRIPTION
## DESCRIBE YOUR PR
Add a note to the triaging playbook overview that triage MAY be bypassed when an issue is created by a team member.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
