### PR TITLE
docs(unreal): Plugin dependencies build instructions

### DIFF
--- a/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
+++ b/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
@@ -8,7 +8,6 @@ The Sentry Unreal plugin ships with pre-built binaries for all supported platfor
 
 - **Testing or debugging** unreleased changes to the underlying platform SDKs
 - **Applying custom patches** to the platform SDKs for your project's specific needs
-- **Enabling client-side stacktrace display** in the [Sentry Crash Reporter](/platforms/unreal/configuration/setup-crashreporter/#stacktrace-display) when using the Crashpad backend
 
 ## Overview
 
@@ -17,7 +16,6 @@ The plugin depends on platform-specific SDKs that are pre-built in CI and bundle
 - **[sentry-native](https://github.com/getsentry/sentry-native)** — Windows and Linux (Crashpad and Native backends)
 - **[sentry-cocoa](https://github.com/getsentry/sentry-cocoa)** — macOS and iOS
 - **[sentry-java](https://github.com/getsentry/sentry-java)** — Android
-- **[sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter)** — External crash reporter application (Windows and Linux)
 
 The [sentry-unreal](https://github.com/getsentry/sentry-unreal) repository includes a `build-deps.ps1` script that automates building these SDKs and copying the resulting binaries to the correct locations within the plugin. The `plugin-dev/` directory then serves as the complete plugin package that can be copied into any Unreal project.
 
@@ -41,22 +39,15 @@ git checkout 1.XX.0  # match your installed plugin version
 
 <Alert>
 
-The initialization scripts require [GitHub CLI](https://cli.github.com/) to be installed.
-
-</Alert>
-
-You also need a local clone of the SDK you want to build (see links in [Overview](#overview)).
-
-<Alert>
-
-Each SDK version is pinned as a Git submodule under `modules/` in the sentry-unreal repository. When cloning an SDK to build locally, check out the same commit or tag in your local clone. You can find the expected version by looking at the submodule reference for your plugin's release tag on [GitHub](https://github.com/getsentry/sentry-unreal).
+The initialization scripts require [GitHub CLI](https://cli.github.com/) to be installed. You also need a local clone of the SDK you want to build (see links in [Overview](#overview)). Each SDK version is pinned as a Git submodule under `modules/` in the sentry-unreal repository — check out the same commit or tag in your local clone. You can find the expected version by looking at the submodule reference for your plugin's release tag on [GitHub](https://github.com/getsentry/sentry-unreal).
 
 </Alert>
 
 ### Prerequisites
 
 - **PowerShell** 7+ (or Windows PowerShell 5.1)
-- **Git** and **CMake** 3.16+
+- **Git**
+- **CMake** 3.16+
 - **Platform toolchain**: Visual Studio 2019+ on Windows, Clang 13+ on Linux, Xcode on macOS
 
 ## Using the Build Script
@@ -90,106 +81,7 @@ Each flag has a corresponding path parameter (e.g., `-NativePath`, `-CocoaPath`)
 
 <Alert>
 
-**Windows**: `-All` builds Native + Java + CrashReporter (Cocoa requires macOS).
-**macOS**: `-All` builds Cocoa + Java + CrashReporter (Native requires Windows).
+**Windows**: `-All` builds Native + Java + CrashReporter.
+**macOS**: `-All` builds Cocoa + Java + CrashReporter.
 
 </Alert>
-
-## Building sentry-native
-
-The `scripts/build-deps.ps1` script uses a fixed set of CMake flags that match the plugin's CI builds. If you need to pass additional CMake flags (such as `CRASHPAD_ENABLE_STACKTRACE`), you can either edit the script locally or build sentry-native manually with CMake.
-
-Refer to the [sentry-native README](https://github.com/getsentry/sentry-native#build-and-installation) for full build documentation and available options.
-
-### Customizing the Build Script
-
-To add custom CMake flags, modify the `cmake` configure invocation inside the `buildSentryNative()` function in `scripts/build-deps.ps1`, then run the build as usual:
-
-```powershell
-./scripts/build-deps.ps1 -Native -NativePath "D:\projects\sentry-native"
-```
-
-### Enabling Client-Side Stacktrace Support
-
-To enable stacktrace display in the [Sentry Crash Reporter](/platforms/unreal/configuration/setup-crashreporter/#stacktrace-display) when using the Crashpad backend, rebuild sentry-native with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag:
-
-1. Open `scripts/build-deps.ps1` and locate the Crashpad backend's `cmake` configure line inside `buildSentryNative()`:
-
-    ```powershell
-    cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
-    ```
-
-2. Add the stacktrace flag:
-
-    ```powershell
-    cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D CRASHPAD_ENABLE_STACKTRACE=ON
-    ```
-
-3. Run the build:
-
-    ```powershell
-    ./scripts/build-deps.ps1 -Native -NativePath "D:\projects\sentry-native"
-    ```
-
-4. Copy the updated `plugin-dev/` contents to your project's plugin directory.
-
-<Alert>
-
-The `CRASHPAD_ENABLE_STACKTRACE` feature is experimental. On Linux, it requires the `libunwind-ptrace` development package to be installed.
-
-</Alert>
-
-### Building Manually
-
-If you prefer to build [sentry-native](https://github.com/getsentry/sentry-native) outside of the `build-deps.ps1` script, you can do so directly with CMake.
-
-When building for Unreal, the following CMake flags are required for compatibility:
-
-| Flag | Value | Purpose |
-|------|-------|---------|
-| `SENTRY_BACKEND` | `crashpad` or `native` | Select crash handling backend |
-| `SENTRY_SDK_NAME` | `sentry.native.unreal` | SDK identifier reported in events |
-| `SENTRY_BUILD_SHARED_LIBS` | `OFF` | Build static libraries (required for Unreal) |
-
-### Windows
-
-```powershell
-cd D:\projects\sentry-native
-
-# Configure (Crashpad backend)
-cmake -G "Visual Studio 17 2022" -S . -B build `
-    -D SENTRY_BACKEND=crashpad `
-    -D SENTRY_SDK_NAME=sentry.native.unreal `
-    -D SENTRY_BUILD_SHARED_LIBS=OFF
-
-# Build
-cmake --build build --target sentry --config RelWithDebInfo --parallel
-cmake --build build --target crashpad_handler --config RelWithDebInfo --parallel
-
-# Install to a local directory
-cmake --install build --prefix install --config RelWithDebInfo
-```
-
-Add `-D CRASHPAD_ENABLE_STACKTRACE=ON` to the configure command to enable [client-side stacktrace support](#enabling-client-side-stacktrace-support).
-
-### Linux
-
-Building for Linux requires a two-pass build with different standard libraries for runtime compatibility with Unreal Engine. Refer to the [CI build scripts](https://github.com/getsentry/sentry-unreal/tree/main/scripts) (`build-linux-crashpad.sh`, `build-linux-native.sh`) for the full build process.
-
-### Replacing Plugin Binaries
-
-After building, copy the output files into your project's plugin directory. The plugin expects the following layout relative to `YourProject/Plugins/sentry-unreal/Source/ThirdParty/`:
-
-| Platform | Crashpad backend | Native backend |
-|----------|-----------------|----------------|
-| Windows | `Win64/Crashpad/` | `Win64/Native/` |
-| Linux | `Linux/Crashpad/` | `Linux/Native/` |
-
-Each backend directory contains:
-- `bin/` — executables (`crashpad_handler` for Crashpad, `sentry-crash` for Native)
-- `lib/` — static libraries (`sentry.lib` / `libsentry.a` and backend-specific libraries)
-- `include/` — headers (`sentry.h`)
-
-Make sure to replace **all** files in the target directory — partial updates can cause linker errors or runtime crashes.
-
-After replacing binaries, delete your project's `Build` and `Intermediate` directories and rebuild to ensure the updated files are picked up by Unreal Build Tool.

--- a/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
+++ b/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
@@ -1,0 +1,195 @@
+---
+title: Building Plugin Dependencies
+sidebar_order: 14
+description: "Learn how to build platform SDK dependencies locally for advanced customization."
+---
+
+The Sentry Unreal plugin ships with pre-built binaries for all supported platforms. In most cases, you don't need to build anything yourself. However, building dependencies locally may be needed when:
+
+- **Testing or debugging** unreleased changes to the underlying platform SDKs
+- **Applying custom patches** to the platform SDKs for your project's specific needs
+- **Enabling client-side stacktrace display** in the [Sentry Crash Reporter](/platforms/unreal/configuration/setup-crashreporter/#stacktrace-display) when using the Crashpad backend
+
+## Overview
+
+The plugin depends on platform-specific SDKs that are pre-built in CI and bundled into the `Source/ThirdParty/` directory:
+
+- **[sentry-native](https://github.com/getsentry/sentry-native)** — Windows and Linux (Crashpad and Native backends)
+- **[sentry-cocoa](https://github.com/getsentry/sentry-cocoa)** — macOS and iOS
+- **[sentry-java](https://github.com/getsentry/sentry-java)** — Android
+- **[sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter)** — External crash reporter application (Windows and Linux)
+
+The [sentry-unreal](https://github.com/getsentry/sentry-unreal) repository includes a `build-deps.ps1` script that automates building these SDKs and copying the resulting binaries to the correct locations within the plugin. The `plugin-dev/` directory then serves as the complete plugin package that can be copied into any Unreal project.
+
+## Setup
+
+Clone the [sentry-unreal](https://github.com/getsentry/sentry-unreal) repository, check out the tag that matches your installed plugin version, and run the initialization script:
+
+```bash
+git clone https://github.com/getsentry/sentry-unreal.git
+cd sentry-unreal
+git checkout 1.XX.0  # match your installed plugin version
+```
+
+```powershell
+# Windows
+./scripts/init-win.ps1
+
+# macOS/Linux
+./scripts/init.sh
+```
+
+<Alert>
+
+The initialization scripts require [GitHub CLI](https://cli.github.com/) to be installed.
+
+</Alert>
+
+You also need a local clone of the SDK you want to build (see links in [Overview](#overview)).
+
+<Alert>
+
+Each SDK version is pinned as a Git submodule under `modules/` in the sentry-unreal repository. When cloning an SDK to build locally, check out the same commit or tag in your local clone. You can find the expected version by looking at the submodule reference for your plugin's release tag on [GitHub](https://github.com/getsentry/sentry-unreal).
+
+</Alert>
+
+### Prerequisites
+
+- **PowerShell** 7+ (or Windows PowerShell 5.1)
+- **Git** and **CMake** 3.16+
+- **Platform toolchain**: Visual Studio 2019+ on Windows, Clang 13+ on Linux, Xcode on macOS
+
+## Using the Build Script
+
+Use `scripts/build-deps.ps1` to rebuild specific SDKs:
+
+```powershell
+# Point the script to your local SDK clone via environment variable or parameter
+$env:SENTRY_NATIVE_PATH = "D:\projects\sentry-native"
+
+# Build sentry-native (both Crashpad and Native backends)
+./scripts/build-deps.ps1 -Native
+
+# Or pass the path directly
+./scripts/build-deps.ps1 -Native -NativePath "D:\projects\sentry-native"
+```
+
+The script builds the SDK and copies the output binaries into `plugin-dev/Source/ThirdParty/`, replacing the pre-built ones. After that, copy the contents of `plugin-dev/` to your project's `Plugins/sentry-unreal/` directory — this replaces the plugin with your custom-built version.
+
+Available flags:
+
+| Flag | SDK | Platform |
+|------|-----|----------|
+| `-Native` | sentry-native | Windows |
+| `-Cocoa` | sentry-cocoa | macOS |
+| `-Java` | sentry-java | Any |
+| `-CrashReporter` | sentry-desktop-crash-reporter | Windows, macOS, Linux |
+| `-All` | All SDKs available on current platform | — |
+
+Each flag has a corresponding path parameter (e.g., `-NativePath`, `-CocoaPath`) that overrides the environment variable.
+
+<Alert>
+
+**Windows**: `-All` builds Native + Java + CrashReporter (Cocoa requires macOS).
+**macOS**: `-All` builds Cocoa + Java + CrashReporter (Native requires Windows).
+
+</Alert>
+
+## Building sentry-native
+
+The `scripts/build-deps.ps1` script uses a fixed set of CMake flags that match the plugin's CI builds. If you need to pass additional CMake flags (such as `CRASHPAD_ENABLE_STACKTRACE`), you can either edit the script locally or build sentry-native manually with CMake.
+
+Refer to the [sentry-native README](https://github.com/getsentry/sentry-native#build-and-installation) for full build documentation and available options.
+
+### Customizing the Build Script
+
+To add custom CMake flags, modify the `cmake` configure invocation inside the `buildSentryNative()` function in `scripts/build-deps.ps1`, then run the build as usual:
+
+```powershell
+./scripts/build-deps.ps1 -Native -NativePath "D:\projects\sentry-native"
+```
+
+### Enabling Client-Side Stacktrace Support
+
+To enable stacktrace display in the [Sentry Crash Reporter](/platforms/unreal/configuration/setup-crashreporter/#stacktrace-display) when using the Crashpad backend, rebuild sentry-native with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag:
+
+1. Open `scripts/build-deps.ps1` and locate the Crashpad backend's `cmake` configure line inside `buildSentryNative()`:
+
+    ```powershell
+    cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+    ```
+
+2. Add the stacktrace flag:
+
+    ```powershell
+    cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D CRASHPAD_ENABLE_STACKTRACE=ON
+    ```
+
+3. Run the build:
+
+    ```powershell
+    ./scripts/build-deps.ps1 -Native -NativePath "D:\projects\sentry-native"
+    ```
+
+4. Copy the updated `plugin-dev/` contents to your project's plugin directory.
+
+<Alert>
+
+The `CRASHPAD_ENABLE_STACKTRACE` feature is experimental. On Linux, it requires the `libunwind-ptrace` development package to be installed.
+
+</Alert>
+
+### Building Manually
+
+If you prefer to build [sentry-native](https://github.com/getsentry/sentry-native) outside of the `build-deps.ps1` script, you can do so directly with CMake.
+
+When building for Unreal, the following CMake flags are required for compatibility:
+
+| Flag | Value | Purpose |
+|------|-------|---------|
+| `SENTRY_BACKEND` | `crashpad` or `native` | Select crash handling backend |
+| `SENTRY_SDK_NAME` | `sentry.native.unreal` | SDK identifier reported in events |
+| `SENTRY_BUILD_SHARED_LIBS` | `OFF` | Build static libraries (required for Unreal) |
+
+### Windows
+
+```powershell
+cd D:\projects\sentry-native
+
+# Configure (Crashpad backend)
+cmake -G "Visual Studio 17 2022" -S . -B build `
+    -D SENTRY_BACKEND=crashpad `
+    -D SENTRY_SDK_NAME=sentry.native.unreal `
+    -D SENTRY_BUILD_SHARED_LIBS=OFF
+
+# Build
+cmake --build build --target sentry --config RelWithDebInfo --parallel
+cmake --build build --target crashpad_handler --config RelWithDebInfo --parallel
+
+# Install to a local directory
+cmake --install build --prefix install --config RelWithDebInfo
+```
+
+Add `-D CRASHPAD_ENABLE_STACKTRACE=ON` to the configure command to enable [client-side stacktrace support](#enabling-client-side-stacktrace-support).
+
+### Linux
+
+Building for Linux requires a two-pass build with different standard libraries for runtime compatibility with Unreal Engine. Refer to the [CI build scripts](https://github.com/getsentry/sentry-unreal/tree/main/scripts) (`build-linux-crashpad.sh`, `build-linux-native.sh`) for the full build process.
+
+### Replacing Plugin Binaries
+
+After building, copy the output files into your project's plugin directory. The plugin expects the following layout relative to `YourProject/Plugins/sentry-unreal/Source/ThirdParty/`:
+
+| Platform | Crashpad backend | Native backend |
+|----------|-----------------|----------------|
+| Windows | `Win64/Crashpad/` | `Win64/Native/` |
+| Linux | `Linux/Crashpad/` | `Linux/Native/` |
+
+Each backend directory contains:
+- `bin/` — executables (`crashpad_handler` for Crashpad, `sentry-crash` for Native)
+- `lib/` — static libraries (`sentry.lib` / `libsentry.a` and backend-specific libraries)
+- `include/` — headers (`sentry.h`)
+
+Make sure to replace **all** files in the target directory — partial updates can cause linker errors or runtime crashes.
+
+After replacing binaries, delete your project's `Build` and `Intermediate` directories and rebuild to ensure the updated files are picked up by Unreal Build Tool.

--- a/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
+++ b/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
@@ -86,4 +86,4 @@ Each flag has a corresponding path parameter (e.g., `-NativePath`, `-CocoaPath`)
 
 </Alert>
 
-The script uses a fixed set of build flags that match the plugin's CI builds. If you need to customize the build (for example, passing additional CMake flags to sentry-native), you can modify the corresponding build function in `scripts/build-deps.ps1` before running it.
+The script uses a fixed set of build settings that match the plugin's CI builds. If you need to customize the build (for example, passing additional CMake flags to sentry-native), you can modify the corresponding build function in `scripts/build-deps.ps1` before running it.

--- a/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
+++ b/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
@@ -17,6 +17,7 @@ The Sentry Unreal plugin ships with pre-built binaries for all supported platfor
 - **CMake** 3.16+
 - **Platform toolchain**: Visual Studio 2019+ on Windows, Clang 13+ on Linux, Xcode on macOS
 - **Android builds**: Java 17, Android SDK (API 33), Android NDK r25b
+- **Crash Reporter builds**: [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0)
 
 ## Overview
 

--- a/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
+++ b/docs/platforms/unreal/configuration/building-plugin-dependencies/index.mdx
@@ -9,13 +9,23 @@ The Sentry Unreal plugin ships with pre-built binaries for all supported platfor
 - **Testing or debugging** unreleased changes to the underlying platform SDKs
 - **Applying custom patches** to the platform SDKs for your project's specific needs
 
+## Prerequisites
+
+- **[GitHub CLI](https://cli.github.com/)**
+- **PowerShell** 7+ (or Windows PowerShell 5.1)
+- **Git**
+- **CMake** 3.16+
+- **Platform toolchain**: Visual Studio 2019+ on Windows, Clang 13+ on Linux, Xcode on macOS
+- **Android builds**: Java 17, Android SDK (API 33), Android NDK r25b
+
 ## Overview
 
-The plugin depends on platform-specific SDKs that are pre-built in CI and bundled into the `Source/ThirdParty/` directory:
+The plugin depends on platform-specific SDKs and other tools that are pre-built in CI and bundled into the `Source/ThirdParty/` directory:
 
-- **[sentry-native](https://github.com/getsentry/sentry-native)** — Windows and Linux (Crashpad and Native backends)
+- **[sentry-native](https://github.com/getsentry/sentry-native)** — Windows and Linux
 - **[sentry-cocoa](https://github.com/getsentry/sentry-cocoa)** — macOS and iOS
 - **[sentry-java](https://github.com/getsentry/sentry-java)** — Android
+- **[sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter)** — External crash reporter application for desktop platforms
 
 The [sentry-unreal](https://github.com/getsentry/sentry-unreal) repository includes a `build-deps.ps1` script that automates building these SDKs and copying the resulting binaries to the correct locations within the plugin. The `plugin-dev/` directory then serves as the complete plugin package that can be copied into any Unreal project.
 
@@ -37,18 +47,7 @@ git checkout 1.XX.0  # match your installed plugin version
 ./scripts/init.sh
 ```
 
-<Alert>
-
-The initialization scripts require [GitHub CLI](https://cli.github.com/) to be installed. You also need a local clone of the SDK you want to build (see links in [Overview](#overview)). Each SDK version is pinned as a Git submodule under `modules/` in the sentry-unreal repository — check out the same commit or tag in your local clone. You can find the expected version by looking at the submodule reference for your plugin's release tag on [GitHub](https://github.com/getsentry/sentry-unreal).
-
-</Alert>
-
-### Prerequisites
-
-- **PowerShell** 7+ (or Windows PowerShell 5.1)
-- **Git**
-- **CMake** 3.16+
-- **Platform toolchain**: Visual Studio 2019+ on Windows, Clang 13+ on Linux, Xcode on macOS
+You also need a local clone of the SDK you want to build (see links in [Overview](#overview)). Each SDK version is pinned as a Git submodule under `modules/` in the sentry-unreal repository — check out the same commit or tag in your local clone. You can find the expected version by looking at the submodule reference for your plugin's release tag on [GitHub](https://github.com/getsentry/sentry-unreal).
 
 ## Using the Build Script
 
@@ -85,3 +84,5 @@ Each flag has a corresponding path parameter (e.g., `-NativePath`, `-CocoaPath`)
 **macOS**: `-All` builds Cocoa + Java + CrashReporter.
 
 </Alert>
+
+The script uses a fixed set of build flags that match the plugin's CI builds. If you need to customize the build (for example, passing additional CMake flags to sentry-native), you can modify the corresponding build function in `scripts/build-deps.ps1` before running it.

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -234,7 +234,7 @@ The Sentry Crash Reporter can display a symbolicated stacktrace of the crashed t
 This feature requires client-side stack walking, which is supported through two backend configurations:
 
 - **[Native backend](/platforms/unreal/configuration/native-backend/)**: Performs stack walking and symbolication automatically using the platform's debug APIs. No additional configuration is needed.
-- **Crashpad backend**: Requires a custom build of `sentry-native` with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag enabled.
+- **Crashpad backend**: Requires a custom build of `sentry-native` with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag enabled. See [Building Plugin Dependencies](/platforms/unreal/configuration/building-plugin-dependencies/#enabling-client-side-stacktrace-support) for step-by-step instructions.
 
 <Alert>
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -218,14 +218,26 @@ These settings are applied each time the SDK initializes. Properties that are no
 
 #### Using a Custom Crash Reporter Build
 
-For more advanced customization (such as custom logos or layout changes), you can fork the [sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter) project and build a custom version following the instructions in its documentation.
+For more advanced customization (such as custom logos or layout changes), you can fork the [sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter) project and build a custom version. The crash reporter is a .NET/Uno Platform application — you need the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) to build it.
 
-To use your custom build, replace the crash reporter executable in the plugin's ThirdParty binaries directory:
+To build on Windows:
+
+```powershell
+cd sentry-desktop-crash-reporter
+dotnet publish -f net9.0-desktop -r win-x64 Sentry.CrashReporter/Sentry.CrashReporter.csproj -o build-output
+```
+
+For other platforms, replace the runtime identifier: `linux-x64`, `linux-arm64`, or `osx-arm64`.
+
+Copy the output executable into the plugin's ThirdParty binaries directory:
 
 - **Windows**: `Plugins/sentry-unreal/Source/ThirdParty/Win64/bin/Sentry.CrashReporter.exe`
 - **Linux**: `Plugins/sentry-unreal/Source/ThirdParty/Linux/bin/Sentry.CrashReporter`
+- **macOS**: `Plugins/sentry-unreal/Source/ThirdParty/Mac/bin/Sentry.CrashReporter`
 
-After replacing the executable, delete the project's `Build` and `Intermediate` directories and rebuild the project to ensure the updated binary is picked up.
+After replacing the executable, delete the project's `Build` and `Intermediate` directories and rebuild to ensure the updated binary is picked up.
+
+Refer to the project's [customization guide](https://github.com/getsentry/sentry-desktop-crash-reporter/blob/main/CUSTOMIZATION.md) for details on what can be changed.
 
 ### Stacktrace Display
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -234,11 +234,45 @@ The Sentry Crash Reporter can display a symbolicated stacktrace of the crashed t
 This feature requires client-side stack walking, which is supported through two backend configurations:
 
 - **[Native backend](/platforms/unreal/configuration/native-backend/)**: Performs stack walking and symbolication automatically using the platform's debug APIs. No additional configuration is needed.
-- **Crashpad backend**: Requires a custom build of `sentry-native` with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag enabled. See [Building Plugin Dependencies](/platforms/unreal/configuration/building-plugin-dependencies/#enabling-client-side-stacktrace-support) for step-by-step instructions.
+- **Crashpad backend**: Requires a custom build of `sentry-native` with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag enabled. See [below](#building-sentry-native-with-stacktrace-support) for instructions.
 
 <Alert>
 
 For **Shipping builds**, the stacktrace can only be symbolicated if debug information is available at runtime. Enable **Include Debug Files in Shipping Builds** in **Project Settings > Packaging** to ensure function names are resolved in the crash reporter dialog.
+
+</Alert>
+
+#### Building sentry-native With Stacktrace Support
+
+To enable client-side stacktrace display when using the Crashpad backend, you need to rebuild `sentry-native` with the `CRASHPAD_ENABLE_STACKTRACE` CMake flag. The example below shows a Windows build — for other platforms, refer to the [sentry-native build documentation](https://github.com/getsentry/sentry-native#build-and-installation) and the [CI build scripts](https://github.com/getsentry/sentry-unreal/tree/main/scripts) in the sentry-unreal repository.
+
+Clone [sentry-native](https://github.com/getsentry/sentry-native) and check out the version that matches your plugin (pinned under `modules/sentry-native` in the [sentry-unreal](https://github.com/getsentry/sentry-unreal) repository). Then build:
+
+```powershell
+cd D:\projects\sentry-native
+
+cmake -G "Visual Studio 17 2022" -S . -B build `
+    -D SENTRY_BACKEND=crashpad `
+    -D SENTRY_SDK_NAME=sentry.native.unreal `
+    -D SENTRY_BUILD_SHARED_LIBS=OFF `
+    -D CRASHPAD_ENABLE_STACKTRACE=ON
+
+cmake --build build --target sentry --config RelWithDebInfo --parallel
+cmake --build build --target crashpad_handler --config RelWithDebInfo --parallel
+cmake --install build --prefix install --config RelWithDebInfo
+```
+
+Copy the build output into your project's plugin directory:
+
+- `install/lib/*` → `Plugins/sentry-unreal/Source/ThirdParty/Win64/Crashpad/lib/`
+- `install/bin/crashpad_handler.exe` → `Plugins/sentry-unreal/Source/ThirdParty/Win64/Crashpad/bin/`
+- `install/include/sentry.h` → `Plugins/sentry-unreal/Source/ThirdParty/Win64/Crashpad/include/`
+
+After replacing binaries, delete your project's `Build` and `Intermediate` directories and rebuild.
+
+<Alert>
+
+The `CRASHPAD_ENABLE_STACKTRACE` feature is experimental. On Linux, it requires the `libunwind-ptrace` development package.
 
 </Alert>
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -227,13 +227,12 @@ cd sentry-desktop-crash-reporter
 dotnet publish -f net9.0-desktop -r win-x64 Sentry.CrashReporter/Sentry.CrashReporter.csproj -o build-output
 ```
 
-For other platforms, replace the runtime identifier: `linux-x64`, `linux-arm64`, or `osx-arm64`.
+For other platforms, replace the runtime identifier with `win-arm64`, `linux-x64`, or `linux-arm64`.
 
 Copy the output executable into the plugin's ThirdParty binaries directory:
 
 - **Windows**: `Plugins/sentry-unreal/Source/ThirdParty/Win64/bin/Sentry.CrashReporter.exe`
 - **Linux**: `Plugins/sentry-unreal/Source/ThirdParty/Linux/bin/Sentry.CrashReporter`
-- **macOS**: `Plugins/sentry-unreal/Source/ThirdParty/Mac/bin/Sentry.CrashReporter`
 
 After replacing the executable, delete the project's `Build` and `Intermediate` directories and rebuild to ensure the updated binary is picked up.
 

--- a/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
+++ b/docs/platforms/unreal/configuration/setup-crashreporter/index.mdx
@@ -218,7 +218,7 @@ These settings are applied each time the SDK initializes. Properties that are no
 
 #### Using a Custom Crash Reporter Build
 
-For more advanced customization (such as custom logos or layout changes), you can fork the [sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter) project and build a custom version. The crash reporter is a .NET/Uno Platform application — you need the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) to build it.
+For more advanced customization (such as custom logos or layout changes), you can fork the [sentry-desktop-crash-reporter](https://github.com/getsentry/sentry-desktop-crash-reporter) project and build a custom version.
 
 To build on Windows:
 

--- a/docs/platforms/unreal/install/index.mdx
+++ b/docs/platforms/unreal/install/index.mdx
@@ -69,6 +69,12 @@ This script links the checked out version of the plugin (the [plugin-dev](https:
 
 After successful initialization, copy the contents of the `plugin-dev` directory to `<your_project_root>/Plugins/Sentry`. This will allow you to use Sentry in your Unreal Engine project.
 
+<Alert>
+
+The initialization scripts download pre-built SDK binaries from CI. If you need to customize the native SDK builds (for example, to enable client-side stacktrace support), see [Building Plugin Dependencies](/platforms/unreal/configuration/building-plugin-dependencies/).
+
+</Alert>
+
 ## Confirm Installation
 
 To make sure the Sentry plugin has been enabled after installation has been completed, go to the editor and navigate to the **Settings > Plugins > Code Plugins** menu and check for the installation.


### PR DESCRIPTION
This PR adds documentation for building Sentry Unreal plugin dependencies locally.                                                              
                                                                                                                                           
- New page: `Building Plugin Dependencies` - covers prerequisites, setup, and using the `build-deps.ps1` script to rebuild platform SDKs (sentry-native, sentry-cocoa, sentry-java, crash reporter)
- Updated Crash Reporter Client page with build instructions for custom crash reporter builds (`dotnet publish`) and sentry-native with stacktrace support (CMake)                                                                                                               
- Added a cross-reference from the `Install` page to the new building guide