### PR TITLE
feat(ci): cancel in-progress PR workflows on new commit push

### DIFF
--- a/.github/workflows/check-redirects-on-rename.yml
+++ b/.github/workflows/check-redirects-on-rename.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-redirects:
     name: Check redirects for renamed files

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ on:
       - '**.ts'
       - '**.tsx'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-version-convention.yml
+++ b/.github/workflows/enforce-version-convention.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-version-convention:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-404s.yml
+++ b/.github/workflows/lint-404s.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint-404:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-external-links.yml
+++ b/.github/workflows/lint-external-links.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Job for PRs: check only changed files
   check-pr:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -10,6 +10,11 @@ on:
       - .github/labels.yml
 
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   job_lint:
     name: Lint


### PR DESCRIPTION
this adds concurrency cancellation to pull_request workflows so that pushing a new commit to a PR automatically cancels any still-running workflow from the previous commit

99% of the time if you push a new commit you don't care about the previous workflow if its still running

**we already do this for all sentry+getsentry pull_request workflows**

we (devinfra) can't measure this yet but this would greatly help decrease org-wide runner queue pressure!