### PR TITLE
feat(dashboards): Removed beta alerts on Sentry Dashboards

### DIFF
--- a/docs/product/dashboards/sentry-dashboards/ai/agents.mdx
+++ b/docs/product/dashboards/sentry-dashboards/ai/agents.mdx
@@ -12,12 +12,6 @@ keywords:
 og_image: /og-images/ai-monitoring-agents-dashboard.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 AI Agents Dashboards, found in [Sentry Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/) provide a comprehensive view of your AI workflows, including executions, model costs and token usage, tool calls, and recent errors. Once you've [configured the Sentry SDK](/ai/monitoring/agents/getting-started/) for your AI agent project, telemetry data is collected and displayed in the dashboard to support analysis of system behavior and performance.
 
 AI Agent monitoring have three dashboards: 

--- a/docs/product/dashboards/sentry-dashboards/ai/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/ai/index.mdx
@@ -4,12 +4,6 @@ sidebar_order: 10
 description: "Use Sentry Dashboards to monitor AI agents and MCP performance."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Sentry Dashboards include dedicated views for AI monitoring. Use them to track agent executions, token usage, tool calls, and MCP (Model Context Protocol) traffic.
 
 - **[AI Agents Dashboards](/product/dashboards/sentry-dashboards/ai/agents/)** — View AI agent workflows, model costs, token usage, and tool calls. See [Set up AI Agent Monitoring](/ai/monitoring/agents/getting-started/) to get started.

--- a/docs/product/dashboards/sentry-dashboards/ai/mcp.mdx
+++ b/docs/product/dashboards/sentry-dashboards/ai/mcp.mdx
@@ -11,12 +11,6 @@ keywords:
 og_image: /og-images/ai-monitoring-mcp-dashboard.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 MCP Dashboards, found in [Sentry Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/), provide a comprehensive view of your MCP server activities, including requests, tool executions, resource access, and prompt usage. Once you've [configured the Sentry SDK](/ai/monitoring/mcp/getting-started/) for your MCP project, telemetry data is collected and displayed in the dashboard to support analysis of system behavior and performance.
 
 MCP monitoring has four dashboards:

--- a/docs/product/dashboards/sentry-dashboards/backend/caches.mdx
+++ b/docs/product/dashboards/sentry-dashboards/backend/caches.mdx
@@ -4,12 +4,6 @@ sidebar_order: 70
 description: "Learn more about cache monitoring with Sentry and how it can help improve your application's performance."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 A cache can be used to speed up data retrieval, improving application performance. It temporarily stores data to speed up subsequent access to that data, allowing your application to get data from cached memory (if it is available) instead having to repeatedly fetch the data from a potentially slow data layer. Caching can speed up read-heavy workloads for applications like Q&A portals, gaming, media sharing, and social networking.
 
 A successful cache results in a high hit rate which means the data was present when fetched. A cache miss occurs when the data fetched was not present in the cache. If you have [performance monitoring](/product/sentry-basics/performance-monitoring/#how-to-set-up-performance-monitoring) enabled and your application uses caching, you can see how your caches are performing with Sentry.

--- a/docs/product/dashboards/sentry-dashboards/backend/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/backend/index.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-backend.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Sentry's [**Backend dashboards**](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/) page gives you an overview of the health of your application.
 
 ## Backend Overview Dashboard

--- a/docs/product/dashboards/sentry-dashboards/backend/queries.mdx
+++ b/docs/product/dashboards/sentry-dashboards/backend/queries.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-backend-queries.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 With the Queries dashboard in [Sentry Dashboards](/product/dashboards/sentry-dashboards/), you can see how your database queries are performing in Sentry.
 
 Sentry's query monitoring helps you investigate the performance of your queries and get more information to improve them.

--- a/docs/product/dashboards/sentry-dashboards/backend/queues.mdx
+++ b/docs/product/dashboards/sentry-dashboards/backend/queues.mdx
@@ -4,12 +4,6 @@ sidebar_order: 30
 description: "Learn how to monitor your queues with Sentry for improved application performance and health."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Message Queues make asynchronous service-to-service communication possible in distributed architectures. Queues are great for helping work that sometimes fails become more resilient, and are therefore a building block for distributed applications. Some examples of what queues can help with include handling webhooks from third-party APIs or handling periodic tasks, such as calculating daily metrics for your users.
 
 If you have [performance monitoring](/product/sentry-basics/performance-monitoring/#how-to-set-up-performance-monitoring) enabled and your application interacts with message queue systems, you can configure Sentry to monitor their performance and health.

--- a/docs/product/dashboards/sentry-dashboards/frontend/assets.mdx
+++ b/docs/product/dashboards/sentry-dashboards/frontend/assets.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-frontend-assets.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 If you have [tracing](/product/sentry-basics/tracing/) enabled for your frontend, you can see how your browser assets are performing in Sentry.
 
 Starting with the [Assets dashboard](#assets-dashboard), you get a high-level overview of how your assets are doing. From there, you can drill into a specific asset's [Asset Summary dashboard](#asset-summary-dashboard) and then investigate sample events from the [Sample List](#sample-list) to better understand the context of its performance in a specific page.

--- a/docs/product/dashboards/sentry-dashboards/frontend/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/frontend/index.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-frontend.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Sentry's Frontend dashboards give you an overview of the health of your application. 
 
 ## Frontend Overview

--- a/docs/product/dashboards/sentry-dashboards/frontend/session-health.mdx
+++ b/docs/product/dashboards/sentry-dashboards/frontend/session-health.mdx
@@ -4,12 +4,6 @@ sidebar_order: 30
 description: "Get insights about your application's session health over time."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 <Include name="dashboards-session-health-body.mdx" />
 
 ## Charts

--- a/docs/product/dashboards/sentry-dashboards/frontend/web-vitals/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/frontend/web-vitals/index.mdx
@@ -4,12 +4,6 @@ sidebar_order: 0
 description: "Get a clear picture of your app's Performance Score and how each Web Vital shapes it. Then, learn how to drill in to explore opportunities to improve your app's overall performance."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Web vitals are a set of key metrics that measure how users actually experience your site; these include load speed, responsiveness and visual stability. [Learn more about these metrics in Web Vitals Concepts](/product/dashboards/sentry-dashboards/frontend/web-vitals/web-vitals-concepts/).
 
 For your instrumented web apps, Sentry gathers Web Vitals from real user traffic across [supported browsers](web-vitals-concepts/#browser-support). These metrics are used to calculate a [Performance Score](#performance-score) for your web application. Using these metrics, we surface the pages that have the most [opportunity](#opportunity) to improve your app's overall performance.

--- a/docs/product/dashboards/sentry-dashboards/frontend/web-vitals/web-vitals-concepts.mdx
+++ b/docs/product/dashboards/sentry-dashboards/frontend/web-vitals/web-vitals-concepts.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-frontend-web-vitals-web-vitals-concepts.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 [Web Vitals](https://web.dev/vitals/) are a set of metrics defined by Google to measure render time, response time, and layout shift. Each data point provides insights about the overall [performance](/product/dashboards/sentry-dashboards/) of your application.
 
 The in-browser Sentry SDKs collect web vitals information (where supported) and adds that information to frontend [transactions](/product/dashboards/sentry-dashboards/transaction-summary/). These web vitals are then summarized in the [Web Vitals dashboard](/product/dashboards/sentry-dashboards/frontend/web-vitals/) to give you a quick overview of how each page is performing for your users.

--- a/docs/product/dashboards/sentry-dashboards/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/index.mdx
@@ -6,12 +6,6 @@ description: >-
 og_image: /og-images/product-insights-overview.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Spot trends, fix issues, and boost application performance with Sentry's frontend, backend, mobile, and AI performance dashboards in [**Sentry Dashboards**](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/). Get a summary of the telemetry and events impacting the performance of your application, like web vitals, crash rate, session health, and outbound API requests. You can also use it to drill deeper into specific workflows and review traces, errors, and releases. 
 
 Sentry Dashboards use [tracing data](/concepts/key-terms/tracing/). By enabling tracing, Sentry tracks application performance, measuring metrics like throughput and latency, displaying the impact of errors across multiple services. Sentry captures [distributed traces](/product/sentry-basics/tracing/distributed-tracing/) consisting of multiple [spans](/product/explore/trace-explorer/#spans) to measure individual services and operations within those services. 

--- a/docs/product/dashboards/sentry-dashboards/mobile/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/mobile/index.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-mobile.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 The Mobile Dashboard found on [Sentry Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/) gives an overview of the metrics that let you know how fast your app starts, including the number of slow and frozen frames your users may be experiencing. Each metric provides insights into the overall performance health of your mobile application. Digging into the details helps prioritize critical performance issues and allows you to identify and troubleshoot the root cause faster.
 
 {/*![Mobile performance overview page.](../img/mobile-performance-overview.png)*/}

--- a/docs/product/dashboards/sentry-dashboards/mobile/mobile-vitals/app-starts.mdx
+++ b/docs/product/dashboards/sentry-dashboards/mobile/mobile-vitals/app-starts.mdx
@@ -7,12 +7,6 @@ description: >-
 og_image: /og-images/product-insights-mobile-mobile-vitals-app-starts.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 ![Example of App Starts =900x](./img/mobile-app-starts.png)
 
 The **App Starts** dashboard in [Sentry Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/) shows an overview of the amount of time it takes for your application to complete cold and warm starts. It helps you identify slow or regressed screens and gives additional information so you can better understand the factors contributing to the slowness of your application start times.

--- a/docs/product/dashboards/sentry-dashboards/mobile/mobile-vitals/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/mobile/mobile-vitals/index.mdx
@@ -5,12 +5,6 @@ description: Track the performance of your app.
 og_image: /og-images/product-insights-mobile-mobile-vitals.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 The Mobile Vitals dashboard, found in [Sentry Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/) provides a high-level overview of the performance of your screens, and allows you to drill down into the performance metrics of individual screens.
 
 ![The Mobile Vitals Dashboard. =800x](./img/mobile-vitals-dash.png)

--- a/docs/product/dashboards/sentry-dashboards/mobile/mobile-vitals/screen-loads.mdx
+++ b/docs/product/dashboards/sentry-dashboards/mobile/mobile-vitals/screen-loads.mdx
@@ -8,12 +8,6 @@ description: >-
 og_image: /og-images/product-insights-mobile-mobile-vitals-screen-loads.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 {/*![Example of Screen Loads](./img/screen-loads.png)*/}
 
 The **Screen Loads** dashboard in [Sentry Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/) shows an overview of the amount of time it takes for your application to load its screens. It helps you identify slow or regressed screens and gives additional information so you can better understand the factors contributing to the slowness of both time to initial display (TTID) and time to full display (TTFD).

--- a/docs/product/dashboards/sentry-dashboards/mobile/session-health.mdx
+++ b/docs/product/dashboards/sentry-dashboards/mobile/session-health.mdx
@@ -4,12 +4,6 @@ sidebar_order: 40
 description: "Get insights about your application's session health over time."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 <Include name="dashboards-session-health-body.mdx" />
 
 ![Mobile Session Health dashboard =800x](../img/mobile-session-health-dash.png)

--- a/docs/product/dashboards/sentry-dashboards/outbound-api-requests.mdx
+++ b/docs/product/dashboards/sentry-dashboards/outbound-api-requests.mdx
@@ -4,12 +4,6 @@ sidebar_order: 15
 description: "Track the performance of your application's HTTP requests and drill into the domains serving those requests."
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 This page applies to outbound HTTP requests from **frontend**, **mobile**, and **backend** applications. With performance monitoring enabled, Sentry tracks all outgoing HTTP requests and helps you investigate the domains that serve those requests.
 
 On the [Requests page](#requests-page), you get an overview of the domains that serve your application's outgoing requests. From there, you can check each individual domain's behavior on its [Domain Summary page](#domain-summary-page) and find sample events in the [Sample List](#sample-list).

--- a/docs/product/dashboards/sentry-dashboards/transaction-summary.mdx
+++ b/docs/product/dashboards/sentry-dashboards/transaction-summary.mdx
@@ -8,12 +8,6 @@ description: >-
 og_image: /og-images/product-insights-overview-transaction-summary.png
 ---
 
-<Alert title="Beta">
-
-This feature is currently in beta. Features in beta are still in-progress and may have bugs. We recognize the irony. Learn more about enabling Early Adopter Features [here](/organization/early-adopter-features/).
-
-</Alert>
-
 Every transaction has a summary view that gives you a better understanding of its overall health. With this view, you'll find graphs, instances of these events, stats, facet maps, related errors, and more.
 
 ![Example of Transaction Summary =900x](./img/transaction-summary.png)


### PR DESCRIPTION
## DESCRIBE YOUR PR
Sentry dashboards are going GA. Removed beta alerts on Sentry Dashboards. 

https://sentry-docs-git-feat-remove-beta-sentry-dash.sentry.dev/product/dashboards/sentry-dashboards/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Today
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)