### PR TITLE
docs(develop-docs): Fix commit messages guide to reflect squash-merge workflow

### DIFF
--- a/develop-docs/engineering-practices/commit-messages.mdx
+++ b/develop-docs/engineering-practices/commit-messages.mdx
@@ -29,7 +29,7 @@ When your branch is behind the default branch, we advise **merging** main into y
 
 #### Squashing a Merge Commit Message
 
-When squash-merging via GitHub’s UI, consider taking this opportunity to craft a clear final commit message that follows the commit guidelines below. GitHub’s default squash-merge message is a combination of all individual commit messages, which may not read well as a single entry in the project history.
+When squash-merging via GitHub’s UI, consider taking this opportunity to craft a clear final commit message that follows the commit guidelines below. The default squash-merge message varies by repository — some use the PR title and description, while others concatenate all individual commit messages.
 
 ### Commit Message Format
 

--- a/develop-docs/engineering-practices/commit-messages.mdx
+++ b/develop-docs/engineering-practices/commit-messages.mdx
@@ -29,7 +29,7 @@ When your branch is behind the default branch, prefer **merging** main into your
 
 #### Squash Merge Commit Message
 
-When squash-merging via GitHub’s UI, make sure to update the commit message to follow the commit guidelines. GitHub’s default squash-merge message is a combination of all individual commit messages, which typically **does not follow the commit guidelines**.
+When squash-merging via GitHub’s UI, consider taking the opportunity to craft a clear final commit message that follows the commit guidelines below. GitHub’s default squash-merge message is a combination of all individual commit messages, which may not read well as a single entry in the project history.
 
 ### Commit Message Format
 

--- a/develop-docs/engineering-practices/commit-messages.mdx
+++ b/develop-docs/engineering-practices/commit-messages.mdx
@@ -22,14 +22,14 @@ Because of this, you do **not** need to keep your branch’s individual commits 
 
 #### Updating Your Branch
 
-When your branch is behind the default branch, prefer **merging** main into your branch over rebasing:
+When your branch is behind the default branch, we advise **merging** main into your branch over rebasing:
 
 - **Merge** preserves the existing commit history and, importantly, keeps the context of already-reviewed changes intact. Reviewers can see only the new changes since their last review.
 - **Rebase** rewrites your branch’s commit history, which makes every commit appear new to reviewers and loses the ability to see incremental changes. This is especially disruptive on PRs that have already received review feedback.
 
-#### Squash Merge Commit Message
+#### Squashing a Merge Commit Message
 
-When squash-merging via GitHub’s UI, consider taking the opportunity to craft a clear final commit message that follows the commit guidelines below. GitHub’s default squash-merge message is a combination of all individual commit messages, which may not read well as a single entry in the project history.
+When squash-merging via GitHub’s UI, consider taking this opportunity to craft a clear final commit message that follows the commit guidelines below. GitHub’s default squash-merge message is a combination of all individual commit messages, which may not read well as a single entry in the project history.
 
 ### Commit Message Format
 

--- a/develop-docs/engineering-practices/commit-messages.mdx
+++ b/develop-docs/engineering-practices/commit-messages.mdx
@@ -14,21 +14,22 @@ sidebar_order: 10
 6.  Use the body to explain what and why vs. how
 7.  Each commit should be a single, stable change
 
-### Merge vs Rebase
+### Squash Merge
 
-Sentry uses a rebase workflow. That means that every commit on its own should be a clear, functional, and stable change. This means that when you’re building a new feature, you should try to parse it down into functional steps, and when that’s not reasonable, the end patch should be a single commit. This is counter to having a Pull Request which may include “fix [unmerged] behavior”. Those commits should be squashed, and the final patch when landed should be rebased.
+Sentry enforces **squash-merge** for all pull requests into the default branch. This means that regardless of how many commits your feature branch has, they will be combined into a single commit when merged. The resulting commit message is what matters — it should follow the commit message format described below.
 
-Remember: each commit should follow the commit message format and be stable (green build).
+Because of this, you do **not** need to keep your branch’s individual commits clean or rebased. Feel free to commit incrementally, use fixup commits, or have “WIP” messages during development — they will all be squashed away on merge.
 
-#### Rebase and Merge
+#### Updating Your Branch
 
-The GitHub UI exposes a “Rebase and Merge” option, which, if your commits already follow the commit guidelines, is a great way to bring your change into the codebase.
+When your branch is behind the default branch, prefer **merging** main into your branch over rebasing:
 
-#### Squashing
+- **Merge** preserves the existing commit history and, importantly, keeps the context of already-reviewed changes intact. Reviewers can see only the new changes since their last review.
+- **Rebase** rewrites your branch’s commit history, which makes every commit appear new to reviewers and loses the ability to see incremental changes. This is especially disruptive on PRs that have already received review feedback.
 
-When you are squashing your branch, it’s important to make sure you update the commit message. If you’re using GitHub’s UI it will by default create a new commit message which is a combination of all commits and **does not follow the commit guidelines**.
+#### Squash Merge Commit Message
 
-If you’re working locally, it often can be useful to `--amend` a commit, or utilize `rebase -i` to reorder, squash, and reword your commits.
+When squash-merging via GitHub’s UI, make sure to update the commit message to follow the commit guidelines. GitHub’s default squash-merge message is a combination of all individual commit messages, which typically **does not follow the commit guidelines**.
 
 ### Commit Message Format
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The [commit messages](https://develop.sentry.dev/engineering-practices/commit-messages/) guide incorrectly described Sentry as using a rebase workflow. Sentry actually enforces squash-merge for all PRs into the default branch.

- Replaced "Merge vs Rebase" section with "Squash Merge" — clarifying that all PRs are squash-merged and individual branch commits don't need to be clean
- Added "Updating Your Branch" subsection recommending merge over rebase, since rebase loses review context on already-reviewed PRs
- Replaced "Squashing" subsection with focused guidance on editing the squash-merge commit message

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Co-Authored-By: Claude <noreply@anthropic.com>