### PR TITLE
fix(js): Fix Mastra docs link formatting and remove beta references

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -366,9 +366,7 @@ await Sentry.startSpan(
 
 If you're using an AI framework with a Sentry exporter, you can send traces to Sentry:
 
-- <PlatformLink to="/ai-agent-monitoring/mastra/">
-    Mastra Sentry Exporter
-  </PlatformLink>
+- <PlatformLink to="/ai-agent-monitoring/mastra/">Mastra Sentry Exporter</PlatformLink>
 
 ## MCP Server Monitoring
 

--- a/docs/platforms/javascript/common/ai-agent-monitoring/mastra.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/mastra.mdx
@@ -25,12 +25,6 @@ supported:
   - javascript.tanstackstart-react
 ---
 
-<Alert>
-
-This is a server-side exporter for Mastra AI tracing that uses the Node.js Sentry SDK. It requires Node.js or compatible runtimes. Requires `@mastra/sentry@beta` package.
-
-</Alert>
-
 [Mastra](https://mastra.ai/) is a framework for building AI-powered applications and agents with a modern TypeScript stack. The Mastra Sentry Exporter sends tracing data to Sentry using OpenTelemetry semantic conventions, providing insights into model performance, token usage, and tool executions.
 
 ## Installation
@@ -38,42 +32,64 @@ This is a server-side exporter for Mastra AI tracing that uses the Node.js Sentr
 Install the Mastra Sentry exporter package:
 
 ```bash {tabTitle:npm}
-npm install @mastra/sentry@beta
+npm install @mastra/sentry@latest
 ```
 
 ```bash {tabTitle:yarn}
-yarn add @mastra/sentry@beta
+yarn add @mastra/sentry@latest
 ```
 
 ```bash {tabTitle:pnpm}
-pnpm add @mastra/sentry@beta
+pnpm add @mastra/sentry@latest
 ```
 
 ## Configuration
 
 ### Zero-Config Setup
 
-The Sentry exporter can automatically read configuration from environment variables:
+The Sentry exporter can automatically read configuration from environment variables (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`):
 
 ```javascript
+import { Mastra } from "@mastra/core";
+import { Observability } from "@mastra/observability";
 import { SentryExporter } from "@mastra/sentry";
 
-// Reads from SENTRY_DSN, SENTRY_ENVIRONMENT, SENTRY_RELEASE
-const exporter = new SentryExporter();
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      sentry: {
+        serviceName: "my-service",
+        exporters: [new SentryExporter()],
+      },
+    },
+  }),
+});
 ```
 
 ### Explicit Configuration
 
-You can also configure the exporter explicitly:
+You can also pass configuration directly:
 
 ```javascript
+import { Mastra } from "@mastra/core";
+import { Observability } from "@mastra/observability";
 import { SentryExporter } from "@mastra/sentry";
 
-const exporter = new SentryExporter({
-  dsn: process.env.SENTRY_DSN,
-  environment: "production",
-  tracesSampleRate: 1.0,
-  release: "1.0.0",
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      sentry: {
+        serviceName: "my-service",
+        exporters: [
+          new SentryExporter({
+            dsn: process.env.SENTRY_DSN,
+            environment: "production",
+            tracesSampleRate: 1.0,
+          }),
+        ],
+      },
+    },
+  }),
 });
 ```
 
@@ -178,4 +194,4 @@ For complete documentation on using Mastra with Sentry, see the [Mastra Sentry E
 
 ## Supported Versions
 
-- `@mastra/sentry`: `>=1.0.0-beta.2`
+- `@mastra/sentry`: `>=1.0.0`


### PR DESCRIPTION
## DESCRIBE YOUR PR

| Before | After |
|--------|--------|
| <img width="686" height="193" alt="CleanShot 2026-04-14 at 09 22 05" src="https://github.com/user-attachments/assets/01533334-a5c1-4ae2-a00c-f03e34f418b6" /> | <img width="682" height="152" alt="CleanShot 2026-04-14 at 09 21 43" src="https://github.com/user-attachments/assets/8ddbcf01-013f-45de-b72c-ef2705b1f0fb" /> | 

Fix three issues with the Mastra Sentry Exporter documentation:

- Fix broken `<PlatformLink>` rendering on the AI agent monitoring page (multi-line tag caused bullet and link text to appear on separate lines)
- Remove beta alert and update `@mastra/sentry@beta` to `@mastra/sentry@latest` since [Mastra's docs](https://mastra.ai/docs/observability/tracing/exporters/sentry) no longer reference beta
- Update setup examples to match current Mastra `Observability` API pattern

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)