### PR TITLE
docs(react-native): Document SENTRY_PROJECT_ROOT for monorepo setups

### DIFF
--- a/docs/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/docs/platforms/react-native/manual-setup/manual-setup.mdx
@@ -92,11 +92,11 @@ export MODULES_PATHS="../node_modules,../my-custom-module"
 export SENTRY_PROJECT_ROOT="/path/to/packages/mobile" # Override project root for monorepo setups
 ```
 
-<Note>
+<Alert>
 
 If you're using a monorepo (for example, NX or Turborepo), the script may resolve the project root incorrectly due to symlinked `node_modules`. Set `SENTRY_PROJECT_ROOT` to the absolute path of your React Native package to fix build failures caused by incorrect path resolution.
 
-</Note>
+</Alert>
 
 By default, uploading of source maps for debug simulator builds is disabled for speed reasons. If you want to generate source maps for debug builds, you can pass `--allow-fetch` as a parameter to `SENTRY_CLI_RN_XCODE_EXTRA_ARGS` in the above mentioned script.
 

--- a/docs/platforms/react-native/manual-setup/manual-setup.mdx
+++ b/docs/platforms/react-native/manual-setup/manual-setup.mdx
@@ -88,7 +88,15 @@ export SENTRY_CLI_RN_XCODE_EXTRA_ARGS="--extra --flags"
 export SOURCE_MAP_PATH="path/to/source-maps" # From where collect-modules should read modules
 export SENTRY_COLLECT_MODULES="path/to/collect-modules.sh"
 export MODULES_PATHS="../node_modules,../my-custom-module"
+
+export SENTRY_PROJECT_ROOT="/path/to/packages/mobile" # Override project root for monorepo setups
 ```
+
+<Note>
+
+If you're using a monorepo (for example, NX or Turborepo), the script may resolve the project root incorrectly due to symlinked `node_modules`. Set `SENTRY_PROJECT_ROOT` to the absolute path of your React Native package to fix build failures caused by incorrect path resolution.
+
+</Note>
 
 By default, uploading of source maps for debug simulator builds is disabled for speed reasons. If you want to generate source maps for debug builds, you can pass `--allow-fetch` as a parameter to `SENTRY_CLI_RN_XCODE_EXTRA_ARGS` in the above mentioned script.
 
@@ -110,6 +118,8 @@ export SENTRY_INCLUDE_NATIVE_SOURCES=true # Upload native iOS sources
 export SENTRY_CLI_EXECUTABLE="path/to/@sentry/cli/bin/sentry-cli"
 export SENTRY_CLI_EXTRA_ARGS="--extra --flags" # Extra arguments for sentry-cli in all build phases
 export SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS="--extra --flags"
+
+export SENTRY_PROJECT_ROOT="/path/to/packages/mobile" # Override project root for monorepo setups
 ```
 
 For more information about what options to use in `SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS` visit the [Sentry CLI Apple Debug Symbols](/platforms/apple/dsym/#sentry-cli) documentation.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds documentation for the new `SENTRY_PROJECT_ROOT` environment variable in the React Native manual setup guide.

This env var allows monorepo users (NX, Turborepo) to override the project root in Xcode build phase scripts, fixing incorrect path resolution caused by symlinked `node_modules`.

- Added `SENTRY_PROJECT_ROOT` to both the source maps and debug symbols upload env var sections
- Added a `<Note>` explaining when to use it

Companion SDK PR: getsentry/sentry-react-native#5961
Fixes: getsentry/sentry-react-native#2880

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/5961 is released

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)