### PR TITLE
docs(js): Use split layout in Astro & Hydrogen with React Router quick start guides

### DIFF
--- a/docs/platforms/javascript/guides/astro/index.mdx
+++ b/docs/platforms/javascript/guides/astro/index.mdx
@@ -19,14 +19,18 @@ You need:
 - If you're using Astro's Netlify adapter (`@astrojs/netlify`), you need version `5.0.0` or above
 
 <Alert level="warning" title="What runtime do you use?">
-  This SDK currently only works on Node runtimes, such as Node adapter or Vercel
-  with Lambda functions. If you use Cloudflare Workers or Cloudflare Pages, refer to our [Astro on
-  Cloudflare guide](/platforms/javascript/guides/cloudflare/frameworks/astro/).
-  Other non-Node runtimes, like Vercel's Edge runtime, are currently **not
-  supported**.
+
+This SDK currently only works on Node runtimes, such as Node adapter or Vercel
+with Lambda functions. If you use Cloudflare Workers or Cloudflare Pages, refer to our [Astro on
+Cloudflare guide](/platforms/javascript/guides/cloudflare/frameworks/astro/).
+Other non-Node runtimes, like Vercel's Edge runtime, are currently **not
+supported**.
+
 </Alert>
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 Choose the features you want to configure, and this guide will show you how:
 
@@ -44,3 +48,5 @@ Choose the features you want to configure, and this guide will show you how:
 <Include name="quick-start-features-expandable" />
 
 <PlatformContent includePath="getting-started-complete" />
+
+</StepConnector>

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
@@ -19,9 +19,17 @@ Sentry integration and full feature support.
 
 <Expandable level="info" title="Using Astro on Cloudflare Pages?">
 
+<SplitLayout>
+
 For Cloudflare Pages, you need to manually set up the `@sentry/cloudflare` SDK using the Pages middleware.
 
+<SplitSection>
+<SplitSectionText>
+
 1. Install both SDKs:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {tabTitle:npm}
 npm install @sentry/astro @sentry/cloudflare
@@ -35,7 +43,16 @@ yarn add @sentry/astro @sentry/cloudflare
 pnpm add @sentry/astro @sentry/cloudflare
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 2. Add the Sentry Astro integration to your `astro.config.mjs`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:astro.config.mjs}
 import { defineConfig } from "astro/config";
@@ -48,7 +65,16 @@ export default defineConfig({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 3. <Include name="cloudflare-pages-middleware-intro.mdx" />
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:functions/_middleware.js}
 import * as Sentry from "@sentry/cloudflare";
@@ -64,11 +90,22 @@ export const onRequest = [
 ];
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 4. Make sure to [configure Cloudflare for Sentry](/platforms/javascript/guides/cloudflare/#wrangler-configuration).
 
+</SplitSectionText>
+</SplitSection>
+</SplitLayout>
 </Expandable>
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 <OnboardingOptionButtons
   options={[
@@ -86,3 +123,5 @@ export const onRequest = [
   includePath="getting-started-complete"
   platform="javascript.astro"
 />
+
+</StepConnector>

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
@@ -16,7 +16,9 @@ You need:
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - Your Hydrogen application (v2025.5.0+), you want to host on Shopify Oxygen
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 Choose the features you want to configure, and this guide will show you how:
 
@@ -34,7 +36,14 @@ Choose the features you want to configure, and this guide will show you how:
 
 ### Install the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Run the command for your preferred package manager to add the React Router and Cloudflare SDK:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {tabTitle:npm}
 npm install @sentry/react-router @sentry/cloudflare --save
@@ -48,11 +57,24 @@ yarn add @sentry/react-router @sentry/cloudflare
 pnpm add @sentry/react-router @sentry/cloudflare
 ```
 
-## Step 2: Configure
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+## Configure
 
 ### Configure Client-side Sentry
 
-Initialize Sentry in your `entry.client.tsx` file:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Initialize Sentry in your `entry.client.tsx` file.
+
+The `sentryOnError` handler integrates with React Router's [`onError` hook](https://reactrouter.com/how-to/error-reporting) to automatically capture and report client-side errors to Sentry.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {filename: app/entry.client.tsx}
 import { HydratedRouter } from "react-router/dom";
@@ -121,11 +143,20 @@ startTransition(() => {
 });
 ```
 
-The `sentryOnError` handler integrates with React Router's [`onError` hook](https://reactrouter.com/how-to/error-reporting) to automatically capture and report client-side errors to Sentry.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 ### Configure Server-side Sentry
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, create an `instrument.server.mjs` file to initialize Sentry on the server:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```js {filename:instrument.server.mjs}
 import * as Sentry from "@sentry/react-router";
@@ -153,7 +184,16 @@ Sentry.init({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 Next, update your `server.ts` file to use the `wrapRequestHandler` method from `@sentry/cloudflare`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```ts {filename:server.ts}
 import { wrapRequestHandler } from "@sentry/cloudflare";
@@ -201,11 +241,22 @@ export default {
 };
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 
 ### Enable Distributed Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Update your `entry.server.tsx` file to inject trace meta tags:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {filename:app/entry.server.tsx}
 import "./instrument.server";
@@ -248,13 +299,24 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
 export default Sentry.wrapSentryHandleRequest(handleRequest);
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+### Add Readable Stack Traces With Source Maps (Optional)
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
 The stack traces in your Sentry errors probably won't look like your actual code without unminifying them. To fix this, upload your source maps to Sentry.
 
-First, update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it:
+First, update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```ts {filename:vite.config.ts}
 import { reactRouter } from "@react-router/dev/vite";
@@ -284,7 +346,16 @@ export default defineConfig((config) => ({
 }));
 ```
 
-Since the `buildEnd` hook will not be executed for Hydrogen, you need to manually upload source maps using the [Sentry CLI](/cli/) instead:
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
+Since the `buildEnd` hook will not be executed for Hydrogen, you need to manually upload source maps using the [Sentry CLI](/cli/) instead.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash
 # Inject debug IDs
@@ -293,13 +364,28 @@ sentry-cli sourcemaps inject /path/to/build/dir
 sentry-cli sourcemaps upload /path/to/build/dir
 ```
 
-## Step 4: Verify Your Setup
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 
 ### Issues
 
-To verify that Sentry captures errors and creates issues in your Sentry project, throw an error in a loader:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+
+To verify that Sentry captures errors and creates issues in your Sentry project, throw an error in a loader.
+
+Next, open the `/sentry-test` route in your browser, and you should trigger an error.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {filename: app/routes/sentry-test.tsx}
 import type { Route } from "./+types/sentry-test";
@@ -313,16 +399,23 @@ export default function SentryTestPage() {
 }
 ```
 
-<OnboardingOption optionId="performance" hideForThisOption>
-  Open the `/sentry-test` route in your browser, and you should trigger an
-  error.
-</OnboardingOption>
-
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 <OnboardingOption optionId="performance">
 ### Tracing
-To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code.
+
+Open the `/sentry-test` route in your browser. You should start a trace and trigger an error.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {filename: app/routes/sentry-test.tsx}
 import * as Sentry from "@sentry/react-router/cloudflare";
@@ -345,13 +438,15 @@ export default function SentryTestPage() {
 }
 ```
 
-Open the `/sentry-test` route in your browser. You should start a trace and trigger an error.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>
 
@@ -380,3 +475,5 @@ Our next recommended steps for you are:
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>

--- a/platform-includes/getting-started-complete/javascript.astro.mdx
+++ b/platform-includes/getting-started-complete/javascript.astro.mdx
@@ -2,7 +2,14 @@
 
 ### Install the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Install and add the Sentry integration using the `astro` CLI:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {tabTitle:npm}
 npx astro add @sentry/astro
@@ -16,9 +23,17 @@ yarn astro add @sentry/astro
 pnpm astro add @sentry/astro
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
 <OnboardingOption optionId="profiling">
+<SplitSection>
+<SplitSectionText>
 
 Next, install the Profiling package using your preferred package manager:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {tabTitle:npm}
 npm install @sentry/profiling-node
@@ -32,15 +47,25 @@ yarn add @sentry/profiling-node
 pnpm add @sentry/profiling-node
 ```
 
+</SplitSectionCode>
+</SplitSection>
 </OnboardingOption>
 
+</SplitLayout>
 </PlatformSection>
 
 <PlatformSection supported={["javascript.cloudflare"]}>
 
 ### Install the Sentry SDKs
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Install both `@sentry/astro` and `@sentry/cloudflare`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {tabTitle:npm}
 npm install @sentry/astro @sentry/cloudflare
@@ -54,19 +79,34 @@ yarn add @sentry/astro @sentry/cloudflare
 pnpm add @sentry/astro @sentry/cloudflare
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 </PlatformSection>
 
-## Step 2: Configure
+## Configure
 
 <PlatformSection supported={["javascript.cloudflare"]}>
 
 ### Wrangler Configuration
 
-<PlatformContent includePath="getting-started-config" />
+<PlatformContent
+  includePath="getting-started-config"
+  platform="javascript.cloudflare.splitlayout"
+/>
 
 ### Register the Sentry Integration
 
-Follow [Astro's Cloudflare deployment guide](https://docs.astro.build/en/guides/deploy/cloudflare/) if you haven't already. Then add the Sentry integration to your `astro.config.mjs` alongside the Cloudflare adapter:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Follow [Astro's Cloudflare deployment guide](https://docs.astro.build/en/guides/deploy/cloudflare/) if you haven't already. Then add the Sentry integration to your `astro.config.mjs` alongside the Cloudflare adapter.
+
+The `@sentry/astro` integration automatically detects the Cloudflare adapter and wraps your Worker with the `@sentry/cloudflare` SDK for proper request isolation and async context.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:astro.config.mjs}
 import { defineConfig } from "astro/config";
@@ -79,7 +119,9 @@ export default defineConfig({
 });
 ```
 
-The `@sentry/astro` integration automatically detects the Cloudflare adapter and wraps your Worker with the `@sentry/cloudflare` SDK for proper request isolation and async context.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 </PlatformSection>
 
@@ -87,7 +129,14 @@ The `@sentry/astro` integration automatically detects the Cloudflare adapter and
 
 ### Apply Instrumentation to Your App
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Register the Sentry integration in your `astro.config.mjs` file:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:astro.config.mjs}
 import { defineConfig } from "astro/config";
@@ -98,11 +147,21 @@ export default defineConfig({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 </PlatformSection>
 
 ### Configure Client-side Sentry
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Create a `sentry.client.config.(ts|js)` file in the root of your project. In this file, import and initialize Sentry for the client:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:sentry.client.config.(ts|js)}
 import * as Sentry from "@sentry/astro";
@@ -152,12 +211,23 @@ Sentry.init({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <PlatformSection notSupported={["javascript.cloudflare"]}>
 
 <Expandable title="Want to change your Sentry config files location or name?">
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Sentry automatically detects configuration files named `sentry.(client|server).config.(ts|js)` in the root of your project. You can rename these files or move them to a custom folder within your project.
 To change their location or names, specify the paths in the Sentry Astro integration options in your `astro.config.mjs`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:astro.config.mjs}
 export default defineConfig({
@@ -171,6 +241,9 @@ export default defineConfig({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 </Expandable>
 
 </PlatformSection>
@@ -178,8 +251,20 @@ export default defineConfig({
 ### Configure Server-side Sentry
 
 <PlatformSection notSupported={["javascript.cloudflare"]}>
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
 Create a `sentry.server.config.(ts|js)` file in the root of your project. In this file, import and initialize Sentry for the server:
+
+<Alert title="Instrumentation for Astro <3.5.2">
+
+For Astro versions below `3.5.2`, you need to manually add server instrumentation via the Sentry middleware as explained on our <PlatformLink to="/configuration/apis/#server-request-instrumentation">APIs page</PlatformLink>.
+
+</Alert>
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:sentry.server.config.(ts|js)}
 import * as Sentry from "@sentry/astro";
@@ -219,17 +304,29 @@ Sentry.init({
 });
 ```
 
-<Alert title="Instrumentation for Astro <3.5.2">
-
-For Astro versions below `3.5.2`, you need to manually add server instrumentation via the Sentry middleware as explained on our <PlatformLink to="/configuration/apis/#server-request-instrumentation">APIs page</PlatformLink>.
-
-</Alert>
-
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 </PlatformSection>
 
 <PlatformSection supported={["javascript.cloudflare"]}>
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Create a `sentry.server.config.(ts|js)` file in the root of your project. In this file, import and initialize Sentry for the server:
+
+<Alert level="warning" title="Production Configuration via Environment Variables">
+
+The `sentry.server.config.(ts|js)` file only works during local development. In production on Cloudflare Workers, you must use [environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/) to configure Sentry.
+
+The SDK reads standard Sentry environment variables including `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_RELEASE`, `SENTRY_ENVIRONMENT`, and others. See the [SDK configuration spec](https://develop.sentry.dev/sdk/foundations/client/configuration/#environment-variables) for the full list.
+
+</Alert>
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:sentry.server.config.(ts|js)}
 import * as Sentry from "@sentry/astro";
@@ -254,19 +351,22 @@ Sentry.init({
 });
 ```
 
-<Alert level="warning" title="Production Configuration via Environment Variables">
-
-The `sentry.server.config.(ts|js)` file only works during local development. In production on Cloudflare Workers, you must use [environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/) to configure Sentry.
-
-The SDK reads standard Sentry environment variables including `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_RELEASE`, `SENTRY_ENVIRONMENT`, and others. See the [SDK configuration spec](https://develop.sentry.dev/sdk/foundations/client/configuration/#environment-variables) for the full list.
-
-</Alert>
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 </PlatformSection>
 
-## Step 3: Add Readable Stack Traces With Source Maps
+### Add Readable Stack Traces With Source Maps
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
 To upload source maps for clear error stack traces, add your Sentry auth token, organization, and project slugs in the `sentry` options inside `astro.config.mjs`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <PlatformSection supported={["javascript.cloudflare"]}>
 
@@ -310,37 +410,53 @@ export default defineConfig({
 
 </PlatformSection>
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 To keep your auth token secure, set the `SENTRY_AUTH_TOKEN` environment variable in your build environment:
 
 <OrgAuthTokenNote />
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash {filename:.env.sentry-build-plugin}
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-<Include name="vite-loadenv-hint.mdx" />
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+<Include name="vite-loadenv-hint-splitlayout.mdx" />
 
 <PlatformSection notSupported={["javascript.cloudflare"]}>
 
-## Step 4: Avoid Ad Blockers With Tunneling (Optional)
+### Avoid Ad Blockers With Tunneling (Optional)
 
-<PlatformContent includePath="getting-started-tunneling" />
-
-## Step 5: Verify Your Setup
+<PlatformContent includePath="getting-started-tunneling-splitlayout" />
 
 </PlatformSection>
 
-<PlatformSection supported={["javascript.cloudflare"]}>
-
-## Step 4: Verify Your Setup
-
-</PlatformSection>
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 
 ### Issues
 
-To verify that Sentry captures errors and creates issues in your Sentry project, create a test page, for example, at `src/pages/test.astro` with two buttons:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+To verify that Sentry captures errors and creates issues in your Sentry project,
+create a test page, for example, at `src/pages/test.astro` with two buttons.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```html {filename: test.astro}
 <script>
@@ -363,7 +479,17 @@ To verify that Sentry captures errors and creates issues in your Sentry project,
 <button id="two" type="button">Throw an API error</button>
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
 Then also create the route we're calling in our test page, like `src/pages/api/test-error.(js|ts)`:
+
+Next, open your test page in a browser and click the buttons to trigger a frontend error and an error in the API route.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename: test-error.(js|ts)}
 export async function GET() {
@@ -371,15 +497,22 @@ export async function GET() {
 }
 ```
 
-Open the page in a browser and click the buttons to trigger a frontend error and an error in the API route.
-
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 <OnboardingOption optionId="performance">
 
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test tracing, create a custom span to measure the time it takes for the API request to complete:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```html {filename: test.astro}
 <script>
@@ -405,11 +538,15 @@ To test tracing, create a custom span to measure the time it takes for the API r
 <button id="one" type="button">Throw an API error with a trace</button>
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>
 

--- a/platform-includes/getting-started-complete/javascript.astro.mdx
+++ b/platform-includes/getting-started-complete/javascript.astro.mdx
@@ -317,7 +317,7 @@ Sentry.init({
 
 Create a `sentry.server.config.(ts|js)` file in the root of your project. In this file, import and initialize Sentry for the server:
 
-<Alert level="warning" title="Production Configuration via Environment Variables">
+<Alert level="warning" title="Production configuration via environment variables">
 
 The `sentry.server.config.(ts|js)` file only works during local development. In production on Cloudflare Workers, you must use [environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/) to configure Sentry.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This branch updates the following quick start guides to use the new split layout:
- Astro
- Astro on Cloudflare
- Hydrogen with React Router (Cloudflare)

Closes: #17314

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
