### PR TITLE
docs(godot): Add Steam, SteamOS, and Proton support page

### DIFF
--- a/docs/platforms/godot/configuration/steam.mdx
+++ b/docs/platforms/godot/configuration/steam.mdx
@@ -22,7 +22,7 @@ If you distribute your game on Steam using the oldest Linux runtime (`scout`), t
 
 ```
 ERROR: Can't open dynamic library: libsentry.linux.debug.x86_64.so.
-Error: libcurl.so.4: version `CURL_OPENSSL_4' not found
+Error: libcurl.so.4: version `CURL_OPENSSL_4` not found
 (required by libsentry.linux.debug.x86_64.so).
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add a new documentation page for Steam environment support in the Godot SDK (added in 1.5.0).

Covers automatic Steam detection (`steam` tag, Proton runtime filtering) and troubleshooting for the `scout` runtime libcurl incompatibility, including a warning about the Godot editor on Steam being locked to `scout`.

- Godot SDK PR: https://github.com/getsentry/sentry-godot/pull/591
- Refs getsentry/sentry-godot#613
- Refs getsentry/sentry-godot#125

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)