### PR TITLE
feat(usageStats): Add  missing client discard reason

### DIFF
--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -92,6 +92,9 @@ Events and attachments discarded by the SDK. The following reasons are currently
 - **Internal SDK Error**: An event was dropped due to an internal SDK error (for example, a web worker crash).
 - **Insufficient Data**: An event was dropped due to a lack of data in the event (for example, not enough samples in a profile).
 - **Backpressure**: An event was dropped due to downsampling caused by the system being under load.
+- **Invalid**: An event was dropped because it contained invalid data (e.g. replay session exceeded maximum allowed length).
+- **Ignored**: An event was ignored by the SDK (for example, a span was ignored by `ignore_spans`).
+- **No Parent Span**: A span was not started or dropped because no parent span was present at span start (for example, auto-instrumented request spans suppressed when the request happens outside an active span).
 
 For more details, please consult the [Client Reports](https://develop.sentry.dev/sdk/telemetry/client-reports/#envelope-item-payload) documentation.
 


### PR DESCRIPTION
Adds three missing client (SDK) discard reasons to the `/product/stats/` page. These reasons were added over the course of last year (no_parent_span is currently being added) and we missed adding them to docs. This PR backfills them.

ref: https://linear.app/getsentry/issue/SDK-1123/add-client-report-outcome-for-dropped-spans-because-of-missing-parent
