### PR TITLE
docs(size-analysis): Document APK ProGuard mapping limitation

### DIFF
--- a/docs/platforms/android/size-analysis/index.mdx
+++ b/docs/platforms/android/size-analysis/index.mdx
@@ -15,6 +15,10 @@ new: true
 
 **Accepted Formats**: AAB (preferred) | APK
 
+<Alert>
+APK uploads do not support ProGuard/R8 mapping file correlation. If your build uses ProGuard or R8, Size Analysis will report a missing ProGuard mapping and will not show a deobfuscated Dex breakdown. Upload an AAB instead to get the full Dex analysis with deobfuscated class names.
+</Alert>
+
 **Upload Mechanisms**: [Gradle](#uploading-with-gradle) | [Sentry CLI](#uploading-with-the-sentry-cli) | [Fastlane Plugin](#uploading-with-fastlane)
 
 ### Uploading With Gradle
@@ -36,6 +40,14 @@ new: true
 ### Build Configuration
 
 <Include name="size-analysis/build-configuration-android" />
+
+## Troubleshooting
+
+### Missing ProGuard Mapping
+
+If Size Analysis reports "Missing ProGuard mapping" even though your ProGuard/R8 mapping files uploaded successfully, you are likely uploading an APK. APK uploads do not support ProGuard/R8 mapping correlation for Size Analysis, so the Dex breakdown cannot be deobfuscated.
+
+To fix this, switch your build to produce an AAB and upload that instead. AAB is the recommended format for Size Analysis and supports full Dex analysis with deobfuscated class names.
 
 ## What's Next?
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document that APK uploads do not support ProGuard/R8 mapping file correlation for Size Analysis. This addresses a common support question where users successfully upload both an APK and ProGuard mappings, but Size Analysis still reports "Missing ProGuard mapping" and does not show a deobfuscated Dex breakdown.

- Add an alert on the Getting Started page clarifying the limitation
- Add a Troubleshooting section with a "Missing ProGuard Mapping" entry

See vercel deployment here: https://sentry-docs-git-no-eme-1022-document-apk-proguard-limitation.sentry.dev/platforms/android/size-analysis/

Refs EME-1022

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)