### PR TITLE
docs(size-analysis): Link to status check rules API reference

### DIFF
--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -154,13 +154,13 @@ Rules are evaluated independently. If any rule's threshold is exceeded, the stat
 
 ### Fetching Status Check Rules for External CI
 
-If you're consuming the `preprod_artifact.size_analysis_completed` webhook in your own CI, you can fetch the project's current status check rule config from the Size Analysis status check rules API:
+If you're consuming the `preprod_artifact.size_analysis_completed` webhook in your own CI, you can fetch the project's current status check rule config from the [Size Analysis status check rules API](/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/):
 
 ```http
 GET /api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/preprod/size-analysis/status-check-rules/
 ```
 
-Use this when you want external CI to evaluate the same thresholds that Sentry uses for Size Analysis status checks, without duplicating rule configuration outside Sentry. Once the generated API reference is available, it will document the response shape, filter operators, AND/OR grouping semantics, wildcard matching behavior, and invalid-filter handling.
+Use this when you want external CI to evaluate the same thresholds that Sentry uses for Size Analysis status checks, without duplicating rule configuration outside Sentry.
 
 The endpoint returns the **current project configuration**, not a historical snapshot from when the webhook was emitted. If rules change between webhook delivery and your API request, you'll receive the updated rules.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The [Size Analysis status check rules API reference](https://docs.sentry.io/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/) is now published, so link it from the "Fetching Status Check Rules for External CI" section and drop the placeholder note that anticipated its arrival.

- Link the in-text mention of the API to `/api/mobile-builds/retrieve-size-analysis-status-check-rules-for-a-project/`
- Remove the "Once the generated API reference is available…" sentence

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)