### PR TITLE
feat(vercel-ai): add docs for the ToolLoopAgent class in Vercel AI

### DIFF
--- a/docs/ai/monitoring/agents/naming.mdx
+++ b/docs/ai/monitoring/agents/naming.mdx
@@ -14,18 +14,18 @@ Sentry uses the `gen_ai.agent.name` span attribute to identify agents in the [AI
 
 ## Quick Reference
 
-| Framework               | Platform | How to Name                                                        |
-| ----------------------- | -------- | ------------------------------------------------------------------ |
-| OpenAI Agents SDK       | Python   | `Agent(name="...")`                                                |
-| Pydantic AI             | Python   | `Agent(..., name="...")`                                           |
-| LangChain               | Python   | `create_agent(model, tools, name="...")`                           |
-| LangGraph               | Python   | `.compile(name="...")` or `create_react_agent(..., name="...")`    |
-| Vercel AI SDK           | JS       | `experimental_telemetry: { functionId: "..." }`                    |
-| LangGraph               | JS       | `.compile({ name: "..." })` or `createReactAgent({ name: "..." })` |
-| LangChain               | JS       | `createAgent({ name: "..." })`                                     |
-| Mastra                  | JS       | `Agent({ id: "...", name: "..." })`                                |
-| .NET (M.E.AI)           | .NET     | `options.Experimental.AgentName = "..."`                           |
-| Other / raw LLM clients | Any      | [Manual instrumentation](#manual-instrumentation)                  |
+| Framework               | Platform | How to Name                                                                          |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------ |
+| OpenAI Agents SDK       | Python   | `Agent(name="...")`                                                                  |
+| Pydantic AI             | Python   | `Agent(..., name="...")`                                                             |
+| LangChain               | Python   | `create_agent(model, tools, name="...")`                                             |
+| LangGraph               | Python   | `.compile(name="...")` or `create_react_agent(..., name="...")`                      |
+| Vercel AI SDK           | JS       | `experimental_telemetry: { functionId: "..." }` on `generateText` or `ToolLoopAgent` |
+| LangGraph               | JS       | `.compile({ name: "..." })` or `createReactAgent({ name: "..." })`                   |
+| LangChain               | JS       | `createAgent({ name: "..." })`                                                       |
+| Mastra                  | JS       | `Agent({ id: "...", name: "..." })`                                                  |
+| .NET (M.E.AI)           | .NET     | `options.Experimental.AgentName = "..."`                                             |
+| Other / raw LLM clients | Any      | [Manual instrumentation](#manual-instrumentation)                                    |
 
 ## Framework Integrations
 
@@ -113,7 +113,7 @@ agent = create_react_agent(model, tools, name="dice_agent")
 
 #### Vercel AI SDK
 
-Vercel AI SDK doesn't have a dedicated agent name field. Instead, set `functionId` in `experimental_telemetry` — Sentry uses this as the agent identifier.
+Set `functionId` in `experimental_telemetry` — Sentry uses this as the agent identifier. This works for both `generateText` and `ToolLoopAgent`:
 
 ```javascript
 import { generateText } from "ai";
@@ -125,6 +125,24 @@ const result = await generateText({
   experimental_telemetry: {
     isEnabled: true,
     functionId: "joke_agent",
+  },
+});
+```
+
+For the `ToolLoopAgent` class, set `functionId` in the constructor:
+
+```javascript
+import { ToolLoopAgent } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+const agent = new ToolLoopAgent({
+  model: openai("gpt-4o"),
+  tools: {
+    /* ... */
+  },
+  experimental_telemetry: {
+    isEnabled: true,
+    functionId: "weather_agent",
   },
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -84,7 +84,7 @@ Sentry.init({
 </PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare', 'javascript.nextjs']}>
-To correctly capture spans, pass the `experimental_telemetry` object with `isEnabled: true` to every `generateText`, `generateObject`, and `streamText` function call. For more details, see the [AI SDK Telemetry Metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
+To correctly capture spans, pass the `experimental_telemetry` object with `isEnabled: true` to every `generateText`, `generateObject`, `streamText`, and `ToolLoopAgent` call. For more details, see the [AI SDK Telemetry Metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
 
 ```javascript
 const result = await generateText({

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -160,6 +160,34 @@ Sentry.init({
 
 </PlatformSection>
 
+## ToolLoopAgent
+
+The integration also captures spans for the [`ToolLoopAgent`](https://ai-sdk.dev/docs/agents/overview#toolloopagent-class) class. Each call to `generate()` or `stream()` creates an agent span with individual LLM requests and tool executions as child spans.
+
+<PlatformSection notSupported={["javascript.cloudflare", "javascript.nextjs"]}>
+
+No additional configuration is needed — `ToolLoopAgent` spans are captured automatically.
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.nextjs']}>
+
+Pass `experimental_telemetry` with `isEnabled: true` to the `ToolLoopAgent` constructor to correctly capture spans:
+
+</PlatformSection>
+
+```javascript
+const agent = new ToolLoopAgent({
+  model: openai("gpt-4o"),
+  tools: { /* ... */ },
+  experimental_telemetry: { isEnabled: true },
+});
+
+const result = await agent.generate({
+  prompt: "What is the weather in San Francisco?",
+});
+```
+
 ## Identifying functions
 
 In order to make it easier to correlate captured spans with the function calls we recommend setting `functionId` in `experimental_telemetry` in all generation function calls:
@@ -170,6 +198,19 @@ const result = await generateText({
   experimental_telemetry: {
     isEnabled: true,
     functionId: "my-awesome-function",
+  },
+});
+```
+
+For `ToolLoopAgent`, set `functionId` in the constructor:
+
+```javascript
+const agent = new ToolLoopAgent({
+  model: openai("gpt-4o"),
+  tools: { /* ... */ },
+  experimental_telemetry: {
+    isEnabled: true,
+    functionId: "weather-agent",
   },
 });
 ```


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-2149/add-support-for-vercel-ai-sdks-toolloopagent

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
