### PR TITLE
chore(code-review): Remove note about AI code review toggle

### DIFF
--- a/docs/product/ai-in-sentry/seer/code-review/index.mdx
+++ b/docs/product/ai-in-sentry/seer/code-review/index.mdx
@@ -105,7 +105,7 @@ Error Prediction is automatically triggered by the following GitHub pull_request
 
   The status check shows as neutral if there's a temporary service issue or the review timed out. We use neutral status (rather than error) so users don't assume there's something wrong with their code when the issue is on our end. The status check does not fail based on code quality issues found during review - those appear as review comments on your PR.
   
-  If you don't see a status check at all, ensure that your GitHub integration has the required Checks permission.
+  If you don't see a status check at all, ensure that your GitHub integration has the required [Checks permission](/organization/integrations/source-code-mgmt/github/#github-permissions), and that [Code Review is enabled](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/repos/) for that repo.
 
 - **Can I disable status checks while keeping AI Code Review comments?**
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## PR Description

Needed for https://github.com/getsentry/sentry/pull/111055. No longer have that organization setting, everything will be driven by the settings UI and seat based billing add-on.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+


**Before**

<img width="1277" height="422" alt="Screenshot 2026-03-19 at 1 51 49 PM" src="https://github.com/user-attachments/assets/e348fcda-05c8-49f4-9aff-bd56e33bbfb1" />


**From Preview Deploy**
<img width="1255" height="403" alt="Screenshot 2026-03-19 at 1 53 46 PM" src="https://github.com/user-attachments/assets/defcf72f-35f6-4aa7-a5bd-666400818d21" />



## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [X] Checked Vercel preview for correctness, including links
- [X] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
