### PR TITLE
docs(releases): Clarify commit-based issue resolution

### DIFF
--- a/docs/product/issues/states-triage/index.mdx
+++ b/docs/product/issues/states-triage/index.mdx
@@ -51,7 +51,7 @@ You can manually mark an issue as `Resolved` when it’s been fixed. You can als
 
 or
 
-- By [including the issue ID in a commit](/product/releases/associate-commits/?original_referrer=https%3A%2F%2Fdocs.sentry.io%2Fproduct%2Fissues%2Fstates-triage%2F#resolve-issues-by-commit)
+- By [including the issue ID in a commit or pull request associated with a release](/product/releases/associate-commits/?original_referrer=https%3A%2F%2Fdocs.sentry.io%2Fproduct%2Fissues%2Fstates-triage%2F#resolve-issues-by-commit)
 
 If the same issue comes back, its status will automatically change to `Regressed`.
 

--- a/docs/product/releases/associate-commits/index.mdx
+++ b/docs/product/releases/associate-commits/index.mdx
@@ -211,7 +211,7 @@ If you receive an "Unable to Fetch Commits" email, take a look at our [help cent
 
 ## Resolve Issues by Commit
 
-Additionally, when you've started associating commits with a release, you'll be able to resolve issues by including the issue ID in your commit message. You can find the issue ID at the top of the **Issue Details** page, next to the assignee dropdown.
+Additionally, when you've started associating commits with a release, you can resolve issues as part of a release by including the issue ID in your commit message. You can find the issue ID at the top of the **Issue Details** page, next to the assignee dropdown.
 
 A commit message might look like this, for example:
 
@@ -221,7 +221,7 @@ Prevent empty queries on users
 Fixes SENTRY-317
 ```
 
-When Sentry sees this commit, we’ll reference the commit in the issue, and when you create a release in Sentry, we’ll mark the issue as resolved in that release. You can also resolve issues with pull requests by including `fixes <SENTRY-SHORT-ID>` in the title or description.
+When Sentry sees this commit, we’ll reference the commit in the issue, but we won’t mark the issue as resolved immediately. When you create a release in Sentry that includes the commit, we’ll mark the issue as resolved in that release. You can also resolve issues with pull requests by including `fixes <SENTRY-SHORT-ID>` in the title or description; Sentry resolves the issue when the pull request’s merge commit is included in a release.
 
 <Alert>
 

--- a/docs/product/releases/index.mdx
+++ b/docs/product/releases/index.mdx
@@ -33,7 +33,7 @@ Releases offer significant additional features when [fully configured](/product/
 
 - Determine the issues and regressions introduced in a new release
 - Predict which commit caused an issue and who is likely responsible
-- Resolve issues by including the issue number in your commit message
+- Resolve issues by including the issue number in a commit or pull request associated with a release
 - [Receive email notifications when your code gets deployed](/product/notifications/#deploy-notifications)
 
 <Alert>


### PR DESCRIPTION
## Summary
- Clarify that commit references do not resolve issues immediately
- Explain that issues resolve once the referenced commit or pull request merge commit is included in a release
- Update short release and issue status mentions to avoid implying immediate commit-push resolution

## Test plan
- Not run locally; docs-only change
- CI should run formatting checks