### PR TITLE
Remove deprecated FeedbackButton from React Native docs

### DIFF
--- a/docs/platforms/react-native/user-feedback/configuration/index.mdx
+++ b/docs/platforms/react-native/user-feedback/configuration/index.mdx
@@ -8,23 +8,14 @@ og_image: /og-images/platforms-react-native-user-feedback-configuration.png
 The User Feedback Form offers many customization options, and if the available options are insufficient, you can [use your own UI](/platforms/react-native/user-feedback/#user-feedback-api).
 
 ![An image showing the main customization options for the User Feedback Form](./img/mobile-user-feedback-widget-customization.png)
-To collect user feedback from inside your application, use the `showFeedbackButton`/`hideFeedbackButton` to show/hide a button that triggers the Feedback Form or the `showFeedbackForm` method to present the form directly.
+To collect user feedback from inside your application, use the `showFeedbackForm` method to present the form.
 
-```JavaScript {tabTitle:Form}
+```JavaScript
 import * as Sentry from "@sentry/react-native";
 
 Sentry.wrap(RootComponent);
 
 Sentry.showFeedbackForm();
-```
-
-```JavaScript {tabTitle:Button}
-import * as Sentry from "@sentry/react-native";
-
-Sentry.wrap(RootComponent);
-
-Sentry.showFeedbackButton();
-Sentry.hideFeedbackButton();
 ```
 
 Note that [the root application component must be wrapped with `Sentry.wrap`](/platforms/react-native/#wrap-your-app) for this to work.
@@ -140,47 +131,6 @@ The following styles are available for customisation.
 | `screenshotThumbnail` | `ImageStyle` | The screenshot thumbnail image style.           |
 | `titleContainer`      | `ViewStyle`  | The title container style.                      |
 
-## Feedback Button Customization
-
-You can customize placement of the feedback button, as well as the fonts and colors.
-
-The example below shows how to customize the bottom margin with the `feedbackIntegration`.
-
-```javascript
-import * as Sentry from "@sentry/react-native";
-
-Sentry.init({
-  integrations: [
-    Sentry.feedbackIntegration({
-      buttonOptions: {
-        styles: {
-          triggerButton: {
-            marginBottom: 75,
-          },
-        },
-      },
-    }),
-  ],
-});
-
-Sentry.showFeedbackButton();
-```
-
-You can customize the button text with the following options.
-
-| Key                | Default          | Description                                                          |
-| ------------------ | ---------------- | -------------------------------------------------------------------- |
-| `triggerLabel`     | `"Report a Bug"` | The label for the Feedback button that opens the form.               |
-| `triggerAriaLabel` | -                | The aria label for the Feedback button that opens the form.          |
-
-The following styles are available for customisation.
-
-| Style           | Type         | Description                       |
-| --------------- | ------------ | --------------------------------- |
-| `triggerButton` | `ViewStyle`  | The feedback button style.        |
-| `triggerText`   | `TextStyle`  | The feedback button text style.   |
-| `triggerIcon`   | `ImageStyle` | The feedback button icon style.   |
-
 ## Event Callbacks
 
 The following callbacks can be configured for the integration in `feedbackIntegration({})` or passed in the `FeedbackForm` component props:
@@ -228,7 +178,7 @@ Sentry.init({
 });
 ```
 
-The `imagePicker` integration is used when launching the feedback form with the `showFeedbackForm` or the `FeedbackButton`. In order to use it with a custom `FeedbackForm` component, you need to pass the `imagePicker` prop to the component as shown below:
+The `imagePicker` integration is used when launching the feedback form with `showFeedbackForm`. In order to use it with a custom `FeedbackForm` component, you need to pass the `imagePicker` prop to the component as shown below:
 
 ```javascript
 <FeedbackForm
@@ -270,6 +220,7 @@ import * as Sentry from "@sentry/react-native";
 Sentry.init({
   integrations: [
     Sentry.feedbackIntegration({
+      enableTakeScreenshot: true,
       screenshotButtonOptions: {
         triggerLabel: 'Take Screenshot',
         styles: {
@@ -281,8 +232,6 @@ Sentry.init({
     }),
   ],
 });
-
-Sentry.showFeedbackButton();
 ```
 
 You can customize the Feedback Form screenshot button text with the following options.

--- a/docs/platforms/react-native/user-feedback/index.mdx
+++ b/docs/platforms/react-native/user-feedback/index.mdx
@@ -29,20 +29,9 @@ Sentry.wrap(RootComponent);
 Sentry.showFeedbackForm();
 ```
 
-You may also use the `showFeedbackButton` and `hideFeedbackButton` to show and hide a button that opens the Feedback Form.
+Note that [the root application component must be wrapped with `Sentry.wrap`](/platforms/react-native/#wrap-your-app) for the `showFeedbackForm` method to work. The method depends on the React Native `Modal` implementation. It is supported fully in the legacy architecture. For the new architecture (Fabric renderer) it requires React Native `0.71` and up.
 
-```javascript
-import * as Sentry from "@sentry/react-native";
-
-Sentry.wrap(RootComponent);
-
-Sentry.showFeedbackButton();
-Sentry.hideFeedbackButton();
-```
-
-Note that [the root application component must be wrapped with `Sentry.wrap`](/platforms/react-native/#wrap-your-app) for the `showFeedbackForm` and `showFeedbackButton` methods to work. The methods depend on the React Native `Modal` implementation. It is supported fully in the legacy architecture. For the new architecture (Fabric renderer) it requires React Native `0.71` and up.
-
-To configure the widget or the button you can use the `Sentry.feedbackIntegration({})` or add it to your Sentry initialization.
+To configure the form you can use the `Sentry.feedbackIntegration({})` or add it to your Sentry initialization.
 
 ```javascript
 import * as Sentry from "@sentry/react-native";
@@ -106,7 +95,7 @@ Note that when the device is offline, the feedback will be stored locally and se
 
 ### Session Replay
 
-The User Feedback widget integrates seamlessly with Session Replay. When the widget is opened, the SDK buffers up to 30 seconds of the user's session. If feedback is submitted, this replay is sent along with the feedback, allowing you to view both the feedback and the user's actions leading up to the feedback submission.
+The User Feedback Form integrates seamlessly with Session Replay. When the widget is opened, the SDK buffers up to 30 seconds of the user's session. If feedback is submitted, this replay is sent along with the feedback, allowing you to view both the feedback and the user's actions leading up to the feedback submission.
 
 ## User Feedback API
 


### PR DESCRIPTION
**Based on https://github.com/getsentry/sentry-docs/pull/17190**

## DESCRIBE YOUR PR

Remove all references to the deprecated `FeedbackButton`, `showFeedbackButton`, and `hideFeedbackButton` APIs from the React Native user feedback documentation.

Removed:
- `showFeedbackButton`/`hideFeedbackButton` code examples and mentions from the main user feedback page
- Entire "Feedback Button Customization" section from the configuration page
- `FeedbackButton` reference in the image picker section

Follows SDK deprecation in getsentry/sentry-react-native#5933.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/5933 is released

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)