### PR TITLE
docs(android): Document Gradle 8.14.2+ requirement for Sentry Android Gradle Plugin 6.x

### DIFF
--- a/docs/platforms/android/configuration/gradle.mdx
+++ b/docs/platforms/android/configuration/gradle.mdx
@@ -41,6 +41,12 @@ The `io.sentry.android.gradle` >= `3.0.0` requires [Android Gradle Plugin >= 7.0
 
 </Alert>
 
+<Alert level="warning" title="Minimum Gradle version for plugin 6.x">
+
+`io.sentry.android.gradle` >= `6.0.0` is built against Gradle `8.14.2` and requires Gradle `8.14.2` or later at runtime. Older Gradle versions (including `8.10.x`) will fail at task registration with a `java.lang.NoSuchMethodError` such as `'org.gradle.api.tasks.Exec org.gradle.api.tasks.Exec.setIgnoreExitValue(boolean)'`. This is a Gradle ABI incompatibility, not a feature flag, so you can't work around it by disabling individual upload tasks. If you can't update Gradle yet, stay on `io.sentry.android.gradle:5.x` until you can. The plugin's minimum supported [Android Gradle Plugin](https://developer.android.com/studio/releases/gradle-plugin) version is `7.4.0`, and the minimum [Kotlin language version](https://kotlinlang.org/docs/compatibility-modes.html) is `1.8`.
+
+</Alert>
+
 ### Configure
 
 Set the auth token as an environment variable to be used when running your release build.

--- a/docs/platforms/android/migration/gradle-plugin-v5-to-v6.mdx
+++ b/docs/platforms/android/migration/gradle-plugin-v5-to-v6.mdx
@@ -1,0 +1,53 @@
+---
+title: Migrate from sentry-android-gradle-plugin 5.x to 6.0.0
+sidebar_order: 8885
+description: "Learn about migrating from Sentry Android Gradle Plugin 5.x to 6.0.0."
+---
+
+## Build Tooling Requirements
+
+`io.sentry.android.gradle` `6.0.0` updates the minimum supported build tooling. Before upgrading, make sure your project meets all of the following:
+
+- **Gradle**: `8.14.2` or later. The plugin is built against Gradle `8.14.2` and requires that version (or later) at runtime. Older Gradle versions (including `8.10.x`) will fail at Gradle configuration with `java.lang.NoSuchMethodError: 'org.gradle.api.tasks.Exec org.gradle.api.tasks.Exec.setIgnoreExitValue(boolean)'`. See the [Android troubleshooting guide](/platforms/android/troubleshooting/#nosuchmethoderror-during-gradle-configuration-with-sentry-android-gradle-plugin-6x) for the underlying cause.
+- **Android Gradle Plugin**: `7.4.0` or later. To stay on AGP `7.3.X` or below, keep using `io.sentry.android.gradle:5.12.x`.
+- **Kotlin**: language version `1.8` or later.
+
+To update your Gradle wrapper, from your Android project root run:
+
+```bash
+./gradlew wrapper --gradle-version=8.14.2 --distribution-type=bin
+./gradlew wrapper --gradle-version=8.14.2 --distribution-type=bin
+```
+
+Running the command twice is intentional so the wrapper regenerates itself with the new version.
+
+## sentry-cli 3.x and Sentry Self-Hosted Compatibility
+
+`io.sentry.android.gradle` `6.0.0` bundles `sentry-cli` `3.0.0`, which officially supports:
+
+- Sentry SaaS, and
+- Sentry self-hosted version `25.11.1` or later.
+
+Many `sentry-cli` features may continue to work against older self-hosted versions, but support is not guaranteed. If you're on an older self-hosted Sentry instance and can't update yet, stay on `io.sentry.android.gradle:5.x` until you can upgrade self-hosted to `25.11.1` or later.
+
+## Sentry Android SDK Compatibility
+
+`io.sentry.android.gradle` `6.x` ships with a recent `8.x` release of the Sentry Android SDK. If you have `autoInstallation` enabled (the default), the plugin will pin `io.sentry:sentry-android-*` to a compatible version automatically.
+
+If you have `autoInstallation { enabled = false }` (common in brownfield apps and React Native setups), you're responsible for keeping `io.sentry:sentry-*` modules aligned across all Gradle modules in your build. Mismatched Sentry SDK versions can cause `IllegalStateException: Sentry SDK has detected a mix of versions` at app startup, or `NoSuchMethodError` at runtime. To pin the SDK version explicitly without enabling auto-installation, configure each `io.sentry:sentry-*` dependency you use to the same version, or enable auto-installation with a fixed version:
+
+```kotlin
+sentry {
+  autoInstallation {
+    enabled.set(true)
+    sentryVersion.set("8.0.0")
+  }
+}
+```
+
+## React Native and Flutter
+
+If you're using `@sentry/react-native` or `sentry_flutter`, the relevant migration guide for your hybrid SDK already pulls in the matching Sentry Android Gradle Plugin version, but you still need to bump your Gradle wrapper to `8.14.2` or later in your Android project before upgrading the hybrid SDK. See:
+
+- [React Native v7 to v8 migration guide](/platforms/react-native/migration/v7-to-v8/)
+- [Flutter migration guide](/platforms/dart/guides/flutter/migration/)

--- a/docs/platforms/android/troubleshooting/index.mdx
+++ b/docs/platforms/android/troubleshooting/index.mdx
@@ -5,6 +5,29 @@ sidebar_order: 9000
 sidebar_section: configuration
 ---
 
+## `NoSuchMethodError` During Gradle Configuration With Sentry Android Gradle Plugin 6.x
+
+If you upgrade to `io.sentry.android.gradle` `6.x` and your build fails during Gradle configuration (often when assembling a release variant) with a stack trace similar to the one below, the cause is a Gradle ABI incompatibility, not a problem with native symbol upload:
+
+```
+Caused by: java.lang.NoSuchMethodError: 'org.gradle.api.tasks.Exec org.gradle.api.tasks.Exec.setIgnoreExitValue(boolean)'
+        at io.sentry.android.gradle.util.SentryCliExecKt.asSentryCliExec(SentryCliExec.kt:19)
+        at io.sentry.android.gradle.tasks.SentryUploadNativeSymbolsTask$Companion$register$...
+```
+
+The Sentry Android Gradle Plugin `6.x` is built against Gradle `8.14.2` and requires Gradle `8.14.2` or later at runtime. Older Gradle versions (including `8.10.x`) don't expose the exact `Exec.setIgnoreExitValue(boolean)` signature the plugin was compiled against, so registration of any task that wraps `sentry-cli` (native symbols, ProGuard mapping upload, source context, debug files) fails with `NoSuchMethodError`.
+
+To resolve this, update your Gradle wrapper to `8.14.2` or later. From your Android project root run:
+
+```bash
+./gradlew wrapper --gradle-version=8.14.2 --distribution-type=bin
+./gradlew wrapper --gradle-version=8.14.2 --distribution-type=bin
+```
+
+Running the command twice is intentional so the wrapper regenerates itself with the new version. If you can't update Gradle yet, stay on `io.sentry.android.gradle:5.x` until you can.
+
+Disabling `uploadNativeSymbols`, `includeSourceContext`, or `autoUploadProguardMapping` may appear to "fix" the build, but it only sidesteps the failing task registration. The underlying ABI mismatch remains and other Sentry tasks will hit the same error as soon as they run.
+
 ## Obfuscated stack traces, missing Android-specific context
 
 If stack traces don't get deobfuscated properly, even though <PlatformLink to="/enhance-errors/proguard/">mapping files are uploaded correctly</PlatformLink>, or if Android context information is missing from events, a possible reason is that the SDK is initialized with `Sentry.init` instead of `SentryAndroid.init`.

--- a/docs/platforms/react-native/migration/v7-to-v8.mdx
+++ b/docs/platforms/react-native/migration/v7-to-v8.mdx
@@ -44,7 +44,14 @@ The Android build tooling requirements have been updated:
 - **Sentry Android Gradle Plugin**: **6.0.0** (previously 5.x)
   - Drops support for Android Gradle Plugin 7.3.X and below
 - **Android Gradle Plugin**: **7.4.0+** (previously 7.3.0+)
+- **Gradle**: **8.14.2+** (previously 7.5.1+)
 - **Kotlin**: **1.8+** (previously no minimum specified)
+
+<Alert level="warning" title="Update your Gradle wrapper">
+
+The Sentry Android Gradle Plugin `6.x` is built against Gradle `8.14.2` and requires Gradle `8.14.2` or later at runtime. If your `android/gradle/wrapper/gradle-wrapper.properties` is on an older Gradle (commonly `8.10.x` for projects on AGP `8.7`), the build will fail at task registration with `java.lang.NoSuchMethodError: 'org.gradle.api.tasks.Exec org.gradle.api.tasks.Exec.setIgnoreExitValue(boolean)'`. Update your Gradle wrapper before bumping `@sentry/react-native` to v8. See the [Android troubleshooting guide](/platforms/android/troubleshooting/#nosuchmethoderror-during-gradle-configuration-with-sentry-android-gradle-plugin-6x) for details.
+
+</Alert>
 
 Update your `android/build.gradle` file to ensure compatibility. If you're using the Android SDK directly, see the [Android SDK migration guide](/platforms/android/migration/) for details:
 

--- a/docs/platforms/react-native/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/troubleshooting/index.mdx
@@ -5,6 +5,10 @@ sidebar_order: 12
 sidebar_section: configuration
 ---
 
+## `NoSuchMethodError` After Upgrading To `@sentry/react-native` v8 On Android
+
+If you've upgraded `@sentry/react-native` to v8 and your Android build fails with `java.lang.NoSuchMethodError: 'org.gradle.api.tasks.Exec org.gradle.api.tasks.Exec.setIgnoreExitValue(boolean)'` (originating from `io.sentry.android.gradle.util.SentryCliExecKt.asSentryCliExec`), your Gradle wrapper is older than what the Sentry Android Gradle Plugin `6.x` requires. `@sentry/react-native` v8 ships with `io.sentry.android.gradle` `6.x`, which is built against Gradle `8.14.2` and requires Gradle `8.14.2` or later at runtime. Update `android/gradle/wrapper/gradle-wrapper.properties` to use `8.14.2` or later, then re-run the build. See the [Android troubleshooting guide](/platforms/android/troubleshooting/#nosuchmethoderror-during-gradle-configuration-with-sentry-android-gradle-plugin-6x) for the full explanation and the exact wrapper command.
+
 ## Support 16 KB Page Sizes on Android
 
 Starting with Android 15, AOSP supports devices with a 16 KB page size. If your app uses NDK libraries (directly or via an SDK), you'll need to rebuild it for compatibility with these devices.


### PR DESCRIPTION
## Summary

The `sentry-android-gradle-plugin` 6.x line is built against Gradle 8.14.2 and requires Gradle 8.14.2+ at runtime, but this is currently not surfaced in user-facing docs. Customers upgrading to `@sentry/react-native` v8 (which bundles SAGP 6.x) on Gradle 8.10.x hit a confusing `java.lang.NoSuchMethodError: 'org.gradle.api.tasks.Exec org.gradle.api.tasks.Exec.setIgnoreExitValue(boolean)'` at task registration. Disabling `uploadNativeSymbols` masks the error temporarily but doesn't fix the underlying ABI mismatch, so users have been chasing the wrong fix.

These doc changes were made at the request of a customer who hit this exact issue while upgrading to Sentry React Native v8 on a brownfield Android app. Support ticket: https://app.intercom.com/a/inbox/onh0p2wm/inbox/admin/9850682/conversation/215474146376271?view=List

## What's in this PR

- New migration guide page for SAGP 5.x → 6.0 (the migration directory previously had no entry for this version jump).
- New troubleshooting entry on the Android troubleshooting page with the literal stack trace and the exact `gradlew wrapper` fix.
- Cross-referenced troubleshooting entry on the React Native troubleshooting page.
- Added the missing `Gradle: 8.14.2+` bullet (with a warning Alert) to the React Native v7 → v8 migration guide's Android section.
- Added a warning Alert to the main `Gradle` configuration page calling out the minimum runtime Gradle version for plugin 6.x.

## Test plan

- [ ] \`pnpm dev\` and confirm the new and modified pages render correctly.
- [ ] Confirm the anchor link \`#nosuchmethoderror-during-gradle-configuration-with-sentry-android-gradle-plugin-6x\` resolves from both the React Native troubleshooting page and the React Native v7-to-v8 migration page.
- [ ] Verify the new SAGP v5-to-v6 migration page appears in the Android migration sidebar above the v3-to-v4 entry.
- [ ] \`pnpm lint\` passes.

## Background

The only workaround the customer initially found was disabling \`uploadNativeSymbols\` and \`includeNativeSources\`, which obscured the actual root cause. Adding an explicit minimum-version guard inside the plugin itself (so Gradle fails fast with an actionable message) is being tracked separately in the [sentry-android-gradle-plugin repo](https://github.com/getsentry/sentry-android-gradle-plugin); this PR is just the documentation half.