### PR TITLE
docs(snapshots): Restructure Android Step 2 around generation paths

### DIFF
--- a/docs/product/snapshots/android/index.mdx
+++ b/docs/product/snapshots/android/index.mdx
@@ -6,7 +6,7 @@ description: Set up snapshot testing for Android apps with the Sentry Android Gr
 
 <Include name="feature-available-for-user-group-early-adopter" />
 
-Set up snapshot testing for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub check status updates.
+Set up [Snapshots](/product/snapshots) for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub status checks.
 
 ## Step 1: Enable Snapshots
 
@@ -22,26 +22,18 @@ sentry {
 }
 ```
 
-## Step 2: Connect Your Snapshot Tool
+## Step 2: Generate Images
 
-### Paparazzi (Recommended)
+There are two paths for generating snapshot images on Android:
 
-If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, add `generateSnapshotTests = false` to your snapshot config:
+- **From Compose Previews (recommended)** — if you don't have snapshot tests yet, Sentry auto-wires Paparazzi with ComposePreviewScanner so every `@Preview` composable becomes a snapshot. No test code required.
+- **From existing snapshot tests** — if you already use Paparazzi, Roborazzi, or another tool, point Sentry at your existing output instead.
 
-```kotlin
-sentry {
-  snapshots {
-    enabled = true
-    generateSnapshotTests = false
-  }
-}
-```
+### From Compose Previews (Recommended)
 
-Then continue to [Step 3](#step-3-test-locally).
+Use this path if you don't have a snapshot test suite yet. Paparazzi and ComposePreviewScanner turn every `@Preview` composable in your project into a snapshot automatically.
 
----
-
-If you don't have Paparazzi yet, first choose a version compatible with your project:
+First, choose a Paparazzi version compatible with your project:
 
 | Version         | Gradle         | compileSdk | JDK | compose-bom  |
 | --------------- | -------------- | ---------- | --- | ------------ |
@@ -57,11 +49,28 @@ plugins {
 }
 ```
 
-Paparazzi integrates with ComposePreviewScanner to automatically generate snapshots for all Compose Previews in your project — no test-writing required.
+Continue to [Step 3](#step-3-test-locally).
 
-Then continue to [Step 3](#step-3-test-locally).
+### From Existing Snapshot Tests
 
-### Roborazzi
+Use this path if you already have a snapshot test suite. The configuration depends on which tool you use.
+
+#### Paparazzi
+
+If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, set `generateSnapshotTests = false` so Sentry uses your existing tests instead of auto-generating preview-based ones:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    generateSnapshotTests = false
+  }
+}
+```
+
+Continue to [Step 3](#step-3-test-locally).
+
+#### Roborazzi
 
 If you already have [Roborazzi](https://github.com/takahirom/roborazzi) configured, wire the Sentry upload task to the output of your Roborazzi record task:
 
@@ -76,9 +85,9 @@ afterEvaluate {
 }
 ```
 
-Then continue to [Step 3](#step-3-test-locally).
+Continue to [Step 3](#step-3-test-locally).
 
-### Other Tools
+#### Other Tools
 
 The same pattern works with any snapshot tool. Set `snapshotsPath` to the directory your tool writes images to, and add a `dependsOn` for the task that generates them:
 
@@ -101,4 +110,6 @@ Verify your setup by running:
 ./gradlew sentryUploadSnapshotsDebug
 ```
 
-If that succeeds, you can proceed with integrating into CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for an example CI workflow.
+## Step 4: Integrate Into CI
+
+Once the local upload succeeds, wire the same command into your CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for an example GitHub Actions workflow.


### PR DESCRIPTION
Addresses @mtopo27's review on #17425:

- Intro: link Snapshots to the product page; "check status updates" -> "status checks"
- Step 2: reframe as "Generate Images" with two H3 paths (Compose Previews recommended / Existing Snapshot Tests) so the preview-to-image workflow is visible up front; Paparazzi/Roborazzi/Other move under Existing Tests
- Promote the trailing CI sentence to "Step 4: Integrate Into CI"

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
