### PR TITLE
docs(unreal): Add `EnableLargeAttachments` option

### DIFF
--- a/docs/platforms/unreal/configuration/options.mdx
+++ b/docs/platforms/unreal/configuration/options.mdx
@@ -147,6 +147,20 @@ This option is turned off by default.
 
 </SdkOption>
 
+<SdkOption name="EnableLargeAttachments" type="bool" defaultValue="false">
+
+When enabled, attachments above an internal size threshold are uploaded out-of-band via a separate request before the event is sent, instead of being embedded in the envelope. This lets attachments exceed the inline envelope size limits. When disabled, oversized attachments are rejected by Sentry.
+
+Learn more in the <PlatformLink to="/enriching-events/attachments/#large-attachments">Attachments documentation</PlatformLink>.
+
+<Alert>
+
+Currently supported on Windows, Linux, Mac (with native backend) and consoles.
+
+</Alert>
+
+</SdkOption>
+
 <SdkOption name="AttachGpuDump" type="bool" defaultValue="true">
 
 When enabled, [Nsight Aftermath](https://developer.nvidia.com/nsight-aftermath) mini-dump file is automatically attached to GPU crash events captured.

--- a/docs/platforms/unreal/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unreal/enriching-events/attachments/index.mdx
@@ -6,12 +6,6 @@ description: >-
 og_image: /og-images/platforms-unreal-enriching-events-attachments.png
 ---
 
-<Alert>
-
-This feature is supported for iOS and Android only.
-
-</Alert>
-
 Sentry can enrich your events for further investigation by storing additional files, such as config or log files, as attachments.
 
 ## Creating Attachments

--- a/docs/platforms/unreal/enriching-events/attachments/index.mdx
+++ b/docs/platforms/unreal/enriching-events/attachments/index.mdx
@@ -94,7 +94,7 @@ The same result can be achieved by calling the corresponding function in bluepri
 
 <Alert>
 
-Sentry allows at most 40MB for a compressed request, and at most 200MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To add larger or more files, consider secondary storage options.
+Sentry allows at most 40MB for a compressed request, and at most 200MB of uncompressed attachments per event, including the crash report file (if applicable). Uploads exceeding this size are rejected with HTTP error `413 Payload Too Large` and the data is dropped immediately. To send files that exceed these limits, enable [Large Attachments](#large-attachments) on supported platforms.
 
 </Alert>
 
@@ -133,3 +133,13 @@ Alternately, attachments also appear in the _Attachments_ tab on the **Issue Det
 The scale is bytes and the default is `20 MiB`. Please also check the
 [maximum attachment size of Relay](/product/relay/options/)
 to make sure your attachments don't get discarded there.
+
+## Large Attachments
+
+By default, all attachments are embedded inline in the event envelope, so they're subject to the [size limits](#uploading-attachments) above. To send larger files, enable the `EnableLargeAttachments` option in plugin settings — when enabled, attachments above an internal size threshold are uploaded out-of-band via a separate request and referenced from the envelope by location.
+
+<Alert>
+
+Currently supported on Windows, Linux, Mac (with native backend) and consoles.
+
+</Alert>


### PR DESCRIPTION
This PR documents the new `EnableLargeAttachments` Unreal plugin setting which enables out-of-band upload of attachments that exceed the inline envelope size limits.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1364