### PR TITLE
docs(cli): Update bundle-jvm to reflect 3.4.x capabilities

### DIFF
--- a/docs/cli/dif.mdx
+++ b/docs/cli/dif.mdx
@@ -258,14 +258,24 @@ Before you can upload source files, you must configure the Sentry CLI with the o
 
 ### Creating a Source Bundle
 
-Run the `debug-files bundle-jvm` command to create a source bundle for a
-source directory.
+Run the `debug-files bundle-jvm` command to create a source bundle. The path argument can be a single source directory, a module, or a Gradle/Maven project root — `sentry-cli` collects only JVM source files (`.java`, `.kt`, `.scala`, `.groovy`, `.clj`) and automatically skips common build output and IDE directories (`build`, `.gradle`, `.idea`, etc.) as well as anything matched by `.gitignore`.
 
 ```bash
 sentry-cli debug-files bundle-jvm \
     --output some/dir \
     --debug-id A_VALID_UUID \
-    path/to/source/dir
+    path/to/project/root
+```
+
+Use `--exclude '<glob>'` (repeatable) to drop additional paths. This is useful when multiple source sets contribute the same fully-qualified class name — for example, an Android app where `src/main/` and `src/debug/` both define `com.example.Foo`. By default, `bundle-jvm` keeps the first occurrence and prints a warning for the rest; pass `--exclude` to scope the bundle to a single source set:
+
+```bash
+sentry-cli debug-files bundle-jvm \
+    --output some/dir \
+    --debug-id A_VALID_UUID \
+    --exclude '**/src/debug/**' \
+    --exclude '**/src/release/**' \
+    path/to/project/root
 ```
 
 You must provide the UUID of the source bundle for the Java/Android SDK to send.

--- a/platform-includes/source-context/java.mdx
+++ b/platform-includes/source-context/java.mdx
@@ -329,11 +329,17 @@ You can also use a `.sentryclirc` or a `.properties` file, which you can link us
 
 ### Creating the Source Bundle
 
-First, create the source bundle containing your source files:
+First, create the source bundle containing your source files. The path can be a project or module root — `sentry-cli` collects JVM source files (`.java`, `.kt`, `.scala`, `.groovy`, `.clj`) and skips build output directories and `.gitignore`d paths automatically.
 
 ```
-sentry-cli debug-files bundle-jvm --output path/to/store/bundle --debug-id A_VALID_UUID path/to/source-code
+sentry-cli debug-files bundle-jvm --output path/to/store/bundle --debug-id A_VALID_UUID path/to/project/root
 ```
+
+<PlatformSection supported={["android"]}>
+
+If multiple source sets in your project define the same fully-qualified class name (for example, when both `src/main/` and `src/debug/` contain `com.example.Foo`), `bundle-jvm` keeps the first occurrence and warns about the rest. Use `--exclude` to scope the bundle to a single source set — see [Debug Information Files](/cli/dif/#jvm-source-bundles) for details.
+
+</PlatformSection>
 
 ### Uploading the Source Bundle
 


### PR DESCRIPTION
## Summary

Updates the JVM source bundle docs to reflect the changes shipped in `sentry-cli` 3.4.0 ([#3260](https://github.com/getsentry/sentry-cli/pull/3260)) and 3.4.1 ([#3275](https://github.com/getsentry/sentry-cli/pull/3275)):

- The path passed to `bundle-jvm` can now be a project or module root. `sentry-cli` filters by JVM extensions (`.java`, `.kt`, `.scala`, `.groovy`, `.clj`), skips common build output / IDE directories, and respects `.gitignore`.
- Documents the `--exclude '<glob>'` flag, including the case where multiple source sets contribute the same fully-qualified class name (e.g. Android `src/main/` vs `src/debug/`) — `bundle-jvm` keeps the first occurrence and warns about the rest, and `--exclude` is the way to scope the bundle.
