### PR TITLE
docs(snapshots): Bump SAGP to 6.5.0 and reword "snapshot tests"

### DIFF
--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -3,17 +3,17 @@ title: Set Up Snapshots
 sidebar_title: Snapshots
 sidebar_order: 5275
 sidebar_section: features
-description: Set up snapshot testing for Android apps with the Sentry Android Gradle Plugin.
+description: Set up snapshots for Android apps with the Sentry Android Gradle Plugin.
 beta: true
 ---
 
 <Include name="feature-available-for-user-group-early-adopter" />
 
-Set up [Snapshots](/product/snapshots/) for your Android app with the Sentry Android Gradle Plugin. Run snapshot tests locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub status checks.
+Set up [Snapshots](/product/snapshots/) for your Android app with the Sentry Android Gradle Plugin. Generate snapshots locally or in your own CI using your preferred snapshot library, then upload the generated images to Sentry for image diffing, visual review, and GitHub status checks.
 
 ## Step 1: Enable Snapshots
 
-Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.4.0 or higher is applied and configured.
+Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.5.0 or higher is applied and configured.
 
 Then enable snapshots in your `build.gradle`:
 
@@ -29,12 +29,12 @@ sentry {
 
 There are two paths for generating snapshot images on Android:
 
-- **From Compose Previews (recommended)** — if you don't have snapshot tests yet, Sentry auto-wires Paparazzi with ComposePreviewScanner so every `@Preview` composable becomes a snapshot. No test code required.
-- **From existing snapshot tests** — if you already use Paparazzi, Roborazzi, or another tool, point Sentry at your existing output instead.
+- **From Compose Previews (recommended)** — if you don't generate snapshots yet, Sentry auto-wires Paparazzi with ComposePreviewScanner so every `@Preview` composable becomes a snapshot. No test code required.
+- **From an existing snapshot tool** — if you already use Paparazzi, Roborazzi, or another tool, point Sentry at your existing output instead.
 
 ### From Compose Previews (Recommended)
 
-Use this path if you don't have a snapshot test suite yet. Paparazzi and ComposePreviewScanner turn every `@Preview` composable in your project into a snapshot automatically.
+Use this path if you don't generate snapshots yet. Paparazzi and ComposePreviewScanner turn every `@Preview` composable in your project into a snapshot automatically.
 
 First, choose a Paparazzi version compatible with your project:
 
@@ -88,9 +88,9 @@ If `theme` references a style the renderer can't resolve (typo, wrong prefix, or
 
 Continue to [Step 3](#step-3-test-locally).
 
-### From Existing Snapshot Tests
+### From an Existing Snapshot Tool
 
-Use this path if you already have a snapshot test suite. The configuration depends on which tool you use.
+Use this path if you already generate snapshots with another tool. The configuration depends on which tool you use.
 
 #### Paparazzi
 

--- a/docs/product/snapshots/index.mdx
+++ b/docs/product/snapshots/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Snapshots
 sidebar_order: 138
-description: Snapshot testing to catch visual changes on every pull request.
+description: Catch visual changes on every pull request with snapshots.
 beta: true
 ---
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Small follow-ups on top of `mtopo27/snapshots-ea-product-docs`:

- Bump the Sentry Android Gradle Plugin minimum version from 6.4.0 to 6.5.0 in the Android snapshots setup guide.
- Reword "snapshot tests" / "snapshot testing" to emphasize snapshot generation, since Sentry generates snapshots rather than runs tests.

Note: references to the **Snapshot Testing** GitHub Check were left as-is — those appear to name a literal status check produced by Sentry. Let me know if you'd like those renamed too.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)