### PR TITLE
docs: Fix build suffix `-` → `+` in SemVer

### DIFF
--- a/develop-docs/sdk/getting-started/standards/release-versioning.mdx
+++ b/develop-docs/sdk/getting-started/standards/release-versioning.mdx
@@ -25,7 +25,7 @@ These standards define how SDK versions are numbered and how releases are built 
 All SDK versions **MUST** follow [semantic versioning (SemVer)](https://semver.org/):
 
 ```
-<major>.<minor>.<patch>(-<prerelease>)?(-<build>)?
+<major>.<minor>.<patch>(-<prerelease>)?(+<build>)?
 ```
 
 ### Pre-release identifiers


### PR DESCRIPTION
From [SemVer spec, item 10](https://semver.org/#spec-item-10) (emphasis added):

> Build metadata MAY be denoted **by appending a plus sign** and a series of dot separated identifiers immediately following the patch or pre-release version. [...] Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3----117B344092BD.

Our template was using `-` instead of `+`. The examples below are already correctly using `+`.