### PR TITLE
docs: Remove Vite config hint for Nuxt configs

### DIFF
--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -375,8 +375,6 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 </SplitSection>
 </SplitLayout>
 
-<Include name="vite-loadenv-hint-splitlayout.mdx" />
-
 #### Enable Client-Side Source Maps
 
 <SplitLayout>

--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -256,8 +256,6 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-<Include name="vite-loadenv-hint.mdx" />
-
 While Nuxt generates source maps on the server side by default, you need to explicitly enable client-side source maps in your Nuxt configuration:
 
 ```javascript {filename:nuxt.config.ts} {2}

--- a/platform-includes/sourcemaps/overview/javascript.nuxt.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.nuxt.mdx
@@ -24,8 +24,6 @@ Add your auth token to your environment:
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-<Include name="vite-loadenv-hint.mdx" />
-
 ```javascript {filename:nuxt.config.ts}
 export default defineNuxtConfig({
   modules: ["@sentry/nuxt/module"],


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
I noticed that these hints are not needed for Nuxt configs. Follow up to the introduction #16991

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
