### PR TITLE
fix(electron): Clarify renderer `init` args

### DIFF
--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -74,7 +74,7 @@ Sentry.init({
 
 ### Configure the Renderer Process
 
-Initialize the SDK in your Electron renderer processes:
+Initialize the SDK in your Electron renderer processes as early as possible. All renderer events are sent through the main process so passing `dsn`, `release` or `environment` to renderer `init` will have no effect.
 
 ```javascript
 import * as Sentry from "@sentry/electron/renderer";


### PR DESCRIPTION
This PR clarifies the Electron renderer `init` args. 

You should not supply `dsn`, `release` or `environment` when initialising the renderer SDK. Our TypeScript types already have these properties marked as deprecated:

https://github.com/getsentry/sentry-electron/blob/1141949f7157d8f34886464a93e6ad2e93914fdf/src/renderer/sdk.ts#L21-L27