### PR TITLE
docs(android): Add variant filtering disclaimer for Gradle uploads

### DIFF
--- a/docs/platforms/android/configuration/gradle.mdx
+++ b/docs/platforms/android/configuration/gradle.mdx
@@ -366,6 +366,12 @@ sentry {
 }
 ```
 
+<Alert level="info">
+
+When a variant is excluded via `ignoredVariants`, `ignoredBuildTypes`, or `ignoredFlavors`, most Sentry Gradle plugin tasks are disabled for that variant — including [Size Analysis](/platforms/android/size-analysis/) and [Build Distribution](/platforms/android/build-distribution/) uploads. Snapshot uploads are the exception and will still run for excluded variants. To upload builds for a variant, it must not be excluded by these filters. You can disable specific features individually (such as `autoUploadProguardMapping` or `tracingInstrumentation.enabled`) while keeping uploads enabled.
+
+</Alert>
+
 ## ProGuard/R8 & DexGuard
 
 The plugin will automatically generate appropriate ProGuard mapping files and upload them when you run `gradle assemble{BuildVariant}`. For example, `assembleRelease`. Release is the default, but the plugin works for others as long as you've enabled ProGuard/R8. The credentials for the upload step are defined in the Gradle extension above or loaded from a `sentry.properties` file in your project.

--- a/docs/platforms/android/configuration/gradle.mdx
+++ b/docs/platforms/android/configuration/gradle.mdx
@@ -493,7 +493,7 @@ Check [Integrations](/platforms/android/integrations/) page for more detailed ex
 
 <Alert>
 
-To learn more about the internals of auto-instrumentation, check out this [blog post](https://blog.sentry.io/2021/12/14/bytecode-transformations-the-android-gradle-plugin).
+To learn more about the internals of auto-instrumentation, check out this [blog post](https://blog.sentry.io/bytecode-transformations-the-android-gradle-plugin/).
 
 </Alert>
 

--- a/src/components/gradleFeatureConfig.tsx
+++ b/src/components/gradleFeatureConfig.tsx
@@ -1,3 +1,7 @@
+import Link from 'next/link';
+import {Fragment} from 'react';
+
+import {Alert} from './alert';
 import {CodeBlock} from './codeBlock';
 import {CodeTabs} from './codeTabs';
 import {codeToJsx} from './highlightCode';
@@ -8,6 +12,7 @@ type Props = {
 
 export function GradleFeatureConfig({feature}: Props) {
   return (
+    <Fragment>
     <CodeTabs>
       <CodeBlock language="kotlin" filename="build.gradle.kts">
         <pre>
@@ -35,5 +40,15 @@ export function GradleFeatureConfig({feature}: Props) {
         </pre>
       </CodeBlock>
     </CodeTabs>
+    <Alert level="info">
+      Gradle-based uploads require the variant to not be excluded by the Sentry
+      Gradle plugin's variant filters (<code>ignoredVariants</code>,{' '}
+      <code>ignoredBuildTypes</code>, or <code>ignoredFlavors</code>). See{' '}
+      <Link href="/platforms/android/configuration/gradle/#variant-filtering">
+        Variant Filtering
+      </Link>{' '}
+      for details.
+    </Alert>
+    </Fragment>
   );
 }

--- a/src/components/gradleFeatureConfig.tsx
+++ b/src/components/gradleFeatureConfig.tsx
@@ -13,42 +13,42 @@ type Props = {
 export function GradleFeatureConfig({feature}: Props) {
   return (
     <Fragment>
-    <CodeTabs>
-      <CodeBlock language="kotlin" filename="build.gradle.kts">
-        <pre>
-          {codeToJsx(
-            `sentry {
+      <CodeTabs>
+        <CodeBlock language="kotlin" filename="build.gradle.kts">
+          <pre>
+            {codeToJsx(
+              `sentry {
   ${feature} {
     enabled = providers.environmentVariable("GITHUB_ACTIONS").isPresent
   }
 }`,
-            'kotlin'
-          )}
-        </pre>
-      </CodeBlock>
+              'kotlin'
+            )}
+          </pre>
+        </CodeBlock>
 
-      <CodeBlock language="groovy" filename="build.gradle">
-        <pre>
-          {codeToJsx(
-            `sentry {
+        <CodeBlock language="groovy" filename="build.gradle">
+          <pre>
+            {codeToJsx(
+              `sentry {
   ${feature} {
     enabled = providers.environmentVariable("GITHUB_ACTIONS").present
   }
 }`,
-            'groovy'
-          )}
-        </pre>
-      </CodeBlock>
-    </CodeTabs>
-    <Alert level="info">
-      Gradle-based uploads require the variant to not be excluded by the Sentry
-      Gradle plugin's variant filters (<code>ignoredVariants</code>,{' '}
-      <code>ignoredBuildTypes</code>, or <code>ignoredFlavors</code>). See{' '}
-      <Link href="/platforms/android/configuration/gradle/#variant-filtering">
-        Variant Filtering
-      </Link>{' '}
-      for details.
-    </Alert>
+              'groovy'
+            )}
+          </pre>
+        </CodeBlock>
+      </CodeTabs>
+      <Alert level="info">
+        Gradle-based uploads require the variant to not be excluded by the Sentry Gradle
+        plugin's variant filters (<code>ignoredVariants</code>,{' '}
+        <code>ignoredBuildTypes</code>, or <code>ignoredFlavors</code>). See{' '}
+        <Link href="/platforms/android/configuration/gradle/#variant-filtering">
+          Variant Filtering
+        </Link>{' '}
+        for details.
+      </Alert>
     </Fragment>
   );
 }


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds info-level disclaimers explaining that Gradle-based uploads (size analysis and build distribution) require the variant to not be excluded by the Sentry Gradle plugin's variant filters (`ignoredVariants`, `ignoredBuildTypes`, or `ignoredFlavors`).

- **Gradle config page** (`gradle.mdx`): Detailed note in the Variant Filtering section explaining the all-or-nothing behavior, the snapshots exception, and the workaround of disabling individual features instead
- **`GradleFeatureConfig` component**: Short note in step 3 of the upload instructions (shared by both size analysis and build distribution pages) linking to the Variant Filtering docs

**Pages to verify on the Vercel preview:**
- `/platforms/android/configuration/gradle/#variant-filtering`
- `/platforms/android/build-distribution/`
- `/platforms/android/size-analysis/`

Closes EME-501

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)