### PR TITLE
chore(platform): Move deprecated  webpack options

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -176,10 +176,9 @@ module.exports = withSentryConfig(nextConfig, {
     reactComponentAnnotation: {
       enabled: true,
     },
-  },
-
-  unstable_sentryWebpackPluginOptions: {
-    applicationKey: 'sentry-docs',
+    unstable_sentryWebpackPluginOptions: {
+      applicationKey: 'sentry-docs',
+    },
   },
 
   _experimental: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -162,18 +162,20 @@ module.exports = withSentryConfig(nextConfig, {
 
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
-
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-
-  // Enables automatic instrumentation of Vercel Cron Monitors
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true,
-
-  reactComponentAnnotation: {
-    enabled: true,
+  
+  webpack: {
+    treeshake: {
+      // Automatically tree-shake Sentry logger statements to reduce bundle size
+      removeDebugLogging: true,
+    },
+    // Enables automatic instrumentation of Vercel Cron Monitors
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
+    reactComponentAnnotation: {
+      enabled: true,
+    },
   },
 
   unstable_sentryWebpackPluginOptions: {


### PR DESCRIPTION
Updates config according to https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/webpack-setup/