### PR TITLE
docs(js): Add SDK version requirements to metrics integrations

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/bunruntimemetrics.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/bunruntimemetrics.mdx
@@ -11,6 +11,8 @@ This integration only works in the Bun runtime.
 
 </Alert>
 
+<AvailableSince version="10.47.0" />
+
 _Import name: `Sentry.bunRuntimeMetricsIntegration`_
 
 The `bunRuntimeMetricsIntegration` periodically collects Bun runtime health metrics and sends them to Sentry. Metrics include memory usage, CPU utilization, event loop utilization, and process uptime.

--- a/docs/platforms/javascript/common/configuration/integrations/noderuntimemetrics.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/noderuntimemetrics.mdx
@@ -30,6 +30,8 @@ This integration only works in the Node.js runtime.
 
 </Alert>
 
+<AvailableSince version="10.46.0" />
+
 _Import name: `Sentry.nodeRuntimeMetricsIntegration`_
 
 The `nodeRuntimeMetricsIntegration` periodically collects Node.js runtime health metrics and sends them to Sentry. Metrics include memory usage, CPU utilization, event loop delay, and process uptime.


### PR DESCRIPTION
Adds SDK version requirements to metrics integrations for Node and Bun.

ref https://github.com/getsentry/sentry-docs/pull/17151
ref https://github.com/getsentry/sentry-docs/pull/17150