### PR TITLE
docs(python): Use sentry_sdk.logger in log examples

### DIFF
--- a/docs/guides/logs.mdx
+++ b/docs/guides/logs.mdx
@@ -15,8 +15,7 @@ Sentry.logger.<level>(message, { attributes });
 ```
 
 ```python {tabTitle: Python}
-from sentry_sdk import logger
-logger.<level>(message, attribute=value)
+sentry_sdk.logger.<level>(message, attribute=value)
 ```
 
 ```php {tabTitle: PHP}
@@ -63,9 +62,7 @@ Sentry.logger.info("Order completed", {
 ```
 
 ```python {tabTitle: Python}
-from sentry_sdk import logger as sentry_logger
-
-sentry_logger.info("Order completed",
+sentry_sdk.logger.info("Order completed",
     order_id="order_123",
     user_id=user.id,
     amount=149.99,
@@ -155,17 +152,17 @@ Sentry.logger.warn("Login failed", {
 ```
 
 ```python {tabTitle: Python}
-from sentry_sdk import logger as sentry_logger
+import sentry_sdk
 
 # After successful authentication
-sentry_logger.info("User logged in",
+sentry_sdk.logger.info("User logged in",
     user_id=user.id,
     auth_method="oauth",
     provider="google"
 )
 
 # After authentication fails
-sentry_logger.warning("Login failed",
+sentry_sdk.logger.warning("Login failed",
     email=masked_email,
     reason="invalid_password",
     attempt_count=3
@@ -282,10 +279,10 @@ Sentry.logger.error("Payment failed", {
 ```
 
 ```python {tabTitle: Python}
-from sentry_sdk import logger as sentry_logger
+import sentry_sdk
 
 # After payment gateway returns an error
-sentry_logger.error("Payment failed",
+sentry_sdk.logger.error("Payment failed",
     order_id="order_123",
     amount=99.99,
     gateway="stripe",
@@ -388,13 +385,13 @@ Sentry.logger.info("Webhook received", {
 
 ```python {tabTitle: Python}
 import time
-from sentry_sdk import logger as sentry_logger
+import sentry_sdk
 
 # Third-party API call
 start = time.time()
 response = shipping_api.get_rates(items)
 
-sentry_logger.info("Shipping rates fetched",
+sentry_sdk.logger.info("Shipping rates fetched",
     service="shipping-provider",
     endpoint="/rates",
     duration_ms=int((time.time() - start) * 1000),
@@ -402,7 +399,7 @@ sentry_logger.info("Shipping rates fetched",
 )
 
 # Webhook received
-sentry_logger.info("Webhook received",
+sentry_sdk.logger.info("Webhook received",
     source="stripe",
     event_type="payment_intent.succeeded",
     payment_id=event["data"]["object"]["id"]
@@ -549,16 +546,16 @@ Sentry.logger.error("Job failed", {
 ```
 
 ```python {tabTitle: Python}
-from sentry_sdk import logger as sentry_logger
+import sentry_sdk
 
 # Inside background job handler
-sentry_logger.info("Job started",
+sentry_sdk.logger.info("Job started",
     job_type="email-digest",
     job_id="job_456",
     queue="notifications"
 )
 
-sentry_logger.error("Job failed",
+sentry_sdk.logger.error("Job failed",
     job_type="email-digest",
     job_id="job_456",
     retry_count=3,
@@ -680,16 +677,16 @@ Sentry.logger.warn("Config reloaded", {
 ```
 
 ```python {tabTitle: Python}
-from sentry_sdk import logger as sentry_logger
+import sentry_sdk
 
 # When feature flag is checked or config changes
-sentry_logger.info("Feature flag evaluated",
+sentry_sdk.logger.info("Feature flag evaluated",
     flag="new-checkout-flow",
     enabled=True,
     user_id=user.id
 )
 
-sentry_logger.warning("Config reloaded",
+sentry_sdk.logger.warning("Config reloaded",
     reason="env-change",
     changed_keys=["API_TIMEOUT", "MAX_CONNECTIONS"]
 )
@@ -902,9 +899,9 @@ Sentry.logger.error("Payment failed", { reason: "Insufficient Funds" });
 ```
 
 ```python {tabTitle: Python}
-sentry_logger.info("Checkout started", user_id="882")
-sentry_logger.info("Discount applied", code="WINTER20")
-sentry_logger.error("Payment failed", reason="Insufficient Funds")
+sentry_sdk.logger.info("Checkout started", user_id="882")
+sentry_sdk.logger.info("Discount applied", code="WINTER20")
+sentry_sdk.logger.error("Payment failed", reason="Insufficient Funds")
 ```
 
 ```php {tabTitle: PHP}
@@ -960,7 +957,7 @@ Sentry.logger.error("Checkout failed", {
 ```
 
 ```python {tabTitle: Python}
-sentry_logger.error("Checkout failed",
+sentry_sdk.logger.error("Checkout failed",
     user_id="882",
     order_id="order_pc_991",
     cart_total=142.50,

--- a/docs/guides/logs.mdx
+++ b/docs/guides/logs.mdx
@@ -281,6 +281,8 @@ Sentry.logger.error("Payment failed", {
 ```python {tabTitle: Python}
 import sentry_sdk
 
+sentry_sdk.init(...)
+
 # After payment gateway returns an error
 sentry_sdk.logger.error("Payment failed",
     order_id="order_123",
@@ -386,6 +388,8 @@ Sentry.logger.info("Webhook received", {
 ```python {tabTitle: Python}
 import time
 import sentry_sdk
+
+sentry_sdk.init(...)
 
 # Third-party API call
 start = time.time()
@@ -548,6 +552,8 @@ Sentry.logger.error("Job failed", {
 ```python {tabTitle: Python}
 import sentry_sdk
 
+sentry_sdk.init(...)
+
 # Inside background job handler
 sentry_sdk.logger.info("Job started",
     job_type="email-digest",
@@ -678,6 +684,8 @@ Sentry.logger.warn("Config reloaded", {
 
 ```python {tabTitle: Python}
 import sentry_sdk
+
+sentry_sdk.init(...)
 
 # When feature flag is checked or config changes
 sentry_sdk.logger.info("Feature flag evaluated",

--- a/platform-includes/logs/best-practices/python.mdx
+++ b/platform-includes/logs/best-practices/python.mdx
@@ -13,13 +13,13 @@ This makes debugging dramatically faster — one query returns everything about 
 
 ```python
 # ❌ Scattered thin logs
-sentry_logger.info("Starting checkout")
-sentry_logger.info("Validating cart")
-sentry_logger.info("Processing payment")
-sentry_logger.info("Checkout complete")
+sentry_sdk.logger.info("Starting checkout")
+sentry_sdk.logger.info("Validating cart")
+sentry_sdk.logger.info("Processing payment")
+sentry_sdk.logger.info("Checkout complete")
 
 # ✅ One wide event with full context
-sentry_logger.info(
+sentry_sdk.logger.info(
     "Checkout completed",
     attributes={
         "order_id": order.id,
@@ -54,7 +54,7 @@ This lets you filter logs by high-value customers or specific features.
 <SplitSectionCode>
 
 ```python
-sentry_logger.info(
+sentry_sdk.logger.info(
     "API request completed",
     attributes={
         # User context

--- a/platform-includes/logs/usage/python.mdx
+++ b/platform-includes/logs/usage/python.mdx
@@ -5,22 +5,22 @@ The `logger` namespace exposes six methods that you can use to log messages at d
 You can send structured messages by using the `{attribute_name}` placeholder syntax. The properties of this message will be sent to Sentry, and can be searched from within the Logs UI, and even added to the Logs views as a dedicated column.
 
 ```python
-from sentry_sdk import logger as sentry_logger
+import sentry_sdk
 
-sentry_logger.trace('Starting database connection {database}', database="users")
-sentry_logger.debug('Cache miss for user {user_id}', user_id=123)
-sentry_logger.info('Updated global cache')
-sentry_logger.warning('Rate limit reached for endpoint {endpoint}', endpoint='/api/results/')
-sentry_logger.error('Failed to process payment. Order: {order_id}. Amount: {amount}', order_id="or_2342", amount=99.99)
-sentry_logger.fatal('Database {database} connection pool exhausted', database="users")
+sentry_sdk.init(...)
+
+sentry_sdk.logger.trace('Starting database connection {database}', database="users")
+sentry_sdk.logger.debug('Cache miss for user {user_id}', user_id=123)
+sentry_sdk.logger.info('Updated global cache')
+sentry_sdk.logger.warning('Rate limit reached for endpoint {endpoint}', endpoint='/api/results/')
+sentry_sdk.logger.error('Failed to process payment. Order: {order_id}. Amount: {amount}', order_id="or_2342", amount=99.99)
+sentry_sdk.logger.fatal('Database {database} connection pool exhausted', database="users")
 ```
 
 You can also pass additional attributes directly to the logging functions via the `attributes` kwarg.
 
 ```python
-from sentry_sdk import logger as sentry_logger
-
-sentry_logger.error(
+sentry_sdk.logger.error(
     'Payment processing failed',
     attributes={
         'payment.provider': 'stripe',


### PR DESCRIPTION
Replace "from sentry_sdk import logger as sentry_logger" with "import sentry_sdk" and use "sentry_sdk.logger" throughout Python log examples for consistency with the documented public API.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)