### PR TITLE
feat: Add link to API docs

### DIFF
--- a/docs/platforms/python/usage/index.mdx
+++ b/docs/platforms/python/usage/index.mdx
@@ -26,6 +26,8 @@ While capturing an event, you can also record the breadcrumbs that lead up to th
 
 <PlatformContent includePath="capture-error" />
 
+See the [API documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.capture_exception) for details on the `capture_exception` function.
+
 ## Capturing Messages
 
 Another common operation is to capture a bare message. A message is textual information that should be sent to Sentry. Typically, our SDKs don't automatically capture messages, but you can capture them manually.
@@ -33,3 +35,5 @@ Another common operation is to capture a bare message. A message is textual info
 Messages show up as issues on your issue stream, with the message as the issue name.
 
 <PlatformContent includePath="capture-message" />
+
+See the [API documentation](https://getsentry.github.io/sentry-python/api.html#sentry_sdk.api.capture_message) for details on the `capture_message` function.


### PR DESCRIPTION
The Capturing Errors page for Python doesn't go into much detail about how the API can be used. Add links to our API docs for anyone interested in learning more.