### PR TITLE
docs(cli): Fix typo in sourcemaps upload command docs

### DIFF
--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -117,7 +117,7 @@ You can upload sourcemaps via the `sentry-cli sourcemaps upload` command:
 sentry-cli sourcemaps upload /path/to/sourcemaps
 ```
 
-This command provides several options and attempts as much auto detection as possible. By default, it will scan the provided path for files and upload them named by their path with a `~/` prefix. It will also attempt to figure out references between minified files and source maps based on the filename. So if you have a file named `foo.min.js` which is a minified JavaScript file and a source map named `foo.min.map` for example, it will send a long a `Sourcemap` header to associate them. This works for files the system can detect a relationship of.
+This command provides several options and attempts as much auto detection as possible. By default, it will scan the provided path for files and upload them named by their path with a `~/` prefix. It will also attempt to figure out references between minified files and source maps based on the filename. So if you have a file named `foo.min.js` which is a minified JavaScript file and a source map named `foo.min.map` for example, it will send along a `Sourcemap` header to associate them. This works for files the system can detect a relationship of.
 
 By default, `sentry-cli` rewrites source maps before upload:
 


### PR DESCRIPTION
"a long" -> "along"