### PR TITLE
fix(platforms): Remove aggressive redirect from /platforms/ page

### DIFF
--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -157,17 +157,7 @@ export function PlatformSelector({
     } else if (isOnPlatformsIndex) {
       const stored = localStorage.getItem('active-platform');
       setStoredPlatformKey(stored);
-
-      // If we have a stored platform, redirect to it immediately
-      if (stored) {
-        const storedPlatformData = platformsAndGuides.find(p => p.key === stored);
-        if (storedPlatformData) {
-          setIsRedirecting(true);
-          // Use hard navigation for instant redirect
-          window.location.replace(storedPlatformData.url);
-          return;
-        }
-      }
+      // Don't redirect when on /platforms/ - let users stay on the page they navigated to
     } else {
       setStoredPlatformKey(localStorage.getItem('active-platform'));
     }

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -150,7 +150,7 @@ export function PlatformSelector({
     } else {
       setStoredPlatformKey(localStorage.getItem('active-platform'));
     }
-  }, [currentPlatformKey, platformsAndGuides]);
+  }, [currentPlatformKey]);
 
   const isPlatformPage = Boolean(
     pathname?.startsWith('/platforms/') &&

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -87,10 +87,6 @@ export function PlatformSelector({
   // Auto-open selector when on /platforms/ index page (no SDK selected)
   const isOnPlatformsIndex = pathname === '/platforms/' || pathname === '/platforms';
 
-  // Track if we're redirecting to prevent flash of selector
-  // Always initialize to false to avoid SSR hydration mismatch
-  // The useLayoutEffect below will set this to true before paint if redirecting
-  const [isRedirecting, setIsRedirecting] = useState(false);
   const [open, setOpen] = useState(alwaysOpen || isOnPlatformsIndex);
   const [searchValue, setSearchValue] = useState('');
 
@@ -153,7 +149,6 @@ export function PlatformSelector({
   useLayoutEffect(() => {
     if (currentPlatformKey) {
       localStorage.setItem('active-platform', currentPlatformKey);
-      setIsRedirecting(false);
     } else if (isOnPlatformsIndex) {
       const stored = localStorage.getItem('active-platform');
       setStoredPlatformKey(stored);
@@ -177,11 +172,6 @@ export function PlatformSelector({
     storedPlatformKey &&
     storedPlatform &&
     pathname !== '/platforms/';
-
-  // Don't render anything while redirecting to prevent flash
-  if (isRedirecting) {
-    return null;
-  }
 
   if (listOnly) {
     return (

--- a/src/components/platformSelector/index.tsx
+++ b/src/components/platformSelector/index.tsx
@@ -140,8 +140,6 @@ export function PlatformSelector({
   const storedPlatform = platformsAndGuides.find(
     platform => platform.key === storedPlatformKey
   );
-  // Check for stored platform and redirect if on /platforms/ index
-  // Use useLayoutEffect to redirect before paint for faster UX
   useLayoutEffect(() => {
     setHasMounted(true);
   }, []);
@@ -149,14 +147,10 @@ export function PlatformSelector({
   useLayoutEffect(() => {
     if (currentPlatformKey) {
       localStorage.setItem('active-platform', currentPlatformKey);
-    } else if (isOnPlatformsIndex) {
-      const stored = localStorage.getItem('active-platform');
-      setStoredPlatformKey(stored);
-      // Don't redirect when on /platforms/ - let users stay on the page they navigated to
     } else {
       setStoredPlatformKey(localStorage.getItem('active-platform'));
     }
-  }, [currentPlatformKey, isOnPlatformsIndex, platformsAndGuides]);
+  }, [currentPlatformKey, platformsAndGuides]);
 
   const isPlatformPage = Boolean(
     pathname?.startsWith('/platforms/') &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## DESCRIBE YOUR PR

This PR fixes an issue where users navigating directly to `https://docs.sentry.io/platforms/` (via typed URL or shared links with hash fragments) were being redirected to their previously selected SDK platform. This prevented users from accessing the platforms overview page when intended.

### Changes Made

Removed the auto-redirect logic in the `PlatformSelector` component that was triggering whenever a user visited `/platforms/` with a stored platform preference in localStorage. Also cleaned up the dead `isRedirecting` state that was left over after removing the redirect logic.

**Before:** When visiting `/platforms/`, users would be automatically redirected to their last-visited SDK page (e.g., `/platforms/javascript/guides/nextjs/`)

**After:** Users stay on `/platforms/` when navigating directly to it, allowing them to:
- Access the full platforms overview
- Share links with hash fragments (e.g., `https://docs.sentry.io/platforms/#sdks-supported-by-our-community`)
- Browse all available SDKs

The platform selector still:
- Opens automatically when on `/platforms/`
- Stores platform preferences for use elsewhere
- Works normally when users select a platform from the dropdown

### Testing

[Platforms page showing no redirect after visiting Next.js SDK](https://cursor.com/agents/bc-0c7e060d-2e39-5a20-93e1-0e7d87fd16e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplatforms_page_no_redirect.png)

[Platforms page with hash fragment preserved](https://cursor.com/agents/bc-0c7e060d-2e39-5a20-93e1-0e7d87fd16e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplatforms_page_with_hash.png)

Manual testing confirmed:
- ✅ Direct navigation to `/platforms/` no longer redirects to stored platform
- ✅ Hash fragments are preserved (e.g., `#sdks-supported-by-our-community`)
- ✅ Platform selector still functions normally
- ✅ Platform preferences are still stored and used elsewhere in the app

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C090UM766J2/p1777931011915039?thread_ts=1777931011.915039&cid=C090UM766J2)

<div><a href="https://cursor.com/agents/bc-0c7e060d-2e39-5a20-93e1-0e7d87fd16e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c7e060d-2e39-5a20-93e1-0e7d87fd16e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

