### PR TITLE
docs(native): add send_client_reports option

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -74,7 +74,7 @@ Controls whether the SDK should propagate the W3C `traceparent` HTTP header alon
 
 <SdkOption name="send_client_reports" type="bool" defaultValue="true" availableSince="0.13.6">
 
-Set this boolean to `false` to disable sending of client reports. Client reports are a protocol feature that let clients send status reports about themselves to Sentry. They are currently mainly used to emit outcomes for events that were never sent.
+Set this boolean to `false` to disable client reports. Client reports are a protocol feature that allows clients to send status information about themselves to Sentry. They’re currently used mainly to report outcomes for events that were never sent.
 
 </SdkOption>
 

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -72,6 +72,12 @@ Controls whether the SDK should propagate the W3C `traceparent` HTTP header alon
 
 </SdkOption>
 
+<SdkOption name="send_client_reports" type="bool" defaultValue="true" availableSince="0.13.6">
+
+Set this boolean to `false` to disable sending of client reports. Client reports are a protocol feature that let clients send status reports about themselves to Sentry. They are currently mainly used to emit outcomes for events that were never sent.
+
+</SdkOption>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the new `send_client_reports` option added in sentry-native 0.13.6 (getsentry/sentry-native#1549), which lets users opt out of client reports tracking for discarded events. The description was directly copied from other SDKs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
