### PR TITLE
fix(attachments): Placeholder content-type

### DIFF
--- a/develop-docs/sdk/telemetry/attachments.mdx
+++ b/develop-docs/sdk/telemetry/attachments.mdx
@@ -178,7 +178,7 @@ Trace attachments use item type `"attachment"` with content type `"application/v
 Attachment placeholders are an experimental feature, the protocol is subject to change.
 </Alert>
 
-Attachment placeholders use item type `"attachment"` with content type `"application/vnd.sentry.attachment-ref"`. A placeholder contains a **reference** to an attachment uploaded elsewhere — it does _not_ contain the actual attachment payload. The purpose is for the attachment to be handled (rate limited, filtered, etc.) together with the event payload, even if it was uploaded separately.
+Attachment placeholders use item type `"attachment"` with content type `"application/vnd.sentry.attachment-ref+json"`. A placeholder contains a **reference** to an attachment uploaded elsewhere — it does _not_ contain the actual attachment payload. The purpose is for the attachment to be handled (rate limited, filtered, etc.) together with the event payload, even if it was uploaded separately.
 
 SDKs **SHOULD** send placeholders in the same envelope as the event the file is attached to.
 
@@ -250,7 +250,7 @@ SDKs **SHOULD** send placeholders in the same envelope as the event the file is 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | String | **REQUIRED** | **MUST** be `"attachment"`. |
-| `content_type` | String | **REQUIRED** | **MUST** be `"application/vnd.sentry.attachment-ref"`. |
+| `content_type` | String | **REQUIRED** | **MUST** be `"application/vnd.sentry.attachment-ref+json"`. |
 | `length` | Integer | **REQUIRED** | Size of the placeholder payload in bytes. |
 | `attachment_length` | Integer | **REQUIRED** | Size of the referenced attachment in bytes. |
 | `filename` | String | **REQUIRED** | The name of the uploaded file without a path component. |
@@ -387,7 +387,7 @@ Hello World!
 
 ```
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}
-{"type":"attachment","content_type":"application/vnd.sentry.attachment-ref","length":123,"attachment_length":212341234,"filename":"myfile.log"}
+{"type":"attachment","content_type":"application/vnd.sentry.attachment-ref+json","length":123,"attachment_length":212341234,"filename":"myfile.log"}
 {"location":"/api/42/upload/019c7a950dd376a1817a9ced5cb7c4b5/?length=212341234&signature=Zct1IMmM3BIJrzDOwG3tUn5AlrLhqIJFBu8Kd59dXCz","content_type":"text/plain"}
 ```
 


### PR DESCRIPTION


## DESCRIBE YOUR PR

Add a +json suffix to the attachment placeholder content type to signal that it is syntactically JSON. The old value is still parsed correctly for compatibility.

See https://www.rfc-editor.org/rfc/rfc6838#section-4.2.8.

Depends on https://github.com/getsentry/relay/pull/5752.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
