### PR TITLE
docs: Update attachment header requirements in documentation

### DIFF
--- a/develop-docs/sdk/telemetry/attachments.mdx
+++ b/develop-docs/sdk/telemetry/attachments.mdx
@@ -255,7 +255,7 @@ SDKs **SHOULD** send placeholders in the same envelope as the event the file is 
 | `attachment_length` | Integer | **REQUIRED** | Size of the referenced attachment in bytes. |
 | `filename` | String | **REQUIRED** | The name of the uploaded file without a path component. |
 
-The item header **MUST** also contain the original file's `attachment_type` (if any) and **MAY** contain the original file's `content_type` as an additional field (see [Standard Attachment Item](#standard-attachment-item)).
+The item header **MUST** also contain the original file's `attachment_type` if it was set. The item payload **MUST** contain the original file's `content_type` as a field in the JSON object (see [Standard Attachment Item](#standard-attachment-item)).
 
 **Item payload:**
 


### PR DESCRIPTION
While implementing this in Relay noticed that `ChunkedAttachment` has a `attachment_type` field which we want to set with the original file's attachment type.