### PR TITLE
docs(react-native): Clarify options merging and release alignment for native auto-init

### DIFF
--- a/docs/platforms/react-native/manual-setup/app-start-error-capture.mdx
+++ b/docs/platforms/react-native/manual-setup/app-start-error-capture.mdx
@@ -36,7 +36,9 @@ Create a `sentry.options.json` file in your React Native project root with the s
 
 <Alert level="info" title="Options Merging">
 
-Options from `sentry.options.json` are merged with options from `Sentry.init()` in JavaScript. Options specified in JavaScript take precedence over the configuration file, allowing you to override settings at runtime.
+When `Sentry.init()` runs in JavaScript, the native SDK is re-initialized with the JS options merged on top of the file options. This means JavaScript options take precedence for events captured **after** JS loads.
+
+However, crashes and errors that occur **before** JavaScript loads (which is the purpose of this feature) are captured using only the values from `sentry.options.json` and native auto-detection. If you set a custom `release` or `dist` in `Sentry.init()`, make sure the same values are also in `sentry.options.json`. Otherwise, pre-JS crashes will be attributed to a different release than post-JS events. See [Setting Release and Distribution](#setting-release-and-distribution) for details.
 
 </Alert>
 
@@ -49,6 +51,30 @@ SENTRY_ENVIRONMENT=staging npx react-native run-android
 ```
 
 This works in any CI/CD system by setting the environment variable in your build configuration.
+
+### Setting Release and Distribution
+
+If you use a custom `release` or `dist` in `Sentry.init()`, you should set matching values in `sentry.options.json` so that pre-JavaScript crashes are attributed to the correct release:
+
+```json {filename:sentry.options.json}
+{
+  "dsn": "https://key@example.io/value",
+  "release": "my-app@1.0.0+42",
+  "dist": "42"
+}
+```
+
+For dynamic values that change per build, you can generate `sentry.options.json` as a build step or use the `SENTRY_RELEASE` and `SENTRY_DIST` environment variables at build time. The SDK build scripts will use these to override the values in your `sentry.options.json`, similar to how `SENTRY_ENVIRONMENT` works.
+
+```bash
+SENTRY_RELEASE="my-app@1.0.0+42" SENTRY_DIST="42" npx react-native run-ios
+```
+
+<Alert level="warning" title="Release Alignment">
+
+If the `release` or `dist` in `sentry.options.json` doesn't match what you pass to `Sentry.init()`, you'll see two separate releases in Sentry — one for native crashes captured before JS loads and another for events captured after. Make sure both sources use the same values.
+
+</Alert>
 
 ## Android Setup
 

--- a/docs/platforms/react-native/manual-setup/app-start-error-capture.mdx
+++ b/docs/platforms/react-native/manual-setup/app-start-error-capture.mdx
@@ -38,7 +38,7 @@ Create a `sentry.options.json` file in your React Native project root with the s
 
 When `Sentry.init()` runs in JavaScript, the native SDK is re-initialized with the JS options merged on top of the file options. This means JavaScript options take precedence for events captured **after** JS loads.
 
-However, crashes and errors that occur **before** JavaScript loads (which is the purpose of this feature) are captured using only the values from `sentry.options.json` and native auto-detection. If you set a custom `release` or `dist` in `Sentry.init()`, make sure the same values are also in `sentry.options.json`. Otherwise, pre-JS crashes will be attributed to a different release than post-JS events. See [Setting Release and Distribution](#setting-release-and-distribution) for details.
+However, crashes and errors that occur **before** JavaScript loads (which is the purpose of this feature) are captured using only the values from `sentry.options.json` and native auto-detection. If you set a custom `release` or `dist` in `Sentry.init()`, make sure the same values are also in `sentry.options.json`. Otherwise, pre-JS crashes will be attributed to a different release than post-JS events.
 
 </Alert>
 
@@ -62,12 +62,6 @@ If you use a custom `release` or `dist` in `Sentry.init()`, you should set match
   "release": "my-app@1.0.0+42",
   "dist": "42"
 }
-```
-
-For dynamic values that change per build, you can generate `sentry.options.json` as a build step or use the `SENTRY_RELEASE` and `SENTRY_DIST` environment variables at build time. The SDK build scripts will use these to override the values in your `sentry.options.json`, similar to how `SENTRY_ENVIRONMENT` works.
-
-```bash
-SENTRY_RELEASE="my-app@1.0.0+42" SENTRY_DIST="42" npx react-native run-ios
 ```
 
 <Alert level="warning" title="Release Alignment">


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarifies how `sentry.options.json` and `Sentry.init()` options interact when using native auto-initialization.

Users enabling `useNativeInit` with a custom `release` in `Sentry.init()` see two separate releases in Sentry — one from native init (auto-detected) and one from JS init (custom). The previous docs implied JS always overrides, which isn't true for crashes captured before JS loads.

- Rewrote the "Options Merging" alert to explain that pre-JS crashes use only file values, not JS overrides
- Added "Setting Release and Distribution" section with guidance on keeping native and JS release values aligned

This is related to the investigation in https://github.com/getsentry/sentry-react-native/issues/6069

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)