### PR TITLE
docs(elixir): add metrics section

### DIFF
--- a/docs/platforms/elixir/metrics/index.mdx
+++ b/docs/platforms/elixir/metrics/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Set Up Metrics
+sidebar_title: Metrics
+description: "Metrics allow you to send, view and query counters, gauges and measurements sent from your applications within Sentry."
+sidebar_order: 7
+sidebar_section: features
+beta: true
+---
+
+<Alert>
+
+This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
+
+</Alert>
+
+Sentry metrics help you pinpoint and solve issues that impact user experience and app performance by measuring the data points that are important to you. You can track things like processing time, event size, user signups, and conversion rates, then correlate them back to tracing data in order to get deeper insights and solve issues faster.
+
+Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
+
+## Requirements
+
+<PlatformContent includePath="metrics/requirements" />
+
+## Usage
+
+<PlatformContent includePath="metrics/usage" />
+
+## Options
+
+<PlatformContent includePath="metrics/options" />
+
+## Default Attributes
+
+<PlatformContent includePath="metrics/default-attributes" />

--- a/platform-includes/metrics/default-attributes/elixir.mdx
+++ b/platform-includes/metrics/default-attributes/elixir.mdx
@@ -1,0 +1,5 @@
+The Elixir SDK automatically sets several default attributes on all metrics to provide context and improve debugging:
+
+<Include name="metrics/default-attributes/core" />
+
+<Include name="metrics/default-attributes/server" />

--- a/platform-includes/metrics/options/elixir.mdx
+++ b/platform-includes/metrics/options/elixir.mdx
@@ -1,0 +1,49 @@
+#### enable_metrics
+
+You can disable metrics collection globally by setting `enable_metrics` to `false`. When disabled, calls to `Sentry.Metrics` functions will be no-ops. Metrics are enabled by default.
+
+```elixir
+config :sentry, enable_metrics: false
+```
+
+#### before_send_metric
+
+To filter metrics, or update them before they are sent to Sentry, you can use the `before_send_metric` option. If the callback returns `nil`, the metric is not emitted. Attributes can also be updated in the callback function.
+
+```elixir
+config :sentry,
+  before_send_metric: fn metric ->
+    # filter metric
+    if metric.name == "removed-metric" do
+      nil
+    else
+      # add attributes
+      attributes = Map.put(metric.attributes, "extra", "foo")
+
+      # remove attributes
+      attributes = Map.delete(attributes, "browser")
+
+      %{metric | attributes: attributes}
+    end
+  end
+```
+
+You can also pass a `{module, function}` tuple:
+
+```elixir
+config :sentry,
+  before_send_metric: {MyApp.SentryFilters, :filter_metric}
+```
+
+The `before_send_metric` callback receives a `Sentry.Metric` struct, and should return a `Sentry.Metric` struct if you want it to be sent to Sentry, or `nil` if you want to discard it.
+
+The `Sentry.Metric` struct has the following fields:
+
+- `name`: (`String.t()`) The name of the metric.
+- `type`: (`:counter | :gauge | :distribution`) The type of metric.
+- `value`: (`number()`) The numeric value of the metric.
+- `unit`: (`String.t() | nil`) The unit of measurement for the metric value.
+- `attributes`: (`map()`) Additional attributes to be sent with the metric.
+- `timestamp`: (`float()`) Timestamp in seconds indicating when the metric was recorded.
+- `trace_id`: (`String.t() | nil`) The trace ID of the trace this metric belongs to.
+- `span_id`: (`String.t() | nil`) The span ID of the span that was active when the metric was emitted.

--- a/platform-includes/metrics/requirements/elixir.mdx
+++ b/platform-includes/metrics/requirements/elixir.mdx
@@ -1,0 +1,11 @@
+Metrics for Elixir are supported in Sentry Elixir SDK version `13.0.0` and above.
+
+Add `sentry` to your `mix.exs` dependencies:
+
+```elixir
+defp deps do
+  [
+    {:sentry, "~> 13.0"}
+  ]
+end
+```

--- a/platform-includes/metrics/usage/elixir.mdx
+++ b/platform-includes/metrics/usage/elixir.mdx
@@ -1,0 +1,50 @@
+Metrics are enabled by default. Once you initialize the SDK, you can send metrics using the `Sentry.Metrics` module.
+
+The module exposes three functions that you can use to capture different types of metric information: `count`, `gauge`, and `distribution`.
+
+### Emit a Counter
+
+Counters are one of the more basic types of metrics and can be used to count certain event occurrences.
+
+To emit a counter, do the following:
+
+```elixir
+# Record five total button clicks
+Sentry.Metrics.count(
+  "button_click",
+  5,
+  attributes: %{browser: "Firefox", app_version: "1.0.0"}
+)
+```
+
+### Emit a Distribution
+
+Distributions help you get the most insights from your data by allowing you to obtain aggregations such as `p90`, `min`, `max`, and `avg`.
+
+To emit a distribution, do the following:
+
+```elixir
+# Add '15.0' to a distribution used for tracking the loading times per page.
+Sentry.Metrics.distribution(
+  "page_load",
+  15.0,
+  unit: "millisecond",
+  attributes: %{page: "/home"}
+)
+```
+
+### Emit a Gauge
+
+Gauges let you obtain aggregates like `min`, `max`, `avg`, `sum`, and `count`. They can be represented in a more space-efficient way than distributions, but they can't be used to get percentiles. If percentiles aren't important to you, we recommend using gauges.
+
+To emit a gauge, do the following:
+
+```elixir
+# Add '15.0' to a gauge used for tracking the loading times for a page.
+Sentry.Metrics.gauge(
+  "page_load",
+  15.0,
+  unit: "millisecond",
+  attributes: %{page: "/home"}
+)
+```


### PR DESCRIPTION
This adds Metrics section to the Elixir SDK docs.

## Preview

https://sentry-docs-git-feat-elixir-add-metrics.sentry.dev/platforms/elixir/metrics/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
