### PR TITLE
docs(dart): Remove beta marker from metrics docs

### DIFF
--- a/docs/platforms/dart/common/metrics/index.mdx
+++ b/docs/platforms/dart/common/metrics/index.mdx
@@ -3,16 +3,10 @@ title: Set Up Metrics
 sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges and measurements from your Sentry-configured apps to track application health and drill down into related traces, logs, and errors."
 sidebar_order: 5756
-beta: true
 sidebar_section: features
 ---
 
 With Sentry's [Application Metrics](/product/explore/metrics/), you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
-
-<Alert>
-  This feature is currently in open beta. Features in beta are still in progress
-  and may have bugs.
-</Alert>
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Remove the beta frontmatter flag from the Dart/Flutter metrics setup page.
- Remove the open beta alert now that Metrics is GA.

Made with [Cursor](https://cursor.com)