### PR TITLE
Remove duplicate entries for github integration

### DIFF
--- a/docs/organization/integrations/index.mdx
+++ b/docs/organization/integrations/index.mdx
@@ -45,8 +45,7 @@ For more details, see the [full Integration Platform documentation](/organizatio
 | [Azure DevOps](/organization/integrations/source-code-mgmt/azure-devops/) | X               | X                     |                 |
 | [Bitbucket](/organization/integrations/source-code-mgmt/bitbucket/)       | X               | X                     |                 |
 | [Continue](/organization/integrations/source-code-mgmt/continuedev/)       |               | X                     |                 |
-| [GitHub](/organization/integrations/source-code-mgmt/github/)             | X               | X                     | X               |
-| [GitHub Enterprise](/organization/integrations/source-code-mgmt/github/)  | X               | X                     | X               |
+| [GitHub/GitHub Enterprise](/organization/integrations/source-code-mgmt/github/)             | X               | X                     | X               |
 | [GitLab](/organization/integrations/source-code-mgmt/gitlab/)             | X               | X                     | X               |
 | [Perforce](/organization/integrations/source-code-mgmt/perforce/) (Beta) | X               |                       | X               |
 


### PR DESCRIPTION
Documentation for github and github enterprise were merged into one doc. The main integrations page showed both entries pointing to the same documentation. 

This PR merges them into one line.