### PR TITLE
Fix workflow skills link in agent skills documentation

### DIFF
--- a/docs/ai/agent-skills.mdx
+++ b/docs/ai/agent-skills.mdx
@@ -16,7 +16,7 @@ keywords:
   - OpenCode
 ---
 
-Agent skills are instruction sets that teach AI coding assistants how to perform specific tasks. Sentry's official agent skills give your AI assistant the knowledge to set up and configure Sentry in your projects with no manual configuration required. Use [workflow skills](/ai/agent-skills/#workflow-skills) to debug and fix issues in your projects.
+Agent skills are instruction sets that teach AI coding assistants how to perform specific tasks. Sentry's official agent skills give your AI assistant the knowledge to set up and configure Sentry in your projects with no manual configuration required. Use [workflow skills](https://skills.sh/getsentry/sentry-for-ai/sentry-workflow) to debug and fix issues in your projects.
 
 <StepComponent>
 


### PR DESCRIPTION
Updated the link for workflow skills to a new URL.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
