### PR TITLE
docs(apple): Add attachAllThreads option documentation

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -94,6 +94,16 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 </SdkOption>
 
+<SdkOption name="attachAllThreads" type="bool" defaultValue="false" availableSince="9.9.0">
+
+When enabled, all threads are attached with full stack traces to all captured events. This requires briefly suspending all threads to collect their stack traces. When disabled (the default), only the current thread gets a stack trace.
+
+This option requires `attachStacktrace` to also be enabled for it to have any effect.
+
+You can also override this option on a per-call basis by passing the `attachAllThreads` parameter to `SentrySDK.capture(event:)`, `SentrySDK.capture(error:)`, `SentrySDK.capture(exception:)`, or `SentrySDK.capture(message:)`.
+
+</SdkOption>
+
 <SdkOption name="enableSigtermReporting" type="bool" availableSince="8.27.0">
 
 _(New in [sentry-cocoa version 8.27.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8270))_


### PR DESCRIPTION
## DESCRIBE YOUR PR
Document the new `attachAllThreads` option added in sentry-cocoa 9.9.0. This option enables attaching all threads with full stack traces to captured events.

Also documents the per-call `attachAllThreads` parameter override for `SentrySDK.capture(event:)`, `SentrySDK.capture(error:)`, `SentrySDK.capture(exception:)`, and `SentrySDK.capture(message:)`.

## IS YOUR CHANGE URGENT?  

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)