### PR TITLE
docs: Add a hint for env variable loading for Vite configs

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
@@ -54,6 +54,8 @@ Learn more about configuring the plugin in our [Sentry Vite Plugin documentation
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 <Alert level="info" title="Plugin Order Matters">
 
 Place the Sentry Vite plugin **after all other plugins** in your `plugins` array. This ensures source maps are generated correctly and tree-shaking doesn't remove Sentry's instrumentation.

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -480,6 +480,8 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 Next, include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
 
 ```typescript {filename: react-router.config.ts} {diff}

--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -290,6 +290,8 @@ SENTRY_PROJECT="___PROJECT_SLUG___"
 SENTRY_AUTH_TOKEN="___ORG_AUTH_TOKEN___"
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ## Step 5: Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup__v10.7.0.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup__v10.7.0.mdx
@@ -227,6 +227,8 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ### Override Adapter Detection
 
 `sentrySvelteKit` tries to auto-detect your SvelteKit adapter to configure source maps upload correctly. If you're using an unsupported adapter or the wrong one is detected, set it using the `adapter` option:

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup__v8.x.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup__v8.x.mdx
@@ -133,6 +133,8 @@ Or, you can set them by passing a `sourceMapsUploadOptions` object to `sentrySve
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ```javascript {filename:vite.config.(js|ts)} {7-16}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -21,7 +21,9 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-and configure `sentryTanstackStart` in your vite.config.ts:
+<Include name="vite-loadenv-hint.mdx" />
+
+Configure `sentryTanstackStart` in your vite.config.ts:
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";

--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -152,7 +152,9 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-and configure `sentryTanstackStart` in your `vite.config.ts`:
+<Include name="vite-loadenv-hint.mdx" />
+
+Configure `sentryTanstackStart` in your `vite.config.ts`:
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";

--- a/includes/vite-loadenv-hint.mdx
+++ b/includes/vite-loadenv-hint.mdx
@@ -1,0 +1,24 @@
+<Expandable title="Using environment variables in Vite configs">
+
+Vite doesn't automatically load `.env` files into `process.env` when evaluating the config file. If you store your auth token in a `.env` file and want to access it via `process.env.SENTRY_AUTH_TOKEN`, use Vite's [`loadEnv`](https://vite.dev/guide/api-javascript#loadenv) helper:
+
+```javascript {filename:vite.config.js}
+import { defineConfig, loadEnv } from "vite";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [
+      sentryVitePlugin({
+        authToken: env.SENTRY_AUTH_TOKEN,
+        // ...
+      }),
+    ],
+  };
+});
+```
+
+Alternatively, use a `.env.sentry-build-plugin` file, which the Sentry plugin reads automatically.
+
+</Expandable>

--- a/platform-includes/getting-started-complete/javascript.astro.mdx
+++ b/platform-includes/getting-started-complete/javascript.astro.mdx
@@ -318,6 +318,8 @@ To keep your auth token secure, set the `SENTRY_AUTH_TOKEN` environment variable
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 <PlatformSection notSupported={["javascript.cloudflare"]}>
 
 ## Step 4: Avoid Ad Blockers With Tunneling (Optional)

--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -256,6 +256,8 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 While Nuxt generates source maps on the server side by default, you need to explicitly enable client-side source maps in your Nuxt configuration:
 
 ```javascript {filename:nuxt.config.ts} {2}

--- a/platform-includes/getting-started-complete/javascript.remix.mdx
+++ b/platform-includes/getting-started-complete/javascript.remix.mdx
@@ -319,6 +319,8 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 <PlatformSection notSupported={["javascript.cloudflare"]}>
 ## Step 4: Avoid Ad Blockers With Tunneling (Optional)
 

--- a/platform-includes/getting-started-complete/javascript.sveltekit.mdx
+++ b/platform-includes/getting-started-complete/javascript.sveltekit.mdx
@@ -349,6 +349,8 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 <PlatformSection notSupported={["javascript.cloudflare"]}>
 ### Override Adapter Detection
 

--- a/platform-includes/sourcemaps/overview/javascript.astro.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.astro.mdx
@@ -12,6 +12,8 @@ To automatically upload source maps during production builds, add the `SENTRY_AU
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 Next, add your project slug to the `sentry` integration options in your Astro config:
 
 ```javascript {filename:astro.config.mjs}

--- a/platform-includes/sourcemaps/overview/javascript.nuxt.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.nuxt.mdx
@@ -24,6 +24,8 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ```javascript {filename:nuxt.config.ts}
 export default defineNuxtConfig({
   modules: ["@sentry/nuxt/module"],

--- a/platform-includes/sourcemaps/overview/javascript.solidstart.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.solidstart.mdx
@@ -24,6 +24,8 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ```javascript {filename:app.config.ts}
 export default defineConfig(
   withSentry(

--- a/platform-includes/sourcemaps/overview/javascript.svelte.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.svelte.mdx
@@ -62,6 +62,8 @@ You likely want to add the auth token as an environment variable to your CI/CD e
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 Configure Vite to emit source maps and use the Sentry Vite plugin:
 
 

--- a/platform-includes/sourcemaps/overview/javascript.sveltekit.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.sveltekit.mdx
@@ -34,6 +34,8 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ```javascript {filename:vite.config.js}
 import { sveltekit } from "@sveltejs/kit/vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";

--- a/platform-includes/sourcemaps/overview/javascript.tanstackstart-react.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.tanstackstart-react.mdx
@@ -10,7 +10,9 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-and configure `sentryTanstackStart` in your `vite.config.ts`:
+<Include name="vite-loadenv-hint.mdx" />
+
+Configure `sentryTanstackStart` in your `vite.config.ts`:
 
 ```typescript {filename:vite.config.ts}
 import { defineConfig } from "vite";

--- a/platform-includes/sourcemaps/overview/javascript.vue.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.vue.mdx
@@ -52,6 +52,8 @@ You likely want to add the auth token as an environment variable to your CI/CD e
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 Example:
 
 

--- a/platform-includes/sourcemaps/upload/primer/javascript.sveltekit.mdx
+++ b/platform-includes/sourcemaps/upload/primer/javascript.sveltekit.mdx
@@ -52,6 +52,8 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
+<Include name="vite-loadenv-hint.mdx" />
+
 ### Override SvelteKit Adapter Detection
 
 By default, `sentrySvelteKit` will try to detect your SvelteKit adapter to configure the source maps upload correctly. If you're not using one of the [supported adapters](/platforms/javascript/guides/sveltekit) or the wrong one is detected, you can override the adapter detection by passing the `adapter` option to `sentrySvelteKit`:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

There are a lot of different ways to load env variables. Usually frameworks do have `dotenv` included, so `.env` files are loaded by default. This is usually not the case and users might be confused if it is not the case. This adds a line everywhere where we have a Vite config for sourcemap uploads to also include how `.env` files are added. This has nothing to do with Sentry itself, but it is better to support early in the process in this regard.

It got raised that this is missing in the docs: https://github.com/getsentry/sentry-javascript/issues/19523#issuecomment-4074794881

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
