### PR TITLE
fix(unreal): drop outdated feedback platform support note

### DIFF
--- a/platform-includes/user-feedback/sdk-api-example/unreal.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/unreal.mdx
@@ -19,9 +19,3 @@ SentrySubsystem->CaptureFeedbackWithParams("Feedback message", "Jon Doe", "test@
 The same result can be achieved by calling corresponding functions in blueprint:
 
 ![Capture user feedback](./img/unreal_user_feedback.png)
-
-<Alert>
-
-The ability to capture user feedback is only supported on macOS, iOS, and Android.
-
-</Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Remove outdated note.

Windows and Linux support originally added in Mar 2024: https://github.com/getsentry/sentry-unreal/pull/521

Switched to the new API in Aug 2025: https://github.com/getsentry/sentry-unreal/pull/1051

Brough up at: https://www.reddit.com/r/unrealengine/comments/1sm5tai/helpful_ue_plugin_discord_bug_reporter/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
