### PR TITLE
docs(docker): Update notes about docker images

### DIFF
--- a/develop-docs/self-hosted/configuration/index.mdx
+++ b/develop-docs/self-hosted/configuration/index.mdx
@@ -39,7 +39,7 @@ Sentry comes with a cleanup cron job that prunes events older than `90 days` by 
 
 If you want to install a specific release of Sentry, use the tags/releases on the self-hosted repository.
 
-We continuously push the Docker image for each commit made into [Sentry](https://github.com/getsentry/sentry), and other services such as [Snuba](https://github.com/getsentry/snuba) or [Symbolicator](https://github.com/getsentry/symbolicator) to [our Docker Hub](https://hub.docker.com/u/getsentry) and tag the latest version on master as `:nightly`. This is also usually what we have on sentry.io and what the install script uses. You can use a custom Sentry image, such as a modified version that you have built on your own, or refer a specific commit hash as the image tag by setting the `SENTRY_IMAGE` environment variable to that image name before running `./install.sh`:
+We continuously push the Docker image for [Sentry](https://github.com/getsentry/sentry/pkgs/container/sentry) and other services such as [Snuba](https://github.com/getsentry/snuba/pkgs/container/snuba) and [Symbolicator](https://github.com/getsentry/symbolicator/pkgs/container/symbolicator) to GitHub Container Registry. The latest version on master is tagged with `:nightly`. This is also usually what we have on sentry.io and what the install script uses. You can use a custom Sentry image, such as a modified version that you have built on your own, or refer a specific commit hash as the image tag by setting the `SENTRY_IMAGE` environment variable to that image name before running `./install.sh`:
 
 ```bash
 SENTRY_IMAGE=getsentry/sentry:83b138090a3078352e3f733de7209fb02ef4f98a ./install.sh

--- a/docs/product/relay/operating-guidelines.mdx
+++ b/docs/product/relay/operating-guidelines.mdx
@@ -8,7 +8,7 @@ This page reviews our guidelines for operation when self-hosting external Relays
 
 ## General Considerations
 
-- We recommend [running Relay](/product/relay/getting-started/) using the officially provided Docker image (`getsentry/relay`) found on [DockerHub](https://hub.docker.com/r/getsentry/relay/) and tagged with its Git revision identifier, rather than building from source.
+- We recommend [running Relay](/product/relay/getting-started/) using the officially provided Docker image (`getsentry/relay`) found on [GitHub Container Registry](https://github.com/getsentry/relay/pkgs/container/relay) and tagged with its Git revision identifier, rather than building from source.
 
 - We recommend running at least two Relay instances (containers) with a reverse proxy (such as [HAProxy](https://www.haproxy.org/) or [Nginx](https://nginx.org)) in front of them for improved availability, simplified Relay updates, and SSL/TLS support.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Update the location of published docker images now that Sentry, Snuba, Symbolicator, and Relay all publish to GitHub Container Registry instead of Docker Hub.

Fixes [RELAY-133](https://linear.app/getsentry/issue/RELAY-133/stop-publishing-releases-to-dockerhub)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)