### PR TITLE
docs(node): Add `nodeRuntimeMetricsIntegration` documentation

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/noderuntimemetrics.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/noderuntimemetrics.mdx
@@ -1,0 +1,105 @@
+---
+title: NodeRuntimeMetrics
+description: "Collect Node.js runtime health metrics such as memory usage, CPU utilization, and event loop delay."
+supported:
+  - javascript.node
+  - javascript.aws-lambda
+  - javascript.azure-functions
+  - javascript.connect
+  - javascript.express
+  - javascript.fastify
+  - javascript.gcp-functions
+  - javascript.hapi
+  - javascript.hono
+  - javascript.koa
+  - javascript.nestjs
+  - javascript.electron
+  - javascript.nextjs
+  - javascript.nuxt
+  - javascript.solidstart
+  - javascript.sveltekit
+  - javascript.remix
+  - javascript.react-router
+  - javascript.astro
+  - javascript.tanstackstart-react
+---
+
+<Alert>
+
+This integration only works in the Node.js runtime.
+
+</Alert>
+
+_Import name: `Sentry.nodeRuntimeMetricsIntegration`_
+
+The `nodeRuntimeMetricsIntegration` periodically collects Node.js runtime health metrics and sends them to Sentry. Metrics include memory usage, CPU utilization, event loop delay, and process uptime.
+
+```javascript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.nodeRuntimeMetricsIntegration()],
+});
+```
+
+## Default Metrics
+
+The following metrics are emitted every 30 seconds by default:
+
+| Metric | Type | Unit | Description |
+|---|---|---|---|
+| `node.runtime.mem.rss` | gauge | byte | Resident Set Size — actual process memory footprint |
+| `node.runtime.mem.heap_used` | gauge | byte | V8 heap currently in use |
+| `node.runtime.mem.heap_total` | gauge | byte | Total V8 heap allocated |
+| `node.runtime.cpu.utilization` | gauge | ratio | CPU time / wall-clock time ratio |
+| `node.runtime.event_loop.delay.p50` | gauge | second | Median event loop delay |
+| `node.runtime.event_loop.delay.p99` | gauge | second | 99th percentile event loop delay |
+| `node.runtime.event_loop.utilization` | gauge | ratio | Fraction of time the event loop was active |
+| `node.runtime.process.uptime` | counter | second | Cumulative process uptime |
+
+## Options
+
+### `collect`
+
+_Type: `object`_
+
+Configure which metrics to collect. You can enable opt-in metrics or disable default ones.
+
+**Opt-in metrics (off by default):**
+
+```javascript
+Sentry.nodeRuntimeMetricsIntegration({
+  collect: {
+    cpuTime: true, // node.runtime.cpu.user + node.runtime.cpu.system
+    memExternal: true, // node.runtime.mem.external + node.runtime.mem.array_buffers
+    eventLoopDelayMin: true,
+    eventLoopDelayMax: true,
+    eventLoopDelayMean: true,
+    eventLoopDelayP90: true,
+  },
+});
+```
+
+**Disabling default metrics:**
+
+```javascript
+Sentry.nodeRuntimeMetricsIntegration({
+  collect: {
+    uptime: false,
+    eventLoopDelayP50: false,
+  },
+});
+```
+
+### `collectionIntervalMs`
+
+_Type: `number`_
+
+The interval in milliseconds between metric collections. Defaults to `30000` (30 seconds).
+
+```javascript
+Sentry.nodeRuntimeMetricsIntegration({
+  collectionIntervalMs: 60_000,
+});
+```

--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -79,6 +79,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
 | [`openAIIntegration`](./openai)                           |        ✓         |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
+++ b/platform-includes/configuration/integrations/javascript.aws-lambda.mdx
@@ -35,6 +35,7 @@
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
 | [`lruMemoizerIntegration`](./lrumemoizer)                 |                  |            |      ✓      |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`mongoIntegration`](./mongo)                             |                  |            |      ✓      |                        |
 | [`mongooseIntegration`](./mongoose)                       |                  |            |      ✓      |                        |
 | [`mysqlIntegration`](./mysql)                             |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.connect.mdx
+++ b/platform-includes/configuration/integrations/javascript.connect.mdx
@@ -43,6 +43,7 @@
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`prismaIntegration`](./prisma)                           |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.fastify.mdx
+++ b/platform-includes/configuration/integrations/javascript.fastify.mdx
@@ -43,6 +43,7 @@
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
 | [`supabaseIntegration`](./supabase)                       |                  |     ✓      |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.gcp-functions.mdx
+++ b/platform-includes/configuration/integrations/javascript.gcp-functions.mdx
@@ -36,6 +36,7 @@
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
 | [`lruMemoizerIntegration`](./lrumemoizer)                 |                  |            |      ✓      |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`mongoIntegration`](./mongo)                             |                  |            |      ✓      |                        |
 | [`mongooseIntegration`](./mongoose)                       |                  |            |      ✓      |                        |
 | [`mysqlIntegration`](./mysql)                             |                  |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.hapi.mdx
+++ b/platform-includes/configuration/integrations/javascript.hapi.mdx
@@ -43,6 +43,7 @@
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
 | [`supabaseIntegration`](./supabase)                       |                  |     ✓      |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nestjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nestjs.mdx
@@ -39,6 +39,7 @@
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`rewriteFramesIntegration`](./rewriteframes)             |                  |     ✓      |             |                        |
 | [`supabaseIntegration`](./supabase)                       |                  |     ✓      |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -84,6 +84,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
 | [`vercelAiIntegration`](./vercelai)                       |        ✓         |            |      ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.node.mdx
+++ b/platform-includes/configuration/integrations/javascript.node.mdx
@@ -31,6 +31,7 @@
 | [`nativeNodeFetchIntegration`](./nodefetch)               |        ✓         |            |      ✓      |           ✓            |
 | [`nodeContextIntegration`](./nodecontext)                 |        ✓         |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`onUncaughtExceptionIntegration`](./onuncaughtexception) |        ✓         |     ✓      |             |                        |
 | [`onUnhandledRejectionIntegration`](./unhandledrejection) |        ✓         |     ✓      |             |                        |
 | [`postgresIntegration`](./postgres)                       |        ✓         |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -78,6 +78,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
 | [`openAIIntegration`](./openai)                           |        ✓         |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -78,6 +78,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
 | [`openAIIntegration`](./openai)                           |        ✓         |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -78,6 +78,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |
 | [`openAIIntegration`](./openai)                           |        ✓         |            |      ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -77,6 +77,7 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`fsIntegration`](./fs)                                   |                  |            |      ✓      |                        |
 | [`knexIntegration`](./knex)                               |                  |            |      ✓      |                        |
 | [`localVariablesIntegration`](./localvariables)           |                  |     ✓      |             |                        |
+| [`nodeRuntimeMetricsIntegration`](./noderuntimemetrics)   |                  |            |             |           ✓            |
 | [`nodeProfilingIntegration`](./nodeprofiling)             |                  |            |      ✓      |                        |
 | [`supabaseIntegration`](./supabase)                       |                  |     ✓      |      ✓      |                        |
 | [`trpcMiddleware`](./trpc)                                |                  |     ✓      |      ✓      |           ✓            |


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the new `nodeRuntimeMetricsIntegration` added in getsentry/sentry-javascript#19923.

Documents getsentry/sentry-javascript#19923

- Add integration documentation page with default/opt-in metrics table and configuration options
- Add integration to all Node.js-based platform integration tables

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)