### PR TITLE
docs(react-native): Recommend @sentry/expo-upload-sourcemaps for Expo source maps

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo.mdx
@@ -21,7 +21,7 @@ When the Sentry Expo Plugin `@sentry/react-native/expo` and the Sentry Metro Plu
 
 ## Manual Upload for EAS Updates
 
-To upload source maps for EAS Updates and `npx expo export`, set up the Sentry Expo Plugin, the Sentry Metro plugin and execute the `sentry-expo-upload-sourcemaps` command.
+To upload source maps for EAS Updates and `npx expo export`, set up the Sentry Expo Plugin, the Sentry Metro plugin and execute the `@sentry/expo-upload-sourcemaps` command.
 
 ### Create Update
 
@@ -38,7 +38,7 @@ To upload source maps for all platforms use the following command:
 
 ```bash
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___ \
-npx --package=@sentry/react-native sentry-expo-upload-sourcemaps dist
+npx @sentry/expo-upload-sourcemaps dist
 ```
 
 To upload source maps without expo plugin (bare workflow):
@@ -48,8 +48,20 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___ \
 SENTRY_PROJECT=___PROJECT_SLUG___ \
 SENTRY_ORG=___ORG_SLUG___ \
 SENTRY_URL=https://sentry.io/ \
+npx @sentry/expo-upload-sourcemaps dist
+```
+
+<Alert>
+
+The `@sentry/expo-upload-sourcemaps` package is available starting with `@sentry/react-native` 8.9.0. If you are on an older version, invoke the bin bundled with the SDK instead:
+
+```bash
 npx --package=@sentry/react-native sentry-expo-upload-sourcemaps dist
 ```
+
+Both forms produce identical results; the scoped package is preferred for new setups.
+
+</Alert>
 
 
 #### Notes


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates the Expo source-maps upload guide to recommend the new scoped CLI package:

```bash
SENTRY_AUTH_TOKEN=<token> \
npx @sentry/expo-upload-sourcemaps dist
```

This is the long-term form of the mitigation we started in #17391. That PR routed the command through `--package=@sentry/react-native` to take the unscoped registry name off the documented happy path; this PR switches to the dedicated scoped package `@sentry/expo-upload-sourcemaps`, which is shorter to type, cannot be squatted (scope-protected), and is published and owned by Sentry.

An `<Alert>` block retains the previous `npx --package=@sentry/react-native sentry-expo-upload-sourcemaps dist` form for users on `@sentry/react-native` versions older than 8.9.0, where the new package is not yet available. Both forms produce identical results.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## ⚠️ Blocked on upstream

This PR should only merge **after** `@sentry/expo-upload-sourcemaps` is published to npm. The first release is scheduled to ship with `@sentry/react-native` 8.9.0 via https://github.com/getsentry/sentry-react-native/pull/6027. If this doc lands before the package exists on the registry, users copy-pasting the command will get `npm error 404 Not Found`.

## PRE-MERGE CHECKLIST

- [ ] `@sentry/expo-upload-sourcemaps` is live on npm (verify with `npm view @sentry/expo-upload-sourcemaps version`)
- [ ] The version gate in the `<Alert>` (`8.9.0`) matches the actual release version of `@sentry/react-native` that introduces the package; update if the number shifts
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)