### PR TITLE
docs(develop): clarify scope data PII gating as write-time, not read-time

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -205,6 +205,18 @@ SDKs **SHOULD** only replace sensitive values with `"[Filtered]"` when the data 
 
 Users can register callbacks (e.g., `beforeSend`, event processors) to remove or redact any data (including keys) before events are sent. This spec does not replace those hooks; they remain the primary mechanism for custom filtering and key removal.
 
+#### Scope Data: Write-Time Gating, Not Read-Time Gating
+
+`dataCollection` (and its predecessor `sendDefaultPii`) guards **writing** data to the scope through auto-instrumentation. It does **not** guard **reading** data from the scope when attaching it to outgoing telemetry (events, logs, metrics, etc.).
+
+Concretely:
+
+- **Auto-instrumentation writes to scope** — When SDK instrumentation automatically populates scope data (e.g., inferring `user.ip_address` from an HTTP request), the write **MUST** be gated by the relevant `dataCollection` option (e.g., `userInfo`). If the option is disabled, the SDK **MUST NOT** write that data to the scope.
+- **Reading from scope to attach to telemetry** — When the SDK reads data already present on the scope to attach it as attributes on logs, metrics, or other telemetry, it **MUST NOT** re-apply `dataCollection` gating. The data was already accepted at write time.
+- **User-set data** — Data the user explicitly sets (e.g., via `Sentry.setUser()`, `scope.setTag()`, or direct attribute assignment) is **never** gated by `dataCollection`. The user has made a deliberate choice to include that data.
+
+This means if a user calls `Sentry.setUser({ email: "jane@example.com" })`, that email **MUST** appear on logs, metrics, and events regardless of `dataCollection.userInfo` or `sendDefaultPii`. The gate only applies to auto-instrumentation that would populate user fields without the user's explicit action.
+
 </SpecSection>
 
 ---

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -2,7 +2,7 @@
 title: Logs
 description: Structured logging protocol with severity levels, trace context, and batched envelope delivery.
 spec_id: sdk/telemetry/logs
-spec_version: 2.0.0
+spec_version: 2.1.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
@@ -10,6 +10,9 @@ spec_depends_on:
   - id: sdk/foundations/state-management/scopes/attributes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 2.1.0
+    date: 2026-05-06
+    summary: Clarified sendDefaultPii gating for user attributes — allowed when user manually sets data
   - version: 2.0.0
     date: 2026-04-09
     summary: Default enableLogs to true, add auto-emitted logs opt-in requirements for integrations
@@ -198,7 +201,7 @@ Since 1.9.0, logs follow these rules:
 
 ### User Attributes
 
-SDKs **MAY** attach user information as attributes, guarded by `sendDefaultPii` (since 1.14.0):
+SDKs **MAY** attach user information as attributes, guarded by `sendDefaultPii` ([unless manually set by user](/sdk/foundations/client/data-collection/#user-set-data-scrubbing), since 2.1.0):
 
 | Attribute | Description |
 |-----------|-------------|


### PR DESCRIPTION
Add specification that `dataCollection`/`sendDefaultPii` gates writing data to the scope via auto-instrumentation, not reading it when attaching to outgoing telemetry. User-set data (e.g., `Sentry.setUser()`) is never gated.

Bump logs spec to 2.1.0 to reflect the clarified `sendDefaultPii` behavior for user attributes.
