### PR TITLE
docs(tanstackstart-react): Document tunnel route adapter

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
@@ -3,7 +3,7 @@ title: createSentryTunnelRoute
 description: "Learn how to manually define a Sentry tunnel route in your TanStack Start app."
 ---
 
-<AvailableSince version="TBD" />
+<AvailableSince version="10.51.0" />
 
 <Alert level="info">
   If you can use the `sentryTanstackStart` Vite plugin, prefer its

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
@@ -19,7 +19,7 @@ The `createSentryTunnelRoute` helper returns a TanStack Start server-route confi
 
 Create a server route at the path you want to tunnel through, and pass the list of DSNs you want to allow:
 
-```ts {filename:src/routes/monitor.ts}
+```typescript {filename:src/routes/monitor.ts}
 import { createFileRoute } from "@tanstack/react-router";
 import * as Sentry from "@sentry/tanstackstart-react";
 
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/monitor")({
 
 Then, set the matching `tunnel` option in your client `Sentry.init()` so the browser SDK sends events to your route instead of directly to Sentry:
 
-```ts {filename:src/router.tsx} {5}
+```tsx {filename:src/router.tsx} {5}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // ...
@@ -48,7 +48,7 @@ A list of DSN strings that the route is allowed to forward to. The route validat
 
 If `allowedDsns` is omitted or empty, the route falls back to the DSN of the active server-side Sentry SDK at runtime. If neither is available, requests to the route return a 500 response.
 
-```ts {filename:src/routes/monitor.ts}
+```typescript {filename:src/routes/monitor.ts}
 Sentry.createSentryTunnelRoute({
   allowedDsns: [
     "https://public@o0.ingest.sentry.io/1",

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/monitor")({
 
 Then, set the matching `tunnel` option in your client `Sentry.init()` so the browser SDK sends events to your route instead of directly to Sentry:
 
-```tsx {filename:src/router.tsx} {5}
+```tsx {filename:src/router.tsx} {4}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   // ...

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute.mdx
@@ -1,0 +1,58 @@
+---
+title: createSentryTunnelRoute
+description: "Learn how to manually define a Sentry tunnel route in your TanStack Start app."
+---
+
+<AvailableSince version="TBD" />
+
+<Alert level="info">
+  If you can use the `sentryTanstackStart` Vite plugin, prefer its
+  [`tunnelRoute`](/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart/#tunnel-route)
+  option. It registers the route for you and automatically wires up the client
+  `tunnel` option. Use `createSentryTunnelRoute` only when you need full control over
+  the route file, the DSN allowlist, or can't use the Vite plugin.
+</Alert>
+
+The `createSentryTunnelRoute` helper returns a TanStack Start server-route configuration with a `POST` handler that forwards Sentry envelopes to Sentry's ingest servers. Use it inside a file route to expose a same-origin tunnel endpoint.
+
+## Usage
+
+Create a server route at the path you want to tunnel through, and pass the list of DSNs you want to allow:
+
+```ts {filename:src/routes/monitor.ts}
+import { createFileRoute } from "@tanstack/react-router";
+import * as Sentry from "@sentry/tanstackstart-react";
+
+export const Route = createFileRoute("/monitor")({
+  server: Sentry.createSentryTunnelRoute({
+    allowedDsns: ["___PUBLIC_DSN___"],
+  }),
+});
+```
+
+Then, set the matching `tunnel` option in your client `Sentry.init()` so the browser SDK sends events to your route instead of directly to Sentry:
+
+```ts {filename:src/router.tsx} {5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // ...
+  tunnel: "/monitor",
+});
+```
+
+## Options
+
+### `allowedDsns`
+
+A list of DSN strings that the route is allowed to forward to. The route validates each incoming envelope against this list and rejects any DSN that isn't allowed.
+
+If `allowedDsns` is omitted or empty, the route falls back to the DSN of the active server-side Sentry SDK at runtime. If neither is available, requests to the route return a 500 response.
+
+```ts {filename:src/routes/monitor.ts}
+Sentry.createSentryTunnelRoute({
+  allowedDsns: [
+    "https://public@o0.ingest.sentry.io/1",
+    "https://public@o0.ingest.sentry.io/2",
+  ],
+});
+```

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -64,7 +64,7 @@ sentryTanstackStart({
 
 ## Tunnel Route
 
-<AvailableSince version="TBD" />
+<AvailableSince version="10.51.0" />
 
 The `tunnelRoute` option registers a same-origin TanStack Start server route that forwards Sentry envelopes to Sentry's ingest servers. It also automatically sets the client `tunnel` option in `Sentry.init()` so browser events go through that route. This helps avoid ad blockers and corporate firewalls that block requests to `*.sentry.io`.
 

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -61,3 +61,61 @@ sentryTanstackStart({
   autoInstrumentMiddleware: false,
 }),
 ```
+
+## Tunnel Route
+
+<AvailableSince version="TBD" />
+
+The `tunnelRoute` option registers a same-origin TanStack Start server route that forwards Sentry envelopes to Sentry's ingest servers. It also automatically sets the client `tunnel` option in `Sentry.init()` so browser events go through that route. This helps avoid ad blockers and corporate firewalls that block requests to `*.sentry.io`.
+
+`tunnelRoute` accepts three shapes:
+
+### `tunnelRoute: true` (recommended)
+
+Generates an opaque, unguessable route path for each dev session and production build. Because the path changes between builds, ad blockers can't reliably target it.
+
+```typescript {filename:vite.config.ts}
+sentryTanstackStart({
+  tunnelRoute: true,
+}),
+```
+
+### Static path
+
+Pass a string to use a fixed route path. This is easier to reason about, but a known path is easier for ad blockers to add to a list.
+
+```typescript {filename:vite.config.ts}
+sentryTanstackStart({
+  tunnelRoute: "/monitor",
+}),
+```
+
+### Object form
+
+Use the object form to control the DSN allowlist or set a static path explicitly:
+
+```typescript {filename:vite.config.ts}
+sentryTanstackStart({
+  tunnelRoute: {
+    allowedDsns: ["___PUBLIC_DSN___"],
+    path: "/monitor",
+  },
+}),
+```
+
+- **`allowedDsns`** — only envelopes targeting one of these DSNs are forwarded. If omitted or empty, the route falls back to the DSN of the active server-side Sentry SDK at runtime.
+- **`path`** — the public route path. If omitted, an opaque path is generated (same behavior as `tunnelRoute: true`).
+
+<Alert
+  level="info"
+  title="Setting `tunnel` in `Sentry.init()` overrides this option"
+>
+  If you also pass `tunnel` to `Sentry.init()`, the runtime option wins and the
+  managed tunnel route is bypassed. The SDK logs a warning when this happens.
+</Alert>
+
+<Alert level="warning" title="Opaque paths are not stable">
+  When using `tunnelRoute: true` (or the object form without `path`), the
+  generated path changes for each dev session and each production build. Don't
+  hard-code it elsewhere in your app or infrastructure.
+</Alert>

--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -347,7 +347,28 @@ If you need more control over the upload process, see our [source maps guide](/p
 
 ## Step 5: Avoid Ad Blockers With Tunneling (Optional)
 
-<PlatformContent includePath="getting-started-tunneling" />
+Ad blockers and corporate firewalls often block requests to `*.sentry.io`, which can cause events to be dropped before they reach Sentry. To work around this, you can tunnel events through a same-origin route in your TanStack Start app.
+
+The `sentryTanstackStart` Vite plugin can register a tunnel route for you and automatically wire up the client `tunnel` option:
+
+```typescript {filename:vite.config.ts} {9}
+import { defineConfig } from "vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
+
+export default defineConfig({
+  plugins: [
+    tanstackStart(),
+    sentryTanstackStart({
+      tunnelRoute: true,
+    }),
+  ],
+});
+```
+
+With `tunnelRoute: true`, an opaque route path is generated for each dev session and production build, making it harder for ad blockers to target. See the [`sentryTanstackStart`](/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart/#tunnel-route) feature page for static paths and the full set of options.
+
+If you can't use the Vite plugin, or you need full control over the route file and DSN allowlist, use [`createSentryTunnelRoute`](/platforms/javascript/guides/tanstackstart-react/features/createSentryTunnelRoute/) to define the route yourself.
 
 ## Step 6: Verify
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new tunnel APIs shipped in [sentry-javascript#20264](https://github.com/getsentry/sentry-javascript/pull/20264) for `@sentry/tanstackstart-react@10.51.0`. The SDK now exposes two ways to tunnel browser events through a same-origin route to dodge ad blockers and corporate firewalls:

- **`sentryTanstackStart({ tunnelRoute })`** — Vite plugin option that auto-registers the route AND auto-sets the client `tunnel` option. Recommended path.
- **`createSentryTunnelRoute({ allowedDsns? })`** — manual server-route helper for users who need full control over the route file or DSN allowlist, or can't use the Vite plugin.

Changes:

- Replace the generic tunneling include in Step 5 of the TanStack Start setup guide with TanStack-specific copy that recommends `tunnelRoute: true` (opaque path regenerated each build) and links to both feature pages.
- Add a `Tunnel Route` section to the existing `sentryTanstackStart` feature page covering all three accepted shapes (`true`, static string, `{ allowedDsns, path }`), plus override behavior and the opaque-path caveat.
- Add a new dedicated `createSentryTunnelRoute` feature page (auto-discovered via `<PageGrid />`) with a `src/routes/monitor.ts` example, the matching client `tunnel` reminder, and `allowedDsns` fallback behavior.

Refs JS-2144

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] `<AvailableSince>` versions set to `10.51.0`
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)