### PR TITLE
docs(snapshots): Align Android DSL with plugin restructuring

### DIFF
--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -13,7 +13,7 @@ Set up [Snapshots](/product/snapshots/) for your Android app with the Sentry And
 
 ## Step 1: Enable Snapshots
 
-Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.5.0 or higher is applied and configured.
+Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.6.0 or higher is applied and configured.
 
 Then enable snapshots in your `build.gradle`:
 

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -53,22 +53,26 @@ plugins {
 
 #### Customize Preview Generation
 
-The `snapshots` block on the Sentry extension exposes two options that shape the generated Paparazzi tests. Both only apply when `generateSnapshotTests` is `true` (the default).
+The `previews` block inside `snapshots` exposes options that shape the generated Paparazzi tests. These only apply when `generateTests` is `true` (the default).
 
 ```kotlin
 sentry {
   snapshots {
     enabled = true
-    theme = "@style/Theme.MyApp"   // optional
-    includePrivatePreviews = false // optional, defaults to true
+    previews {
+      theme = "@style/Theme.MyApp"          // optional
+      includePrivatePreviews = false        // optional, defaults to true
+      packageTrees = listOf("com.example")  // optional, defaults to Android namespace
+    }
   }
 }
 ```
 
-| Option                   | Default                                                             | Description                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `theme`                  | Paparazzi default (`android:Theme.Material.NoActionBar.Fullscreen`) | Android theme resource used when rendering previews. Set this if your previews rely on a specific theme.                            |
-| `includePrivatePreviews` | `true`                                                              | Whether `@Preview` composables declared `private` are snapshotted. Set to `false` to exclude in-progress or internal-only previews. |
+| Option                   | Default                                                             | Description                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `theme`                  | Paparazzi default (`android:Theme.Material.NoActionBar.Fullscreen`) | Android theme resource used when rendering previews. Set this if your previews rely on a specific theme.                                     |
+| `includePrivatePreviews` | `true`                                                              | Whether `@Preview` composables declared `private` are snapshotted. Set to `false` to exclude in-progress or internal-only previews.          |
+| `packageTrees`           | `[]` (falls back to Android namespace)                              | Package prefixes to scan for `@Preview` composables. When empty, the plugin uses the Android namespace from the build variant.               |
 
 If you don't set a `theme`, Paparazzi uses its own default (`android:Theme.Material.NoActionBar.Fullscreen`). If the background of your previews isn't important — for example, when you just want to compare component geometry — you can use a translucent platform theme such as `android:Theme.Translucent.NoTitleBar`:
 
@@ -76,7 +80,9 @@ If you don't set a `theme`, Paparazzi uses its own default (`android:Theme.Mater
 sentry {
   snapshots {
     enabled = true
-    theme = "android:Theme.Translucent.NoTitleBar"
+    previews {
+      theme = "android:Theme.Translucent.NoTitleBar"
+    }
   }
 }
 ```
@@ -96,13 +102,15 @@ Use this path if you already generate snapshots with another tool. The configura
 
 #### Paparazzi
 
-If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, set `generateSnapshotTests = false` so Sentry uses your existing tests instead of auto-generating preview-based ones:
+If you already have [Paparazzi](https://github.com/cashapp/paparazzi) configured, set `generateTests = false` inside the `previews` block so Sentry uses your existing tests instead of auto-generating preview-based ones:
 
 ```kotlin
 sentry {
   snapshots {
     enabled = true
-    generateSnapshotTests = false
+    previews {
+      generateTests = false
+    }
   }
 }
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Aligns Android Snapshots docs with the DSL restructuring from sentry-android-gradle-plugin [PR #1167](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1167):

- Nest `theme`, `includePrivatePreviews`, and `generateTests` under the new `previews {}` block
- Rename `generateSnapshotTests` → `generateTests`
- Document the new `packageTrees` option

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)