### PR TITLE
docs(unreal): Update default feature flag values for logs and metrics

### DIFF
--- a/platform-includes/logs/options/unreal.mdx
+++ b/platform-includes/logs/options/unreal.mdx
@@ -2,12 +2,12 @@ The following configuration options are available for Sentry Logs in Unreal Engi
 
 | Option | Description | Default |
 |--------|-------------|------------|
-| **Enable Structured Logging** | Master toggle for the structured logging feature | `false` |
+| **Enable Structured Logging** | Master toggle for the structured logging feature | `true` |
 | **Enable Debug Logs** | Forward Debug level UE_LOG calls to Sentry | `false` |
 | **Enable Info Logs** | Forward Info level UE_LOG calls to Sentry | `false` |
-| **Enable Warning Logs** | Forward Warning level UE_LOG calls to Sentry | `true` |
-| **Enable Error Logs** | Forward Error level UE_LOG calls to Sentry | `true` |
-| **Enable Fatal Logs** | Forward Fatal level UE_LOG calls to Sentry | `true` |
+| **Enable Warning Logs** | Forward Warning level UE_LOG calls to Sentry | `false` |
+| **Enable Error Logs** | Forward Error level UE_LOG calls to Sentry | `false` |
+| **Enable Fatal Logs** | Forward Fatal level UE_LOG calls to Sentry | `false` |
 | **Send Logs As Breadcrumbs** | Send UE_LOG calls BOTH as Logs and as Breadcrumbs, instead of just Logs | `false` |
 | **Log Category Filter** | Array of log categories to include (empty = all categories) | Empty |
 | **Before Log Callback** | Handler to modify or filter log events before sending | None |

--- a/platform-includes/logs/usage/unreal.mdx
+++ b/platform-includes/logs/usage/unreal.mdx
@@ -71,10 +71,6 @@ SentrySubsystem->LogInfo(TEXT("Game started")); // Includes game_version and pla
 SentrySubsystem->RemoveAttribute(TEXT("platform"));
 ```
 
-<Alert level="warning">
-  Global log attributes are not currently supported on Android. The `SetAttribute` and `RemoveAttribute` methods will be no-ops on that platform.
-</Alert>
-
 ### Log Levels
 
 Sentry Logs supports the following log levels:

--- a/platform-includes/metrics/options/unreal.mdx
+++ b/platform-includes/metrics/options/unreal.mdx
@@ -2,7 +2,7 @@ The following configuration options are available for Sentry's [Application Metr
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| **Enable Metrics** | Master toggle for the metrics feature | `false` |
+| **Enable Metrics** | Master toggle for the metrics feature | `true` |
 | **Collect frame time metrics** | Automatically emit frame time and per-thread performance metrics. | `false` |
 | **Frame time sample interval (frames)** | Emit performance metrics every Nth frame. | `30` |
 | **Collect GC pause metrics** | Emit a metric for each garbage collection pause duration. | `false` |


### PR DESCRIPTION
This PR updates Unreal SDK docs to reflect metrics and structured logging now being enabled by default.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1363
- https://github.com/getsentry/sentry-unreal/pull/1371