### PR TITLE
docs(templates): Add assigned-issue check to CONTRIBUTING.md template

### DIFF
--- a/develop-docs/sdk/getting-started/playbooks/development/handling-external-contributor-pr.mdx
+++ b/develop-docs/sdk/getting-started/playbooks/development/handling-external-contributor-pr.mdx
@@ -41,11 +41,7 @@ Related resources:
 
 If the PR is non-trivial and has no linked issue, use the ["Open an issue first" saved reply](/sdk/getting-started/templates/saved-replies#closing-pull-requests) and close the PR.
 
-#### 3. Check whether the linked issue is already assigned
-
-If the linked issue is already assigned to someone, that person is likely working on it. Before proceeding, leave a comment on the issue asking if they need help.
-
-#### 4. Check CI status
+#### 3. Check CI status
 
 If checks are failing, comment specifically on what's broken and give the contributor a chance to fix it.
 

--- a/develop-docs/sdk/getting-started/templates/contributing-md.mdx
+++ b/develop-docs/sdk/getting-started/templates/contributing-md.mdx
@@ -10,7 +10,7 @@ description: Boilerplate CONTRIBUTING.md template for Sentry SDK repositories. T
 
 ## What Belongs in CONTRIBUTING.md
 
-- **Welcome + issue-first policy** — ask contributors to open an issue before a non-trivial PR. Link to the [handling external contributor PRs playbook](https://develop.sentry.dev/sdk/getting-started/playbooks/development/handling-external-contributor-pr/).
+- **Welcome + issue-first policy** — ask contributors to open an issue before a non-trivial PR. If the issue is already assigned to someone, contributors should ask in the issue whether help is needed before opening a PR. Link to the [handling external contributor PRs playbook](https://develop.sentry.dev/sdk/getting-started/playbooks/development/handling-external-contributor-pr/).
 - **Getting started** — environment setup steps specific to this repo. Refer readers to the README for general project overview; CONTRIBUTING.md covers what's extra.
 - **Development workflow** — commit format, branch naming, and changelog requirement. Link to the [code submission standard](https://develop.sentry.dev/sdk/getting-started/standards/code-submission/) rather than restating it.
 - **Testing** — exact commands to run the test suite, a subset, and lint. Include platform-specific notes (tox environments, Gradle tasks, Xcode schemes, etc.).
@@ -48,7 +48,8 @@ Remove sections that don't apply and replace all `[placeholder]` values with rea
 # Contributing to \[SDK name\]
 
 We welcome contributions! Before submitting a non-trivial change, please open an issue
-so we can align on scope and approach. Want to understand how we work? Our
+so we can align on scope and approach. If the issue is already assigned to someone,
+leave a comment asking if you can help before opening a PR. Want to understand how we work? Our
 [SDK development docs](https://develop.sentry.dev/sdk/) cover our engineering process
 in detail.
 


### PR DESCRIPTION
Add guidance to the CONTRIBUTING.md template (and its authoring notes) that contributors should check whether the linked issue is already assigned before opening a PR — if so, they should ask in the issue whether help is needed first.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)