### PR TITLE
docs(go): Update OpenTelemetry docs for OTLP migration

### DIFF
--- a/docs/platforms/go/common/tracing/instrumentation/opentelemetry.mdx
+++ b/docs/platforms/go/common/tracing/instrumentation/opentelemetry.mdx
@@ -26,7 +26,8 @@ With the OTLP-based setup, your OpenTelemetry spans are exported to Sentry using
 
 If you also want captured Sentry errors to be linked to the active OpenTelemetry trace, register `sentryotel.NewErrorLinkingIntegration()` in `sentry.Init` and capture errors with an `EventHint` that includes the active `context.Context`.
 
-If you're using an OpenTelemetry Collector, you don't need `sentryotlp.NewTraceExporter()`. Keep `sentryotel.NewErrorLinkingIntegration()` in your Sentry SDK setup, then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. For the collector configuration, see the <PlatformLink to="/concepts/otlp/forwarding/pipelines/collector/">OpenTelemetry Collector Setup</PlatformLink> page.
+
+If you're using an OpenTelemetry Collector, you don't need `sentryotlp.NewTraceExporter()`. Keep `sentryotel.NewErrorLinkingIntegration()` in your Sentry SDK setup, then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. For the collector configuration, see the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
 
 ## Additional Configuration
 

--- a/docs/platforms/go/common/tracing/instrumentation/opentelemetry.mdx
+++ b/docs/platforms/go/common/tracing/instrumentation/opentelemetry.mdx
@@ -4,7 +4,13 @@ description: "Using OpenTelemetry with Sentry Performance."
 sidebar_order: 20
 ---
 
-You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces and spans to Sentry.
+You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send traces to Sentry over OTLP.
+
+<Alert title="Span Processor Deprecation">
+
+The legacy `sentryotel.NewSentrySpanProcessor()` integration is deprecated in `sentry-go`. Prefer OTLP export instead: use `sentryotlp.NewTraceExporter()` to send traces directly to Sentry, or use a standard OpenTelemetry exporter if you're sending data through an OpenTelemetry Collector.
+
+</Alert>
 
 ## Install
 
@@ -16,7 +22,11 @@ You can configure your [OpenTelemetry SDK](https://opentelemetry.io/) to send tr
 
 ## OpenTelemetry and Sentry
 
-With Sentry’s OpenTelemetry SDK, an OpenTelemetry `Span` becomes a Sentry `Transaction` or `Span`. The first `Span` sent through the Sentry `SpanProcessor` is a `Transaction`, and any child `Span` gets attached to the first `Transaction` upon checking the parent `Span` context. This is true for the OpenTelemetry root `Span` and any top level `Span` in the system. For example, a request sent from frontend to backend will create an OpenTelemetry root `Span` with a corresponding Sentry `Transaction`. The backend request will create a new Sentry `Transaction` for the OpenTelemetry `Span`. The Sentry `Transaction` and `Span` are linked as a trace for navigation and error tracking purposes.
+With the OTLP-based setup, your OpenTelemetry spans are exported to Sentry using the standard OpenTelemetry trace pipeline instead of being converted locally by a Sentry span processor. Root spans show up in Sentry as transactions, child spans appear under those transactions, and the full trace remains connected across services.
+
+If you also want captured Sentry errors to be linked to the active OpenTelemetry trace, register `sentryotel.NewErrorLinkingIntegration()` in `sentry.Init` and capture errors with an `EventHint` that includes the active `context.Context`.
+
+If you're using an OpenTelemetry Collector, you don't need `sentryotlp.NewTraceExporter()`. Keep `sentryotel.NewErrorLinkingIntegration()` in your Sentry SDK setup, then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. For the collector configuration, see the <PlatformLink to="/concepts/otlp/forwarding/pipelines/collector/">OpenTelemetry Collector Setup</PlatformLink> page.
 
 ## Additional Configuration
 

--- a/docs/platforms/go/common/tracing/instrumentation/opentelemetry.mdx
+++ b/docs/platforms/go/common/tracing/instrumentation/opentelemetry.mdx
@@ -24,10 +24,10 @@ The legacy `sentryotel.NewSentrySpanProcessor()` integration is deprecated in `s
 
 With the OTLP-based setup, your OpenTelemetry spans are exported to Sentry using the standard OpenTelemetry trace pipeline instead of being converted locally by a Sentry span processor. Root spans show up in Sentry as transactions, child spans appear under those transactions, and the full trace remains connected across services.
 
-If you also want captured Sentry errors to be linked to the active OpenTelemetry trace, register `sentryotel.NewErrorLinkingIntegration()` in `sentry.Init` and capture errors with an `EventHint` that includes the active `context.Context`.
+If you also want captured Sentry errors to be linked to the active OpenTelemetry trace, register `sentryotel.NewOtelIntegration()` in `sentry.Init` and capture errors with an `EventHint` that includes the active `context.Context`.
 
 
-If you're using an OpenTelemetry Collector, you don't need `sentryotlp.NewTraceExporter()`. Keep `sentryotel.NewErrorLinkingIntegration()` in your Sentry SDK setup, then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. For the collector configuration, see the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
+If you're using an OpenTelemetry Collector, you don't need `sentryotlp.NewTraceExporter()`. Keep `sentryotel.NewOtelIntegration()` in your Sentry SDK setup, then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. For the collector configuration, see the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
 
 ## Additional Configuration
 

--- a/platform-includes/performance/opentelemetry-install/go.mdx
+++ b/platform-includes/performance/opentelemetry-install/go.mdx
@@ -10,9 +10,10 @@ The Sentry Go OpenTelemetry integration requires `go.opentelemetry.io/otel` (and
 
 </Alert>
 
-Install the `otel` module in addition to the main SDK:
+Install the `otel` and `otel/otlp` modules in addition to the main SDK:
 
 ```bash
 go get github.com/getsentry/sentry-go \
-       github.com/getsentry/sentry-go/otel
+       github.com/getsentry/sentry-go/otel \
+       github.com/getsentry/sentry-go/otel/otlp
 ```

--- a/platform-includes/performance/opentelemetry-setup/go.mdx
+++ b/platform-includes/performance/opentelemetry-setup/go.mdx
@@ -1,13 +1,15 @@
-You need to register the Sentry-provided SpanProcessor and Propagator as shown below:
+Create a trace exporter and register Sentry's error-linking integration:
 
 
 ```go
 import (
+	"context"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/getsentry/sentry-go"
 	sentryotel "github.com/getsentry/sentry-go/otel"
+	sentryotlp "github.com/getsentry/sentry-go/otel/otlp"
 	// ...
 )
 
@@ -16,22 +18,30 @@ sentry.Init(sentry.ClientOptions{
 	EnableTracing:    true,
 	TracesSampleRate: 1.0,
 	Debug:            true,
+	Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+		return append(integrations, sentryotel.NewErrorLinkingIntegration())
+	},
 })
 
+ctx := context.Background()
+exporter, err := sentryotlp.NewTraceExporter(ctx, "___PUBLIC_DSN___")
+if err != nil {
+	panic(err)
+}
+
 tp := sdktrace.NewTracerProvider(
-	sdktrace.WithSpanProcessor(sentryotel.NewSentrySpanProcessor()),
+	sdktrace.WithBatcher(exporter),
 )
 otel.SetTracerProvider(tp)
-otel.SetTextMapPropagator(sentryotel.NewSentryPropagator())
 ```
 
-Now, all spans produced by OpenTelemetry will also be captured and sent to Sentry.
+Now, spans produced by OpenTelemetry will be exported to Sentry over OTLP.
+
+If you're exporting through an OpenTelemetry Collector instead of sending traces directly to Sentry, you only need to keep the same `sentry.Init(...)` integration setup for error linking in your Go app. Then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. See the <PlatformLink to="/concepts/otlp/forwarding/pipelines/collector/">OpenTelemetry Collector Setup</PlatformLink> page.
 
 ### Linking Errors to Transactions
 
-If you want the errors and messages the SDK produces (for example, via `CaptureException` or
-`CaptureMessage`) to be linked to transactions in the UI, a couple of extra steps are required. Most importantly, the current OpenTelemetry-enhanced context has to be passed as part
-of `EventHint` to `client.Capture*` methods:
+To link errors and messages captured by the Sentry SDK to the active trace in the UI, pass the current OpenTelemetry-enhanced context in the `EventHint`:
 
 ```go
 hub := sentry.CurrentHub()
@@ -45,5 +55,4 @@ client.CaptureException(
 )
 ```
 
-Events captured with the high-level `sentry.CaptureException` or `sentry.CaptureMessage` functions are
-NOT linked to transactions or spans at the moment. This will be improved in future releases.
+Events captured with the high-level `sentry.CaptureException` or `sentry.CaptureMessage` functions are not linked unless the active context is included in the event hint.

--- a/platform-includes/performance/opentelemetry-setup/go.mdx
+++ b/platform-includes/performance/opentelemetry-setup/go.mdx
@@ -37,6 +37,13 @@ otel.SetTracerProvider(tp)
 
 Now, spans produced by OpenTelemetry will be exported to Sentry over OTLP.
 
+### Distributed Tracing
+
+The OTLP integration does not set up a propagator for you. How you configure propagation depends on your setup:
+
+- **Sentry frontend → OTel backend:** If a Sentry SDK on your frontend sends requests to this OTel-instrumented service, enable [`propagateTraceparent`](/concepts/otlp/sentry-with-otel/#linking-sentry-and-otlp-traces) in your frontend SDK. This sends the W3C `traceparent` header, which your OTel-instrumented backend will pick up automatically.
+- **OTel ↔ OTel:** If all your services use OpenTelemetry, configure propagators using the standard OpenTelemetry API (for example, `propagation.TraceContext{}`). See the [OpenTelemetry propagation documentation](https://opentelemetry.io/docs/languages/go/instrumentation/#propagators-and-context) for details.
+
 If you're exporting through an OpenTelemetry Collector instead of sending traces directly to Sentry, you only need to keep the same `sentry.Init(...)` with `sentryotel.NewOtelIntegration()` in your Go app. Then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. See the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
 
 ### Linking Errors to Transactions

--- a/platform-includes/performance/opentelemetry-setup/go.mdx
+++ b/platform-includes/performance/opentelemetry-setup/go.mdx
@@ -37,7 +37,7 @@ otel.SetTracerProvider(tp)
 
 Now, spans produced by OpenTelemetry will be exported to Sentry over OTLP.
 
-If you're exporting through an OpenTelemetry Collector instead of sending traces directly to Sentry, you only need to keep the same `sentry.Init(...)` integration setup for error linking in your Go app. Then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. See the <PlatformLink to="/concepts/otlp/forwarding/pipelines/collector/">OpenTelemetry Collector Setup</PlatformLink> page.
+If you're exporting through an OpenTelemetry Collector instead of sending traces directly to Sentry, you only need to keep the same `sentry.Init(...)` integration setup for error linking in your Go app. Then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. See the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
 
 ### Linking Errors to Transactions
 

--- a/platform-includes/performance/opentelemetry-setup/go.mdx
+++ b/platform-includes/performance/opentelemetry-setup/go.mdx
@@ -1,4 +1,4 @@
-Create a trace exporter and register Sentry's error-linking integration:
+Create a trace exporter and register Sentry's OTel integration:
 
 
 ```go
@@ -19,7 +19,7 @@ sentry.Init(sentry.ClientOptions{
 	TracesSampleRate: 1.0,
 	Debug:            true,
 	Integrations: func(integrations []sentry.Integration) []sentry.Integration {
-		return append(integrations, sentryotel.NewErrorLinkingIntegration())
+		return append(integrations, sentryotel.NewOtelIntegration())
 	},
 })
 
@@ -37,7 +37,7 @@ otel.SetTracerProvider(tp)
 
 Now, spans produced by OpenTelemetry will be exported to Sentry over OTLP.
 
-If you're exporting through an OpenTelemetry Collector instead of sending traces directly to Sentry, you only need to keep the same `sentry.Init(...)` integration setup for error linking in your Go app. Then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. See the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
+If you're exporting through an OpenTelemetry Collector instead of sending traces directly to Sentry, you only need to keep the same `sentry.Init(...)` with `sentryotel.NewOtelIntegration()` in your Go app. Then configure the collector's `otlphttp` exporter to send traces to Sentry's OTLP endpoints. See the [OpenTelemetry Collector](/concepts/otlp/forwarding/pipelines/collector/) guide.
 
 ### Linking Errors to Transactions
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Update the Go OpenTelemetry docs to reflect the migration away from the deprecated span processor setup and toward OTLP.

This updates the landing page and shared Go snippets to:
- recommend `sentryotlp.NewTraceExporter()` for direct-to-Sentry tracing
- document `sentryotel.NewOtelIntegration()` for linking Sentry errors to OTel traces
- call out the collector-based path and link to the OTLP collector setup docs

## IS YOUR CHANGE URGENT?  
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA
- [ ] Added reviewer

## PRE-MERGE CHECKLIST
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
