### PR TITLE
docs(dotnet): move up Metrics feature in sidebar

### DIFF
--- a/docs/platforms/dotnet/common/crons/index.mdx
+++ b/docs/platforms/dotnet/common/crons/index.mdx
@@ -2,7 +2,7 @@
 title: Set Up Crons
 sidebar_title: Crons
 description: "Sentry Crons allows you to monitor the uptime and performance of any scheduled, recurring job in your application."
-sidebar_order: 5
+sidebar_order: 6
 sidebar_section: features
 ---
 

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -2,7 +2,7 @@
 title: Set Up Metrics
 sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges and measurements sent from your applications within Sentry."
-sidebar_order: 7
+sidebar_order: 3
 sidebar_section: features
 new: true
 ---

--- a/docs/platforms/dotnet/common/metrics/index.mdx
+++ b/docs/platforms/dotnet/common/metrics/index.mdx
@@ -4,6 +4,7 @@ sidebar_title: Metrics
 description: "Metrics allow you to send, view and query counters, gauges and measurements sent from your applications within Sentry."
 sidebar_order: 7
 sidebar_section: features
+new: true
 ---
 
 <AgentSkillsCallout skill="sentry-dotnet-sdk" platformName=".NET" />

--- a/docs/platforms/dotnet/common/profiling/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/index.mdx
@@ -2,7 +2,7 @@
 title: Set Up .NET Profiling
 sidebar_title: Profiling
 description: "Learn how to enable profiling in your app if it is not already set up."
-sidebar_order: 4
+sidebar_order: 5
 sidebar_section: features
 notSupported:
   - dotnet.uwp

--- a/docs/platforms/dotnet/common/tracing/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/index.mdx
@@ -2,7 +2,7 @@
 title: Set Up Tracing
 sidebar_title: Tracing
 description: "Learn how to enable tracing in your app and discover valuable performance insights of your application."
-sidebar_order: 3
+sidebar_order: 4
 sidebar_section: features
 ---
 

--- a/docs/platforms/dotnet/common/user-feedback/index.mdx
+++ b/docs/platforms/dotnet/common/user-feedback/index.mdx
@@ -2,7 +2,7 @@
 title: Set Up User Feedback
 sidebar_title: User Feedback
 description: "Learn more about collecting user feedback when an event occurs. Sentry pairs the feedback with the original event, giving you additional insight into issues."
-sidebar_order: 6
+sidebar_order: 7
 sidebar_section: features
 ---
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
- mark Metrics as "New"
  - Logs are currently also "New"
- move Metrics feature in sidebar
  - to be below Logs, not at the end

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Metrics GA
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
