### PR TITLE
docs(laravel): Document SentryTracesSampleRate job middleware

### DIFF
--- a/docs/platforms/php/guides/laravel/configuration/laravel-options.mdx
+++ b/docs/platforms/php/guides/laravel/configuration/laravel-options.mdx
@@ -101,6 +101,33 @@ class Sentry
 }
 ```
 
+### Lower Sample Rate for Specific Jobs
+
+If your application processes a large number of queued jobs, tracing every job at the same rate as your HTTP requests can create more transaction volume than you need. Use the `Sentry\Laravel\Jobs\Middleware\SentryTracesSampleRate` job middleware to keep fewer traces for specific jobs while leaving your global tracing configuration unchanged.
+
+This middleware only affects queue job transactions, so `tracing.queue_job_transactions` must stay enabled. It can only lower the sample rate for jobs that were already sampled by your global `traces_sample_rate` or `traces_sampler`; it does not upsample jobs that were excluded earlier.
+
+```php {filename:app/Jobs/ProcessPodcast.php}
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Sentry\Laravel\Jobs\Middleware\SentryTracesSampleRate;
+
+class ProcessPodcast implements ShouldQueue
+{
+    public function middleware(): array
+    {
+        return [
+            new SentryTracesSampleRate(0.1), // Keep 10% of already-sampled traces for this job
+        ];
+    }
+}
+```
+
+This is useful for high-volume or lower-priority background work, such as imports, notifications, fan-out jobs, or other queue consumers where you still want representative performance data without sending every transaction.
+
 ### More Configuration
 
 You can also configure which parts of your application are traced automatically.

--- a/docs/platforms/php/guides/laravel/index.mdx
+++ b/docs/platforms/php/guides/laravel/index.mdx
@@ -104,6 +104,8 @@ The example configuration above will transmit 100% of captured traces. Be sure t
 
 You can also be more granular with the sample rate by using the `traces_sampler` option. Learn more in [Using Sampling to Filter Transaction Events](configuration/filtering/#using-sampling-to-filter-transaction-events).
 
+If your queued jobs generate more traces than your web requests, you can also lower the sample rate for specific jobs with `Sentry\Laravel\Jobs\Middleware\SentryTracesSampleRate`. See [Laravel Options](configuration/laravel-options/#lower-sample-rate-for-specific-jobs).
+
 Performance data is transmitted using a new event type called "transactions", which you can learn about in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/#traces-transactions-and-spans).
 
 ## Local Development and Testing

--- a/docs/platforms/php/guides/laravel/other-versions/laravel8-10.mdx
+++ b/docs/platforms/php/guides/laravel/other-versions/laravel8-10.mdx
@@ -86,6 +86,8 @@ The example configuration above will transmit 100% of captured traces. Be sure t
 
 You can also be more granular with the sample rate by using the `traces_sampler` option. Learn more in [Using Sampling to Filter Transaction Events](/platforms/php/guides/laravel/configuration/filtering/#using-sampling-to-filter-transaction-events).
 
+If your queued jobs generate more traces than your web requests, you can also lower the sample rate for specific jobs with `Sentry\Laravel\Jobs\Middleware\SentryTracesSampleRate`. See [Laravel Options](/platforms/php/guides/laravel/configuration/laravel-options/#lower-sample-rate-for-specific-jobs).
+
 Performance data is transmitted using a new event type called "transactions", which you can learn about in [Distributed Tracing](/product/sentry-basics/tracing/distributed-tracing/#traces-transactions-and-spans).
 
 ## Local Development and Testing


### PR DESCRIPTION
Add documentation for the SentryTracesSampleRate job middleware that lets users lower the tracing sample rate for specific queued jobs. Includes a full code example and cross-references from the main Laravel guide and the Laravel 8-10 guide.

getsentry/sentry-laravel#1114

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)