### PR TITLE
docs(mcp): Restructure and expand MCP server documentation

### DIFF
--- a/docs/ai/mcp.mdx
+++ b/docs/ai/mcp.mdx
@@ -168,31 +168,18 @@ npx @sentry/mcp-server@latest --access-token=YOUR_TOKEN --host=sentry.example.co
 
 ### Debug an Issue from a Link
 
-Paste a Sentry issue URL into your agent. The MCP pulls the stack trace, event details, and tags so the agent can investigate and propose a fix.
+Paste a Sentry issue URL into your agent. The MCP server pulls the stack trace, event details, and tags so the agent can investigate and propose a fix. Try prompts like:
 
-```
-fix https://sentry.io/issues/6811213890/
-```
-
-```
-Look at this Sentry issue and tell me the root cause: https://my-org.sentry.io/issues/PROJECT-123/
-```
+- "Fix this issue: `https://sentry.io/issues/6811213890/`"
+- "What's the root cause of `https://my-org.sentry.io/issues/PROJECT-123/`?"
 
 ### Analyze Incidents with Search
 
-Ask questions in plain English. The `search_issues` and `search_events` tools translate your queries into Sentry's search syntax.
+Ask questions in plain English. The `search_issues` and `search_events` tools translate your queries into Sentry's search syntax:
 
-```
-What are the top unresolved errors in production this week?
-```
-
-```
-Show me errors that started after the last deploy.
-```
-
-```
-Compare error rates between v2.3 and v2.4 for my-project.
-```
+- "What are the top unresolved errors in production this week?"
+- "Show me errors that started after the last deploy."
+- "Compare error rates between v2.3 and v2.4 for my-project."
 
 ## Client Instructions
 


### PR DESCRIPTION
Restructure the MCP docs page for clarity and expand coverage of stdio
transport, self-hosted setup, and practical workflows.

The page was a flat list of sections that made it hard to find what you
needed — cloud and stdio setup were interleaved, self-hosted was buried
in a collapsible, and the "Example Usage" / "Available Tools" / "Seer
Integration" sections were filler without actionable guidance.

New structure:
- **Setup** — cloud as the default path, stdio as a subsection with
  device-code OAuth documented
- **Configuration** — org/project URL scoping (cloud) and CLI flags (stdio)
- **Self-Hosted Sentry** — promoted to top-level with token setup,
  `--host` config, and `--disable-skills` guidance
- **Common Workflows** — practical examples replacing the old generic
  sections (issue link debugging, incident analysis with search)
- **Client Instructions** — moved to end as reference material
- **Troubleshooting** — tightened

Also applied Sentry brand guidelines throughout (shorter sentences,
active voice, less fluff).