### PR TITLE
docs(develop-docs): Document no_parent_span discard reason

### DIFF
--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -2,12 +2,15 @@
 title: Client Reports
 description: SDK self-reporting protocol for tracking discarded events and their discard reasons.
 spec_id: sdk/telemetry/client-reports
-spec_version: 1.21.0
+spec_version: 1.22.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.22.0
+    date: 2026-04-09
+    summary: Added `no_parent_span` discard reason
   - version: 1.21.0
     date: 2026-03-06
     summary: Added log byte outcomes for tracking discarded log data size
@@ -340,6 +343,7 @@ The following discard reasons are defined for `discarded_events`:
 | `cache_overflow` | 1.0.0 | SDK internal cache (e.g., offline event cache) overflowed. |
 | `ratelimit_backoff` | 1.0.0 | Rate limit instructed the SDK to back off. |
 | `network_error` | 1.0.0 | Network errors, not retried. |
+| `no_parent_span` | 1.22.0 | Span was not started or dropped because no parent span was present at span start (for example, auto-instrumented spans suppressed when the request happens outside an active span). |
 | `sample_rate` | 1.0.0 | Configured sample rate. |
 | `before_send` | 1.0.0 | Dropped in `before_send`. |
 | `event_processor` | 1.0.0 | Dropped by event processor; may also be used for ignored exceptions/errors (since 1.6.0). |


### PR DESCRIPTION
Adds `no_parent_span` to the Client Reports developer spec (`develop-docs/sdk/telemetry/client-reports.mdx`, version 1.22.0), matching the Snuba client discard allowlist for this outcome.

Refs https://linear.app/getsentry/issue/SDK-1123/add-client-report-outcome-for-dropped-spans-because-of-missing-parent