### PR TITLE
docs(react-native): Use scoped @sentry/cli in sourcemap upload examples

### DIFF
--- a/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/codepush.mdx
@@ -94,7 +94,7 @@ export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 To upload source maps for your CodePush release, use the `sourcemaps upload` command.
 
 ```bash {tabTitle:Sentry CLI}
-npx sentry-cli sourcemaps upload \
+npx @sentry/cli sourcemaps upload \
   --debug-id-reference \
   --strip-prefix /path/to/project/root \
   ./sourcemaps

--- a/docs/platforms/react-native/sourcemaps/uploading/expo-advanced.mdx
+++ b/docs/platforms/react-native/sourcemaps/uploading/expo-advanced.mdx
@@ -139,14 +139,14 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 Upload the bundle and source maps to Sentry:
 
 ```bash {tabTitle:Android}
-npx sentry-cli sourcemaps upload \
+npx @sentry/cli sourcemaps upload \
   --debug-id-reference \
   --strip-prefix /path/to/project/root \
   index.android.bundle index.android.bundle.map
 ```
 
 ```bash {tabTitle:iOS}
-npx sentry-cli sourcemaps upload \
+npx @sentry/cli sourcemaps upload \
   --debug-id-reference \
   --strip-prefix /path/to/project/root \
   main.jsbundle main.jsbundle.map
@@ -203,13 +203,13 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 Upload the bundle and source map to Sentry:
 
 ```bash {tabTitle:Android}
-npx sentry-cli sourcemaps upload \
+npx @sentry/cli sourcemaps upload \
   --strip-prefix /path/to/project/root \
   index.android.bundle index.android.bundle.map
 ```
 
 ```bash {tabTitle:iOS}
-npx sentry-cli sourcemaps upload \
+npx @sentry/cli sourcemaps upload \
   --strip-prefix /path/to/project/root \
   main.jsbundle main.jsbundle.map
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Replaces every `npx sentry-cli sourcemaps upload …` invocation in the React Native source-map upload guides with `npx @sentry/cli sourcemaps upload …`. 5 occurrences across 2 files:

- `docs/platforms/react-native/sourcemaps/uploading/codepush.mdx` (1)
- `docs/platforms/react-native/sourcemaps/uploading/expo-advanced.mdx` (4)

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## Motivation

The unscoped `sentry-cli` name on npm is currently owned by a personal account (`kamilogorek`) that is no longer at Sentry. The package itself is a defensively crafted stub — no `bin`, and a `postinstall` that exits with `"Use @sentry/cli instead"` — so a user who runs `npx sentry-cli …` today without a local install gets a loud error rather than an exploit. That is the good case.

The residual risk is that the account sits outside Sentry's governance. If the credentials were ever compromised, an attacker could push a new version with a real `bin` and active payload, and anyone following the documented command (CI step without a prior `npm install`, copy-pasted shell, fresh environment) would execute it. Every `npx sentry-cli …` in the Sentry docs is a fall-through path into that account.

Routing the documented command through the `@sentry/cli` scoped name removes that fall-through entirely — `@sentry` is a locked npm scope that only Sentry members can publish to, so the transitive registry lookup can never reach a third-party-maintained package.

In-project behavior is unchanged: users with `@sentry/cli` installed locally already resolve the bin via `./node_modules/.bin/sentry-cli`, so the scoped form is purely a safer spelling of the same invocation.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Follow-ups (not blocking this PR)

- Reach out to the current `sentry-cli` npm maintainer and transfer package ownership to the Sentry npm org. One-time cleanup; permanently removes the account-compromise risk.
- Audit the other Sentry SDK repos (`sentry-javascript`, `sentry-java`, etc.) for bare `npx sentry-cli` in their READMEs or examples. No other hits in `sentry-docs` itself (verified via grep).