### PR TITLE
feat: added replay lifecycle hooks docs

### DIFF
--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -129,6 +129,8 @@ Calling `flush()` while Session Replay is stopped will start a new session recor
 
 ## Lifecycle Hooks
 
+<AvailableSince version="10.50.0" />
+
 You can listen to replay lifecycle events on the Sentry client to know when recording starts and stops. This is useful for wrapper libraries or custom UIs that need to stay in sync with replay state.
 
 ```javascript

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -127,6 +127,36 @@ In `session` mode, this will upload any pending recording data to Sentry. In `bu
 
 Calling `flush()` while Session Replay is stopped will start a new session recording.
 
+## Lifecycle Hooks
+
+You can listen to replay lifecycle events on the Sentry client to know when recording starts and stops. This is useful for wrapper libraries or custom UIs that need to stay in sync with replay state.
+
+```javascript
+const client = Sentry.getClient();
+
+client.on('replayStart', ({ sessionId, recordingMode }) => {
+  // recordingMode: 'session' | 'buffer'
+  console.log(`Replay ${sessionId} started in ${recordingMode} mode`);
+});
+
+client.on('replayEnd', ({ sessionId, reason }) => {
+  // reason: 'manual' | 'sessionExpired' | 'sendError' | 'mutationLimit'
+  //       | 'eventBufferError' | 'eventBufferOverflow'
+  console.log(`Replay ${sessionId} ended: ${reason}`);
+});
+```
+
+The `replayEnd` hook includes a typed `reason` so you can distinguish calling `replay.stop()` yourself from an internal stop:
+
+| Reason | Description |
+|--------|-------------|
+| `manual` | You called `replay.stop()` |
+| `sessionExpired` | The session exceeded max duration or idle timeout |
+| `sendError` | The SDK failed to send recording data to Sentry |
+| `mutationLimit` | The DOM mutation limit was exceeded |
+| `eventBufferError` | The event buffer hit an internal error |
+| `eventBufferOverflow` | The event buffer exceeded its size limit |
+
 ## Examples of Custom Sampling
 
 There are ways to enable custom sampling if you're interested in tracking a particular action or group, for example, a specific segment of users or a problematic URL.

--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -127,7 +127,7 @@ In `session` mode, this will upload any pending recording data to Sentry. In `bu
 
 Calling `flush()` while Session Replay is stopped will start a new session recording.
 
-## Lifecycle Hooks
+## Listening to Lifecycle Events
 
 <AvailableSince version="10.50.0" />
 


### PR DESCRIPTION
This PR adds documentation for the replay client lifecycle hooks, it was released in `10.50.0` via https://github.com/getsentry/sentry-javascript/pull/20369

I initially thought about adding `lifecycle.mdx` file and a sidebar item for replays, but maybe it is a bit of an overkill.