### PR TITLE
docs(metrics): Update Android and Java SDK minimum version to 8.34.0

### DIFF
--- a/platform-includes/metrics/requirements/android.mdx
+++ b/platform-includes/metrics/requirements/android.mdx
@@ -1,1 +1,1 @@
-Metrics are supported in Sentry Android SDK version `8.30.0` and above.
+Metrics are supported in Sentry Android SDK version `8.34.0` and above.

--- a/platform-includes/metrics/requirements/java.mdx
+++ b/platform-includes/metrics/requirements/java.mdx
@@ -1,1 +1,1 @@
-Metrics are supported in Sentry Java SDK version `8.30.0` and above.
+Metrics are supported in Sentry Java SDK version `8.34.0` and above.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Update the minimum supported SDK version for metrics from `8.30.0` to `8.34.0` for both Android and Java platforms. 

While `8.30.0` is technically correct, `8.34+` contains a few fixes and improvements, so we should just recommend that version.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)