### PR TITLE
Change loader script source to js-de.sentry-cdn.com

### DIFF
--- a/docs/platforms/javascript/common/install/loader.mdx
+++ b/docs/platforms/javascript/common/install/loader.mdx
@@ -47,7 +47,7 @@ To use the loader, go in the Sentry UI to **Settings > Projects > (select projec
 
 ```html
 <script
-  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  src="https://js-de.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
 ></script>
 ```
@@ -91,7 +91,7 @@ Alternatively, you can set the loader to request the full SDK earlier: still as 
 
 ```html
 <script
-  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  src="https://js-de.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
   data-lazy="no"
 ></script>
@@ -140,7 +140,7 @@ The loader script always includes a call to `Sentry.init` with a default configu
 </script>
 
 <script
-  src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js"
+  src="https://js-de.sentry-cdn.com/___PUBLIC_KEY___.min.js"
   crossorigin="anonymous"
 ></script>
 ```
@@ -183,7 +183,7 @@ If you want to call any other method when using the Loader, you have to guard it
   };
 </script>
 
-<script src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js" crossorigin="anonymous"></script>
+<script src="https://js-de.sentry-cdn.com/___PUBLIC_KEY___.min.js" crossorigin="anonymous"></script>
 
 <script>
   // Guard against window.Sentry not being available, e.g. due to Ad-blockers
@@ -220,7 +220,7 @@ If this is a critical issue for you, you have two options to ensure that all you
     };
   </script>
 
-  <script src="https://js.sentry-cdn.com/___PUBLIC_KEY___.min.js" crossorigin="anonymous"></script>
+  <script src="https://js-de.sentry-cdn.com/___PUBLIC_KEY___.min.js" crossorigin="anonymous"></script>
 
   <script>
     Sentry.onLoad(function () {
@@ -449,5 +449,5 @@ Without doing this you will find that it's possible for errors to occur before S
 
 If you have a Content Security Policy (CSP) set up on your site, you will need to add the `script-src` of wherever you're loading the SDK from, and the origin of your DSN. For example:
 
-- `script-src: https://browser.sentry-cdn.com https://js.sentry-cdn.com`
+- `script-src: https://browser.sentry-cdn.com https://js-de.sentry-cdn.com`
 - `connect-src: *.sentry.io`


### PR DESCRIPTION
Updated the loader script source from 'sentry-cdn.com' to 'js-de.sentry-cdn.com'.

## DESCRIBE YOUR PR
Currently, the docs refer to `js.sentry-cdn.com`, which produces the following loader being loaded, which does nothing except output "The Sentry loader you are trying to use isn't working anymore, check your configuration."

```
function _sentry_noopWarning() {
  console.warn("The Sentry loader you are trying to use isn't working anymore, check your configuration.");
}
var Sentry = {
    addBreadcrumb: _sentry_noopWarning,
    captureEvent: _sentry_noopWarning,
    captureException: _sentry_noopWarning,
    captureMessage: _sentry_noopWarning,
    configureScope: _sentry_noopWarning,
    forceLoad: _sentry_noopWarning,
    init: _sentry_noopWarning,
    onLoad: _sentry_noopWarning,
    showReportDialog: _sentry_noopWarning,
    withScope: _sentry_noopWarning,
};
_sentry_noopWarning();
```

This change updates the domain to be the correct `js-de` domain.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
