### PR TITLE
Add setup step for Azure SSO

### DIFF
--- a/docs/organization/authentication/sso/azure-sso.mdx
+++ b/docs/organization/authentication/sso/azure-sso.mdx
@@ -47,7 +47,9 @@ If you change your organization slug, you'll need to make the same update in the
 
    ![SAML Configuration](./img/azure-basic-saml-configuration1.png)
 
-1. In Section (3), labeled "SAML Signing Certificate", copy the "App Federation Metadata URL".
+1. In Section (2), labeled "Attributes & Claims", click Edit. On the new page, click "Unique User Identifier (Name ID)" and change the "Name Identifier Format" to Unspecified. Save the changes.
+
+1. In Section (3), labeled "SAML Certificates", copy the "App Federation Metadata URL".
 
    ![SAML Signing Certificate](./img/azure-saml-signing-certificate.png)
 


### PR DESCRIPTION
Add a configuration step to ensure the Unique User Identifier format is set to unspecified.

Sentry sets the format as unspecified in the SAMLRequest and some users have reported that this caused issues while configuring SSO.

Adding this step to ensure the nameID format is set to unspecified to avoid any related setup issues.

