### PR TITLE
fix: restore Sentry tunnel route to bypass ad blockers

### DIFF
--- a/docs/platforms/javascript/guides/nextjs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/index.mdx
@@ -174,7 +174,7 @@ export default withSentryConfig(nextConfig, {
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
   // Route Sentry requests through your server (avoids ad-blockers)
-  tunnelRoute: "/monitoring",
+  tunnelRoute: "/sentry-tunnel",
 
   silent: !process.env.CI,
 });

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
@@ -355,7 +355,7 @@ Prevent ad blockers from blocking Sentry events by routing them through your Nex
 
 <Expandable title="Using Next.js proxy (middleware) with tunneling">
 
-If you're using Next.js proxy (`proxy.ts`) which was previously called middleware (`middleware.ts`) that intercepts requests, exclude the tunnel route:
+If you're using Next.js proxy/middleware that intercepts requests, exclude the tunnel route. The file is called `proxy.ts` in Next.js 16+ and `middleware.ts` in Next.js 15:
 
 ```typescript {filename:proxy.ts}
 export const config = {

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
@@ -353,13 +353,13 @@ Prevent ad blockers from blocking Sentry events by routing them through your Nex
   This increases server load. Consider the trade-off for your application.
 </Alert>
 
-<Expandable title="Using Next.js middleware with tunneling">
+<Expandable title="Using Next.js proxy (middleware) with tunneling">
 
-If you're using Next.js middleware (`middleware.ts`) that intercepts requests, exclude the tunnel route:
+If you're using Next.js proxy (`proxy.ts`) which was previously called middleware (`middleware.ts`) that intercepts requests, exclude the tunnel route:
 
-```typescript {filename:middleware.ts}
+```typescript {filename:proxy.ts}
 export const config = {
-  matcher: ["/((?!monitoring|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!sentry-tunnel|_next/static|_next/image|favicon.ico).*)"],
 };
 ```
 
@@ -371,7 +371,7 @@ export const config = {
 ```typescript {filename:next.config.ts}
 export default withSentryConfig(nextConfig, {
   // Use a fixed route (recommended)
-  tunnelRoute: "/monitoring",
+  tunnelRoute: "/sentry-tunnel",
 });
 ```
 

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/webpack-setup.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/webpack-setup.mdx
@@ -364,7 +364,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 export default withSentryConfig(nextConfig, {
   // Use a fixed route (recommended)
-  tunnelRoute: "/monitoring",
+  tunnelRoute: "/sentry-tunnel",
 });
 ```
 
@@ -385,13 +385,13 @@ If you're upgrading to Turbopack:
 // Before (Webpack)
 export default withSentryConfig(nextConfig, {
   excludeServerRoutes: ["/api/health"],
-  tunnelRoute: "/monitoring",
+  tunnelRoute: "/sentry-tunnel",
 });
 
 // After (Turbopack)
 export default withSentryConfig(nextConfig, {
   // excludeServerRoutes is not supported with Turbopack
-  tunnelRoute: "/monitoring",
+  tunnelRoute: "/sentry-tunnel",
 });
 ```
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 import type {NextRequest} from 'next/server';
 import {NextResponse, userAgent} from 'next/server';
-
 import {AI_AGENT_PATTERN, type TrafficType} from 'sentry-docs/lib/trafficClassification';
 
 // DEVELOPER_DOCS is set via next.config.ts env field (inlined at build time for edge runtime).
@@ -17,7 +16,7 @@ export const config = {
     // - _next/static (static files)
     // - _next/image (image optimization files)
     // - favicon.ico (favicon file)
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|sentry-tunnel).*)',
   ],
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -188,3 +188,7 @@ module.exports = withSentryConfig(nextConfig, {
     thirdPartyOriginStackFrames: true,
   },
 });
+
+export const config = {
+  matcher: ['/((?!sentry-tunnel|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -188,7 +188,3 @@ module.exports = withSentryConfig(nextConfig, {
     thirdPartyOriginStackFrames: true,
   },
 });
-
-export const config = {
-  matcher: ['/((?!sentry-tunnel|_next/static|_next/image|favicon.ico).*)'],
-};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,8 @@
 import {codecovNextJSWebpackPlugin} from '@codecov/nextjs-webpack-plugin';
 import {withSentryConfig} from '@sentry/nextjs';
 
-import {REMOTE_IMAGE_PATTERNS} from './src/config/images';
 import {redirects} from './redirects.js';
+import {REMOTE_IMAGE_PATTERNS} from './src/config/images';
 
 // Exclude build-time-only dependencies from serverless function bundles to stay under
 // Vercel's 250MB limit. These packages are only needed during build to compile MDX and
@@ -158,14 +158,14 @@ module.exports = withSentryConfig(nextConfig, {
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
   // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers
-  tunnelRoute: '/monitoring',
+  tunnelRoute: '/sentry-tunnel',
 
   // Suppresses source map uploading logs during build
   silent: !process.env.CI,
 
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
-  
+
   webpack: {
     treeshake: {
       // Automatically tree-shake Sentry logger statements to reduce bundle size

--- a/next.config.ts
+++ b/next.config.ts
@@ -157,6 +157,9 @@ module.exports = withSentryConfig(nextConfig, {
   project: process.env.NEXT_PUBLIC_DEVELOPER_DOCS ? 'develop-docs' : 'docs',
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
+  // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers
+  tunnelRoute: '/monitoring',
+
   // Suppresses source map uploading logs during build
   silent: !process.env.CI,
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Re-adds `tunnelRoute: '/monitoring'` to `withSentryConfig` in `next.config.ts`. This was removed in #9152 during the changelog domain switch and never restored.

Without it, ad blockers silently block all browser-side Sentry requests (errors, replays, user feedback) from reaching `ingest.sentry.io`. The tunnel routes these through our own origin at `/monitoring`, bypassing ad blockers.

This also fixes the User Feedback widget (`DocFeedback` component) silently failing — users see "Thanks for your feedback" but nothing is delivered when an ad blocker is active.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)