### PR TITLE
docs(size-analysis): Document status check rules API

### DIFF
--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -152,6 +152,14 @@ Rules are evaluated independently. If any rule's threshold is exceeded, the stat
 - If status checks are **enabled** but **no rules are configured**, checks will post as **neutral** (won't block PRs) but will still show size change information
 - If rules are configured, checks will pass or fail based on whether thresholds are exceeded
 
+### Fetching Status Check Rules for External CI
+
+If you're consuming the `size_analysis.completed` webhook in your own CI, you can fetch the project's current status check rule config from the [Size Analysis status check rules API](/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/).
+
+Use this when you want external CI to evaluate the same thresholds that Sentry uses for Size Analysis status checks, without duplicating rule configuration outside Sentry. The API reference documents the response shape, filter operators, AND/OR grouping semantics, wildcard matching behavior, and invalid-filter handling.
+
+The endpoint returns the **current project configuration**, not a historical snapshot from when the webhook was emitted. If rules change between webhook delivery and your API request, you'll receive the updated rules.
+
 ## Troubleshooting
 
 ### Not Seeing Status Checks

--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -154,9 +154,13 @@ Rules are evaluated independently. If any rule's threshold is exceeded, the stat
 
 ### Fetching Status Check Rules for External CI
 
-If you're consuming the `size_analysis.completed` webhook in your own CI, you can fetch the project's current status check rule config from the [Size Analysis status check rules API](/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/).
+If you're consuming the `size_analysis.completed` webhook in your own CI, you can fetch the project's current status check rule config from the Size Analysis status check rules API:
 
-Use this when you want external CI to evaluate the same thresholds that Sentry uses for Size Analysis status checks, without duplicating rule configuration outside Sentry. The API reference documents the response shape, filter operators, AND/OR grouping semantics, wildcard matching behavior, and invalid-filter handling.
+```http
+GET /api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/preprod/size-analysis/status-check-rules/
+```
+
+Use this when you want external CI to evaluate the same thresholds that Sentry uses for Size Analysis status checks, without duplicating rule configuration outside Sentry. Once the generated API reference is available, it will document the response shape, filter operators, AND/OR grouping semantics, wildcard matching behavior, and invalid-filter handling.
 
 The endpoint returns the **current project configuration**, not a historical snapshot from when the webhook was emitted. If rules change between webhook delivery and your API request, you'll receive the updated rules.
 

--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -154,7 +154,7 @@ Rules are evaluated independently. If any rule's threshold is exceeded, the stat
 
 ### Fetching Status Check Rules for External CI
 
-If you're consuming the `size_analysis.completed` webhook in your own CI, you can fetch the project's current status check rule config from the Size Analysis status check rules API:
+If you're consuming the `preprod_artifact.size_analysis_completed` webhook in your own CI, you can fetch the project's current status check rule config from the Size Analysis status check rules API:
 
 ```http
 GET /api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/preprod/size-analysis/status-check-rules/


### PR DESCRIPTION
Document the new Size Analysis status check rules API for external CI consumers. The docs explain how to fetch the current rule configuration, how to interpret thresholds, and how the machine-readable filter response maps to Sentry's runtime rule evaluation.

**Filter Semantics**

The page now calls out that separate filter objects are ANDed, conditions inside a filter are ORed, and same-key positive and negative groups can both appear. It also documents `filters: []` versus `filters: null`, `in`/`notIn`, decoded literal values, missing metadata behavior, and artifact type mapping.

**API Reference Preview Note**

This PR links the Size Analysis CI guide to the generated API reference page:

`/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/`

That page is generated from the Sentry OpenAPI schema, so it may 404 in this docs preview until the companion Sentry PR lands and the updated schema is published/bumped in `sentry-docs`.

**Local Preview Instructions**

To preview the generated API reference page locally before the schema cascade lands:

1. In the `sentry` repo, check out the companion Sentry branch unless the Sentry PR has already landed in `master`:

   ```bash
   cd /Volumes/Developer/sentry
   git checkout cameroncooke/feat/eme-1061-size-status-rules-api
   ```

2. Generate the OpenAPI schema from that Sentry branch:

   ```bash
   PATH="$PWD/.venv/bin:$PATH" make build-api-docs
   ```

   This writes the local schema to:

   ```text
   /Volumes/Developer/sentry/tests/apidocs/openapi-derefed.json
   ```

3. In the `sentry-docs` repo, run the dev server with that local schema:

   ```bash
   cd /Volumes/Developer/sentry-docs
   OPENAPI_LOCAL_PATH=/Volumes/Developer/sentry/tests/apidocs/openapi-derefed.json \
   DISABLE_THUMBNAILS=1 \
   pnpm dev
   ```

4. Open the generated endpoint page:

   ```text
   http://localhost:3000/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/
   ```

Refs EME-1061