### PR TITLE
fix: Add missing redirects for /integrations/slack/ and /integrations/project-mgmt/jira/

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -301,6 +301,14 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
     to: '/integrations/notification-incidents/discord/',
   },
   {
+    from: '/integrations/slack/',
+    to: '/integrations/notification-incidents/slack/',
+  },
+  {
+    from: '/integrations/project-mgmt/jira/',
+    to: '/integrations/issue-tracking/jira/',
+  },
+  {
     from: '/platforms/python/migration/configuration/filtering/',
     to: '/platforms/python/configuration/filtering/',
   },


### PR DESCRIPTION
## Summary

- Adds redirect from `/integrations/slack/` to `/integrations/notification-incidents/slack/`
- Adds redirect from `/integrations/project-mgmt/jira/` to `/integrations/issue-tracking/jira/`

## Problem

The wildcard redirect in `redirects.js` (`/product/integrations/:path*` → `/integrations/:path*`) strips the `/product/` prefix but doesn't handle integration pages that live under subcategories. This causes 404s when users hit these URLs from links in the Sentry UI:

- `/product/integrations/slack/` → wildcard turns it into `/integrations/slack/` → **404** (actual page is at `/integrations/notification-incidents/slack/`)
- `/product/integrations/project-mgmt/jira/#jira-server` → wildcard turns it into `/integrations/project-mgmt/jira/` → **404** (actual page is at `/integrations/issue-tracking/jira/`)

### Where these links exist in `getsentry/sentry`:
- `/product/integrations/slack/` — `src/sentry_plugins/slack/README.rst`
- `/product/integrations/slack/#upgrading-slack` — `src/sentry/templates/sentry/integrations/slack/reauth-introduction.html` (user-facing during Slack reauth)
- `/product/integrations/project-mgmt/jira/#jira-server` — locale translation files (`django.po`)

## Fix

Added two simple redirects in `middleware.ts` to catch the post-wildcard paths and route them to the correct canonical pages.