### PR TITLE
fix(docs): Improve wording for attachStacktrace in attachAllThreads option documentation

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -98,7 +98,7 @@ Grouping in Sentry is different for events with stack traces and without. As a r
 
 When enabled, all threads are attached with full stack traces to all captured events. This requires briefly suspending all threads to collect their stack traces. When disabled (the default), only the current thread gets a stack trace.
 
-This option requires `attachStacktrace` to also be enabled for it to have any effect.
+This option also requires `attachStacktrace` to be enabled for it to have any effect.
 
 You can also override this option on a per-call basis by passing the `attachAllThreads` parameter to `SentrySDK.capture(event:)`, `SentrySDK.capture(error:)`, `SentrySDK.capture(exception:)`, or `SentrySDK.capture(message:)`.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR improves wording on Sentry-cocoa `attachAllThreads` option with a comment from @coolguyzone on https://github.com/getsentry/sentry-docs/pull/17258

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
