### PR TITLE
docs(api): Add org:ci permission to scopes page

### DIFF
--- a/docs/api/permissions.mdx
+++ b/docs/api/permissions.mdx
@@ -24,6 +24,15 @@ If you're looking for information on membership roles please visit the
 | **PUT/POST** | `org:write` |
 |  **DELETE**  | `org:admin` |
 
+### Continuous Integration (CI)
+
+|                  |          |
+| :--------------: | :------: |
+| **CI Workflows** | `org:ci` |
+
+Use the `org:ci` scope for CI and deployment workflows, including uploading
+source maps, creating releases, and managing code mappings.
+
 ### Projects
 
 |              |                 |


### PR DESCRIPTION
Add the missing `org:ci` scope to the API permissions reference.

Sentry exposes `org:ci` as a special CI permission used for source map uploads, release creation, and code mappings, but `/api/permissions` only listed the standard CRUD-style organization scopes. This updates the page with a dedicated CI section so the public docs match the product and backend scope definitions.

I considered folding this into the existing Organizations table, but `org:ci` behaves as a special-purpose CI scope rather than another organization CRUD level, so a separate section is clearer.