### PR TITLE
docs(github): Update Contents permission to Read & write

### DIFF
--- a/develop-docs/integrations/github.mdx
+++ b/develop-docs/integrations/github.mdx
@@ -45,9 +45,9 @@ When prompted for permissions, choose the following:
 | Repository / Administration                      | Read-only    |
 | Organization permissions / members (optional)    | Read-only    |
 | Account permissions / Email addresses (optional) | Read-only    |
-| Repository / Contents                            | Read & write |
 | Repository / Checks                              | Read & write |
 | Repository / Commit Statuses                     | Read & write |
+| Repository / Contents                            | Read & write |
 | Repository / Issues                              | Read & write |
 | Repository / Pull requests                       | Read & write |
 | Repository / Webhooks                            | Read & write |

--- a/develop-docs/integrations/github.mdx
+++ b/develop-docs/integrations/github.mdx
@@ -20,7 +20,7 @@ For local development make sure to use your ngrok URL as the prefix.
 </Alert>
 
 <CreateGitHubAppForm
-  url="https://github.com/organizations/:org/settings/apps/new?name=:org-Sentry-Integration&public=false&members=read&emails=read&administration=read&contents=read&checks=write&statuses=write&issues=write&pull_requests=write&repository_hooks=write&url=:url-prefix&callback_urls[]=:url-prefix%2Fauth%2Fsso%2F&callback_urls[]=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&setup_url=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&webhook_url=:url-prefix%2Fextensions%2Fgithub%2Fwebhook%2F&events[]=push&events[]=pull_request&webhook_active=true"
+  url="https://github.com/organizations/:org/settings/apps/new?name=:org-Sentry-Integration&public=false&members=read&emails=read&administration=read&contents=write&checks=write&statuses=write&issues=write&pull_requests=write&repository_hooks=write&url=:url-prefix&callback_urls[]=:url-prefix%2Fauth%2Fsso%2F&callback_urls[]=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&setup_url=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&webhook_url=:url-prefix%2Fextensions%2Fgithub%2Fwebhook%2F&events[]=push&events[]=pull_request&webhook_active=true"
   defaultOrg="your-organization"
   defaultUrlPrefix="https://your-sentry-url-prefix.com"
 />
@@ -43,7 +43,7 @@ When prompted for permissions, choose the following:
 | Permission                                       | Setting      |
 | ------------------------------------------------ | ------------ |
 | Repository / Administration                      | Read-only    |
-| Repository / Contents                            | Read-only    |
+| Repository / Contents                            | Read & write |
 | Organization permissions / members (optional)    | Read-only    |
 | Account permissions / Email addresses (optional) | Read-only    |
 | Repository / Checks                              | Read & write |

--- a/develop-docs/integrations/github.mdx
+++ b/develop-docs/integrations/github.mdx
@@ -43,9 +43,9 @@ When prompted for permissions, choose the following:
 | Permission                                       | Setting      |
 | ------------------------------------------------ | ------------ |
 | Repository / Administration                      | Read-only    |
-| Repository / Contents                            | Read & write |
 | Organization permissions / members (optional)    | Read-only    |
 | Account permissions / Email addresses (optional) | Read-only    |
+| Repository / Contents                            | Read & write |
 | Repository / Checks                              | Read & write |
 | Repository / Commit Statuses                     | Read & write |
 | Repository / Issues                              | Read & write |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## DESCRIBE YOUR PR

Updates the GitHub App integration documentation to reflect that the **Repository / Contents** permission requires **Read & write** instead of **Read-only**.

Changes made:
- Updated the permissions table to show "Read & write" for Repository / Contents
- Updated the `CreateGitHubAppForm` URL parameter from `contents=read` to `contents=write`

This change reflects the current requirements for the GitHub App integration with Sentry.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0AAF0JD0GK/p1776798119632559?thread_ts=1776798119.632559&cid=C0AAF0JD0GK)

<div><a href="https://cursor.com/agents/bc-6a606b49-f905-548e-bca6-15d9b862f0dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a606b49-f905-548e-bca6-15d9b862f0dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

