### PR TITLE
fix(mobile): Lock body scroll when sidebar opens on mobile

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -124,6 +124,27 @@ export function Header({
     return () => checkbox.removeEventListener('change', handleChange);
   }, [isHomePage]);
 
+  // Lock body scroll when sidebar is open on mobile (fixes iOS Safari touch scrolling)
+  useEffect(() => {
+    if (sidebarOpen) {
+      document.body.style.overflow = 'hidden';
+
+      // Restore scroll on resize to desktop width
+      const handleResize = () => {
+        if (window.innerWidth >= 768) {
+          document.body.style.overflow = '';
+        }
+      };
+
+      window.addEventListener('resize', handleResize);
+      return () => {
+        document.body.style.overflow = '';
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+    return undefined;
+  }, [sidebarOpen]);
+
   // Show header search if: not on home page, OR on home page but home search is scrolled out of view
   const showHeaderSearch = !isHomePage || !homeSearchVisible;
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -105,6 +105,8 @@ export function Header({
   // Track sidebar checkbox state for non-home pages
   useEffect(() => {
     if (isHomePage) {
+      // Reset sidebar state when navigating to home page to prevent stale scroll lock
+      setSidebarOpen(false);
       return undefined;
     }
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -129,10 +129,16 @@ export function Header({
     if (sidebarOpen) {
       document.body.style.overflow = 'hidden';
 
-      // Restore scroll on resize to desktop width
+      // Close sidebar if viewport is resized to desktop width
       const handleResize = () => {
         if (window.innerWidth >= 768) {
-          document.body.style.overflow = '';
+          const checkbox = document.getElementById(
+            sidebarToggleId
+          ) as HTMLInputElement | null;
+          if (checkbox) {
+            checkbox.checked = false;
+            setSidebarOpen(false);
+          }
         }
       };
 
@@ -283,6 +289,14 @@ export function Header({
                 onClick={() => {
                   setMobileSearchOpen(true);
                   setHomeMobileNavOpen(false);
+                  // Close sidebar to prevent competing scroll locks
+                  const checkbox = document.getElementById(
+                    sidebarToggleId
+                  ) as HTMLInputElement | null;
+                  if (checkbox) {
+                    checkbox.checked = false;
+                    setSidebarOpen(false);
+                  }
                 }}
                 aria-label="Search"
               >


### PR DESCRIPTION
On iOS Safari, the mobile sidebar overlay wasn't scrollable because
touch events were being captured by the scrollable body underneath.
This adds body scroll locking when the sidebar opens on mobile, matching
the existing behavior for the mobile search overlay.

Slack thread: https://sentry.slack.com/archives/C8H0BQRDJ/p1777747105228359

https://claude.ai/code/session_01XpiMadpiudFwxMEpwPDpPE