### PR TITLE
docs(react-native): Improve ErrorBoundary docs with non-render error guidance

### DIFF
--- a/docs/platforms/react-native/integrations/error-boundary.mdx
+++ b/docs/platforms/react-native/integrations/error-boundary.mdx
@@ -3,12 +3,24 @@ title: React Error Boundary
 excerpt: ''
 description: >-
   Learn how the React Native SDK exports an error boundary component that
-  leverages React component APIs.
+  leverages React component APIs to catch rendering errors and display fallback UIs.
 sidebar_order: 60
 og_image: /og-images/platforms-react-native-integrations-error-boundary.png
 ---
 
-The React Native SDK exports an error boundary component that uses [React component APIs](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) to automatically catch and send JavaScript errors from inside a React component tree to Sentry.
+The React Native SDK exports an error boundary component that uses [React component APIs](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) to automatically catch and send JavaScript errors from inside a React component tree to Sentry, and render a fallback UI.
+
+<Alert level="warning" title="Render errors only">
+
+React error boundaries **only catch errors during rendering, in lifecycle methods, and in constructors**. They do **not** catch errors in event handlers, asynchronous code (`setTimeout`, `Promise`), or native errors. See [Handling Non-Render Errors](#handling-non-render-errors) for how to handle those.
+
+</Alert>
+
+<Alert level="info" title="Recommended on Android">
+
+On Android, some render-time errors (such as `TypeError` from calling a non-function) can bypass the global error handler entirely. Wrapping your app or error-prone components with `ErrorBoundary` ensures these errors are reliably captured and reported to Sentry.
+
+</Alert>
 
 ## Prerequisites
 
@@ -18,9 +30,10 @@ To use the Error Boundary component, you need to have the React Native SDK [inst
 
 ```javascript
 import React from "react";
+import { Text } from "react-native";
 import * as Sentry from "@sentry/react-native";
 
-<Sentry.ErrorBoundary fallback={<p>An error has occurred</p>}>
+<Sentry.ErrorBoundary fallback={<Text>An error has occurred</Text>}>
   <Example />
 </Sentry.ErrorBoundary>;
 ```
@@ -29,9 +42,12 @@ The Sentry Error Boundary is also available as a higher-order component.
 
 ```javascript
 import React from "react";
+import { Text } from "react-native";
 import * as Sentry from "@sentry/react-native";
 
-Sentry.withErrorBoundary(Example, { fallback: <p>an error has occurred</p> });
+Sentry.withErrorBoundary(Example, {
+  fallback: <Text>An error has occurred</Text>,
+});
 ```
 
 <Alert level="warning" title="Note">
@@ -44,12 +60,13 @@ In the example below, when the `<Example />` component hits an error, the `<Sent
 
 ```javascript
 import React from "react";
+import { Text } from "react-native";
 import * as Sentry from "@sentry/react-native";
 
 import { Example } from "../example";
 
 function FallbackComponent() {
-  return <div>An error has occurred</div>;
+  return <Text>An error has occurred</Text>;
 }
 
 const myFallback = <FallbackComponent />;
@@ -80,6 +97,114 @@ By default, React [logs all errors to the console](https://github.com/facebook/r
 In [React v17 and above](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#native-component-stacks), the SDK will automatically parse the [error boundary](https://react.dev/reference/react/Component#componentdidcatch-parameters) `componentStack` and attach the full stacktrace to the event via `error.cause`. This requires the `nativeLinkedErrorsIntegration` to be enabled. (It's enabled by default.) To get the full source context, we recommend setting up [source maps](/platforms/react-native/sourcemaps/) for your project.
 
 ![React Error Boundary stacktrace](./img/errorboundary-error.png)
+
+## Handling Non-Render Errors
+
+Errors in event handlers, `async` functions, `setTimeout`, and other non-render code won't be caught by `ErrorBoundary`. This is a [React limitation](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary), not specific to Sentry.
+
+Sentry's [`reactNativeErrorHandlersIntegration`](/platforms/react-native/integrations/default/#reactnativeerrorhandlersintegration) (enabled by default) **automatically reports** these errors to Sentry — you don't need to do anything extra for error reporting. However, it won't display a fallback UI.
+
+### Component-Level Error Handling
+
+For errors in event handlers or async code within a specific component, use `try`/`catch` with local state:
+
+```javascript
+import React, { useState } from "react";
+import { Button, Text } from "react-native";
+import * as Sentry from "@sentry/react-native";
+
+function MyComponent() {
+  const [error, setError] = useState(null);
+
+  const handlePress = async () => {
+    try {
+      await riskyOperation();
+    } catch (e) {
+      Sentry.captureException(e);
+      setError(e);
+    }
+  };
+
+  if (error) {
+    return (
+      <>
+        <Text>Something went wrong.</Text>
+        <Button onPress={() => setError(null)} title="Retry" />
+      </>
+    );
+  }
+
+  return <Button onPress={handlePress} title="Do thing" />;
+}
+```
+
+### Global Error Handling With Fallback UI
+
+To show a fallback UI for **any** unhandled JavaScript error (not just render errors), you can create a provider that listens to React Native's global error handler and combines it with `ErrorBoundary`:
+
+```javascript
+import React, { useState, useEffect } from "react";
+import { Button, DeviceEventEmitter, Text, View } from "react-native";
+import * as Sentry from "@sentry/react-native";
+
+// Set up the global error listener before Sentry.init()
+const globalHandler = global.ErrorUtils?.getGlobalHandler();
+global.ErrorUtils?.setGlobalHandler((error, isFatal) => {
+  DeviceEventEmitter.emit("GLOBAL_UNHANDLED_ERROR", error);
+
+  // Call the default handler in development for the React Native red box.
+  // In production, we skip the default handler to prevent the app from
+  // crashing so the fallback UI can be shown instead.
+  if (__DEV__ && globalHandler) {
+    globalHandler(error, isFatal);
+  }
+});
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+});
+
+function GlobalFallback({ onReset }) {
+  return (
+    <View>
+      <Text>Something went wrong.</Text>
+      <Button onPress={onReset} title="Restart" />
+    </View>
+  );
+}
+
+function AppErrorProvider({ children }) {
+  const [globalError, setGlobalError] = useState(null);
+
+  useEffect(() => {
+    const subscription = DeviceEventEmitter.addListener(
+      "GLOBAL_UNHANDLED_ERROR",
+      (error) => setGlobalError(error)
+    );
+    return () => subscription.remove();
+  }, []);
+
+  if (globalError) {
+    return <GlobalFallback onReset={() => setGlobalError(null)} />;
+  }
+
+  return (
+    <Sentry.ErrorBoundary
+      fallback={({ resetError }) => (
+        <GlobalFallback onReset={resetError} />
+      )}
+    >
+      {children}
+    </Sentry.ErrorBoundary>
+  );
+}
+```
+
+<Alert level="info" title="Note">
+
+When intercepting the global error handler, unhandled errors will still be reported to Sentry by the `reactNativeErrorHandlersIntegration`. You do **not** need to call `Sentry.captureException` manually in the global handler.
+
+</Alert>
 
 ## Options
 
@@ -195,3 +320,25 @@ function MyComponent({ props }) {
 
 export default MyComponent;
 ```
+
+## Troubleshooting
+
+### Fallback Not Rendering
+
+If your `ErrorBoundary` fallback isn't appearing, make sure the error is happening **during rendering**. Errors thrown in event handlers (like `onPress`), `setTimeout`, `async` functions, or Promises won't trigger the fallback. See [Handling Non-Render Errors](#handling-non-render-errors).
+
+To verify your ErrorBoundary is working, trigger a render error via component state:
+
+```javascript
+const [crash, setCrash] = useState(false);
+
+if (crash) {
+  throw new Error("Test render error");
+}
+
+return <Button onPress={() => setCrash(true)} title="Test ErrorBoundary" />;
+```
+
+### Screenshots Capture the Fallback Instead of the Error
+
+When using `attachScreenshot: true` with `ErrorBoundary`, the captured screenshot may show the fallback component instead of the screen at the time of the error. This happens because the screenshot is taken shortly after the error is captured, by which time React has already rendered the fallback UI. This is a known limitation.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Improves the React Native ErrorBoundary documentation to address recurring user confusion about error boundaries not catching non-render errors.

**What changed:**
- Added a warning callout at the top explaining that error boundaries only catch render-phase errors (not event handlers, async code, etc.)
- Added an Android-specific note recommending ErrorBoundary for reliable render error capture (render errors can bypass the global handler on Android)
- Added a new **"Handling Non-Render Errors"** section with:
  - Component-level pattern: `try`/`catch` + `Sentry.captureException` + local state for fallback UI
  - Global pattern: `ErrorUtils` + `DeviceEventEmitter` provider that combines with `ErrorBoundary`
- Added a **Troubleshooting** section covering:
  - "Fallback Not Rendering" — with a verification snippet
  - "Screenshots Capture the Fallback Instead of the Error" — known `attachScreenshot` timing issue
- **Fixed HTML elements in existing code examples** — `<p>` and `<div>` replaced with React Native `<Text>`, added missing `react-native` imports

**Motivation:**
This is the most common source of confusion in our ErrorBoundary-related issues:
- getsentry/sentry-react-native#3803 — user threw in `onPress`, expected fallback
- getsentry/sentry-react-native#1775 — original request to document ErrorBoundary for RN
- getsentry/sentry-react-native#636 — multiple users confused about render-only limitation
- getsentry/sentry-react-native#3114 — ErrorBoundary not catching, app crashes
- getsentry/sentry-react-native#5205 — Android render errors bypassing global handler (ErrorBoundary is the fix)
- getsentry/sentry-react-native#3819 — `attachScreenshot` captures fallback instead of error screen

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)