### PR TITLE
docs(nextjs): Add waitUntil workaround for Vercel functions

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/tracing/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/tracing/index.mdx
@@ -357,25 +357,33 @@ Sentry.init({
 <SplitSection>
 <SplitSectionText>
 
-### Detached spans with `after()`
+### Detached spans with `after()` or `waitUntil()`
 
-If you're using Next.js's [`after()`](https://nextjs.org/docs/app/api-reference/functions/after) and you see multiple root spans (like individual `db` spans) instead of one cohesive trace, your spans are becoming detached.
+If you're using Next.js's [`after()`](https://nextjs.org/docs/app/api-reference/functions/after) or [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) and you see multiple root spans (like individual `db` spans) instead of one cohesive trace, your spans are becoming detached.
 
-This happens when `after()` runs after the response is sent. By then, the request's root span has already ended.
+This happens when `after()` or `waitUntil()` runs after the response is sent. By then, the request's root span has already ended.
 
-Wrap your deferred work with `startSpan` inside the `after()` callback to group all background spans into a single transaction:
+Wrap your deferred work with `startSpan` inside the `after()` or `waitUntil()` callback to group all background spans into a single transaction:
 
 </SplitSectionText>
 <SplitSectionCode>
 
 ```tsx {filename:app/api/webhook/route.ts}
 import { after } from "next/server";
+import { waitUntil } from '@vercel/functions';
 import * as Sentry from "@sentry/nextjs";
 
 export async function POST(request: Request) {
   const data = await request.json();
 
   after(
+    Sentry.startSpan(
+      { name: "webhook.process", op: "task" },
+      () => processWebhook(data)
+    )
+  );
+
+  waitUntil(
     Sentry.startSpan(
       { name: "webhook.process", op: "task" },
       () => processWebhook(data)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

A follow up to https://github.com/getsentry/sentry-docs/pull/16818#discussion_r2973403749 that also adds the usage of `waitUntil`

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
