### PR TITLE
docs(js): Use split layout in browser JS quick start guide

### DIFF
--- a/platform-includes/getting-started-complete/javascript.mdx
+++ b/platform-includes/getting-started-complete/javascript.mdx
@@ -1,7 +1,4 @@
 <PlatformContent includePath="getting-started-prerequisites" />
-
-## Step 1: Install
-
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
@@ -13,28 +10,72 @@ Choose the features you want to configure, and this guide will show you how:
     "logs",
   ]}
 />
-
 <Include name="quick-start-features-expandable" />
 
-### Install the Sentry SDK
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 <PlatformContent includePath="getting-started-install" />
 
-## Step 2: Configure
+## Configure
 
 ### Initialize the Sentry SDK
 
 <PlatformContent includePath="getting-started-config" />
 
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+### Add Readable Stack Traces With Source Maps (Optional)
 
-<PlatformContent includePath="getting-started-sourcemaps-short-version" />
+<SplitLayout>
 
-## Step 4: Avoid Ad Blockers With Tunneling (Optional)
+<SplitSection>
 
-<PlatformContent includePath="getting-started-tunneling" />
+<SplitSectionText>
+  The stack traces in your Sentry errors probably won't look like your actual
+  code without unminifying them. To fix this, upload your{" "}
+  <PlatformLink to="/sourcemaps/">source maps</PlatformLink> to Sentry. The
+  easiest way to do this is by using the Sentry Wizard.
+</SplitSectionText>
 
-## Step 5: Verify Your Setup
+<SplitSectionCode>
+
+```bash
+npx @sentry/wizard@latest -i sourcemaps
+```
+
+</SplitSectionCode>
+
+</SplitSection>
+
+</SplitLayout>
+
+### Avoid Ad Blockers With Tunneling (Optional)
+
+<SplitLayout>
+
+<SplitSection>
+
+<SplitSectionText>
+You can prevent ad blockers from blocking Sentry events using tunneling. Use the `tunnel` option in `Sentry.init` to add an API endpoint in your application that forwards Sentry events to Sentry servers.
+
+This will send all events to the `tunnel` endpoint. However, the events need to be parsed and redirected to Sentry, so you'll need to do additional configuration on the server. You can find a detailed explanation on how to do this on our <PlatformLink to="/troubleshooting/#using-the-tunnel-option"> Troubleshooting page</PlatformLink>.
+
+</SplitSectionText>
+
+<SplitSectionCode>
+```javascript {3}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tunnel: "/tunnel",
+});
+```
+</SplitSectionCode>
+
+</SplitSection>
+
+</SplitLayout>
+
+## Verify Your Setup
 
 <PlatformContent includePath="getting-started-verify" />
 
@@ -43,6 +84,8 @@ Choose the features you want to configure, and this guide will show you how:
 Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
 
 <Include name="quick-start-locate-data-expandable" />
+
+## Next Steps
 
 At this point, you should have integrated Sentry into your JavaScript application and should already be sending data to your Sentry project.
 
@@ -60,3 +103,5 @@ Now's a good time to customize your setup and look into more advanced topics. Ou
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>

--- a/platform-includes/getting-started-config/javascript.mdx
+++ b/platform-includes/getting-started-config/javascript.mdx
@@ -1,4 +1,14 @@
+<SplitLayout>
+
+<SplitSection>
+
+<SplitSectionText>
+
 Initialize Sentry as early as possible in your application's lifecycle. The setup differs slightly depending on how you installed the Sentry SDK. Be sure to follow the instructions in the related tab (npm, Loader, CDN):
+
+</SplitSectionText>
+
+<SplitSectionCode>
 
 ```javascript {tabTitle:npm}
 import * as Sentry from "___SDK_PACKAGE___";
@@ -180,3 +190,9 @@ Sentry.init({
   });
 </script>
 ```
+
+</SplitSectionCode>
+
+</SplitSection>
+
+</SplitLayout>

--- a/platform-includes/getting-started-install/javascript.mdx
+++ b/platform-includes/getting-started-install/javascript.mdx
@@ -1,8 +1,16 @@
 We recommend installing Sentry via a package manager. If that isn't an option for you, you can use the [Loader Script](/platforms/javascript/install/loader/) or a CDN bundle.
 
+<SplitLayout>
+
+<SplitSection>
+
+<SplitSectionText>
 #### Option 1: Package Manager (Recommended)
 
 Run the command for your preferred package manager to add the Sentry SDK to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {tabTitle:npm}
 npm install @sentry/browser --save
@@ -15,6 +23,12 @@ yarn add @sentry/browser
 ```bash {tabTitle:pnpm}
 pnpm add @sentry/browser
 ```
+
+</SplitSectionCode>
+
+</SplitSection>
+
+</SplitLayout>
 
 #### Option 2: Loader Script
 

--- a/platform-includes/getting-started-verify/javascript.mdx
+++ b/platform-includes/getting-started-verify/javascript.mdx
@@ -2,7 +2,22 @@ Let's test your setup and confirm that data reaches your Sentry project.
 
 ### Issues
 
-To verify that Sentry captures errors and creates issues in your Sentry project, add a button that throws an error when clicked:
+<SplitLayout>
+
+<SplitSection>
+
+<SplitSectionText>
+To verify that Sentry captures errors and creates issues in your Sentry project, add a button that throws an error when clicked.
+
+<OnboardingOption optionId="performance" hideForThisOption>
+  Open the page in a browser and click the button to throw an error.
+</OnboardingOption>
+
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+
+</SplitSectionText>
+
+<SplitSectionCode>
 
 ```html
 <script>
@@ -14,15 +29,26 @@ To verify that Sentry captures errors and creates issues in your Sentry project,
 <button onclick="triggerError()">Break the World</button>
 ```
 
-<OnboardingOption optionId="performance" hideForThisOption>
-  Open the page in a browser and click the button to throw an error.
-</OnboardingOption>
+</SplitSectionCode>
 
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+</SplitSection>
+
+</SplitLayout>
 
 <OnboardingOption optionId="performance">
 ### Tracing
-To test your tracing configuration, update the previous code to simulate a longer operation and start a trace:
+<SplitLayout>
+
+<SplitSection>
+
+<SplitSectionText>
+To test your tracing configuration, update the previous code to simulate a longer operation and start a trace.
+
+Open the page in a browser and click the button to throw an error and create a trace.
+
+</SplitSectionText>
+
+<SplitSectionCode>
 
 ```html
 <script>
@@ -41,12 +67,47 @@ To test your tracing configuration, update the previous code to simulate a longe
 <button onclick="triggerError()">Break the World</button>
 ```
 
-Open the page in a browser and click the button to throw an error and create a trace.
+</SplitSectionCode>
+
+</SplitSection>
+
+</SplitLayout>
 
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+### Logs <FeatureBadge type="new" size="small" />
+
+<SplitLayout>
+
+<SplitSection>
+
+<SplitSectionText>
+To verify that Sentry catches your logs, add some log statements to your application:
+
+</SplitSectionText>
+
+<SplitSectionCode>
+
+```javascript
+Sentry.logger.info("User example action completed");
+
+Sentry.logger.warn("Slow operation detected", {
+  operation: "data_fetch",
+  duration: 3500,
+});
+
+Sentry.logger.error("Validation failed", {
+  field: "email",
+  reason: "Invalid email",
+});
+```
+
+</SplitSectionCode>
+
+</SplitSection>
+
+</SplitLayout>
 
 </OnboardingOption>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This is the first in a series of PRs to update all JS quick start guides to the new split layout.

I'm starting with a single guide to validate the approach with @sergical before proceeding. 

Note:
I had to inline some includes temporarily since the include files are shared across multiple guides. I will update and use them again once all guides are updated.

Closes: #16903

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
