### PR TITLE
docs(size-analysis): Document Mobile Builds Monitors

### DIFF
--- a/docs/product/size-analysis/index.mdx
+++ b/docs/product/size-analysis/index.mdx
@@ -82,6 +82,15 @@ Integrate into CI Size Analysis results on pull requests. You can track size on 
 
 Learn how to set it up in the [CI integration guide](/product/size-analysis/integrating-into-ci/).
 
+### Monitoring and Alerting
+
+To get a Slack alert (or other notifications) when a build crosses a size threshold, use [Mobile Builds Monitors](/product/monitors-and-alerts/monitors/#mobile-builds-monitor-settings). Monitors complement [Status Checks](#status-checks) by alerting on cadenced uploads, not just PRs.
+
+Common workflows:
+
+- **Nightly builds** — alert when last night's build grew more than 2% vs. the prior night
+- **Weekly release branch** — alert when the release candidate exceeds an absolute size limit (e.g. 200 MB Download Size)
+
 ## Finding Uploaded Builds
 
 You can find uploaded builds through the Releases page. Builds will show up in two places:


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a new **Monitoring and Alerting** subsection to the Size Analysis product page so users can discover [Mobile Builds Monitors](/product/monitors-and-alerts/monitors/#mobile-builds-monitor-settings) from the size analysis workflow.

The new section frames monitors as the way to wire up Slack (or other) alerts on cadenced uploads — nightlies, weekly release branches — and lightly contrasts them against PR-time Status Checks.

- Add `### Monitoring and Alerting` under `## Features`, immediately after `### Status Checks`
- Deep-link to the Mobile Builds Monitor settings anchor in the Monitors overview
- Two example workflows (nightly builds, weekly release branch)

Refs [EME-1077](https://linear.app/getsentry/issue/EME-1077/document-mobile-builds-monitors-in-size-analysis-docs)

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)