### PR TITLE
docs(native): update metrics to be enabled by default

### DIFF
--- a/platform-includes/metrics/usage/native.mdx
+++ b/platform-includes/metrics/usage/native.mdx
@@ -1,4 +1,4 @@
-Metrics are enabled by default. To disable metrics, set the `enable_metrics` option to 'false' during SDK initialization:
+Metrics are enabled by default. To disable metrics, set the `enable_metrics` option to `false` during SDK initialization:
 
 ```c
 sentry_options_t *options = sentry_options_new();


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Changes made to:
https://docs.sentry.io/platforms/native/metrics/

## DESCRIBE YOUR PR
We enabled metrics by default in https://github.com/getsentry/sentry-native/pull/1609#issue-4170015692 as per the guidelines in https://develop.sentry.dev/sdk/telemetry/metrics/#initialization-options

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)