### PR TITLE
fix(minidump): Fix broken `Passing Additional Data` links

### DIFF
--- a/docs/platforms/native/guides/minidumps/index.mdx
+++ b/docs/platforms/native/guides/minidumps/index.mdx
@@ -48,7 +48,7 @@ You can configure Sentry to store the minidump as attachment.
 
 In addition to this information, you can add further metadata specific to
 Sentry, which can help in organizing and analyzing issues. For more information,
-see [Passing Additional Data](#minidump-additional).
+see [Passing Additional Data](#passing-additional-data).
 
 ## Creating and Uploading Minidumps
 
@@ -74,7 +74,7 @@ curl -X POST \
 
 To send additional information, add more form fields to this request. For a full
 description of fields accepted by Sentry, see [Passing Additional
-Data](#minidump-additional).
+Data](#passing-additional-data).
 
 ## Passing Additional Data
 


### PR DESCRIPTION
These links seem to have been broken since https://github.com/getsentry/sentry-docs/pull/8980 this now fixes them.