### PR TITLE
fix: add tslib as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "svg-pan-zoom": "^3.6.2",
     "tailwindcss-scoped-preflight": "^3.0.4",
     "textarea-markdown-editor": "^1.0.4",
+    "tslib": "^2.8.1",
     "unified": "^11.0.5",
     "unist-util-remove": "^4.0.0",
     "unist-util-visit": "^5.1.0"
@@ -129,6 +130,8 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.15.0",
     "@codecov/nextjs-webpack-plugin": "^1.9.0",
+    "@eslint/js": "^9.26.0",
+    "@next/eslint-plugin-next": "^15.3.3",
     "@spotlightjs/spotlight": "^2.5.0",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
@@ -140,8 +143,6 @@
     "@types/react-dom": "18.3.1",
     "@types/unist": "^3.0.3",
     "@types/ws": "^8.5.10",
-    "@eslint/js": "^9.26.0",
-    "@next/eslint-plugin-next": "^15.3.3",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "autoprefixer": "^10.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       textarea-markdown-editor:
         specifier: ^1.0.4
         version: 1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       unified:
         specifier: ^11.0.5
         version: 11.0.5


### PR DESCRIPTION
## Summary
- Adds `tslib` as a direct dependency to fix Vercel build failures

## Problem
After the ESLint 9 migration (#17108), the dependency tree changed and `tslib` is no longer being hoisted properly. This causes the build to fail with:

```
Module not found: Can't resolve 'tslib'
```

The `@sentry-internal/global-search` package requires `tslib` but it wasn't available at build time.

## Solution
Add `tslib` as a direct dependency so it's always available regardless of hoisting behavior.