### PR TITLE
fix(ci): resolve OOM in Algolia index workflow

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -7,6 +7,8 @@ jobs:
   index:
     name: Update Algolia index
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=6144'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -28,6 +30,15 @@ jobs:
               - 'platform-includes/**'
             dev-docs:
               - 'develop-docs/**'
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ${{ github.workspace }}/.next/cache
+          key: nextjs-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-
+
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.1.34'
@@ -38,7 +49,7 @@ jobs:
       # without introducing another dependency like ts-node or tsx for everyone else
 
       - name: Build index for user docs
-        run: pnpm build && bun ./scripts/algolia.ts
+        run: pnpm enforce-redirects && pnpm generate-og-images && pnpm generate-doctree && pnpm next build && bun ./scripts/algolia.ts
         if: steps.filter.outputs.docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
@@ -50,7 +61,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Build index for developer docs
-        run: pnpm build:developer-docs && bun ./scripts/algolia.ts
+        run: git submodule init && git submodule update && pnpm enforce-redirects && pnpm generate-doctree && NEXT_PUBLIC_DEVELOPER_DOCS=1 pnpm next build && bun ./scripts/algolia.ts
         if: steps.filter.outputs.dev-docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Algolia index workflow has been consistently OOM-ing when user docs change. The runner loses communication with the server during `next build` on `ubuntu-latest` (7GB RAM).

**Root cause:** This is the only workflow running `pnpm build` without `.next/cache` caching — `lint-404s.yml` and `test.yml` both cache it and succeed on the same runner.

**Changes:**
- Cache `.next/cache` between runs (matches existing pattern from `lint-404s.yml`)
- Skip `generate-md-exports` — unnecessary for Algolia (script only reads `.next/server/app/*.html`)
- Set `NODE_OPTIONS=--max-old-space-size=6144` as safety net for cold builds

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)