### PR TITLE
docs(snapshots): Add Android setup guide (EME-1031)

### DIFF
--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -1,12 +1,14 @@
 ---
-title: Android
-sidebar_order: 30
+title: Set Up Snapshots
+sidebar_title: Snapshots
+sidebar_order: 5275
+sidebar_section: features
 description: Set up snapshot testing for Android apps with the Sentry Android Gradle Plugin.
 ---
 
 <Include name="feature-available-for-user-group-early-adopter" />
 
-Set up [Snapshots](/product/snapshots) for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub status checks.
+Set up [Snapshots](/product/snapshots/) for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub status checks.
 
 ## Step 1: Enable Snapshots
 

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -4,6 +4,7 @@ sidebar_title: Snapshots
 sidebar_order: 5275
 sidebar_section: features
 description: Set up snapshot testing for Android apps with the Sentry Android Gradle Plugin.
+beta: true
 ---
 
 <Include name="feature-available-for-user-group-early-adopter" />

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -52,6 +52,40 @@ plugins {
 }
 ```
 
+#### Customize Preview Generation
+
+The `snapshots` block on the Sentry extension exposes two options that shape the generated Paparazzi tests. Both only apply when `generateSnapshotTests` is `true` (the default).
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    theme = "@style/Theme.MyApp"   // optional
+    includePrivatePreviews = false // optional, defaults to true
+  }
+}
+```
+
+| Option                   | Default                                                             | Description                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `theme`                  | Paparazzi default (`android:Theme.Material.NoActionBar.Fullscreen`) | Android theme resource used when rendering previews. Set this if your previews rely on a specific theme.                            |
+| `includePrivatePreviews` | `true`                                                              | Whether `@Preview` composables declared `private` are snapshotted. Set to `false` to exclude in-progress or internal-only previews. |
+
+If you don't set `theme`, Paparazzi uses its own default (`android:Theme.Material.NoActionBar.Fullscreen`). If the background of your previews isn't important — for example, when you just want to compare component geometry — you can use a translucent platform theme such as `android:Theme.Translucent.NoTitleBar`:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    theme = "android:Theme.Translucent.NoTitleBar"
+  }
+}
+```
+
+<Alert level="warning">
+If `theme` references a style the renderer can't resolve (typo, wrong prefix, or a theme not on the classpath), neither Sentry nor Paparazzi raises an error or warning. Snapshots still generate, but with incorrect visuals. Double-check the theme string if rendered output looks unexpected.
+</Alert>
+
 Continue to [Step 3](#step-3-test-locally).
 
 ### From Existing Snapshot Tests

--- a/docs/product/snapshots/android/index.mdx
+++ b/docs/product/snapshots/android/index.mdx
@@ -1,0 +1,104 @@
+---
+title: Android
+sidebar_order: 30
+description: Set up snapshot testing for Android apps with the Sentry Android Gradle Plugin.
+---
+
+<Include name="feature-available-for-user-group-early-adopter" />
+
+Set up snapshot testing for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub check status updates.
+
+## Step 1: Enable Snapshots
+
+Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.4.0 or higher is applied and configured.
+
+Then enable snapshots in your `build.gradle`:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+  }
+}
+```
+
+## Step 2: Connect Your Snapshot Tool
+
+### Paparazzi (Recommended)
+
+If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, add `generateSnapshotTests = false` to your snapshot config:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    generateSnapshotTests = false
+  }
+}
+```
+
+Then continue to [Step 3](#step-3-test-locally).
+
+---
+
+If you don't have Paparazzi yet, first choose a version compatible with your project:
+
+| Version         | Gradle         | compileSdk | JDK | compose-bom  |
+| --------------- | -------------- | ---------- | --- | ------------ |
+| `2.0.0-alpha04` | 9.1.x or 9.2.x | 36         | 21+ | > 2025.05.00 |
+| `1.3.5`         | 8.x or 9.x     | ≤ 35       | 17+ | ≤ 2025.04.00 |
+
+Then apply the plugin:
+
+```kotlin
+plugins {
+  // existing plugins
+  id("app.cash.paparazzi") version "<paparazzi_version>"
+}
+```
+
+Paparazzi integrates with ComposePreviewScanner to automatically generate snapshots for all Compose Previews in your project — no test-writing required.
+
+Then continue to [Step 3](#step-3-test-locally).
+
+### Roborazzi
+
+If you already have [Roborazzi](https://github.com/takahirom/roborazzi) configured, wire the Sentry upload task to the output of your Roborazzi record task:
+
+```kotlin
+afterEvaluate {
+  tasks.named<SentryUploadSnapshotsTask>("sentryUploadSnapshotsDebug") {
+    dependsOn(tasks.named("recordRoborazziDebug"))
+    snapshotsPath.set(
+      project.extensions.getByType<RoborazziExtension>().outputDir
+    )
+  }
+}
+```
+
+Then continue to [Step 3](#step-3-test-locally).
+
+### Other Tools
+
+The same pattern works with any snapshot tool. Set `snapshotsPath` to the directory your tool writes images to, and add a `dependsOn` for the task that generates them:
+
+```kotlin
+afterEvaluate {
+  tasks.named<SentryUploadSnapshotsTask>("sentryUploadSnapshotsDebug") {
+    dependsOn(tasks.named("yourSnapshotTask"))
+    snapshotsPath.set(layout.projectDirectory.dir("path/to/snapshots"))
+  }
+}
+```
+
+Alternatively, you can use `sentry-cli` directly to upload images. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/) for the general upload structure.
+
+## Step 3: Test Locally
+
+Verify your setup by running:
+
+```bash
+./gradlew sentryUploadSnapshotsDebug
+```
+
+If that succeeds, you can proceed with integrating into CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for an example CI workflow.

--- a/docs/product/snapshots/android/index.mdx
+++ b/docs/product/snapshots/android/index.mdx
@@ -6,7 +6,7 @@ description: Set up snapshot testing for Android apps with the Sentry Android Gr
 
 <Include name="feature-available-for-user-group-early-adopter" />
 
-Set up snapshot testing for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub check status updates.
+Set up [Snapshots](/product/snapshots) for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub status checks.
 
 ## Step 1: Enable Snapshots
 
@@ -22,26 +22,18 @@ sentry {
 }
 ```
 
-## Step 2: Connect Your Snapshot Tool
+## Step 2: Generate Images
 
-### Paparazzi (Recommended)
+There are two paths for generating snapshot images on Android:
 
-If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, add `generateSnapshotTests = false` to your snapshot config:
+- **From Compose Previews (recommended)** — if you don't have snapshot tests yet, Sentry auto-wires Paparazzi with ComposePreviewScanner so every `@Preview` composable becomes a snapshot. No test code required.
+- **From existing snapshot tests** — if you already use Paparazzi, Roborazzi, or another tool, point Sentry at your existing output instead.
 
-```kotlin
-sentry {
-  snapshots {
-    enabled = true
-    generateSnapshotTests = false
-  }
-}
-```
+### From Compose Previews (Recommended)
 
-Then continue to [Step 3](#step-3-test-locally).
+Use this path if you don't have a snapshot test suite yet. Paparazzi and ComposePreviewScanner turn every `@Preview` composable in your project into a snapshot automatically.
 
----
-
-If you don't have Paparazzi yet, first choose a version compatible with your project:
+First, choose a Paparazzi version compatible with your project:
 
 | Version         | Gradle         | compileSdk | JDK | compose-bom  |
 | --------------- | -------------- | ---------- | --- | ------------ |
@@ -57,11 +49,28 @@ plugins {
 }
 ```
 
-Paparazzi integrates with ComposePreviewScanner to automatically generate snapshots for all Compose Previews in your project — no test-writing required.
+Continue to [Step 3](#step-3-test-locally).
 
-Then continue to [Step 3](#step-3-test-locally).
+### From Existing Snapshot Tests
 
-### Roborazzi
+Use this path if you already have a snapshot test suite. The configuration depends on which tool you use.
+
+#### Paparazzi
+
+If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, set `generateSnapshotTests = false` so Sentry uses your existing tests instead of auto-generating preview-based ones:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    generateSnapshotTests = false
+  }
+}
+```
+
+Continue to [Step 3](#step-3-test-locally).
+
+#### Roborazzi
 
 If you already have [Roborazzi](https://github.com/takahirom/roborazzi) configured, wire the Sentry upload task to the output of your Roborazzi record task:
 
@@ -76,9 +85,9 @@ afterEvaluate {
 }
 ```
 
-Then continue to [Step 3](#step-3-test-locally).
+Continue to [Step 3](#step-3-test-locally).
 
-### Other Tools
+#### Other Tools
 
 The same pattern works with any snapshot tool. Set `snapshotsPath` to the directory your tool writes images to, and add a `dependsOn` for the task that generates them:
 
@@ -101,4 +110,6 @@ Verify your setup by running:
 ./gradlew sentryUploadSnapshotsDebug
 ```
 
-If that succeeds, you can proceed with integrating into CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for an example CI workflow.
+## Step 4: Integrate Into CI
+
+Once the local upload succeeds, wire the same command into your CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for an example GitHub Actions workflow.

--- a/docs/product/snapshots/index.mdx
+++ b/docs/product/snapshots/index.mdx
@@ -35,7 +35,7 @@ Snapshots works for any platform with a frontend and most platforms have a numbe
 TODO: idk if we even want this, but putting for now
 
 - iOS
-- Android
+- [Android](/platforms/android/snapshots/)
 - React
 
 <PageGrid />

--- a/redirects.js
+++ b/redirects.js
@@ -572,6 +572,10 @@ const developerDocsRedirects = [
 /** @type {import('next/dist/lib/load-custom-routes').Redirect[]} */
 const userDocsRedirects = [
   {
+    source: '/product/snapshots/android/',
+    destination: '/platforms/android/snapshots/',
+  },
+  {
     source: '/integrations/cursor/',
     destination: '/organization/integrations/coding-agents/cursor/',
   },


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add Android setup documentation for the Snapshots EA product. Covers enabling snapshots via the Sentry Android Gradle Plugin and wiring it up to popular snapshot tools.

- Adds `docs/product/snapshots/android/index.mdx`
- Documents SAGP 6.4.0+ setup with `sentry.snapshots` DSL
- Documents Paparazzi (recommended), Roborazzi, and generic-tool integration
- Links back to the existing uploading-snapshots CI guide

Linked to EME-1031.

Stacked on top of #[snapshots-ea-product-docs](https://github.com/getsentry/sentry-docs/pull/new/mtopo27/snapshots-ea-product-docs). Merge that PR first.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)