### PR TITLE
docs: Update logic placement guidelines in API architecture

### DIFF
--- a/develop-docs/sdk/getting-started/standards/api-architecture.mdx
+++ b/develop-docs/sdk/getting-started/standards/api-architecture.mdx
@@ -24,7 +24,7 @@ These standards guide how SDKs are designed and evolved. The core philosophy: pr
 
 When deciding where new logic should live, default to server-side (Relay). Processing data in Relay keeps behavior consistent across SDK versions and avoids duplicating logic in clients that may remain deployed indefinitely.
 
-Logic **SHOULD** only be placed in the SDK only when it genuinely needs to run client-side, for example, if:
+Put logic in the SDK only when it genuinely needs to run client-side:
 
 - It needs to run before data leaves the customer's application (e.g., user-controlled filtering like `before_send_*`)
 - It requires access to platform-specific APIs

--- a/develop-docs/sdk/getting-started/standards/api-architecture.mdx
+++ b/develop-docs/sdk/getting-started/standards/api-architecture.mdx
@@ -24,12 +24,12 @@ These standards guide how SDKs are designed and evolved. The core philosophy: pr
 
 When deciding where new logic should live, default to server-side (Relay). Processing data in Relay keeps behavior consistent across SDK versions and avoids duplicating logic in clients that may remain deployed indefinitely.
 
-Put logic in the SDK only when it genuinely needs to run client-side:
+Logic **SHOULD** only be placed in the SDK only when it genuinely needs to run client-side, for example, if:
 
-- It **MUST** run before data leaves the customer's application (e.g., user-controlled filtering like `before_send_*`)
+- It needs to run before data leaves the customer's application (e.g., user-controlled filtering like `before_send_*`)
 - It requires access to platform-specific APIs
 - It's strictly latency-sensitive
-- It **MUST** function in offline scenarios
+- It needs to function in offline scenarios
 
 If data has already been collected, transform it in Relay.
 


### PR DESCRIPTION
This section was using RFC 2119 requirement levels in a strange way. These levels are meant to designate requirement levels, but here, they were using to describe technical details of data processing features. 

My change removes the strangely-used "**MUST**" specifiers from the examples of changes that need to live in the SDK, instead using generic "needs to" phrasing