### PR TITLE
docs(android): Add Paparazzi workarounds for Gradle 9.2+ and AGP 9.x

### DIFF
--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -39,8 +39,28 @@ First, choose a Paparazzi version compatible with your project:
 
 | Version         | Gradle         | compileSdk | JDK | compose-bom  |
 | --------------- | -------------- | ---------- | --- | ------------ |
-| `2.0.0-alpha04` | 9.1.x or 9.2.x | 36         | 21+ | > 2025.05.00 |
+| `2.0.0-alpha04` | 9.1+            | 36         | 21+ | > 2025.05.00 |
 | `1.3.5`         | 8.x or 9.x     | ≤ 35       | 17+ | ≤ 2025.04.00 |
+
+<Alert level="warning">
+
+Paparazzi `2.0.0-alpha04` has known compatibility issues with newer Gradle versions:
+
+- **Gradle 9.2+**: Test tasks fail because Paparazzi tries to configure HTML reports in a way Gradle no longer allows. Add this workaround to your module's `build.gradle.kts` ([cashapp/paparazzi#2111](https://github.com/cashapp/paparazzi/issues/2111)):
+
+  ```kotlin
+  tasks.withType<Test>().configureEach {
+    reports.html.required = false
+  }
+  ```
+
+- **AGP 9.x**: Paparazzi doesn't support the new Android DSL yet. Add this to your `gradle.properties`:
+
+  ```properties
+  android.newDsl=false
+  ```
+
+</Alert>
 
 Then apply the plugin:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add workarounds for known Paparazzi `2.0.0-alpha04` compatibility issues with newer Gradle/AGP versions:

- Document the HTML reports workaround needed for Gradle 9.2+ ([cashapp/paparazzi#2111](https://github.com/cashapp/paparazzi/issues/2111))
- Document the `android.newDsl=false` property needed for AGP 9.x
- Update the Gradle compatibility column from "9.1.x or 9.2.x" to "9.1+"

Here's what this looks like: 
<img width="1186" height="419" alt="image" src="https://github.com/user-attachments/assets/f9723824-0ad2-4ce3-a26e-ae92434ae702" />

https://sentry-docs-git-no-paparazzi-gradle-9-workarounds.sentry.dev/platforms/android/snapshots/


## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)