### PR TITLE
fix(platform): Align home page top nav with content width

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -161,9 +161,9 @@ export function Header({
         @media (min-width: 1024px) {
           .header-content-home {
             /* 50px (content) - 12px (nav md:pl-3) = 38px on left */
-            /* 50px (content) - 16px (nav md:pr-4) = 34px on right */
+            /* 50px (content) - 24px (right div lg:pr-6) = 26px on right */
             padding-left: 38px;
-            padding-right: 34px;
+            padding-right: 26px;
           }
         }
         /* Doc pages: align header with sidebar and TOC at large viewports */


### PR DESCRIPTION
## DESCRIBE YOUR PR
Make top navigation true align with home page content. Right now, it's wider. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)