### PR TITLE
docs(snapshots): Add sentry-cli reference page for snapshots

### DIFF
--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -96,6 +96,5 @@ sentry-cli build snapshots [OPTIONS] --app-id <APP_ID> <PATH>
 | `--pr-number <NUMBER>`          | Pull request number. Auto-detected in GitHub Actions `pull_request` workflows.                                                                                                 |
 | `--no-git-metadata`             | Skip automatic git metadata detection.                                                                                                                                         |
 | `--force-git-metadata`          | Force git metadata collection outside CI.                                                                                                                                      |
-| `--header <KEY:VALUE>`          | Custom header attached to all requests.                                                                                                                                        |
 | `--log-level <LEVEL>`           | Logging verbosity: `trace`, `debug`, `info`, `warn`, or `error`.                                                                                                               |
 | `--quiet`                       | Suppress output while preserving exit codes. Alias: `--silent`.                                                                                                                |

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -16,7 +16,7 @@ The `sentry-cli build snapshots` command uploads a directory of images to [Snaps
 
 ## Requirements
 
-- `sentry-cli` version 3.3.5 or later. See [Installation](/cli/installation/).
+- `sentry-cli` version 3.4.0 or later. See [Installation](/cli/installation/).
 - A Sentry auth token with `project:write` scope (personal) or `org:ci` scope (org-level). See [Configuration](/cli/configuration/#to-authenticate-manually).
 - A directory of `.png` or `.jpeg` images, optionally with `.json` sidecar metadata. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/) for the directory layout.
 

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -1,0 +1,101 @@
+---
+title: Snapshots (CLI)
+sidebar_order: 6
+description: "Upload snapshot images to Sentry with sentry-cli for visual diffing and GitHub status checks."
+beta: true
+---
+
+<Include name="feature-available-for-user-group-early-adopter" />
+
+The `sentry-cli build snapshots` command uploads a directory of images to [Snapshots](/product/snapshots/) for visual diffing against a base build.
+
+<Alert level="warning">
+  `sentry-cli build snapshots` is experimental. The command is subject to
+  breaking changes, including removal, in any Sentry CLI release.
+</Alert>
+
+## Requirements
+
+- `sentry-cli` version 3.3.5 or later. See [Installation](/cli/installation/).
+- A Sentry auth token with `project:write` scope (personal) or `org:ci` scope (org-level). See [Configuration](/cli/configuration/#to-authenticate-manually).
+- A directory of `.png` or `.jpeg` images, optionally with `.json` sidecar metadata. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/) for the directory layout.
+
+## Basic Usage
+
+With `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` configured:
+
+```bash
+sentry-cli build snapshots ./snapshots --app-id web-frontend
+```
+
+`--app-id` identifies your app or bundle (for example, `web-frontend`, `ios-app`). Keep it consistent across uploads — Sentry uses it to match head and base snapshots.
+
+The `<PATH>` argument is the directory containing images. Images may be nested in subdirectories; subdirectory paths become part of each snapshot's filename in the Sentry UI.
+
+## Git Metadata
+
+When run in a supported CI environment, `sentry-cli` automatically detects:
+
+- `--head-sha` — the current commit SHA.
+- `--base-sha` — the merge-base against the remote tracking branch (PR builds only).
+- `--vcs-provider` — inferred from the git remote (for example, `github`).
+- `--head-repo-name` / `--base-repo-name` — inferred from the git remote.
+- `--head-ref` / `--base-ref` — current and base branch names.
+- `--pr-number` — detected from GitHub Actions environment variables on `pull_request` workflows.
+
+Pass any of these flags explicitly to override auto-detection, or use:
+
+- `--no-git-metadata` to skip detection entirely (for example, when uploading snapshots not tied to a commit).
+- `--force-git-metadata` to require detection outside CI (for example, when testing CI behavior locally).
+
+For PRs from forks, set `--base-repo-name` to the upstream repository so Sentry can locate the base build.
+
+## Selective Uploads
+
+If you shard snapshot generation across parallel CI jobs and upload each shard separately, pass `--selective` on every upload:
+
+```bash
+sentry-cli build snapshots ./shard-1 --app-id web-frontend --selective
+sentry-cli build snapshots ./shard-2 --app-id web-frontend --selective
+```
+
+Sentry merges selective uploads that share the same commit SHA and `app-id`. Removals and renames cannot be detected on PRs when using `--selective`, because Sentry cannot distinguish an intentionally deleted snapshot from one that simply wasn't part of this shard.
+
+## Diff Threshold
+
+Use `--diff-threshold` to ignore sub-pixel or anti-aliasing noise. The value is a float between `0.0` and `1.0` representing the fraction of pixels that must change before Sentry reports an image as changed:
+
+```bash
+sentry-cli build snapshots ./snapshots --app-id web-frontend --diff-threshold 0.01
+```
+
+With `0.01`, images with less than 1% of pixels changed are reported as unchanged.
+
+## Flag Reference
+
+```bash
+sentry-cli build snapshots [OPTIONS] --app-id <APP_ID> <PATH>
+```
+
+| Flag                            | Description                                                                                                                                                                    |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<PATH>`                        | Directory containing `.png` or `.jpeg` images (and optional `.json` sidecars).                                                                                                 |
+| `--app-id <APP_ID>`             | Identifier for the app or bundle (for example, `web-frontend`, `ios-app`). Must be consistent across uploads — Sentry uses it to match head and base snapshots. Max 255 chars. |
+| `--auth-token <TOKEN>`          | Sentry auth token. Can also be set via `SENTRY_AUTH_TOKEN`.                                                                                                                    |
+| `-o`, `--org <ORG>`             | Sentry organization slug. Can also be set via `SENTRY_ORG`.                                                                                                                    |
+| `-p`, `--project <PROJECT>`     | Sentry project slug. Can also be set via `SENTRY_PROJECT`.                                                                                                                     |
+| `--selective`                   | Mark the upload as a subset. Use when sharding snapshot generation across parallel jobs.                                                                                       |
+| `--diff-threshold <THRESHOLD>`  | Float between `0.0` and `1.0`. Sentry only reports images as changed if the percentage of changed pixels exceeds this value.                                                   |
+| `--head-sha <SHA>`              | Commit SHA for the upload. Auto-detected in CI.                                                                                                                                |
+| `--base-sha <SHA>`              | Base commit SHA for comparison (PR only). Auto-detected from merge-base.                                                                                                       |
+| `--vcs-provider <PROVIDER>`     | VCS provider (for example, `github`). Auto-detected from the git remote.                                                                                                       |
+| `--head-repo-name <OWNER/REPO>` | Repository in `owner/repo` format. Auto-detected from the git remote.                                                                                                          |
+| `--base-repo-name <OWNER/REPO>` | Base repository in `owner/repo` format (required for PRs from forks).                                                                                                          |
+| `--head-ref <BRANCH>`           | Head branch name. Auto-detected in CI.                                                                                                                                         |
+| `--base-ref <BRANCH>`           | Base branch name (PR only). Auto-detected from the remote tracking branch.                                                                                                     |
+| `--pr-number <NUMBER>`          | Pull request number. Auto-detected in GitHub Actions `pull_request` workflows.                                                                                                 |
+| `--no-git-metadata`             | Skip automatic git metadata detection.                                                                                                                                         |
+| `--force-git-metadata`          | Force git metadata collection outside CI.                                                                                                                                      |
+| `--header <KEY:VALUE>`          | Custom header attached to all requests.                                                                                                                                        |
+| `--log-level <LEVEL>`           | Logging verbosity: `trace`, `debug`, `info`, `warn`, or `error`.                                                                                                               |
+| `--quiet`                       | Suppress output while preserving exit codes. Alias: `--silent`.                                                                                                                |

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -69,7 +69,7 @@ Use `--diff-threshold` to ignore sub-pixel or anti-aliasing noise. The value is 
 sentry-cli build snapshots ./snapshots --app-id web-frontend --diff-threshold 0.01
 ```
 
-With `0.01`, images with less than 1% of pixels changed are reported as unchanged.
+With a value of `0.01`, images with less than 1% of pixels changed are reported as unchanged.
 
 ## Flag Reference
 

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -147,7 +147,14 @@ afterEvaluate {
 }
 ```
 
-Alternatively, you can use `sentry-cli` directly to upload images. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/) for the general upload structure.
+Alternatively, you can skip the Gradle plugin entirely and upload with [`sentry-cli build snapshots`](/cli/snapshots/):
+
+```bash
+sentry-cli build snapshots ./build/paparazzi/snapshots \
+  --app-id android-app
+```
+
+Use this path if your build pipeline doesn't use Gradle, or if you want to run the upload outside of a Gradle task. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/) for the expected directory layout.
 
 ## Step 3: Test Locally
 

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -88,10 +88,7 @@ sentry {
 ```
 
 <Alert level="warning">
-  If `theme` references a style the renderer can't resolve (typo, wrong prefix,
-  or a theme not on the classpath), neither Sentry nor Paparazzi raises an error
-  or warning. Snapshots still generate, but with incorrect visuals. Double-check
-  the theme string if rendered output looks unexpected.
+  If `theme` references a style the renderer can't resolve (typo, wrong prefix, or a theme not on the classpath), neither Sentry nor Paparazzi raises an error or warning. Snapshots still generate, but with incorrect visuals. Double-check the theme string if rendered output looks unexpected.
 </Alert>
 
 Continue to [Step 3](#step-3-test-locally).

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -163,4 +163,4 @@ Verify your setup by running:
 
 ## Step 4: Integrate Into CI
 
-Once the local upload succeeds, wire the same command into your CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for an example GitHub Actions workflow.
+Once the local upload succeeds, wire the same command into your CI. See [Integrating Into CI](/product/snapshots/integrating-into-ci/) for an example GitHub Actions workflow.

--- a/docs/platforms/apple/common/snapshots/index.mdx
+++ b/docs/platforms/apple/common/snapshots/index.mdx
@@ -93,7 +93,7 @@ Replace the path with the directory your library writes to (for swift-snapshot-t
 
 ## Step 3: Integrate Into CI
 
-Once the local upload succeeds, wire the same commands into your CI. See [Uploading Snapshots](/product/snapshots/uploading-snapshots/#upload-with-ci) for the general GitHub Actions structure.
+Once the local upload succeeds, wire the same commands into your CI. See [Integrating Into CI](/product/snapshots/integrating-into-ci/) for the general GitHub Actions structure.
 
 For end-to-end examples, see the workflows in our [Hacker News sample app](https://github.com/EmergeTools/hackernews):
 

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -21,7 +21,7 @@ sentry-cli build snapshots <output-dir> \
   --project <project-slug> \
 ```
 
-For an end-to-end CI setup, see [Integrating Into CI](/product/snapshots/integrating-into-ci/). The full flag reference is [below](#sentry-cli-build-snapshots-reference).
+For the full command reference, including auto-detected git metadata and sharding behavior, see [Snapshots (CLI)](/cli/snapshots/). For an end-to-end CI setup, see [Integrating Into CI](/product/snapshots/integrating-into-ci/).
 
 ### Upload Structure
 
@@ -65,29 +65,4 @@ Snapshots supports the following image formats:
 - PNG
 - JPEG
 
-## `sentry-cli build snapshots` Reference
-
-```bash
-sentry-cli build snapshots [OPTIONS] --app-id <APP_ID> <PATH>
-```
-
-| Flag                            | Description                                                                                                                                                                  |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<PATH>`                        | Directory containing `.png` images (and optional `.json`).                                                                                                                   |
-| `--app-id <APP_ID>`             | Identifier for the app or bundle (e.g., `web-frontend`, `ios-app`). Must be consistent across uploads — Sentry uses it to match head and base snapshots. Max 255 characters. |
-| `--auth-token <TOKEN>`          | Sentry auth token with `project:write` or `org:ci` scope. Can also be set via `SENTRY_AUTH_TOKEN`.                                                                           |
-| `-o`, `--org <ORG>`             | Sentry organization slug. Can also be set via `SENTRY_ORG`.                                                                                                                  |
-| `-p`, `--project <PROJECT>`     | Sentry project slug. Can also be set via `SENTRY_PROJECT`.                                                                                                                   |
-| `--head-sha <SHA>`              | 40-character commit SHA of the snapshot build. Auto-detected in CI.                                                                                                          |
-| `--base-sha <SHA>`              | Base branch commit SHA for comparison (PR only). Auto-detected in CI.                                                                                                        |
-| `--vcs-provider <PROVIDER>`     | VCS provider, e.g., `github`. Auto-detected from git remote.                                                                                                                 |
-| `--head-repo-name <OWNER/REPO>` | Repository in `owner/repo` format. Auto-detected from git remote.                                                                                                            |
-| `--base-repo-name <OWNER/REPO>` | Base repository in `owner/repo` format (PR only, for forks). Auto-detected in CI.                                                                                            |
-| `--head-ref <BRANCH>`           | Head branch name. Auto-detected in CI.                                                                                                                                       |
-| `--base-ref <BRANCH>`           | Base branch name (PR only). Auto-detected in CI.                                                                                                                             |
-| `--pr-number <NUMBER>`          | Pull request number (PR only). Auto-detected in GitHub Actions.                                                                                                              |
-| `--diff-threshold <THRESHOLD>`  | Value from `0.0` to `1.0`. Sentry reports an image as changed only when the share of changed pixels is greater than this value. `0.01` ignores changes of 1% or less.        |
-| `--no-git-metadata`             | Skip automatic git metadata detection.                                                                                                                                       |
-| `--force-git-metadata`          | Force git metadata collection even outside CI.                                                                                                                               |
-| `--log-level <LEVEL>`           | Logging verbosity: `debug`, `info`, `warn`, or `error`.                                                                                                                      |
-| `--url <URL>`                   | Sentry instance URL. Defaults to `https://sentry.io`.                                                                                                                        |
+For the full `sentry-cli build snapshots` flag reference, see [Snapshots (CLI)](/cli/snapshots/).


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add a dedicated `/cli/snapshots/` page for `sentry-cli build snapshots`, the command that underpins Snapshots uploads. Makes the command discoverable from the CLI left nav and documents behavior that wasn't previously covered.

- Adds `docs/cli/snapshots.mdx` — basic usage, git metadata auto-detection (head/base SHA, VCS provider, PR number), `--selective` sharding, `--diff-threshold`, and a full flag reference.
- Moves the `sentry-cli build snapshots` flag table out of `docs/product/snapshots/uploading-snapshots/index.mdx` — that page now links to the CLI reference.
- Expands the one-line `sentry-cli` mention in `docs/platforms/android/snapshots/index.mdx` into a short section with an example for Android users who don't use the Sentry Android Gradle Plugin.

Stacked on top of `mtopo27/snapshots-ea-product-docs`.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)