### PR TITLE
docs(rust-sdk): Document metrics

### DIFF
--- a/docs/platforms/rust/common/metrics/index.mdx
+++ b/docs/platforms/rust/common/metrics/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Set Up Metrics
+sidebar_title: Metrics
+description: "Metrics allow you to send, view and query counters, gauges and measurements from your Sentry-configured apps to track application health and drill down into related traces, logs, and errors."
+sidebar_section: features
+new: true
+sidebar_order: 5700
+---
+
+With [Sentry's Application Metrics](/product/explore/metrics/), you can send counters, gauges, and distributions from your Rust applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors and searched using their individual attributes.
+
+## Requirements
+
+<PlatformContent includePath="metrics/requirements" />
+
+## Usage
+
+<PlatformContent includePath="metrics/usage" />
+
+## Options
+
+<PlatformContent includePath="metrics/options" />
+
+## Default Attributes
+
+<PlatformContent includePath="metrics/default-attributes" />

--- a/platform-includes/metrics/default-attributes/rust.mdx
+++ b/platform-includes/metrics/default-attributes/rust.mdx
@@ -1,0 +1,10 @@
+Sentry automatically attaches these attributes to every metric:
+
+| Attribute                            | Description                             | When Present                                       |
+| ------------------------------------ | --------------------------------------- | -------------------------------------------------- |
+| `sentry.sdk.name`                    | SDK name                                | Always                                             |
+| `sentry.sdk.version`                 | SDK version                             | Always                                             |
+| `sentry.environment`                 | Environment from SDK configuration      | If configured                                      |
+| `sentry.release`                     | Release from SDK configuration          | If configured                                      |
+| `server.address`                     | Server name from SDK configuration      | If configured                                      |
+| `user.id`, `user.name`, `user.email` | User identifiers from the current scope | If a user is set and `send_default_pii` is enabled |

--- a/platform-includes/metrics/options/rust.mdx
+++ b/platform-includes/metrics/options/rust.mdx
@@ -1,0 +1,35 @@
+### Filtering Metrics
+
+Use [`before_send_metric`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html#structfield.before_send_metric) to drop or update metrics before Sentry sends them. Return `None` to drop a metric.
+
+For example, to filter all metrics with the name `"debug.metric"`, you could use the following `before_send_metric`:
+
+```rust {filename:main.rs}
+let _guard = sentry::init((
+    "___PUBLIC_DSN___",
+    sentry::ClientOptions {
+        before_send_metric: Some(std::sync::Arc::new(|metric| {
+            if metric.name == "debug.metric" {
+                return None;
+            }
+
+            Some(metric)
+        })),
+        ..Default::default()
+    },
+));
+```
+
+### Disabling Metrics
+
+Metrics are enabled by default when the `sentry` crate is compiled with the `metrics` feature. To stop sending metrics, set [`enable_metrics: false`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html#structfield.enable_metrics) in the [`ClientOptions`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html).
+
+```rust {filename:main.rs}
+let _guard = sentry::init((
+    "___PUBLIC_DSN___",
+    sentry::ClientOptions {
+        enable_metrics: false,
+        ..Default::default()
+    },
+));
+```

--- a/platform-includes/metrics/requirements/rust.mdx
+++ b/platform-includes/metrics/requirements/rust.mdx
@@ -1,0 +1,8 @@
+Metrics for Rust are supported in Sentry Rust SDK version `0.48.0` or later when compiled with the `metrics` feature.
+
+```toml {filename:Cargo.toml}
+[dependencies]
+sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["metrics"] }
+```
+
+Metrics are enabled by default.

--- a/platform-includes/metrics/usage/rust.mdx
+++ b/platform-includes/metrics/usage/rust.mdx
@@ -1,0 +1,48 @@
+The SDK's [`sentry::metrics` module](https://docs.rs/sentry/latest/sentry/metrics/index.html) contains functions for capturing each of the [three metric types](/product/explore/metrics/#metric-types) that Sentry supports.
+
+Metrics are automatically associated with the trace and, if applicable, the span they are captured within.
+
+### Capture a Counter
+
+Capture [counter metrics](/product/explore/metrics/#counters) using [`metrics::counter`](https://docs.rs/sentry/latest/sentry/metrics/fn.counter.html).
+
+Counters track occurrences, such as handled HTTP requests, and are always unitless.
+
+```rust {filename:main.rs}
+use sentry::metrics;
+
+metrics::counter("http.requests", 1).capture();
+```
+
+### Capture a Gauge
+
+Capture [gauge metrics](/product/explore/metrics/#gauges) using [`metrics::gauge`](https://docs.rs/sentry/latest/sentry/metrics/fn.gauge.html).
+
+Gauges track current state or level, such as queue depth or active connections, and support [units](https://docs.rs/sentry/latest/sentry/metrics/struct.GaugeMetric.html#method.unit).
+
+```rust {filename:main.rs}
+use sentry::metrics;
+
+metrics::gauge("queue.depth", 42).capture();
+```
+
+### Distribution
+
+Capture [distribution metrics](/product/explore/metrics/#distributions) using [`metrics::distribution`](https://docs.rs/sentry/latest/sentry/metrics/fn.distribution.html).
+
+Distributions track values that vary and need statistical analysis, such as response times or payload sizes, and they support [units](https://docs.rs/sentry/latest/sentry/metrics/struct.DistributionMetric.html#method.unit).
+
+```rust {filename:main.rs}
+use sentry::metrics;
+use sentry::protocol::Unit;
+
+metrics::distribution("http.response_time", 187.5)
+  .unit(Unit::Millisecond)
+  .capture();
+```
+
+### Setting Attributes
+
+Attributes let you filter and group metrics in Sentry. Add them with `.attribute(key, value)` before you call `.capture()`. You can add multiple attributes by chaining calls to `.attribute`.
+
+When possible, use [Sentry Semantic Conventions](https://getsentry.github.io/sentry-conventions/) for attribute keys.


### PR DESCRIPTION
Closes #16556
Closes [RUST-165](https://linear.app/getsentry/issue/RUST-165/document-rust-trace-metrics-support-and-api)
