### PR TITLE
docs(cloudflare): Add waitUntil limitation

### DIFF
--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -223,6 +223,40 @@ Server-side spans will display `0ms` for their durations. In the Cloudflare Work
 
 This is expected behavior in the Cloudflare Workers environment and affects all frameworks deployed to Cloudflare Workers, including Next.js, Astro, Remix, and others.
 
+### Missing Spans in `waitUntil()`
+
+If you're using Cloudflare's [`waitUntil()`](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#contextwaituntil) to run background tasks and spans created inside `waitUntil()` are not showing up in Sentry, this is because the request's root span has already ended by the time the background work runs.
+
+To capture spans inside `waitUntil()`, wrap your deferred work with `startSpan` and set `forceTransaction: true`. This creates a separate transaction for the background work:
+
+```javascript {filename:index.js}
+import * as Sentry from "@sentry/cloudflare";
+
+export default {
+  async fetch(request, env, ctx) {
+    // Main request handling
+    const response = processRequest(request);
+
+    // Background work with proper tracing
+    ctx.waitUntil(
+      Sentry.startSpan(
+        { name: "background.task", op: "task", forceTransaction: true },
+        () => updateCacheAndDatabase()
+      )
+    );
+
+    return response;
+  },
+};
+
+async function updateCacheAndDatabase() {
+  // Database operations
+  // Any spans created here will be captured
+}
+```
+
+The `forceTransaction: true` option is required because it creates a separate transaction for the `waitUntil()` work. Without it, spans created after the request ends might get lost.
+
 ## Next Steps
 
 At this point, you should have integrated Sentry and should already be sending data to your Sentry project.

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -225,7 +225,7 @@ This is expected behavior in the Cloudflare Workers environment and affects all 
 
 ### Missing Spans in `waitUntil()`
 
-If you're using Cloudflare's [`waitUntil()`](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#contextwaituntil) to run background tasks and spans created inside `waitUntil()` are not showing up in Sentry, this is because the request's root span has already ended by the time the background work runs.
+If you're using Cloudflare's [`waitUntil()`](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#contextwaituntil) to run background tasks, spans created inside `waitUntil()` may not appear in Sentry because the request's root span has already finished before the background work starts.
 
 To capture spans inside `waitUntil()`, wrap your deferred work with `startSpan` and set `forceTransaction: true`. This creates a separate transaction for the background work:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

[Similar to NextJS](<https://docs.sentry.io/platforms/javascript/guides/nextjs/tracing/#detached-spans-with-after-or-waituntil>) we got this with Cloudflare.

closes getsentry/sentry-docs#16922

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

* Teamwork makes the dream work, so please add a reviewer to your PRs.
* Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.<br>Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](<https://github.com/orgs/getsentry/teams/docs>)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

* [Sentry Docs contributor guide](<https://docs.sentry.io/contributing/>)