### PR TITLE
ref(ingest-settings): Rename useragent to user_agent

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -380,7 +380,7 @@ An envelope **MUST** contain at most one `log` envelope item — all log entries
   "version": 2,
   "ingest_settings": {
     "infer_ip": "auto",
-    "infer_useragent": "auto"
+    "infer_user_agent": "auto"
   },
   "items": [{..log..}, {..log..}, {..log..}, {..log..}, {..log..}]
 }
@@ -397,7 +397,7 @@ The `log` envelope item `ingest_settings` property is an optional JSON object th
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
-| `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
+| `infer_user_agent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
 
 SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the log as an attribute.
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -279,7 +279,7 @@ An envelope **MUST** contain at most one `trace_metric` envelope item — all me
 	"version": 2,
 	"ingest_settings": {
 		"infer_ip": "auto",
-		"infer_useragent": "auto"
+		"infer_user_agent": "auto"
 	},
 	"items": [{..metric..}, {..metric..}, {..metric..}]
 }
@@ -296,7 +296,7 @@ The `trace_metric` envelope item `ingest_settings` property is an optional JSON 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
-| `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
+| `infer_user_agent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
 
 SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the metric as an attribute.
 

--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -51,7 +51,7 @@ The container is defined as follows:
   "version": 2,
   "ingest_settings": {
     "infer_ip": "auto",
-    "infer_useragent": "auto"
+    "infer_user_agent": "auto"
   },
   "items": [{..span..}, {..span..}, {..span..}]
 }
@@ -66,11 +66,11 @@ The span envelope item `ingest_settings` property is an optional JSON object tha
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `infer_ip` | String | **OPTIONAL** | The setting to infer the IP address from the incoming request. One of `auto` or `never` (default). |
-| `infer_useragent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
+| `infer_user_agent` | String | **OPTIONAL** | The setting to infer the user agent from the incoming request. One of `auto` or `never` (default). |
 
 SDKs like Browser or React Native **MAY** set these to `"auto"` to instruct Relay to infer the IP address or user agent from the incoming request and put it onto the span as an attribute.
 
-For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher. If `version` is omitted, Relay treats the payload as version `1` and doesn't apply `ingest_settings`. 
+For ingestion settings to take effect, the SDK **MUST** also set the `version` property to `2` (`number`) or higher. If `version` is omitted, Relay treats the payload as version `1` and doesn't apply `ingest_settings`.
 
 </SpecSection>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Renames `infer_useragent` to `infer_user_agent`. While implementing the change in Relay I noticed we already have existing user agent fields named `user_agent`, we should consistent with existing protocols.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

