### PR TITLE
docs(js): Use split layout in node quick start guides

### DIFF
--- a/docs/platforms/javascript/guides/cloudflare/frameworks/hono.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/hono.mdx
@@ -12,7 +12,9 @@ description: "Learn how to instrument your Hono app on Cloudflare Workers and ca
   migrate to `@sentry/cloudflare` directly as shown in this guide.
 </Alert>
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 Choose the features you want to configure, and this guide will show you how:
 
@@ -24,17 +26,31 @@ Choose the features you want to configure, and this guide will show you how:
 
 ### Install the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Run the command for your preferred package manager to add the Sentry SDK to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <PlatformContent includePath="getting-started-install" />
 
-## Step 2: Configure
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+## Configure
 
 The main Sentry configuration should happen as early as possible in your app's lifecycle.
 
 ### Wrangler Configuration
 
-<PlatformContent includePath="getting-started-config" />
+<PlatformContent
+  includePath="getting-started-config"
+  platform="javascript.cloudflare.splitlayout"
+/>
 
 ### Initialize the Sentry SDK
 
@@ -45,7 +61,14 @@ The main Sentry configuration should happen as early as possible in your app's l
 
 ### Migration from Community Middleware
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you're currently using the `@hono/sentry` middleware, migrate to the official `@sentry/cloudflare` middleware:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 // New approach using official Sentry SDK
@@ -64,19 +87,23 @@ export default Sentry.withSentry(
 );
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <PlatformContent
   includePath="getting-started-capture-errors"
   platform="javascript.hono"
 />
 
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent
-  includePath="getting-started-sourcemaps-short-version"
-  platform="javascript.hono"
+  includePath="getting-started-sourcemaps-short-version-splitlayout"
+  platform="javascript"
 />
 
-## Step 4: Verify Your Setup
+## Verify Your Setup
 
 <PlatformContent
   includePath="getting-started-verify"
@@ -103,3 +130,5 @@ Now's a good time to customize your setup and look into more advanced topics. Ou
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>

--- a/docs/platforms/javascript/guides/hono/index.mdx
+++ b/docs/platforms/javascript/guides/hono/index.mdx
@@ -11,9 +11,9 @@ categories:
 
 <PlatformContent includePath="getting-started-primer" />
 
-<Alert type="warning" title="Runtime-Specific Setup">
-  This guide focuses on the **Node.js runtime** for Hono. For other runtimes, see the links below. 
-  If you are using the `@sentry/cloudflare` middleware, see the [Hono on Cloudflare guide](/platforms/javascript/guides/cloudflare/frameworks/hono/).
+<Alert level="warning" title="Runtime-Specific Setup">
+  This guide focuses on the **Node.js runtime** for Hono. For other runtimes,
+  see the links below.
 </Alert>
 
 ## Runtime Support
@@ -21,74 +21,15 @@ categories:
 Hono works across multiple JavaScript runtimes. Choose the appropriate Sentry SDK for your environment:
 
 - **Node.js**: Use `@sentry/node` (this guide)
-- **Cloudflare Workers**: Use `@sentry/cloudflare` - see our [Hono on Cloudflare guide](/platforms/javascript/guides/cloudflare/frameworks/hono/)
-- **Deno**: Use `@sentry/deno` - see our [Deno guide](/platforms/javascript/guides/deno/) (Beta)
-- **Bun**: Use `@sentry/bun` - see our [Bun guide](/platforms/javascript/guides/bun/)
+- **Cloudflare Workers**: Use `@sentry/cloudflare` – see our [Hono on Cloudflare guide](/platforms/javascript/guides/cloudflare/frameworks/hono/)
+- **Deno**: Use `@sentry/deno` – see our [Deno guide](/platforms/javascript/guides/deno/) (Beta)
+- **Bun**: Use `@sentry/bun` – see our [Bun guide](/platforms/javascript/guides/bun/)
 
 <Alert>
-  The community middleware `@hono/sentry` has been deprecated in favor of using Sentry's official 
-  packages, which provide better performance and more features. If you're currently using `@hono/sentry` middleware, you'll need to migrate to `@sentry/cloudflare`. 
+  The community middleware `@hono/sentry` has been deprecated in favor of using
+  Sentry's official packages, which provide better performance and more
+  features. If you're currently using `@hono/sentry` middleware, you'll need to
+  migrate to `@sentry/cloudflare`.
 </Alert>
 
-## Runtime-Specific Setup
-
-### Node.js Runtime (This Guide)
-
-This guide focuses on Node.js. The setup uses `@sentry/node` and follows standard Node.js patterns.
-
 <PlatformContent includePath="getting-started-node" />
-
-### Other Runtimes
-
-For other runtimes, use the appropriate Sentry SDK:
-
-<Expandable title="Deno Runtime (Beta)">
-```javascript
-// For Deno, use @sentry/deno (currently in Beta)
-import * as Sentry from "npm:@sentry/deno";
-import { Hono } from "hono";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-});
-
-const app = new Hono();
-// Your Hono app setup...
-```
-</Expandable>
-
-<Expandable title="Bun Runtime">
-```javascript
-// For Bun, use @sentry/bun
-import * as Sentry from "@sentry/bun";
-import { Hono } from "hono";
-
-// Initialize Sentry before importing other modules
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-});
-
-const app = new Hono();
-// Your Hono app setup...
-```
-</Expandable>
-
-<Expandable title="Cloudflare Workers">
-```javascript
-// For Cloudflare Workers, use @sentry/cloudflare
-import * as Sentry from "@sentry/cloudflare";
-import { Hono } from "hono";
-
-const app = new Hono();
-
-export default Sentry.withSentry(
-  (env: Env) => ({
-    dsn: "___PUBLIC_DSN___",
-    tracesSampleRate: 1.0,
-  }),
-  app
-);
-```
-</Expandable>

--- a/docs/platforms/javascript/guides/koa/index.mdx
+++ b/docs/platforms/javascript/guides/koa/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Koa
-description: "Learn how to manually set up Sentry in your Kono app and capture your first errors."
+description: "Learn how to manually set up Sentry in your Koa app and capture your first errors."
 sdk: sentry.javascript.node
 fallbackGuide: javascript.node
 categories:

--- a/docs/platforms/javascript/guides/koa/index.mdx
+++ b/docs/platforms/javascript/guides/koa/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Koa
-description: "This guide explains how to set up Sentry in your Koa application."
+description: "Learn how to manually set up Sentry in your Kono app and capture your first errors."
 sdk: sentry.javascript.node
 fallbackGuide: javascript.node
 categories:

--- a/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
@@ -1,4 +1,11 @@
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Wrap your Hono app with the `withSentry` function, for example, in your `index.ts` file, to initialize the Sentry SDK and hook into the environment:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {filename:index.ts}
 import { Env, Hono } from "hono";
@@ -33,3 +40,6 @@ export default Sentry.withSentry(
 );
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>

--- a/platform-includes/getting-started-node/javascript.mdx
+++ b/platform-includes/getting-started-node/javascript.mdx
@@ -1,6 +1,8 @@
 <PlatformContent includePath="getting-started-prerequisites" />
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 Choose the features you want to configure, and this guide will show you how:
 
@@ -12,17 +14,39 @@ Choose the features you want to configure, and this guide will show you how:
 
 ### Install the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Run the command for your preferred package manager to add the Sentry SDK to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <PlatformContent includePath="getting-started-install" />
 
-## Step 2: Configure
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+## Configure
 
 ### Initialize the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To import and initialize Sentry, create a file named `instrument.(js|mjs)` in the root directory of your project and add the following code:
 
+</SplitSectionText>
+<SplitSectionCode>
+
 <PlatformContent includePath="getting-started-config" />
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 ### Apply Instrumentation to Your App
 
@@ -40,31 +64,48 @@ The method for applying instrumentation depends on whether your application uses
 
 #### CommonJS
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Require the `instrument.js` file before any other modules:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <PlatformContent includePath="getting-started-use" />
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 #### ESM
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 When running your application in ESM mode, use the [--import](https://nodejs.org/api/cli.html#--importmodule) command line option and point it to `instrument.mjs` to load the module before the application starts:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash
 # Note: This is only available for Node v18.19.0 onwards.
 node --import ./instrument.mjs app.mjs
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <PlatformContent includePath="getting-started-capture-errors" />
 
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+### Add Readable Stack Traces With Source Maps (Optional)
 
-The stack traces in your Sentry errors probably won't look like your actual code. To fix this, upload your source maps to Sentry.
-The easiest way to do this is by using the Sentry Wizard:
+<PlatformContent includePath="getting-started-sourcemaps-short-version-splitlayout" />
 
-```bash
-npx @sentry/wizard@latest -i sourcemaps
-```
-
-## Step 4: Verify Your Setup
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 
@@ -96,3 +137,5 @@ Our next recommended steps for you are:
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>

--- a/platform-includes/getting-started-sourcemaps-short-version/javascript.hono.mdx
+++ b/platform-includes/getting-started-sourcemaps-short-version/javascript.hono.mdx
@@ -1,5 +1,0 @@
-The stack traces in your Sentry errors probably won't look like your actual code. To fix this, upload your source maps to Sentry. The easiest way to do this is by using the Sentry Wizard:
-
-```bash
-npx @sentry/wizard@latest -i sourcemaps
-```

--- a/platform-includes/getting-started-verify/javascript.connect.mdx
+++ b/platform-includes/getting-started-verify/javascript.connect.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, let's make sure Sentry is correctly capturing errors and creating issues in your project. Add the following code snippet to your main application file; it defines a route that will deliberately trigger an error when called:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.use("/debug-sentry", (req, res) => {
@@ -8,11 +15,22 @@ app.use("/debug-sentry", (req, res) => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes to execute your code:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.use("/debug-sentry", async (req, res) => {
@@ -29,10 +47,14 @@ app.use("/debug-sentry", async (req, res) => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>

--- a/platform-includes/getting-started-verify/javascript.express.mdx
+++ b/platform-includes/getting-started-verify/javascript.express.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
-First, let’s make sure Sentry is correctly capturing errors and creating issues in your project. Add the following code snippet to your main application file; it defines a route that will deliberately trigger an error when called:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+First, let's make sure Sentry is correctly capturing errors and creating issues in your project. Add the following code snippet to your main application file; it defines a route that will deliberately trigger an error when called:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.get("/debug-sentry", function mainHandler(req, res) {
@@ -8,11 +15,22 @@ app.get("/debug-sentry", function mainHandler(req, res) {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.get("/debug-sentry", async (req, res) => {
@@ -29,10 +47,14 @@ app.get("/debug-sentry", async (req, res) => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>

--- a/platform-includes/getting-started-verify/javascript.fastify.mdx
+++ b/platform-includes/getting-started-verify/javascript.fastify.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, let's make sure Sentry is correctly capturing errors and creating issues in your project. Add the following code snippet to your main application file; it defines a route that will deliberately trigger an error when called:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.get("/debug-sentry", function mainHandler(req, res) {
@@ -8,11 +15,22 @@ app.get("/debug-sentry", function mainHandler(req, res) {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.get("/debug-sentry", async (request, reply) => {
@@ -29,10 +47,14 @@ app.get("/debug-sentry", async (request, reply) => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>

--- a/platform-includes/getting-started-verify/javascript.hapi.mdx
+++ b/platform-includes/getting-started-verify/javascript.hapi.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, let's make sure Sentry is correctly capturing errors and creating issues in your project. Add the following code snippet to your main application file; it defines a route that will deliberately trigger an error when called:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 server.route({
@@ -12,11 +19,22 @@ server.route({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 server.route({
@@ -37,10 +55,14 @@ server.route({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>

--- a/platform-includes/getting-started-verify/javascript.hono.mdx
+++ b/platform-includes/getting-started-verify/javascript.hono.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, let's verify that Sentry captures errors and creates issues in your Sentry project. Add the following code snippet to your main application file, adding a route that triggers an error that Sentry will capture:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.get("/debug-sentry", () => {
@@ -8,11 +15,22 @@ app.get("/debug-sentry", () => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 app.get("/debug-sentry", async () => {
@@ -29,10 +47,14 @@ app.get("/debug-sentry", async () => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>

--- a/platform-includes/getting-started-verify/javascript.koa.mdx
+++ b/platform-includes/getting-started-verify/javascript.koa.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, let's make sure Sentry is correctly capturing errors and creating issues in your project. Add the following code snippet to your main application file; it defines a route that will deliberately trigger an error when called:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 router.get("/debug-sentry", function () {
@@ -8,10 +15,21 @@ router.get("/debug-sentry", function () {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 ### Tracing
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 router.get("/debug-sentry", async (ctx) => {
@@ -28,10 +46,14 @@ router.get("/debug-sentry", async (ctx) => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>

--- a/platform-includes/getting-started-verify/javascript.node.mdx
+++ b/platform-includes/getting-started-verify/javascript.node.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, let's verify that Sentry captures errors and creates issues in your Sentry project. Add the following code snippet to your main application file, which will call an undefined function, triggering an error that Sentry will capture:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 setTimeout(() => {
@@ -12,27 +19,48 @@ setTimeout(() => {
 }, 99);
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 ### Tracing
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To test your tracing configuration, update the previous code snippet by starting a performance trace to measure the time it takes for the execution of your code:
+
+</SplitSectionText>
+<SplitSectionCode>
+
 ```javascript
-Sentry.startSpan({
-  op: "test",
-  name: "My First Test Transaction",
-}, () => {
-  setTimeout(() => {
-    try {
-      foo();
-    } catch (e) {
-      Sentry.captureException(e);
-    }
-  }, 99);
-});
+Sentry.startSpan(
+  {
+    op: "test",
+    name: "My First Test Transaction",
+  },
+  () => {
+    setTimeout(() => {
+      try {
+        foo();
+      } catch (e) {
+        Sentry.captureException(e);
+      }
+    }, 99);
+  }
+);
 ```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This branch updates the following quick start guides to use the new split layout:

- Node.js
- Connect
- Express
- Fastify
- Hapi
- Hono
- Hono on Cloudflare
- Koa

I grouped them all in this PR because they all use the same main content file (except Hono on Cloudflare), and only the "Verify" section uses a dedicated file for each. 

For Hono, I also removed some duplicate content regarding the different runtimes from the quick start guide.

Closes: #17358

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
