### PR TITLE
docs(dart): Replace SentryLogAttribute with SentryAttribute

### DIFF
--- a/platform-includes/logs/best-practices/dart.mdx
+++ b/platform-includes/logs/best-practices/dart.mdx
@@ -20,13 +20,13 @@ Sentry.logger.info('Checkout complete');
 
 // ✅ One wide event with full context
 Sentry.logger.info('Checkout completed', attributes: {
-  'order_id': SentryLogAttribute.string(order.id),
-  'user_id': SentryLogAttribute.string(user.id),
-  'user_tier': SentryLogAttribute.string(user.subscription),
-  'cart_value': SentryLogAttribute.double(cart.total),
-  'item_count': SentryLogAttribute.int(cart.items.length),
-  'payment_method': SentryLogAttribute.string('stripe'),
-  'duration_ms': SentryLogAttribute.int(
+  'order_id': SentryAttribute.string(order.id),
+  'user_id': SentryAttribute.string(user.id),
+  'user_tier': SentryAttribute.string(user.subscription),
+  'cart_value': SentryAttribute.double(cart.total),
+  'item_count': SentryAttribute.int(cart.items.length),
+  'payment_method': SentryAttribute.string('stripe'),
+  'duration_ms': SentryAttribute.int(
       DateTime.now().difference(startTime).inMilliseconds),
 });
 ```
@@ -54,17 +54,17 @@ This lets you filter logs by high-value customers or specific features.
 ```dart
 Sentry.logger.info('API request completed', attributes: {
   // User context
-  'user_id': SentryLogAttribute.string(user.id),
-  'user_tier': SentryLogAttribute.string(user.plan),
-  'account_age_days': SentryLogAttribute.int(user.ageDays),
+  'user_id': SentryAttribute.string(user.id),
+  'user_tier': SentryAttribute.string(user.plan),
+  'account_age_days': SentryAttribute.int(user.ageDays),
 
   // Request data
-  'endpoint': SentryLogAttribute.string('/api/orders'),
-  'method': SentryLogAttribute.string('POST'),
-  'duration_ms': SentryLogAttribute.int(234),
+  'endpoint': SentryAttribute.string('/api/orders'),
+  'method': SentryAttribute.string('POST'),
+  'duration_ms': SentryAttribute.int(234),
 
   // Business context
-  'order_value': SentryLogAttribute.double(149.99),
+  'order_value': SentryAttribute.double(149.99),
 });
 ```
 
@@ -85,17 +85,17 @@ Pick a naming convention and stick with it across your codebase. Inconsistent na
 
 ```dart
 // ❌ Inconsistent naming
-{'user': SentryLogAttribute.string('123')}
-{'userId': SentryLogAttribute.string('123')}
-{'user_id': SentryLogAttribute.string('123')}
-{'UserID': SentryLogAttribute.string('123')}
+{'user': SentryAttribute.string('123')}
+{'userId': SentryAttribute.string('123')}
+{'user_id': SentryAttribute.string('123')}
+{'UserID': SentryAttribute.string('123')}
 
 // ✅ Consistent snake_case
 {
-  'user_id': SentryLogAttribute.string('123'),
-  'order_id': SentryLogAttribute.string('456'),
-  'cart_value': SentryLogAttribute.double(99.99),
-  'item_count': SentryLogAttribute.int(3),
+  'user_id': SentryAttribute.string('123'),
+  'order_id': SentryAttribute.string('456'),
+  'cart_value': SentryAttribute.double(99.99),
+  'item_count': SentryAttribute.int(3),
 }
 ```
 

--- a/platform-includes/logs/usage/dart.mdx
+++ b/platform-includes/logs/usage/dart.mdx
@@ -14,7 +14,7 @@ These properties will be sent to Sentry, and can be searched from within the Log
 Sentry.logger.fmt.error('Uh oh, something broke, here is the error: %s', [
   errorMsg
 ], attributes: {
-  'additional_info': SentryLogAttribute.string('some info'),
+  'additional_info': SentryAttribute.string('some info'),
 });
 Sentry.logger.fmt.info("%s added %s to cart.", [user.username, product.name]);
 ```
@@ -24,11 +24,11 @@ You can also pass additional attributes directly to the logging functions, avoid
 ```dart
 Sentry.logger.error('Uh oh, something broke, here is the error: $errorMsg',
     attributes: {
-      'error': SentryLogAttribute.string(errorMsg),
-      'some_info': SentryLogAttribute.string('some info'),
+      'error': SentryAttribute.string(errorMsg),
+      'some_info': SentryAttribute.string('some info'),
     });
 Sentry.logger.info('User ${user.username} added ${product.name} to cart.', attributes: {
-  'user': SentryLogAttribute.string(user.username),
-  'product': SentryLogAttribute.string(product.name),
+  'user': SentryAttribute.string(user.username),
+  'product': SentryAttribute.string(product.name),
 });
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR
Update Dart log API documentation examples to use `SentryAttribute` instead of
`SentryLogAttribute` in both usage and best-practices snippets.

This aligns the docs with the current Dart/Flutter log attribute API naming and
avoids confusion when copying examples into real projects.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

Made with [Cursor](https://cursor.com)