### PR TITLE
fix(setup): Confirm dotagents npx install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 develop: setup-git
 	[ -f .env.development ] || cp .env.example .env.development
 	pnpm install
-	npx @sentry/dotagents install
+	npx -y @sentry/dotagents install
 
 setup-git:
 ifneq (, $(shell which pre-commit))


### PR DESCRIPTION
Make `make develop` pass `--yes` to `npx` when installing `@sentry/dotagents`.

Without this flag, a clean npm/npx environment can stop at npm's package install confirmation prompt and wait for terminal input during setup. Passing `-y` keeps the bootstrap command non-interactive while preserving the same dotagents install behavior.

Validated with `make -n develop` to confirm the Makefile now expands to `npx -y @sentry/dotagents install`.