### PR TITLE
docs(react-native): Use scoped npx call for expo sourcemap upload

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -38,7 +38,7 @@ To upload source maps for all platforms use the following command:
 
 ```bash
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___ \
-npx --package=@sentry/react-native -- sentry-expo-upload-sourcemaps dist
+npx --package=@sentry/react-native sentry-expo-upload-sourcemaps dist
 ```
 
 To upload source maps without expo plugin (bare workflow):
@@ -48,7 +48,7 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___ \
 SENTRY_PROJECT=___PROJECT_SLUG___ \
 SENTRY_ORG=___ORG_SLUG___ \
 SENTRY_URL=https://sentry.io/ \
-npx --package=@sentry/react-native -- sentry-expo-upload-sourcemaps dist
+npx --package=@sentry/react-native sentry-expo-upload-sourcemaps dist
 ```
 
 

--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -38,7 +38,7 @@ To upload source maps for all platforms use the following command:
 
 ```bash
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___ \
-npx sentry-expo-upload-sourcemaps dist
+npx --package=@sentry/react-native -- sentry-expo-upload-sourcemaps dist
 ```
 
 To upload source maps without expo plugin (bare workflow):
@@ -48,7 +48,7 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___ \
 SENTRY_PROJECT=___PROJECT_SLUG___ \
 SENTRY_ORG=___ORG_SLUG___ \
 SENTRY_URL=https://sentry.io/ \
-npx sentry-expo-upload-sourcemaps dist
+npx --package=@sentry/react-native -- sentry-expo-upload-sourcemaps dist
 ```
 
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Changes the documented command for uploading Expo sourcemaps from `npx sentry-expo-upload-sourcemaps dist` to `npx --package=@sentry/react-native -- sentry-expo-upload-sourcemaps dist`.

The previous form resolves an unscoped package name on npm. Inside a project that has `@sentry/react-native` installed, npx uses the local `node_modules/.bin` entry and behaves correctly. But outside such a project (fresh shell, CI step that runs before `install`, copy-pasted tutorial command), npx falls through to the public registry — where the name is currently held by a third-party account (`sentry-expo-upload-sourcemaps@5.24.1`, published 2024-07-02). Its current payload is a benign `wrapper.sh` that forwards to our real binary, but it's a third-party entry point on the documented happy path.

The scoped form routes through `@sentry/react-native`, which is a locked npm scope — only Sentry org members can publish to it, so the registry fallback path cannot be intercepted. In-project behavior is unchanged because the local bin is still preferred.

A parallel exposure exists for Remix (`sentry-upload-sourcemaps`, same squatter); that doc update will be handled separately.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)