### PR TITLE
fix(workflow): Replace getSantry with dedicated GH app for api schema workflow

### DIFF
--- a/.github/workflows/bump-api-schema-sha.yml
+++ b/.github/workflows/bump-api-schema-sha.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_API_SCHEMA_UPDATER_APP_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_API_SCHEMA_UPDATER_PRIVATE_KEY }}
+          repositories: |
+            sentry-docs
+            sentry-api-schema
       - name: 'Bump API Schema SHA'
         shell: bash
         env:


### PR DESCRIPTION
We added the new default rulesets that requires all commit to go through PRs and that breaks this workflow.
Added the following changes to fix it
- created a new dedicated github app for this
- added the github app to allowlist in the ruleset
- update the workflow to use the new github app instead of `getSantry`
- added the app-id and private key through org secrets and variables
- update the git commit info to use the github app