### PR TITLE
docs(js): Add troubleshooting section for `[PLUGIN_TIMINGS]` warnings

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/vite.mdx
@@ -103,3 +103,15 @@ The Sentry Vite plugin doesn't upload source maps in watch-mode/development-mode
 We recommend running a production build to test your configuration.
 
 </Alert>
+
+## Troubleshooting
+
+<Expandable permalink={false} title="Sentry Vite plugin shows high plugin timings warning">
+
+When using Vite 6+ with the Rolldown bundler, you may see a `[PLUGIN_TIMINGS]` warning reporting that `sentry-vite-plugin` is taking a high percentage of total build time. This warning comes from [Rolldown's plugin timings check](https://rolldown.rs/reference/InputOptions.checks#plugintimings), not from Sentry, and appears when a single plugin uses more than 50% of total build time.
+
+This is expected behavior. The Sentry Vite plugin uploads source maps to Sentry during the build, which involves network requests. In projects with fast compilation (common with Rolldown), the upload step can dominate the total build time percentage even though the absolute duration hasn't increased.
+
+Make sure you only upload source maps for production builds and in CI. See the [configuration section](#configuration) above for setup details.
+
+</Expandable>


### PR DESCRIPTION
Adds a section for warnings like:

```
[PLUGIN_TIMINGS] Warning: Your build spent significant time in plugins. Here is a breakdown:
  - sentry-vite-plugin (76%)
  - vite:css-post (15%)
See https://rolldown.rs/options/checks#plugintimings for more details.
```