### PR TITLE
docs(js): Update React Router Framework quick start guide to use split layout

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -24,7 +24,7 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <PlatformContent includePath="getting-started-prerequisites" />
 
-<StepComponent>
+<StepConnector selector="h2" showNumbers={true}>
 
 ## Install
 
@@ -35,6 +35,18 @@ If you're using React Router in data or declarative mode, follow the instruction
 To install Sentry using the installation wizard, run the command on the right within your project directory.
 
 The wizard guides you through the setup process, asking you to enable additional (optional) Sentry features for your application beyond error monitoring.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```bash
+npx @sentry/wizard@latest -i reactRouter
+```
+
+</SplitSectionCode>
+
+</SplitSection>
+</SplitLayout>
 
 This guide assumes that you enable all features and allow the wizard to create an example page and route. You can add or remove features at any time, but setting them up now will save you the effort of configuring them manually later.
 
@@ -50,17 +62,6 @@ This guide assumes that you enable all features and allow the wizard to create a
 - Creates example page and API route to help verify your Sentry setup
 
 </Expandable>
-
-</SplitSectionText>
-<SplitSectionCode>
-
-```bash
-npx @sentry/wizard@latest -i reactRouter
-```
-
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
 
 ## Configure
 
@@ -234,6 +235,8 @@ If you haven't tested your Sentry configuration yet, let's do it now. You can co
 1. Open the example page `/sentry-example-page` in your browser. For most React Router applications, this will be at localhost.
 2. Observe the example page with a button that triggers test errors.
 
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+
 Clicking the button triggers an error that Sentry captures for you. The example also demonstrates how to test performance tracing.
 
 <Alert level="success" title="Tip">
@@ -245,8 +248,6 @@ Don't forget to explore the example files' code in your project to understand wh
 ### View Captured Data in Sentry
 
 Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
-
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
 <Include name="quick-start-locate-data-expandable" />
 
@@ -270,4 +271,4 @@ Our next recommended steps for you are:
 
 </Expandable>
 
-</StepComponent>
+</StepConnector>

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -18,11 +18,38 @@ description: "Learn how to manually set up Sentry in your React Router v7 app an
 
 <PlatformContent includePath="getting-started-prerequisites" />
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
+
+Choose the features you want to configure, and this guide will show you how:
+
+<OnboardingOptionButtons
+  options={[
+    "error-monitoring",
+    "performance",
+    "session-replay",
+    "user-feedback",
+    "logs",
+    {
+      id: "profiling",
+      checked: false,
+    },
+  ]}
+/>
+
+<Include name="quick-start-features-expandable" />
 
 ### Install the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Run the command for your preferred package manager to add the SDK package to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <OnboardingOption optionId="profiling">
 
@@ -55,37 +82,43 @@ pnpm add @sentry/react-router
 
 </OnboardingOption>
 
-## Step 2: Configure
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-Choose the features you want to configure, and this guide will show you how:
-
-<OnboardingOptionButtons
-  options={[
-    "error-monitoring",
-    "performance",
-    "session-replay",
-    "user-feedback",
-    "logs",
-    {
-      id: "profiling",
-      checked: false,
-    },
-  ]}
-/>
-
-<Include name="quick-start-features-expandable" />
+## Configure
 
 ### Expose Entry Point Files
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Before configuring Sentry, you need to make React Router's entry files (`entry.client.tsx` and `entry.server.tsx`) visible in your project. Run this command to expose them:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```bash
 npx react-router reveal
 ```
 
-### Configure Client-side Sentry
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-Initialize Sentry in your `entry.client.tsx` file:
+### Configure Client-Side Sentry
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Initialize Sentry in your `entry.client.tsx` file.
+
+The `sentryOnError` handler integrates with React Router's [`onError` hook](https://reactrouter.com/how-to/error-reporting) to automatically capture and report client-side errors to Sentry.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {diff} {filename: entry.client.tsx}
 +import * as Sentry from "@sentry/react-router";
@@ -157,14 +190,18 @@ startTransition(() => {
 });
 ```
 
-The `sentryOnError` handler integrates with React Router's [`onError` hook](https://reactrouter.com/how-to/error-reporting) to automatically capture and report client-side errors to Sentry.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-### Configure Server-side Sentry
+### Configure Server-Side Sentry
 
 <Expandable level="warning" title="Limited Node support for auto-instrumentation" permalink>
-  Automatic server-side instrumentation is currently only supported on:
-    - **Node 20:** Version \<20.19
-    - **Node 22:** Version \<22.12
+
+Automatic server-side instrumentation is currently only supported on:
+
+- **Node 20:** Version \<20.19
+- **Node 22:** Version \<22.12
 
 If you're on a different version, you have two options:
 
@@ -205,7 +242,14 @@ export const action = Sentry.wrapServerAction(
 
 </Expandable>
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, create a file called `instrument.server.mjs` in the root of your project to initialize Sentry:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```js {filename: instrument.server.mjs}
 import * as Sentry from "@sentry/react-router";
@@ -246,7 +290,16 @@ Sentry.init({
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 Next, replace the default `handleRequest` and `handleError` functions in your `entry.server.tsx` file with Sentry's wrapped versions:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {diff} {filename: entry.server.tsx}
 +import * as Sentry from '@sentry/react-router';
@@ -270,8 +323,13 @@ Next, replace the default `handleRequest` and `handleError` functions in your `e
 // ... rest of your server entry
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <Expandable title="Do you need to customize your handleRequest function?">
-  If you need to customize the logic of your `handleRequest` function, you'll need to use Sentry's helper functions (`getMetaTagTransformer` and `wrapSentryHandleRequest`) manually:
+
+If you need to customize the logic of your `handleRequest` function, you'll need to use Sentry's helper functions (`getMetaTagTransformer` and `wrapSentryHandleRequest`) manually:
 
 ```tsx {1-4, 44-45, 69-70}
 import {
@@ -349,7 +407,8 @@ export default wrapSentryHandleRequest(handleRequest);
 </Expandable>
 
 <Expandable title="Do you need to customize your handleError function?">
-  If you have custom logic in your `handleError` function, you'll need to capture errors manually:
+
+If you have custom logic in your `handleError` function, you'll need to capture errors manually:
 
 ```tsx {12}
 import {
@@ -375,7 +434,14 @@ export function handleError(
 
 #### Load Instrumentation on Startup
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 React Router runs in ESM mode, which means you need to load the Sentry instrumentation file before the application starts. Update your `package.json` scripts:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```json {filename: package.json}
 "scripts": {
@@ -384,11 +450,22 @@ React Router runs in ESM mode, which means you need to load the Sentry instrumen
 }
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <PlatformContent includePath="node-options-windows" />
 
 **Deploying to Vercel, Netlify, and similar platforms**
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you're deploying to platforms where you can't set the `NODE_OPTIONS` flag, import the instrumentation file directly at the top of your `entry.server.tsx`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {diff} {filename: entry.server.tsx}
 +import './instrument.server';
@@ -398,17 +475,28 @@ If you're deploying to platforms where you can't set the `NODE_OPTIONS` flag, im
  // ... rest of your imports
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <Alert title="Incomplete Auto-instrumentation" level="warning">
 
 When you import the instrumentation file directly instead of using the `--import` flag, automatic instrumentation will be incomplete. You'll miss automatically captured spans and traces for some server-side operations. Only use this approach when the `NODE_OPTIONS` method isn't available.
 
 </Alert>
 
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+### Add Readable Stack Traces With Source Maps (Optional)
 
 The stack traces in your Sentry errors probably won't look like your actual code without unminifying them. To fix this, upload your source maps to Sentry.
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 First, update `vite.config.ts` to include the `sentryReactRouter` plugin, making sure to pass both the Vite and Sentry configurations to it:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {filename: vite.config.ts} {diff}
 import { reactRouter } from '@react-router/dev/vite';
@@ -432,7 +520,16 @@ export default defineConfig(config => {
 });
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 To keep your auth token secure, always store it in an environment variable instead of directly in your files:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <OrgAuthTokenNote />
 
@@ -440,9 +537,20 @@ To keep your auth token secure, always store it in an environment variable inste
 SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
 
-<Include name="vite-loadenv-hint.mdx" />
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+<Include name="vite-loadenv-hint-splitlayout.mdx" />
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
 Next, include the `sentryOnBuildEnd` hook in `react-router.config.ts`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {filename: react-router.config.ts} {diff}
 import type { Config } from "@react-router/dev/config";
@@ -458,17 +566,34 @@ export default {
 } satisfies Config;
 ```
 
-## Step 4: Avoid Ad Blockers With Tunneling (Optional)
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-<PlatformContent includePath="getting-started-tunneling" />
+### Avoid Ad Blockers With Tunneling (Optional)
 
-## Step 5: Verify Your Setup
+<PlatformContent includePath="getting-started-tunneling-splitlayout" />
+
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 
 ### Issues
 
-To verify that Sentry captures errors and creates issues in your Sentry project, throw an error in a loader:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+To verify that Sentry captures errors and creates issues in your Sentry project, throw an error in a loader.
+
+<OnboardingOption optionId="performance" hideForThisOption>
+  Then, open the route in your browser and you should trigger an error.
+</OnboardingOption>
+
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {filename: error.tsx}
 import type { Route } from "./+types/example-page";
@@ -482,15 +607,23 @@ export default function ExamplePage() {
 }
 ```
 
-<OnboardingOption optionId="performance" hideForThisOption>
-  Open the route in your browser and you should trigger an error.
-</OnboardingOption>
-
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 <OnboardingOption optionId="performance">
 ### Tracing
-To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code:
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+To test your tracing configuration, update the previous code snippet by starting a trace to measure the time it takes for the execution of your code.
+
+Then, open the route in your browser. You should start a trace and trigger an error.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```tsx {filename: error.tsx}
 import * as Sentry from "@sentry/react-router";
@@ -513,13 +646,15 @@ export default function ExamplePage() {
 }
 ```
 
-Open the route in your browser. You should start a trace and trigger an error.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>
 
@@ -536,6 +671,7 @@ At this point, you should have integrated Sentry into your React Router Framewor
 Now's a good time to customize your setup and look into more advanced topics.
 Our next recommended steps for you are:
 
+- Explore [practical guides](/guides/) on what to monitor, log, track, and investigate after setup
 - Learn how to <PlatformLink to="/usage">manually capture errors</PlatformLink>
 - Continue to <PlatformLink to="/configuration">customize your configuration</PlatformLink>
 - Get familiar with [Sentry's product features](/product/) like tracing, insights, and alerts
@@ -546,3 +682,5 @@ Our next recommended steps for you are:
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
This branch contains:
- split layout update in the React Router Framework quick start guide (manual setup) 
- small adjustments to the existing split layout quick start guide for React router framework (wizard setup)

I didn't apply the split layout to some of the Expandables because it made the readability worse.

Closes: #17613 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
