### PR TITLE
docs(apple): Promote Metrics to GA

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -949,13 +949,13 @@ SentrySDK.start { options in
 
 </SdkOption>
 
-<SdkOption name="experimental.enableMetrics" type="bool" defaultValue="true" availableSince="9.2.0" removedSince="9.12.0">
+<SdkOption name="experimental.enableMetrics" type="bool" defaultValue="true" availableSince="9.4.0" removedSince="9.12.0">
 
 **Removed in version 9.12.0** — Metrics has graduated to GA. Use the top-level <PlatformIdentifier name="enableMetrics" /> option instead. See [sentry-cocoa#7842](https://github.com/getsentry/sentry-cocoa/pull/7842).
 
 </SdkOption>
 
-<SdkOption name="experimental.beforeSendMetric" type="function" availableSince="9.2.0" removedSince="9.12.0">
+<SdkOption name="experimental.beforeSendMetric" type="function" availableSince="9.4.0" removedSince="9.12.0">
 
 **Removed in version 9.12.0** — Metrics has graduated to GA. Use the top-level <PlatformIdentifier name="beforeSendMetric" /> option instead. See [sentry-cocoa#7842](https://github.com/getsentry/sentry-cocoa/pull/7842).
 

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -908,11 +908,8 @@ This option is only used when <PlatformIdentifier name="enableSpotlight" /> is s
 </SdkOption>
 
 ## Metrics Options
-<Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry-cocoa/discussions) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
-</Alert>
 
-<SdkOption name="experimental.enableMetrics" type="bool" defaultValue="true" availableSince="9.2.0">
+<SdkOption name="enableMetrics" type="bool" defaultValue="true" availableSince="9.12.0">
 
 When enabled, the SDK can send metrics to Sentry. Note that metrics are not collected automatically — you must manually call the `SentrySDK.metrics` API to record counters, gauges, and distributions.
 
@@ -920,7 +917,7 @@ Learn more in the <PlatformLink to="/metrics/">Metrics documentation</PlatformLi
 
 </SdkOption>
 
-<SdkOption name="experimental.beforeSendMetric" type="function" availableSince="9.2.0">
+<SdkOption name="beforeSendMetric" type="function" availableSince="9.12.0">
 
 Use this callback to filter or modify metrics before they're sent to Sentry. Return `nil` to drop the metric.
 
@@ -932,7 +929,7 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     // Metrics are enabled by default, no need to set enableMetrics = true
-    options.experimental.beforeSendMetric = { metric in
+    options.beforeSendMetric = { metric in
         // Create a mutable copy (SentryMetric is a struct)
         var metric = metric
 
@@ -949,5 +946,17 @@ SentrySDK.start { options in
     }
 }
 ```
+
+</SdkOption>
+
+<SdkOption name="experimental.enableMetrics" type="bool" defaultValue="true" availableSince="9.2.0" removedSince="9.12.0">
+
+**Removed in version 9.12.0** — Metrics has graduated to GA. Use the top-level <PlatformIdentifier name="enableMetrics" /> option instead. See [sentry-cocoa#7842](https://github.com/getsentry/sentry-cocoa/pull/7842).
+
+</SdkOption>
+
+<SdkOption name="experimental.beforeSendMetric" type="function" availableSince="9.2.0" removedSince="9.12.0">
+
+**Removed in version 9.12.0** — Metrics has graduated to GA. Use the top-level <PlatformIdentifier name="beforeSendMetric" /> option instead. See [sentry-cocoa#7842](https://github.com/getsentry/sentry-cocoa/pull/7842).
 
 </SdkOption>

--- a/docs/platforms/apple/common/features/experimental-features.mdx
+++ b/docs/platforms/apple/common/features/experimental-features.mdx
@@ -71,22 +71,6 @@ Indicators for reliable environments include:
 
 Learn more in the <PlatformLink to="/session-replay/">Session Replay</PlatformLink> documentation.
 
-## Metrics
-
-Use <PlatformLink to="/metrics/">Metrics</PlatformLink> to send counters, gauges, and distributions from your application to Sentry. Once in Sentry, these metrics can be viewed alongside related errors, traces, and logs, and searched using their individual attributes.
-
-The metrics feature is enabled by default, but metrics are not collected automatically. You must manually call the `SentrySDK.metrics` API to record metrics (e.g., `SentrySDK.metrics.count(key: "my_counter", value: 1)`). To disable the feature entirely:
-
-```swift
-options.experimental.enableMetrics = false
-```
-
-```objc {tabTitle:Objective-C}
-options.experimental.enableMetrics = NO;
-```
-
-Learn more in the <PlatformLink to="/metrics/">Metrics documentation</PlatformLink>.
-
 ## Providing Feedback
 
 Let us know if you have feedback through [GitHub issues](https://github.com/getsentry/sentry-cocoa/issues). Your feedback helps us improve these experimental features and move them toward stable releases.

--- a/docs/platforms/apple/common/metrics/index.mdx
+++ b/docs/platforms/apple/common/metrics/index.mdx
@@ -4,17 +4,9 @@ sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges, and distributions from your Sentry-configured apps to track application health and drill down into related traces, logs, and errors."
 sidebar_order: 7
 sidebar_section: features
-beta: true
 ---
 
 With Sentry's Application Metrics, you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, traces, and logs, and searched using their individual attributes.
-
-<Alert>
-  This feature is currently in open beta. Please reach out on
-  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
-  feedback or questions. Features in beta are still in-progress and may have
-  bugs. We recognize the irony.
-</Alert>
 
 ## Requirements
 

--- a/platform-includes/metrics/options/apple.mdx
+++ b/platform-includes/metrics/options/apple.mdx
@@ -2,14 +2,14 @@ The Sentry Cocoa SDK provides several options to configure how metrics are captu
 
 ### Enabling/Disabling Metrics
 
-Metrics are enabled by default, but are not collected automatically. You must manually call the `SentrySDK.metrics` API to record metrics. If you need to disable metrics entirely, set `options.experimental.enableMetrics` to `false` when initializing the SDK:
+Metrics are enabled by default, but are not collected automatically. You must manually call the `SentrySDK.metrics` API to record metrics. If you need to disable metrics entirely, set `options.enableMetrics` to `false` when initializing the SDK:
 
 ```swift {tabTitle:Swift}
 import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.experimental.enableMetrics = false // Metrics are enabled by default
+    options.enableMetrics = false // Metrics are enabled by default
 }
 ```
 
@@ -18,7 +18,7 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.experimental.enableMetrics = NO; // Metrics are enabled by default
+    options.enableMetrics = NO; // Metrics are enabled by default
 }];
 ```
 
@@ -49,7 +49,7 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     // Metrics are enabled by default, no need to set enableMetrics = true
-    options.experimental.beforeSendMetric = { metric in
+    options.beforeSendMetric = { metric in
         // Create a mutable copy (SentryMetric is a struct)
         var metric = metric
 

--- a/platform-includes/metrics/requirements/apple.mdx
+++ b/platform-includes/metrics/requirements/apple.mdx
@@ -1,1 +1,1 @@
-Metrics are supported in Sentry Cocoa SDK version `9.12.0` and above.
+Metrics are supported in Sentry Cocoa SDK version `9.12.0` and above (previously experimental since `9.4.0`).

--- a/platform-includes/metrics/requirements/apple.mdx
+++ b/platform-includes/metrics/requirements/apple.mdx
@@ -1,1 +1,1 @@
-Metrics are supported in Sentry Cocoa SDK version `9.2.0` and above.
+Metrics are supported in Sentry Cocoa SDK version `9.12.0` and above.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Sentry Cocoa SDK has graduated Metrics from experimental to GA in 9.12.0. The `experimental.enableMetrics` and `experimental.beforeSendMetric` properties are removed; the new top-level `enableMetrics` and `beforeSendMetric` options replace them.

- Drop the `beta: true` flag and open-beta alert from the Apple Metrics page
- Update Swift/Objective-C samples and option docs to use the top-level `enableMetrics` and `beforeSendMetric`
- Document the removed `experimental.*` options with `removedSince="9.12.0"` and pointers to the new GA options
- Drop the Metrics section from the Apple experimental features page
- Bump the requirements include to 9.12.0

The Swift-only limitation on `SentrySDK.metrics` is unchanged (Objective-C support is tracked in getsentry/sentry-cocoa#6342).

Refs https://github.com/getsentry/sentry-cocoa/pull/7842

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): April 28th, 2026
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)