### PR TITLE
docs(native): update logs to be enabled by default

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -118,7 +118,7 @@ A function responsible for determining the percentage chance a given transaction
 
 ## Logs options
 
-<SdkOption name="enable_logs" type="bool" defaultValue="false">
+<SdkOption name="enable_logs" type="bool" defaultValue="true">
 
 This option enables the [logging integration](/platforms/native/logs), which allows the SDK to capture logs and send them to Sentry.
 

--- a/platform-includes/logs/setup/native.mdx
+++ b/platform-includes/logs/setup/native.mdx
@@ -1,8 +1,8 @@
-To enable logging, you need to initialize the SDK with the `enable_logs` option set to `true`.
+Logs are enabled by default. To disable logs, set the `enable_logs` option to `false` during SDK initialization:
 
 ```c
 sentry_options_t *options = sentry_options_new();
-sentry_options_set_enable_logs(options, 1);
+sentry_options_set_enable_logs(options, 0);
 // set other options
 sentry_init(options);
 ```

--- a/platform-includes/logs/usage/native.mdx
+++ b/platform-includes/logs/usage/native.mdx
@@ -1,5 +1,3 @@
-Once the feature is enabled on the SDK and the SDK is initialized, you can send logs using the `sentry_log_X()` APIs.
-
 The API exposes six methods that you can use to log messages at different log levels: `trace`, `debug`, `info`, `warn`, `error`, and `fatal`.
 
 ```c


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Similar to https://github.com/getsentry/sentry-docs/pull/17207, now for logs. Following develop docs [update to the Logs API](https://develop.sentry.dev/sdk/telemetry/logs/#public-api, we enabled them by default in `sentry-native` https://github.com/getsentry/sentry-native/pull/1673
 
## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
