### PR TITLE
add alert for environment settings in docs

### DIFF
--- a/docs/organization/integrations/coding-agents/claude/index.mdx
+++ b/docs/organization/integrations/coding-agents/claude/index.mdx
@@ -27,7 +27,9 @@ Sentry Owner, Manager, or Admin permissions are required to install this integra
 3. Enter your API key. If your workspace isn't "default" or you want to use a specific environment, update those fields here, then save.
 <Alert level="warning">
 
-If you choose to connect your own Claude environment, it must allow the agent to reach GitHub in order for it to push a branch with the generated fix. In your Claude workspace environment settings, either:
+If you connect your own Claude environment, it needs access to GitHub so the agent can push a branch with the generated fix.
+
+ In your Claude workspace environment settings, either:
 
 - Add **api.githubcopilot.com** to the list of allowed network hosts
 - Allow **MCP server network access**.

--- a/docs/organization/integrations/coding-agents/claude/index.mdx
+++ b/docs/organization/integrations/coding-agents/claude/index.mdx
@@ -25,6 +25,16 @@ Sentry Owner, Manager, or Admin permissions are required to install this integra
 2. In Sentry, navigate to **Settings > Integrations** and search for **Claude Agent**.
 
 3. Enter your API key. If your workspace isn't "default" or you want to use a specific environment, update those fields here, then save.
+<Alert level="warning">
+
+If you choose to connect your own Claude environment, it must allow the agent to reach GitHub in order for it to push a branch with the generated fix. In your Claude workspace environment settings, either:
+
+- Add **api.githubcopilot.com** to the list of allowed network hosts
+- Allow **MCP server network access**.
+
+Without one of these, the agent session will not run.
+
+</Alert>
 <br />
 
     <Arcade src="https://demo.arcade.software/GmQwOB82wAeELf3lr43h?embed&show_copy_link=true" width="75%" />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Adds alert for Claude integration users so they know their environment needs to have github access. 
<img width="1246" height="902" alt="Screenshot 2026-04-20 at 2 44 41 PM" src="https://github.com/user-attachments/assets/d2ca7dad-bbce-49b1-86f0-24639b124537" />


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+ (helpful for support though)

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
