### PR TITLE
docs(remix): Add warning banner for Remix 3 incompatibility

### DIFF
--- a/docs/platforms/javascript/guides/remix/index.mdx
+++ b/docs/platforms/javascript/guides/remix/index.mdx
@@ -9,6 +9,12 @@ categories:
   - server-node
 ---
 
+<Alert level="warning" title="Remix 3 Not Yet Supported">
+
+The current `@sentry/remix` SDK does not support [Remix 3](https://remix.run/blog/remix-3-beta-preview). If you're using Remix 3, the SDK may not work as expected. We're tracking support — check back for updates.
+
+</Alert>
+
 <PlatformContent includePath="getting-started-prerequisites" />
 
 <StepConnector selector="h2" showNumbers={true}>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a warning alert to the Remix SDK guide page informing users that `@sentry/remix` does not yet support Remix 3.

- Adds `<Alert level="warning">` banner at the top of the Remix guide (`docs/platforms/javascript/guides/remix/index.mdx`)
- Links to the [Remix 3 beta preview blog post](https://remix.run/blog/remix-3-beta-preview)

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)