### PR TITLE
docs(go): Promote metrics to GA

### DIFF
--- a/docs/platforms/go/common/metrics/index.mdx
+++ b/docs/platforms/go/common/metrics/index.mdx
@@ -4,17 +4,9 @@ sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges and measurements from your Sentry-configured apps to track application health and drill down into related traces, logs, and errors."
 sidebar_order: 5700
 sidebar_section: features
-beta: true
 ---
 
 With [Sentry's Application Metrics](/product/explore/metrics/), you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
-
-<Alert>
-  This feature is currently in open beta. Please reach out on
-  [GitHub](https://github.com/getsentry/sentry/discussions/102275) if you have
-  feedback or questions. Features in beta are still in-progress and may have
-  bugs. We recognize the irony.
-</Alert>
 
 ## Prerequisites
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
- Remove the beta frontmatter flag from the Go metrics docs page.
- Remove the open beta alert from the Go metrics docs page.
- Align the Go SDK docs with Application Metrics GA so the page no longer shows outdated rollout messaging.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [x] Other deadline: April 28, 2026
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
