### PR TITLE
docs(react-native): Add GraphQL integration docs

### DIFF
--- a/docs/platforms/react-native/integrations/graphql.mdx
+++ b/docs/platforms/react-native/integrations/graphql.mdx
@@ -1,0 +1,41 @@
+---
+title: GraphQL
+description: "Enhance spans and breadcrumbs with data from GraphQL requests in React Native."
+---
+
+_(Available in version 7.5.0 and above)_
+
+_Import name: `Sentry.graphqlClientIntegration`_
+
+The `graphqlClientIntegration` enhances the data captured from GraphQL requests in your React Native application.
+It extracts GraphQL-specific information from HTTP requests matching your configured endpoints and enriches
+both spans and breadcrumbs with GraphQL operation details.
+
+When enabled, this integration will:
+- Update span names with the GraphQL operation type and name
+- Add GraphQL query documents to spans
+- Add GraphQL operation information to breadcrumbs
+
+```javascript
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.graphqlClientIntegration({
+      endpoints: ["https://graphql-api.example.com", /\/graphql$/],
+    }),
+  ],
+});
+```
+
+## Options
+
+### `endpoints`
+
+_Type: `(string | RegExp)[]`_
+
+An array of URLs or URL patterns that should be treated as GraphQL endpoints.
+The integration will only process requests to these endpoints. This array can contain strings, regular expressions, or a combination of both.
+
+To **match all** endpoints, set the `endpoints` option to `[/.*/]`.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add documentation for `graphqlClientIntegration` in React Native. This integration was added to `@sentry/react-native` in [v7.5.0](https://github.com/getsentry/sentry-react-native/pull/5299) but had no corresponding docs page.

Fixes #17296

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)