### PR TITLE
docs(monitors): Add Mobile Builds Monitor section

### DIFF
--- a/docs/product/monitors-and-alerts/monitors/index.mdx
+++ b/docs/product/monitors-and-alerts/monitors/index.mdx
@@ -16,6 +16,7 @@ Sentry's Monitors are used to customize when to turn errors and performance prob
 You can use Custom Monitors to track errors based on span attributes and custom metrics, the uptime and performance of any scheduled, recurring job, or the uptime and performance of any HTTP request.
 
 - [Metric Monitors](#metric-monitor-settings): Track for errors based on span attributes and custom metrics.
+- [Mobile Builds Monitors](#mobile-builds-monitor-settings): Track the size of mobile app builds.
 - [Cron Monitors](/product/monitors-and-alerts/monitors/crons/): Track the uptime and performance of any scheduled, recurring job.
 - [Uptime Monitors](/product/monitors-and-alerts/monitors/uptime-monitoring/): Track the uptime and performance of any HTTP request.
 
@@ -78,6 +79,27 @@ Dynamic thresholds are good for when it’s cumbersome to create fixed threshold
 
 - **Seasonal fluctuations**: Seasonal metrics, such as number of transactions, are more accurately monitored by comparing them to the previous day or week, rather than a fixed value.
 - **Unpredictable growth**: Fixed-threshold alerts may require continuous manual adjustment as traffic patterns change, such as with a fast-growing app. Dynamic thresholds work regardless of changing traffic patterns.
+
+### Mobile Builds Monitor Settings
+
+Mobile Builds Monitors track the size of your iOS or Android app across builds. Monitors help alert and enforce thresholds on cadenced uploads, such app store releases or nightlies. See [Size Analysis docs](/product/size-analysis/) to learn how to upload builds.
+
+#### Threshold Types
+
+There are three threshold types for Mobile Builds:
+
+- **Absolute Size**: Fail if size exceeds threshold (e.g., max 50 MB)
+- **Absolute Diff**: Fail if size increases by more than threshold (e.g., max 5 MB increase)
+- **Relative Diff**: Fail if size increases by more than threshold percentage (e.g., max 10% increase)
+
+For any of these threshold types, you can monitor Install/Uncompressed Size or Download Size and filter to a specific subset of builds.
+
+If you choose either of the diff thresholds, the baseline build is the most recent build that matches:
+
+- `platform` (iOS or Android)
+- `package_name` (e.g., `com.example.app`)
+- `build_configuration` (e.g., `Release`)
+- any additional filters you set on the monitor
 
 ### Cron Monitor Settings
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new Mobile Builds Monitor type on the New Monitors and Alerts overview page, alongside the existing Metric, Cron, and Uptime monitors.

- Add a "Mobile Builds Monitors" entry to the Custom Monitors list
- Add a "Mobile Builds Monitor Settings" section covering the three threshold types (Absolute Size, Absolute Diff, Relative Diff)
- Describe baseline build matching rules (platform, package_name, build_configuration, additional filters)
- Link out to the Size Analysis docs for build upload instructions

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)