### PR TITLE
feat(stalebot): Add stale PR automation workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
       interval: daily
     reviewers:
       - '@getsentry/docs'
-    labels: []
+    labels:
+      - dependencies
     # Group dependency updates together in one PR
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
     groups:
@@ -31,6 +32,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: 'daily'
+    labels:
+      - dependencies
 
   - package-ecosystem: gitsubmodule
     directory: '/'
@@ -38,4 +41,6 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     reviewers:
-      - AbhiPrasad
+      - '@getsentry/docs'
+    labels:
+      - dependencies

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -85,7 +85,6 @@
 - name: 'Platform: Xamarin'
   color: '584774'
 
-
 # Waiting for Labels
 - name: 'Waiting for: Support'
   color: '8D5494'
@@ -266,6 +265,11 @@
 - name: sdk-develop-docs
   color: '584774'
   description: PRs touching develop-docs/sdk
+
+# Stale PR management
+- name: do-not-close
+  color: 0E8A16
+  description: Prevents automatic closure of stale PRs
 
 # Miscellaneous
 - name: API Docs

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,47 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # Daily at 3:00 AM UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Only target PRs, not issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 7 days if no further activity occurs.
+
+            If this PR is still relevant, please:
+            - Push new commits, or
+            - Leave a comment to keep it open
+
+            Thank you for your contribution!
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+
+            If you'd like to continue working on this, feel free to reopen the PR or create a new one.
+
+          # Timing
+          days-before-stale: 45
+          days-before-close: 7
+
+          # Labels
+          stale-pr-label: 'Stale'
+
+          # Exemptions
+          exempt-draft-pr: true
+          exempt-pr-labels: 'do-not-close,dependencies'
+
+          # Processing
+          operations-per-run: 100


### PR DESCRIPTION

## DESCRIBE YOUR PR
- Add workflow to mark PRs stale after 45 days of inactivity
- Auto-close PRs 7 days after being marked stale
- Exempt draft PRs, dependabot PRs, and PRs with 'do-not-close' label
- Add 'do-not-close' label definition
- Update dependabot .yml to label so we can exempt their PRs

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)