### PR TITLE
docs(remix): Remove explicit bin name and `--package` from source map upload command

### DIFF
--- a/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -105,10 +105,10 @@ Next, adjust your `package.json`'s production build command to include the `sent
 Alternatively, you can run the script directly with `npx`:
 
 ```bash {tabTitle:Bash}
-npx --package=@sentry/remix sentry-upload-sourcemaps --org ___ORG_SLUG___ --project ___PROJECT_SLUG___
+npx @sentry/remix --upload-sourcemaps --org ___ORG_SLUG___ --project ___PROJECT_SLUG___
 
 # For usage details run
-npx --package=@sentry/remix sentry-upload-sourcemaps --help
+npx @sentry/remix --upload-sourcemaps --help
 ```
 
 <Alert>

--- a/platform-includes/sourcemaps/overview/javascript.remix.mdx
+++ b/platform-includes/sourcemaps/overview/javascript.remix.mdx
@@ -70,9 +70,9 @@ export default defineConfig({
 
 To see the full list of options, refer to the [Vite plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin).
 
-### Using `sentry-upload-sourcemaps` Script
+### Using `npx @sentry/remix --upload-sourcemaps`
 
-If you're not using Vite to build your project, you can use the `sentry-upload-sourcemaps` script to upload source maps to Sentry.
+If you're not using Vite to build your project, you can use `npx @sentry/remix --upload-sourcemaps` to upload source maps to Sentry.
 
 The Sentry Remix SDK provides a script to automatically create a release and upload source maps after you've built your project.
 Under the hood, it uses the [Sentry CLI](/cli/).
@@ -92,17 +92,17 @@ token=___ORG_AUTH_TOKEN___
 export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-Next, adjust your `package.json`'s production build command to include the `sentry-upload-sourcemaps` script:
+Next, adjust your `package.json`'s production build command to upload source maps after the build:
 
 ```json {filename:package.json}
 {
   "scripts": {
-    "build": "remix build --sourcemap && sentry-upload-sourcemaps --org ___ORG_SLUG___ --project ___PROJECT_SLUG___"
+    "build": "remix build --sourcemap && npx @sentry/remix --upload-sourcemaps --org ___ORG_SLUG___ --project ___PROJECT_SLUG___"
   }
 }
 ```
 
-Alternatively, you can run the script directly with `npx`:
+Or run it directly:
 
 ```bash {tabTitle:Bash}
 npx @sentry/remix --upload-sourcemaps --org ___ORG_SLUG___ --project ___PROJECT_SLUG___
@@ -122,7 +122,7 @@ Please refer to the [Remix CLI docs](https://remix.run/docs/en/main/other-api/de
 ### Remove Remix Source Maps
 
 Remix validly discourages hosting source maps in production. After uploading the maps to Sentry, we suggest you delete the `.map` files.
-The `sentry-upload-sourcemaps` script will automatically try to delete all generated source maps after they're uploaded (unless the `--deleteAfterUpload` flag is provided).
+`npx @sentry/remix --upload-sourcemaps` will automatically try to delete all generated source maps after they're uploaded (unless the `--deleteAfterUpload` flag is provided).
 
 If you want to be extra sure they're deleted, you can use the following shell script:
 

--- a/platform-includes/sourcemaps/upload/primer/javascript.remix.mdx
+++ b/platform-includes/sourcemaps/upload/primer/javascript.remix.mdx
@@ -1,4 +1,4 @@
-On release, call `npx --package=@sentry/remix sentry-upload-sourcemaps` to upload source maps and create a release.
+On release, call `npx @sentry/remix --upload-sourcemaps` to upload source maps and create a release.
 
 <Alert level="warning">
 
@@ -6,6 +6,6 @@ On release, call `npx --package=@sentry/remix sentry-upload-sourcemaps` to uploa
 
 </Alert>
 
-To see more details on how to use the command, call `npx --package=@sentry/remix sentry-upload-sourcemaps --help`.
+To see more details on how to use the command, call `npx @sentry/remix --upload-sourcemaps --help`.
 
 For more advanced configuration, [use `sentry-cli` directly to upload source maps.](https://github.com/getsentry/sentry-cli).

--- a/platform-includes/sourcemaps/upload/primer/javascript.remix.mdx
+++ b/platform-includes/sourcemaps/upload/primer/javascript.remix.mdx
@@ -2,7 +2,7 @@ On release, call `npx @sentry/remix --upload-sourcemaps` to upload source maps a
 
 <Alert level="warning">
 
-`sentry-upload-sourcemaps` requires either [`env` variables](/cli/configuration/#configuration-values) or a valid `.sentryclirc` file to pick up your project ID, organization ID, and token. You can create the `.sentryclirc` file with necessary configuration, as documented on this [page](/cli/configuration/).
+`npx @sentry/remix --upload-sourcemaps` requires either [`env` variables](/cli/configuration/#configuration-values) or a valid `.sentryclirc` file to pick up your project ID, organization ID, and token. You can create the `.sentryclirc` file with necessary configuration, as documented on this [page](/cli/configuration/).
 
 </Alert>
 


### PR DESCRIPTION

## DESCRIBE YOUR PR
If a package has only one `bin` script, the name of this script does not have to be specified when "running" the package with `npx`.

Since `@sentry/remix` only has one bin script in the `package.json` we decided to remove the verbose `--package` argument from the docs and we're going to rename the bin script in the future (as the name can be anything when it's not needed to specify it). Therefore, we no longer document the explicit name of the bin script so people can already use the "newer" way of invoking it.

The command was already changed here as part of the issue below: https://github.com/getsentry/sentry-docs/pull/17429
Part of https://github.com/getsentry/sentry-javascript/issues/20422

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

