### PR TITLE
fix(tailwind): Remove red color override that broke palette

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -53,7 +53,6 @@ export default {
         darkPurple: '#1F1633',
         'accent-purple': '#6A5FC1',
         'accent-md-violet': '#584774',
-        red: '#e1567c',
         gold: '#F1B71C',
       },
       screens: {


### PR DESCRIPTION
## DESCRIBE YOUR PR
The custom `red: '#e1567c'` entry in the colors extension replaced Tailwind's entire red color scale with a single value, making numbered variants like red-100, red-800, and red-900 unavailable.

Remove the unused override to restore the default red palette.

after:
<img width="521" height="52" alt="Screenshot 2026-03-16 at 15 19 34" src="https://github.com/user-attachments/assets/061109d8-7995-4140-a91e-f587b2a2cd9a" />
before:
<img width="514" height="60" alt="Screenshot 2026-03-16 at 15 19 20" src="https://github.com/user-attachments/assets/5d8d9782-c395-4d0a-9476-7730cae75d42" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
