### PR TITLE
docs(self-hosted): Update troubleshooting Docker healthcheck (clarify unhealthy container troubleshooting on slower systems)

### DIFF
--- a/develop-docs/self-hosted/troubleshooting/docker.mdx
+++ b/develop-docs/self-hosted/troubleshooting/docker.mdx
@@ -20,15 +20,15 @@ container for service "${servicename}" is unhealthy
 This can usually be resolved by running `docker compose down` and `docker compose up --wait` or rerunning the install script.
 
 <Alert title="Note"> 
-  On slower systems, including systems that only meet the minimum resource requirements for self-hosted Sentry, this issue may still persist even after rerunning <code>docker compose down</code> and <code>docker compose up --wait</code>.
+  On slower systems, including systems that only meet the minimum resource requirements for self-hosted Sentry, this issue may still persist even after rerunning `docker compose down` and `docker compose up --wait`.
 
   In this case, you can override the healthcheck parameters defined in `.env` by setting custom values in `.env.custom`.
 
   For example, increasing `HEALTHCHECK_RETRIES` may resolve the issue:
 
 ```shell
-  # .env.custom
-  HEALTHCHECK_RETRIES=20
+# .env.custom
+HEALTHCHECK_RETRIES=20
 ```
 
   Then start Docker Compose.

--- a/develop-docs/self-hosted/troubleshooting/docker.mdx
+++ b/develop-docs/self-hosted/troubleshooting/docker.mdx
@@ -22,7 +22,7 @@ This can usually be resolved by running `docker compose down` and `docker compos
 > [!NOTE]
 > On slower systems, including systems that only meet the minimum resource requirements for self-hosted Sentry, this issue may still persist even after rerunning `docker compose down` and `docker compose up --wait`.
 >
-> In this case, you can override the healthcheck parameters defined in `.env` by setting custom values in `.env.custom`. 
+> In this case, you can override the healthcheck parameters defined in `.env` by setting custom values in `.env.custom`.
 >
 > For example, increasing `HEALTHCHECK_RETRIES` may resolve the issue:
 >

--- a/develop-docs/self-hosted/troubleshooting/docker.mdx
+++ b/develop-docs/self-hosted/troubleshooting/docker.mdx
@@ -10,7 +10,7 @@ Around version 25.1.0 to 25.4.0, users which did not have `docker compose` plugi
 
 ## Container Healthcheck
 
-There may be some circumstances which you may want to increase or decrease healthcheck interval, timeout or retries for your custom needs. This can be achieved by editing `HEALTHCHECK_INTERVAL`, `HEALTHCHECK_TIMEOUT`, `HEALTHCHECK_RETRIES` variables' values in `.env`.
+There may be some circumstances which you may want to increase or decrease healthcheck interval, timeout or retries for your custom needs. This can be achieved by overriding the values of `HEALTHCHECK_INTERVAL`, `HEALTHCHECK_TIMEOUT` and `HEALTHCHECK_RETRIES` defined in `.env` in `.env.custom`.
 
 Occasionally, you might see an error like this
 ```
@@ -18,6 +18,22 @@ container for service "${servicename}" is unhealthy
 ```
 
 This can usually be resolved by running `docker compose down` and `docker compose up --wait` or rerunning the install script.
+
+> [!NOTE]
+> On slower systems, including systems that only meet the minimum resource requirements for self-hosted Sentry, this issue may still persist even after rerunning `docker compose down` and `docker compose up --wait`.
+>
+> In this case, you can override the healthcheck parameters defined in `.env` by setting custom values in `.env.custom`. 
+>
+> For example, increasing `HEALTHCHECK_RETRIES` may resolve the issue:
+>
+> ```shell
+> # .env.custom
+> HEALTHCHECK_RETRIES=20
+> ```
+>
+> Then start Docker Compose.
+>
+> Depending on your system, you may also need to adjust other `HEALTHCHECK_*` values.
 
 ## Docker Network Conflicting IP Address
 

--- a/develop-docs/self-hosted/troubleshooting/docker.mdx
+++ b/develop-docs/self-hosted/troubleshooting/docker.mdx
@@ -10,7 +10,7 @@ Around version 25.1.0 to 25.4.0, users which did not have `docker compose` plugi
 
 ## Container Healthcheck
 
-There may be some circumstances which you may want to increase or decrease healthcheck interval, timeout or retries for your custom needs. This can be achieved by overriding the values of `HEALTHCHECK_INTERVAL`, `HEALTHCHECK_TIMEOUT` and `HEALTHCHECK_RETRIES` defined in `.env` in `.env.custom`.
+There may be some circumstances where you want to increase or decrease the healthcheck interval, timeout, or retries for your custom needs. You can do this by overriding the `HEALTHCHECK_INTERVAL`, `HEALTHCHECK_TIMEOUT`, and `HEALTHCHECK_RETRIES` values from `.env` in a separate `.env.custom` file and running Docker Compose with both files (for example, `docker compose --env-file .env --env-file .env.custom up`).
 
 Occasionally, you might see an error like this
 ```

--- a/develop-docs/self-hosted/troubleshooting/docker.mdx
+++ b/develop-docs/self-hosted/troubleshooting/docker.mdx
@@ -19,21 +19,22 @@ container for service "${servicename}" is unhealthy
 
 This can usually be resolved by running `docker compose down` and `docker compose up --wait` or rerunning the install script.
 
-> [!NOTE]
-> On slower systems, including systems that only meet the minimum resource requirements for self-hosted Sentry, this issue may still persist even after rerunning `docker compose down` and `docker compose up --wait`.
->
-> In this case, you can override the healthcheck parameters defined in `.env` by setting custom values in `.env.custom`.
->
-> For example, increasing `HEALTHCHECK_RETRIES` may resolve the issue:
->
-> ```shell
-> # .env.custom
-> HEALTHCHECK_RETRIES=20
-> ```
->
-> Then start Docker Compose.
->
-> Depending on your system, you may also need to adjust other `HEALTHCHECK_*` values.
+<Alert title="Note"> 
+  On slower systems, including systems that only meet the minimum resource requirements for self-hosted Sentry, this issue may still persist even after rerunning <code>docker compose down</code> and <code>docker compose up --wait</code>.
+
+  In this case, you can override the healthcheck parameters defined in `.env` by setting custom values in `.env.custom`.
+
+  For example, increasing `HEALTHCHECK_RETRIES` may resolve the issue:
+
+```shell
+  # .env.custom
+  HEALTHCHECK_RETRIES=20
+```
+
+  Then start Docker Compose.
+
+  Depending on your system, you may also need to adjust other `HEALTHCHECK_*` values.
+</Alert>
 
 ## Docker Network Conflicting IP Address
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This PR updates the self-hosted Docker troubleshooting docs with guidance for resolving `container for service "${servicename}" is unhealthy` on slower systems.

It adds a note explaining how to override `HEALTHCHECK_*` values from `.env` in `.env.custom`, with an example using `HEALTHCHECK_RETRIES` that could resolve the problem.

Closes getsentry/self-hosted#4231

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
