### PR TITLE
docs(php): remove hint about excimer and frankenphp

### DIFF
--- a/docs/platforms/php/common/profiling/index.mdx
+++ b/docs/platforms/php/common/profiling/index.mdx
@@ -43,16 +43,6 @@ pecl install excimer
 
 See https://pecl.php.net/package/excimer for more information.
 
-### FrankenPHP and PHP ZTS
-
-If you're using FrankenPHP or another PHP ZTS build, Excimer `1.2.5` currently doesn't produce any profiling samples. Use Excimer `1.2.3` instead:
-
-```bash
-pecl install excimer-1.2.3
-```
-
-If you build from source, check out tag `1.2.3` before running `phpize`.
-
 ### Build from source
 
 ```bash

--- a/docs/platforms/php/guides/laravel/profiling/index.mdx
+++ b/docs/platforms/php/guides/laravel/profiling/index.mdx
@@ -43,16 +43,6 @@ pecl install excimer
 
 See https://pecl.php.net/package/excimer for more information.
 
-### FrankenPHP and PHP ZTS
-
-If you're using FrankenPHP or another PHP ZTS build, Excimer `1.2.5` currently doesn't produce any profiling samples. Use Excimer `1.2.3` instead:
-
-```bash
-pecl install excimer-1.2.3
-```
-
-If you build from source, check out tag `1.2.3` before running `phpize`.
-
 ### Build From Source
 
 ```bash

--- a/docs/platforms/php/guides/symfony/profiling/index.mdx
+++ b/docs/platforms/php/guides/symfony/profiling/index.mdx
@@ -43,16 +43,6 @@ pecl install excimer
 
 See https://pecl.php.net/package/excimer for more information.
 
-### FrankenPHP and PHP ZTS
-
-If you're using FrankenPHP or another PHP ZTS build, Excimer `1.2.5` currently doesn't produce any profiling samples. Use Excimer `1.2.3` instead:
-
-```bash
-pecl install excimer-1.2.3
-```
-
-If you build from source, check out tag `1.2.3` before running `phpize`.
-
 ### Build From Source
 
 ```bash

--- a/docs/platforms/php/index.mdx
+++ b/docs/platforms/php/index.mdx
@@ -46,12 +46,6 @@ To use Profiling, you'll also need to install the Excimer extension via PECL:
 pecl install excimer
 ```
 
-If you're using FrankenPHP or another PHP ZTS build, install `excimer-1.2.3` instead, because Excimer `1.2.5` currently doesn't produce any profiling samples:
-
-```bash
-pecl install excimer-1.2.3
-```
-
 The Excimer PHP extension supports PHP 7.2 and up. Excimer requires Linux or macOS and doesn't support Windows. For additional ways to install Excimer, [see docs](/platforms/php/profiling/#installation).
 
 </OnboardingOption>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Excimer released a new version that works again, so the hint is no longer relevant

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
