### PR TITLE
docs(go): Update Echo guide for v5 and TracesSampler SamplingContext

### DIFF
--- a/docs/platforms/go/guides/echo/index.mdx
+++ b/docs/platforms/go/guides/echo/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Echo
-description: "Echo is a high-performance web framework for building robust and scalable applications in Go. Learn how to set it up with Sentry."
+description: "Echo is a high-performance web framework for building robust and scalable applications in Go. Learn how to set it up with Sentry. Requires Echo v5."
 ---
 
 For a quick reference, there is a [complete example](https://github.com/getsentry/sentry-go/tree/master/_examples/echo) at the Go SDK source code repository.
@@ -63,7 +63,7 @@ app.Use(sentryecho.New(sentryecho.Options{
 }))
 
 // Set up routes
-app.GET("/", func(ctx echo.Context) error {
+app.GET("/", func(ctx *echo.Context) error {
     // capturing an error intentionally to simulate usage
     sentry.CaptureMessage("It works!")
 
@@ -75,7 +75,7 @@ app.Logger.Fatal(app.Start(":3000"))
 
 ## Usage
 
-`sentryecho` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the `echo.Context`, which makes it available throughout the rest of the request's lifetime.
+`sentryecho` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the `*echo.Context`, which makes it available throughout the rest of the request's lifetime.
 You can access it by using the `sentryecho.GetHubFromContext()` method on the context itself in any of your proceeding middleware and routes.
 And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException` or any other calls, as it keeps the separation of data between the requests.
 
@@ -94,7 +94,7 @@ app.Use(sentryecho.New(sentryecho.Options{
 }))
 
 app.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(ctx echo.Context) error {
+	return func(ctx *echo.Context) error {
 		if hub := sentryecho.GetHubFromContext(ctx); hub != nil {
 			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
 		}
@@ -102,7 +102,7 @@ app.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 })
 
-app.GET("/", func(ctx echo.Context) error {
+app.GET("/", func(ctx *echo.Context) error {
 	if hub := sentryecho.GetHubFromContext(ctx); hub != nil {
 		hub.WithScope(func(scope *sentry.Scope) {
 			scope.SetExtra("unwantedQuery", "someQueryDataMaybe")
@@ -112,7 +112,7 @@ app.GET("/", func(ctx echo.Context) error {
 	return ctx.String(http.StatusOK, "Hello, World!")
 })
 
-app.GET("/foo", func(ctx echo.Context) error {
+app.GET("/foo", func(ctx *echo.Context) error {
 	// sentryecho handler will catch it just fine. Also, because we attached "someRandomTag"
 	// in the middleware before, it will be sent through as well
 	panic("y tho")

--- a/platform-includes/performance/always-inherit-sampling-decision/go.mdx
+++ b/platform-includes/performance/always-inherit-sampling-decision/go.mdx
@@ -2,14 +2,22 @@
 err := sentry.Init(sentry.ClientOptions{
 	// ...
 	TracesSampler: sentry.TracesSampler(func(ctx sentry.SamplingContext) float64 {
-		// Inherit decision from parent (works for both local and remote parents).
+		// Inherit decision from a local parent span (same process).
+		if ctx.Parent != nil {
+			if ctx.Parent.Sampled == sentry.SampledTrue {
+				return 1.0
+			}
+			return 0.0
+		}
+		// Inherit decision from a remote parent span (upstream service).
 		if ctx.ParentSampled != sentry.SampledUndefined {
 			if ctx.ParentSampled == sentry.SampledTrue {
 				return 1.0
 			}
 			return 0.0
 		}
-		// Or continue with a custom decision...
+		// No parent — apply a default sample rate.
+		return 0.1
 	}),
 })
 ```

--- a/platform-includes/performance/always-inherit-sampling-decision/go.mdx
+++ b/platform-includes/performance/always-inherit-sampling-decision/go.mdx
@@ -2,9 +2,12 @@
 err := sentry.Init(sentry.ClientOptions{
 	// ...
 	TracesSampler: sentry.TracesSampler(func(ctx sentry.SamplingContext) float64 {
-		// Inherit decision from parent.
-		if ctx.Parent != nil && ctx.Parent.Sampled != sentry.SampledUndefined {
-			return 1.0
+		// Inherit decision from parent (works for both local and remote parents).
+		if ctx.ParentSampled != sentry.SampledUndefined {
+			if ctx.ParentSampled == sentry.SampledTrue {
+				return 1.0
+			}
+			return 0.0
 		}
 		// Or continue with a custom decision...
 	}),

--- a/platform-includes/performance/default-sampling-context-platform/go.mdx
+++ b/platform-includes/performance/default-sampling-context-platform/go.mdx
@@ -3,6 +3,13 @@ For the Go SDK, it is:
 ```go
 type SamplingContext struct {
 	Span   *Span // The current span, always non-nil.
-	Parent *Span // The parent span, may be nil.
+	Parent *Span // The local parent span, non-nil only when the parent exists in the same process.
+	// ParentSampled is the sampling decision of the parent span.
+	//
+	// For a remote span, Parent is nil but ParentSampled reflects the upstream decision.
+	// For a local span, ParentSampled mirrors Parent.Sampled.
+	ParentSampled Sampled
+	// ParentSampleRate is the sample rate used by the parent transaction, propagated via Dynamic Sampling Context.
+	ParentSampleRate *float64
 }
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates Go SDK docs to reflect two changes from recent sentry-go releases:

**Echo v5 ([getsentry/sentry-go#1183](https://github.com/getsentry/sentry-go/pull/1183))**
- Echo v5 changed handler signatures from `echo.Context` (interface) to `*echo.Context` (pointer)
- Updated all code examples in the Echo guide to use `*echo.Context`
- Updated description to mention Echo v5 requirement

**TracesSampler SamplingContext fields ([getsentry/sentry-go#1259](https://github.com/getsentry/sentry-go/pull/1259))**
- `SamplingContext` gained two new fields: `ParentSampled` and `ParentSampleRate`
- `ParentSampled` works for both local and remote parent spans, replacing the old `ctx.Parent != nil` pattern
- `ParentSampleRate` exposes the sample rate from the parent's Dynamic Sampling Context
- Updated `default-sampling-context-platform/go.mdx` with the new struct definition
- Updated `always-inherit-sampling-decision/go.mdx` to use `ctx.ParentSampled` instead of `ctx.Parent.Sampled`

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)