### PR TITLE
docs(react-native): document per-scheme sentry.properties on iOS

### DIFF
--- a/docs/platforms/react-native/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/troubleshooting/index.mdx
@@ -70,6 +70,31 @@ If you're using an older version of the SDK (version `3.2.12` or lower) or `sent
   ../node_modules/react-native/scripts/react-native-xcode.sh --force-foreground
 ```
 
+## Different `sentry.properties` Per Scheme or Build Configuration (iOS)
+
+Unlike Android's `flavorAware` option, iOS doesn't auto-select a `sentry.properties` file per configuration. If your app has multiple schemes or build configurations that need to upload to different Sentry projects, select the file at build time with a User-Defined Build Setting.
+
+1. In Xcode, open the **Build Settings** tab, click **+**, and choose **Add User-Defined Setting**. Name it `SENTRY_PROPERTIES_FILE`.
+2. Expand the new setting and set a value per configuration, for example `sentry-staging.properties` for `Staging` and `sentry-production.properties` for `Production`.
+3. Reference the setting from the Sentry build phases by exporting `SENTRY_PROPERTIES`:
+
+```bash {filename:Bundle React Native code and images}
+export SENTRY_PROPERTIES="$SENTRY_PROPERTIES_FILE"
+
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+SENTRY_XCODE="../node_modules/@sentry/react-native/scripts/sentry-xcode.sh"
+
+/bin/sh -c "$WITH_ENVIRONMENT $SENTRY_XCODE"
+```
+
+```bash {filename:Upload Debug Symbols to Sentry}
+export SENTRY_PROPERTIES="$SENTRY_PROPERTIES_FILE"
+
+/bin/sh ../node_modules/@sentry/react-native/scripts/sentry-xcode-debug-files.sh
+```
+
+Xcode substitutes the User-Defined Build Setting for the active configuration, so each build uploads to the matching Sentry project. The same pattern works for `SENTRY_RELEASE`, `SENTRY_DIST`, and other per-build environment variables.
+
 ## Release Health
 
 If your release health statistics are being attributed to the wrong release, confirm that you [pass the `release` and `dist` to the `init` call](/platforms/react-native/configuration/releases/#bind-the-version).


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the validated workaround from [getsentry/sentry-react-native#2681](https://github.com/getsentry/sentry-react-native/issues/2681) for React Native apps on iOS that need to upload to different Sentry projects per Xcode scheme or build configuration.

iOS has no equivalent of Android's `flavorAware` flag. The thread on that issue produced a working pattern using a User-Defined Build Setting to drive `SENTRY_PROPERTIES` in both Sentry build phases. This PR adds that pattern to the React Native troubleshooting page so future users don't need to rediscover it from the GitHub thread.

Added as a new section under `docs/platforms/react-native/troubleshooting/index.mdx`, placed next to the existing iOS build-script topic for locality.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)