### PR TITLE
Fixed hydration issue with new window/tab anchor links

### DIFF
--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 type TreeItem = {
   children: TreeItem[];
@@ -74,14 +74,16 @@ export function TableOfContents({ignoreIds = []}: Props) {
   // Re-scroll to hash anchor after TOC renders to compensate for layout shift.
   // The TOC starts empty and populates client-side, which pushes content down
   // and causes the browser's initial anchor scroll to land on the wrong section.
+  const hasScrolledToHash = useRef(false);
   useEffect(() => {
-    if (treeItems.length === 0) {
+    if (hasScrolledToHash.current || treeItems.length === 0) {
       return;
     }
     const hash = window.location.hash;
     if (!hash) {
       return;
     }
+    hasScrolledToHash.current = true;
     requestAnimationFrame(() => {
       const id = decodeURIComponent(hash.slice(1));
       document.getElementById(id)?.scrollIntoView();

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -68,9 +68,25 @@ export function TableOfContents({ignoreIds = []}: Props) {
       }
     }
 
-    // Remove groups without children
     setTreeItems(_tocItems);
   }, [ignoreIds]);
+
+  // Re-scroll to hash anchor after TOC renders to compensate for layout shift.
+  // The TOC starts empty and populates client-side, which pushes content down
+  // and causes the browser's initial anchor scroll to land on the wrong section.
+  useEffect(() => {
+    if (treeItems.length === 0) {
+      return;
+    }
+    const hash = window.location.hash;
+    if (!hash) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      const id = decodeURIComponent(hash.slice(1));
+      document.getElementById(id)?.scrollIntoView();
+    });
+  }, [treeItems]);
 
   return (
     <ul>


### PR DESCRIPTION
## DESCRIBE YOUR PR

**TL;DR**: The in-page Table of Contents on the options page renders empty on initial load, then fills in client-side with 100+ items. This layout shift causes anchor links (like #inAppInclude) to land on the wrong section when opened in a new tab. 
**Fix**: re-scroll to the anchor after the TOC finishes rendering by adding another `useEffect`

Example: 
- On https://sentry-docs-git-bug-anchor-redirect-hydration-issue.sentry.dev/platforms/apple/tracing/instrumentation/automatic-instrumentation/#including-framework-bundle-view-controllers, click to open `inAppInclude` in a new tab or window. 

Expectation: 
The page opens on the correct anchor link

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)