### PR TITLE
Update role names to lowercase in Okta SCIM docs

### DIFF
--- a/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
+++ b/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
@@ -108,11 +108,11 @@ Here's how to assign an organization-level role to an Okta group:
 3.  In the form, enter the string for the org-level role
     ![Okta Set Role](./img/okta-set-group-attribute.png)
 
-- If the `sentryOrgField` field is left blank, group members will be provisioned with the default organization-level role. This default role can be configured in Sentry, under Settings -> Organization -> Auth. Otherwise, the role must be one of the following:
-  - Admin
-  - Manager
-  - Billing
-  - Member
+- If the `sentryOrgRole` field is left blank, group members will be provisioned with the default organization-level role. This default role can be configured in Sentry, under Settings -> Organization -> Auth. Otherwise, the role must be one of the following:
+  - admin
+  - manager
+  - billing
+  - member
 - Invalid role names will prevent group members from being provisioned. To try again, you'll need to remove the group first.
 - For security reasons, the "Owner" role cannot be provisioned through SCIM. However, you <i>can</i> deprovision users who have the "Owner" role in Sentry, but aren't provisioned through SCIM.
   - For self-hosted users with custom roles, this extends to any role with the `org:admin` permission


### PR DESCRIPTION
Update role names to lowercase as SCIM endpoint refuses title case. Also updated sentryOrgField to sentryOrgRole.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Updating the SCIM `sentryOrgRole` role list to show lowercase as the SCIM endpoint refuses title case.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.