### PR TITLE
feat(ruby): Add Kamal deploy release detection

### DIFF
--- a/docs/platforms/ruby/common/configuration/options.mdx
+++ b/docs/platforms/ruby/common/configuration/options.mdx
@@ -48,6 +48,7 @@ Lets you track your application version in Sentry.
 We intelligently guess the release in the following order of preference:
 
 - The `SENTRY_RELEASE` environment variable
+- Kamal’s deploy metadata via the `KAMAL_VERSION` environment variable
 - Commit SHA of the last commit (git)
 - Reading from the `REVISION` file in the app root (used by Capistrano)
 - Heroku’s dyno metadata via the `HEROKU_SLUG_COMMIT` environment variable (must have been enabled via Heroku Labs)

--- a/platform-includes/set-release/ruby.mdx
+++ b/platform-includes/set-release/ruby.mdx
@@ -7,6 +7,6 @@ end
 
 <Alert>
 
-We'll automatically attempt to detect the release in certain environments, such as Heroku and Capistrano.
+We'll automatically attempt to detect the release in certain environments, such as Kamal, Heroku, and Capistrano.
 
 </Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document automatic release detection from the `KAMAL_VERSION` environment variable in the Ruby SDK. [Kamal](https://kamal-deploy.org/) sets this variable in containers it builds and deploys, containing the commit SHA of the release.

- Added `KAMAL_VERSION` to the release detection order in the `release` option docs
- Added Kamal to the auto-detected environments alert in the set-release include

Refs getsentry/sentry-ruby#2895

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)