### PR TITLE
docs(java, android): Promote Metrics to GA

### DIFF
--- a/docs/platforms/android/metrics/index.mdx
+++ b/docs/platforms/android/metrics/index.mdx
@@ -4,17 +4,9 @@ sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges and measurements from your Sentry-configured apps to track application health and drill down into related traces, logs, and errors."
 sidebar_order: 4500
 sidebar_section: features
-beta: true
 ---
 
 With Sentry's [Application Metrics](/product/explore/metrics/), you can send counters, gauges, distributions, and sets from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
-
-<Alert>
-  This feature is currently in open beta. Please reach out on
-  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
-  feedback or questions. Features in beta are still in-progress and may have
-  bugs. We recognize the irony.
-</Alert>
 
 ## Requirements
 

--- a/docs/platforms/java/common/metrics/index.mdx
+++ b/docs/platforms/java/common/metrics/index.mdx
@@ -4,14 +4,9 @@ sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges and measurements from your Sentry-configured apps to track application health and drill down into related traces, logs, and errors."
 sidebar_order: 4
 sidebar_section: features
-beta: true
 ---
 
 With Sentry's Application Metrics, you can send counters, gauges, distributions, and sets from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
-
-<Alert>
-This feature is currently in open beta. Please reach out on [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have feedback or questions. Features in beta are still in-progress and may have bugs. We recognize the irony.
-</Alert>
 
 ## Requirements
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Sentry Android and Java SDKs are graduating Metrics from open beta to GA. Mirrors #17494 (Apple).

- Drop the `beta: true` flag and open-beta alert from the Android Metrics page
- Drop the `beta: true` flag and open-beta alert from the Java Metrics page

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)