### PR TITLE
feat(tracing): add flag to ignore prepare spans in Doctrine

### DIFF
--- a/docs/platforms/php/guides/symfony/configuration/symfony-options.mdx
+++ b/docs/platforms/php/guides/symfony/configuration/symfony-options.mdx
@@ -77,6 +77,7 @@ sentry:
         enabled: true
         dbal:
             enabled: true
+            ignore_prepare_spans: false
             connections:
                 - default
         twig:

--- a/docs/platforms/php/guides/symfony/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/php/guides/symfony/tracing/instrumentation/automatic-instrumentation.mdx
@@ -39,6 +39,15 @@ sentry:
       enabled: false
 ```
 
+By default, Doctrine ORM prepares each SQL query before executing it. This leads to traces that contain both `db.sql.prepare` and `db.sql.execute` spans for the same query. Set `ignore_prepare_spans` to `true` to suppress the prepare spans and keep your traces more compact.
+
+```yaml {filename:config/packages/sentry.yaml}
+sentry:
+  tracing:
+    dbal: # DB queries
+      ignore_prepare_spans: true
+```
+
 ## Twig
 
 This integration adds distributed tracing for Twig template rendering using Sentry.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Documentation for the `ignore_prepare_spans` flag, which defaults to `false` to keep current behaviour intact.
Enabling this will make the SDK produce only one span instead of two per query (only execute vs prepare + execute)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
