### PR TITLE
feat(aws-serverless): Add Lambda extension and container images docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -89,7 +89,7 @@ Sets the URL that will be used to transport captured events. This can be used to
 
 <SdkOption name="useLayerExtension" type='boolean' defaultValue='true' envVar='SENTRY_LAYER_EXTENSION'>
 
-Controls whether the SDK proxies envelopes through the [Sentry Lambda extension](/platforms/javascript/guides/aws-lambda/install/layer/#lambda-extension) at `http://localhost:9000/envelope`. The extension keeps running across Lambda's freeze/thaw boundary, so events queued just before a freeze still get delivered.
+Controls whether the SDK proxies envelopes through the Sentry Lambda extension at `http://localhost:9000/envelope`. The extension keeps running across Lambda's freeze/thaw boundary, so events queued just before a freeze still get delivered.
 
 Defaults to `true` when the SDK detects it's running inside the [Sentry Lambda Layer](/platforms/javascript/guides/aws-lambda/install/layer/). Has no effect outside the layer — set [`tunnel`](#tunnel) explicitly instead, for example, when [installing the extension into a container image](/platforms/javascript/guides/aws-lambda/install/container-image/).
 

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -93,7 +93,7 @@ Controls whether the SDK proxies envelopes through the [Sentry Lambda extension]
 
 Defaults to `true` when the SDK detects it's running inside the [Sentry Lambda Layer](/platforms/javascript/guides/aws-lambda/install/layer/). Has no effect outside the layer — set [`tunnel`](#tunnel) explicitly instead, for example, when [installing the extension into a container image](/platforms/javascript/guides/aws-lambda/install/container-image/).
 
-Set to `false` to opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost`.
+Set to `false` to opt out, for example, when using a custom `tunnel` or when running behind an HTTP proxy that intercepts `localhost`.
 
 </SdkOption>
 

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -91,7 +91,7 @@ Sets the URL that will be used to transport captured events. This can be used to
 
 Controls whether the SDK proxies envelopes through the [Sentry Lambda extension](/platforms/javascript/guides/aws-lambda/install/layer/#lambda-extension) at `http://localhost:9000/envelope`. The extension keeps running across Lambda's freeze/thaw boundary, so events queued just before a freeze still get delivered.
 
-Defaults to `true` when the SDK detects it's running inside the [Sentry Lambda Layer](/platforms/javascript/guides/aws-lambda/install/layer/). Has no effect outside the layer — set [`tunnel`](#tunnel) explicitly instead, for example when [installing the extension into a container image](/platforms/javascript/guides/aws-lambda/install/container-image/).
+Defaults to `true` when the SDK detects it's running inside the [Sentry Lambda Layer](/platforms/javascript/guides/aws-lambda/install/layer/). Has no effect outside the layer — set [`tunnel`](#tunnel) explicitly instead, for example, when [installing the extension into a container image](/platforms/javascript/guides/aws-lambda/install/container-image/).
 
 Set to `false` to opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost`.
 

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -16,8 +16,9 @@ sidebar_order: 1
     **Note:** Electron `main` process only.
   </PlatformSection>
 
-  The DSN tells the SDK where to send the events. If this is not set, the SDK will not send any events.
-  Learn more about [DSN utilization](/product/sentry-basics/dsn-explainer/#dsn-utilization).
+The DSN tells the SDK where to send the events. If this is not set, the SDK will not send any events.
+Learn more about [DSN utilization](/product/sentry-basics/dsn-explainer/#dsn-utilization).
+
 <PlatformContent includePath="configuration/dsn" />
 
 </SdkOption>
@@ -83,6 +84,20 @@ Environments are case-sensitive. The environment name can't contain newlines, sp
 Sets the URL that will be used to transport captured events. This can be used to work around ad-blockers or to have more granular control over events sent to Sentry. Adding your DSN is still required when using this option so necessary attributes can be set on the generated Sentry data. This option **requires the implementation** of a custom server endpoint. Learn more and find examples in [Dealing with Ad-Blockers](/platforms/javascript/troubleshooting/#dealing-with-ad-blockers).
 
 </SdkOption>
+
+<PlatformSection supported={['javascript.aws-lambda']}>
+
+<SdkOption name="useLayerExtension" type='boolean' defaultValue='true' envVar='SENTRY_LAYER_EXTENSION'>
+
+Controls whether the SDK proxies envelopes through the [Sentry Lambda extension](/platforms/javascript/guides/aws-lambda/install/layer/#lambda-extension) at `http://localhost:9000/envelope`. The extension keeps running across Lambda's freeze/thaw boundary, so events queued just before a freeze still get delivered.
+
+Defaults to `true` when the SDK detects it's running inside the [Sentry Lambda Layer](/platforms/javascript/guides/aws-lambda/install/layer/). Has no effect outside the layer — set [`tunnel`](#tunnel) explicitly instead, for example when [installing the extension into a container image](/platforms/javascript/guides/aws-lambda/install/container-image/).
+
+Set to `false` to opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost`.
+
+</SdkOption>
+
+</PlatformSection>
 
 <SdkOption name="sendDefaultPii" type='boolean' defaultValue='false'>
 
@@ -227,7 +242,9 @@ The callback gets a second argument (called a "hint") which contains the origina
 <SdkOption name="transport" type="(transportOptions: TransportOptions) => Transport">
 
 <PlatformSection notSupported={["javascript.electron"]}>
-  The JavaScript SDK uses a transport to send events to Sentry. On modern browsers, most transports use the browsers' fetch API to send events. Transports will drop an event if it fails to send due to a lack of connection.
+  The JavaScript SDK uses a transport to send events to Sentry. On modern
+  browsers, most transports use the browsers' fetch API to send events.
+  Transports will drop an event if it fails to send due to a lack of connection.
 </PlatformSection>
 
 <PlatformCategorySection supported={["browser"]}>
@@ -239,7 +256,9 @@ The callback gets a second argument (called a "hint") which contains the origina
 </PlatformCategorySection>
 
 <PlatformSection supported={["javascript.electron"]}>
-  In the Electron `main` process, the default transport handles queuing events when the users device is offline. In Electron `renderer` processes, the default transport forwards events to the main process.
+  In the Electron `main` process, the default transport handles queuing events
+  when the users device is offline. In Electron `renderer` processes, the
+  default transport forwards events to the main process.
 </PlatformSection>
 
 </SdkOption>
@@ -362,7 +381,9 @@ If the callback is not set, or it returns `undefined`, the default naming scheme
 Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 <PlatformSection supported={["javascript.electron"]}>
-  In the Electron `main` process `sampleRate` applies to events captured all processes. In Electron `renderer` processes, the `sampleRate` only applies to that process.
+  In the Electron `main` process `sampleRate` applies to events captured all
+  processes. In Electron `renderer` processes, the `sampleRate` only applies to
+  that process.
 </PlatformSection>
 
 </SdkOption>
@@ -374,7 +395,9 @@ This function is called with an SDK-specific message or error event object, and 
 By the time `beforeSend` is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
 <PlatformSection supported={["javascript.electron"]}>
-  In the Electron `main` process `beforeSend` is called for events captured in all processes. In Electron `renderer` processes, `beforeSend` only applies to that process.
+  In the Electron `main` process `beforeSend` is called for events captured in
+  all processes. In Electron `renderer` processes, `beforeSend` only applies to
+  that process.
 </PlatformSection>
 
 </SdkOption>
@@ -396,7 +419,9 @@ Available options:
 <Include name="platforms/configuration/options/ignore-errors.mdx" />
 
 <PlatformSection supported={["javascript.electron"]}>
-  In the Electron `main` process `ignoreErrors` applies to events captured in all processes. In Electron `renderer` processes, `ignoreErrors` applies only to that process.
+  In the Electron `main` process `ignoreErrors` applies to events captured in
+  all processes. In Electron `renderer` processes, `ignoreErrors` applies only
+  to that process.
 </PlatformSection>
 
 </SdkOption>
@@ -436,7 +461,8 @@ For example, the Sentry Nuxt SDK does not attach an error handler as it's captur
 ## Tracing Options
 
 <PlatformSection supported={["javascript.electron"]}>
-  **Note:** For Electron, tracing options apply to the process where these options are set.
+  **Note:** For Electron, tracing options apply to the process where these
+  options are set.
 </PlatformSection>
 
 <SdkOption name="tracesSampleRate" type='number' envVar='SENTRY_TRACES_SAMPLE_RATE'>
@@ -575,7 +601,8 @@ See <PlatformLink to="/tracing/distributed-tracing/dealing-with-cors-issues/">De
 ## Logs Options
 
 <PlatformSection supported={["javascript.electron"]}>
-  **Note:** For Electron, log options apply to the process where these options are set.
+  **Note:** For Electron, log options apply to the process where these options
+  are set.
 </PlatformSection>
 
 <SdkOption name="enableLogs" type='boolean' defaultValue='false'>

--- a/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
@@ -2,7 +2,7 @@
 title: Container Image
 description: >-
   Learn how to install the Sentry Lambda extension to use Sentry in your
-  container image-based Lambda functions
+  container image-based Lambda functions.
 sidebar_order: 3
 ---
 

--- a/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
@@ -70,4 +70,4 @@ Sentry.init({
 
 When Lambda starts your container, it launches every executable in `/opt/extensions/` alongside the runtime. The Sentry extension registers for `INVOKE` and `SHUTDOWN` events and starts a local HTTP server on port 9000.
 
-Each envelope your SDK sends to `http://localhost:9000/envelope` is forwarded to the Sentry ingestion endpoint derived from the envelope's DSN header. Because the extension is a separate process from your function, Lambda keeps it alive across the freeze/thaw boundary — events queued just before a freeze still get delivered.
+Each envelope your SDK sends to `http://localhost:9000/envelope` is forwarded to the Sentry ingestion endpoint derived from the envelope's DSN header. Because the extension is a separate process from your function, Lambda keeps it alive across the freeze/thaw boundary, so that events queued just before a freeze still get delivered.

--- a/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
@@ -1,0 +1,73 @@
+---
+title: Container Image
+description: >-
+  Learn how to install the Sentry Lambda extension to use Sentry in your
+  container image-based Lambda functions
+sidebar_order: 3
+---
+
+When you deploy a Lambda function as a container image (for example, with the [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter) for SvelteKit, Next.js, or Remix), you can't attach a Lambda layer. That means you also lose the Sentry Lambda extension that ships with our [Lambda Layer](/platforms/javascript/guides/aws-lambda/install/layer/).
+
+Without the extension, events queued at the moment Lambda freezes the runtime can be lost. The extension runs as a sidecar process that receives events on a local port and forwards them to Sentry, so envelopes leave the function before the freeze.
+
+This guide shows how to install the extension into your Docker image and point any Sentry SDK at it.
+
+## 1. Prerequisites
+
+- Your Lambda function is deployed as a [container image](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html).
+- You have a Sentry SDK in your application (`@sentry/aws-serverless`, `@sentry/sveltekit`, `@sentry/nextjs`, etc.).
+
+## 2. Install `@sentry/aws-serverless`
+
+The extension binaries ship inside the `@sentry/aws-serverless` npm package. Install it as a dependency even if your application uses a different Sentry SDK — only the extension files from this package are copied into the image.
+
+```bash {tabTitle:npm}
+npm install @sentry/aws-serverless
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/aws-serverless
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/aws-serverless
+```
+
+## 3. Copy the Extension into Your Docker Image
+
+AWS Lambda discovers extensions by scanning `/opt/extensions/` for executable files. Copy the wrapper script there and the runtime entrypoint to `/opt/sentry-extension/`:
+
+```dockerfile {filename:Dockerfile}
+FROM public.ecr.aws/lambda/nodejs:22
+
+# Copy the Sentry Lambda extension
+RUN mkdir -p /opt/sentry-extension
+COPY node_modules/@sentry/aws-serverless/build/lambda-extension/sentry-extension /opt/extensions/sentry-extension
+COPY node_modules/@sentry/aws-serverless/build/lambda-extension/index.mjs /opt/sentry-extension/index.mjs
+RUN chmod +x /opt/extensions/sentry-extension /opt/sentry-extension/index.mjs
+
+# ... rest of your Dockerfile
+```
+
+The wrapper at `/opt/extensions/sentry-extension` must be executable — Lambda will skip it otherwise.
+
+## 4. Tunnel Sentry Events Through the Extension
+
+Point your SDK at the extension by setting the `tunnel` option to `http://localhost:9000/envelope`. This URL is fixed — the extension always listens on port 9000.
+
+The same setting works with any Sentry SDK in your image:
+
+```javascript {filename:instrument.js}
+import * as Sentry from "@sentry/sveltekit";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tunnel: "http://localhost:9000/envelope",
+});
+```
+
+## How It Works
+
+When Lambda starts your container, it launches every executable in `/opt/extensions/` alongside the runtime. The Sentry extension registers for `INVOKE` and `SHUTDOWN` events and starts a local HTTP server on port 9000.
+
+Each envelope your SDK sends to `http://localhost:9000/envelope` is forwarded to the Sentry ingestion endpoint derived from the envelope's DSN header. Because the extension is a separate process from your function, Lambda keeps it alive across the freeze/thaw boundary — events queued just before a freeze still get delivered.

--- a/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/container-image.mdx
@@ -49,7 +49,7 @@ RUN chmod +x /opt/extensions/sentry-extension /opt/sentry-extension/index.mjs
 # ... rest of your Dockerfile
 ```
 
-The wrapper at `/opt/extensions/sentry-extension` must be executable — Lambda will skip it otherwise.
+Make sure the wrapper at `/opt/extensions/sentry-extension` is executable, or Lambda will skip it.
 
 ## 4. Tunnel Sentry Events Through the Extension
 

--- a/docs/platforms/javascript/guides/aws-lambda/install/index.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/index.mdx
@@ -14,3 +14,7 @@ There are two reasons why you still might want to use the NPM package instead:
 
 1. You want to minimize lambda function size and tree-shake parts of the SDK code that you don't need. A related reason might be because you're transpiling your code and want to transpile your dependencies as well.
 2. You already use NPM packages and deploy `node_modules` with your function and you don't want to add a (or another) Lambda layer to your functions.
+
+### What if I'm deploying a container image?
+
+Container image-based Lambda functions can't attach a layer. Follow the [Container Image guide](/platforms/javascript/guides/aws-lambda/install/container-image/) to install the Sentry Lambda extension into your Docker image so events queued during a Lambda freeze are still delivered.

--- a/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
@@ -123,19 +123,6 @@ The Sentry Lambda Layer also bundles a Sentry Lambda extension that runs as a si
 
 When the SDK detects it's running inside the Sentry Lambda Layer, it automatically routes events through the extension at `http://localhost:9000/envelope`. There's nothing to configure.
 
-To opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost` — set `useLayerExtension: false`:
-
-```javascript {filename:instrument.js}
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  useLayerExtension: false,
-});
-```
-
-Or via environment variable:
-
-```bash
-SENTRY_LAYER_EXTENSION="false"
-```
+To opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost` — set [`useLayerExtension: false`](/platforms/javascript/guides/aws-lambda/configuration/options/#useLayerExtension) or `SENTRY_LAYER_EXTENSION="false"`.
 
 If you're deploying a container image-based Lambda function and can't attach the layer, see the [Container Image guide](/platforms/javascript/guides/aws-lambda/install/container-image/) to install the extension into your Docker image instead.

--- a/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
@@ -33,6 +33,8 @@ Finally, set the region and copy the provided ARN value into the input.
 
 <br />
 
+The Sentry Lambda Layer also bundles a Sentry Lambda extension that automatically handles event delivery. To opt out, see [`useLayerExtension`](/platforms/javascript/guides/aws-lambda/configuration/options/#useLayerExtension) in the configuration options.
+
 ## 2. Setup Options
 
 ### Option A: Automatic Setup (recommended)
@@ -116,13 +118,3 @@ NODE_OPTIONS="--import ./instrument.js"
 ```
 
 That's it — make sure to re-deploy your function and you're all set!
-
-## Lambda Extension
-
-The Sentry Lambda Layer also bundles a Sentry Lambda extension that runs as a sidecar process and forwards envelopes to Sentry. Because the extension stays alive across Lambda's freeze/thaw boundary, events queued at the moment of a freeze are still delivered.
-
-When the SDK detects it's running inside the Sentry Lambda Layer, it automatically routes events through the extension at `http://localhost:9000/envelope`. There's nothing to configure.
-
-To opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost` — set [`useLayerExtension: false`](/platforms/javascript/guides/aws-lambda/configuration/options/#useLayerExtension) or `SENTRY_LAYER_EXTENSION="false"`.
-
-If you're deploying a container image-based Lambda function and can't attach the layer, see the [Container Image guide](/platforms/javascript/guides/aws-lambda/install/container-image/) to install the extension into your Docker image instead.

--- a/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
@@ -116,3 +116,26 @@ NODE_OPTIONS="--import ./instrument.js"
 ```
 
 That's it — make sure to re-deploy your function and you're all set!
+
+## Lambda Extension
+
+The Sentry Lambda Layer also bundles a Sentry Lambda extension that runs as a sidecar process and forwards envelopes to Sentry. Because the extension stays alive across Lambda's freeze/thaw boundary, events queued at the moment of a freeze are still delivered.
+
+When the SDK detects it's running inside the Sentry Lambda Layer, it automatically routes events through the extension at `http://localhost:9000/envelope`. There's nothing to configure.
+
+To opt out — for example, when using a custom `tunnel` or running behind an HTTP proxy that intercepts `localhost` — set `useLayerExtension: false`:
+
+```javascript {filename:instrument.js}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  useLayerExtension: false,
+});
+```
+
+Or via environment variable:
+
+```bash
+SENTRY_LAYER_EXTENSION="false"
+```
+
+If you're deploying a container image-based Lambda function and can't attach the layer, see the [Container Image guide](/platforms/javascript/guides/aws-lambda/install/container-image/) to install the extension into your Docker image instead.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds docs for the Sentry AWS Lambda extension, how to opt out of it and how to set it up when using AWS container images.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
