### PR TITLE
docs(ownership): add caveat for open membership ownership assignment

### DIFF
--- a/docs/product/alerts/create-alerts/metric-alert-config.mdx
+++ b/docs/product/alerts/create-alerts/metric-alert-config.mdx
@@ -187,4 +187,4 @@ Give your alert a descriptive name, such as the team affected and the topic of t
 
 ## Team
 
-You can choose a team to associate with an alert so that members of that team can edit this alert. Note that you can only make this association if you are a member of the team. If no team is selected, anybody can edit the alert.
+You can choose a team to associate with an alert so that members of that team can edit this alert. Note that you can only create this association if you are a member of the team, unless the organization has [Open Membership](/organization/membership/#open-membership) enabled. If no team is selected, anybody can edit the alert.

--- a/docs/product/issues/ownership-rules/index.mdx
+++ b/docs/product/issues/ownership-rules/index.mdx
@@ -37,7 +37,7 @@ The general format of a rule is: `type:pattern owners`
    - `example1@company.com example2@company.com`
    - `#backend-team`
 
-Teams _must_ have access to the project to become owners. To grant a team access to a project, go to your project's [Project Teams](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/teams/) settings, and click "Add Team".
+Teams _must_ have access to the project to become owners, unless the organization has [Open Membership](/organization/membership/#open-membership) enabled. To grant a team access to a project, go to your project's [Project Teams](https://sentry.io/orgredirect/organizations/:orgslug/settings/projects/:projectId/teams/) settings, and click "Add Team".
 
 To grant a user access to a project, the user must be a member of a team with access to the project. To add a user to a team, navigate to **Settings > Teams**, select a team, and click "Add Member".
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Add some notes on caveats to ownership assignment for metric issues and issues. These were behaviors that will be solidified after https://github.com/getsentry/sentry/pull/113707

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
