### PR TITLE
docs(unreal): remove platform support limitation note for user feedback

### DIFF
--- a/platform-includes/user-feedback/sdk-api-example/unreal.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/unreal.mdx
@@ -19,9 +19,3 @@ SentrySubsystem->CaptureFeedbackWithParams("Feedback message", "Jon Doe", "test@
 The same result can be achieved by calling corresponding functions in blueprint:
 
 ![Capture user feedback](./img/unreal_user_feedback.png)
-
-<Alert>
-
-The ability to capture user feedback is only supported on macOS, iOS, and Android.
-
-</Alert>


### PR DESCRIPTION
This PR removes an outdated note about limited platform support for the user feedback feature in Unreal SDK.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/521
- https://github.com/getsentry/sentry-unreal/pull/1051