### PR TITLE
docs(engineering-practices): Remove username prefix from branch naming

### DIFF
--- a/develop-docs/engineering-practices/branch-naming.mdx
+++ b/develop-docs/engineering-practices/branch-naming.mdx
@@ -6,10 +6,9 @@ sidebar_order: 11
 
 ### Format
 
-Use the format `<username>/<type>/<short-description>`:
+Use the format `<type>/<short-description>`:
 
-- **username**: your GitHub username
 - **type**: one of `feat`, `fix`, `ref`, `perf`, `docs`, `test`, `ci`, `build`, `chore`, `style`, `meta`, `license`
 - **short-description**: what the change is about, in kebab-case
 
-For example: `johndoe/feat/add-resolve-action` or `johndoe/fix/empty-reference-handling`.
+For example: `feat/add-resolve-action` or `fix/empty-reference-handling`.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

The SDK code-submission spec dropped the `<username>/` prefix from branch names in v1.2.0 (2026-03-18). Align with code-submission so both show the same format.


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [X] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
