### PR TITLE
docs(develop): Loosen metrics SDK spec for modules

### DIFF
--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -374,7 +374,7 @@ Sentry.init({
 
 SDKs **MUST** expose functionality for capturing `count`, `gauge`, and `distribution` metrics.
 
-Metrics-capturing functionality **SHOULD** be exposed as functions (or another suitable language construct) in a `metrics` module or namespace. If exposing the functionality in a module or namespace is infeasible in a particular SDK's language, the functions/macros/etc. **SHOULD** be prefixed with `metrics`.
+Metrics-capturing functionality **SHOULD** be exposed as functions (or another suitable language construct) in a `metrics` module or namespace. If exposing the functionality in a module or namespace is infeasible in a particular SDK's language, the function names **SHOULD** be prefixed with the word `metric`.
 
 The **RECOMMENDED** API is as follows:
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -370,9 +370,13 @@ Sentry.init({
 
 <SpecSection id="metrics-module" status="stable" since="2.0.0">
 
-### Metrics Module
+### Metrics Capturing Functionality
 
-SDKs **MUST** expose metrics methods in a `metrics` module or namespace. At minimum, the SDK **MUST** implement the following methods:
+SDKs **MUST** expose functionality for capturing `count`, `gauge`, and `distribution` metrics.
+
+Metrics-capturing functionality **SHOULD** be exposed as functions (or another suitable language construct) in a `metrics` module or namespace. If exposing the functionality in a module or namespace is infeasible in a particular SDK's language, the functions/macros/etc. **SHOULD** be prefixed with `metrics`.
+
+The **RECOMMENDED** API is as follows:
 
 - `Sentry.metrics.count(name, value, options)` — increment a counter
 - `Sentry.metrics.gauge(name, value, options)` — set a gauge value


### PR DESCRIPTION
The "metrics module" section in the "metrics" develop spec is too restrictive.

In Rust, for example, we can implement a more ergonomic API by using macros instead of methods. Due to language restrictions, it is not possible to define macros in a module, only in the top-level of the crate, so we use `metric_count!`, `metric_guage!` and `metric_distribution!` instead. This API aligns with what we already do for logs in the Rust SDK.

Therefore, I propose loosening the requirements. The only "**MUST**"-level requirement in my proposal would be to expose this functionality; the precise API is lowered to "**SHOULD**"-level requirements to allow SDKs to deviate where this would be beneficial.