### PR TITLE
docs(react-native): Document touch breadcrumb label fallbacks

### DIFF
--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -52,7 +52,21 @@ Each touch event is automatically logged as a breadcrumb and displays on the das
 
 ## Tracking Specific Components
 
-You can let Sentry know which components to track specifically by passing the `sentry-label` prop to them. If Sentry detects a component with a `sentry-label` within a touch's component tree, it will be logged on the dashboard as having occurred in that component. If Sentry cannot find a component with the label, Sentry will fall back to the `labelName` prop if specified, or else use `displayName`.
+You can let Sentry know which components to track specifically by passing the `sentry-label` prop to them. If Sentry detects a component with a `sentry-label` within a touch's component tree, it will be logged on the dashboard as having occurred in that component.
+
+For each component in the touch path, the SDK extracts a **label** and a **name**. The breadcrumb message uses the label if any component in the path has one; otherwise it falls back to the root component's name.
+
+The **label** is determined by the first available value from:
+
+1. `sentry-label` prop
+2. Custom `labelName` prop (if configured on the boundary)
+3. `accessibilityLabel` prop
+4. `aria-label` prop
+5. `testID` prop
+
+The **name** comes from the Babel plugin annotation (`data-sentry-component`) or `displayName`. See [Component Names](/platforms/react-native/integrations/component-names/) for details.
+
+This means apps that use accessibility labels or test IDs get meaningful touch breadcrumbs automatically, without any extra configuration.
 
 ```javascript
 const YourCoolComponent = (props) => {
@@ -114,7 +128,7 @@ _Array&lt;string | RegExp>, Accepts strings and regular expressions_. Component 
 
 `labelName`
 
-_String_. The name of the prop to look for when determining the label of a component. If the prop is not found, Sentry will fall back to the `displayName` of the component.
+_String_. The name of a custom prop to look for when determining the label of a component. Takes priority over the automatic `accessibilityLabel`, `aria-label`, and `testID` fallbacks.
 
 ## Minified Names in Production
 

--- a/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
@@ -37,7 +37,7 @@ const App = () => <View>Your App</View>;
 export default Sentry.wrap(App);
 ```
 
-The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, `sentry-label` will be used instead. If an element can't be identified, the transaction won't be captured.
+The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, the SDK will look for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` as fallbacks. If an element can't be identified, the transaction won't be captured.
 
 ```javascript {2-2}
 export default Sentry.wrap(App, {

--- a/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
@@ -37,7 +37,7 @@ const App = () => <View>Your App</View>;
 export default Sentry.wrap(App);
 ```
 
-The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, the SDK will look for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` as fallbacks. If an element can't be identified, the transaction won't be captured.
+The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, the SDK will look for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` as fallbacks. `sentry-label` always takes priority, even when `labelName` is configured. If an element can't be identified, the transaction won't be captured.
 
 ```javascript {2-2}
 export default Sentry.wrap(App, {

--- a/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
@@ -37,7 +37,7 @@ const App = () => <View>Your App</View>;
 export default Sentry.wrap(App);
 ```
 
-The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, the SDK will look for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` as fallbacks. If an element can't be identified, the transaction won't be captured.
+The SDK identifies UI elements by looking for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` props. You can also specify a custom prop name with the `labelName` option in `Sentry.wrap`, which takes priority over `accessibilityLabel`, `aria-label`, and `testID`. If an element can't be identified, the transaction won't be captured.
 
 ```javascript {2-2}
 export default Sentry.wrap(App, {

--- a/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
+++ b/docs/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation.mdx
@@ -37,7 +37,7 @@ const App = () => <View>Your App</View>;
 export default Sentry.wrap(App);
 ```
 
-The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, the SDK will look for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` as fallbacks. `sentry-label` always takes priority, even when `labelName` is configured. If an element can't be identified, the transaction won't be captured.
+The label by which UI elements are identified is set by the `labelName` option in `Sentry.wrap`. If no value is supplied, the SDK will look for `sentry-label`, then `accessibilityLabel`, `aria-label`, and `testID` as fallbacks. If an element can't be identified, the transaction won't be captured.
 
 ```javascript {2-2}
 export default Sentry.wrap(App, {


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates React Native touch event docs to reflect that `accessibilityLabel`, `aria-label`, and `testID` are now automatically used as label fallbacks for touch breadcrumbs (added in [getsentry/sentry-react-native#6103](https://github.com/getsentry/sentry-react-native/pull/6103)).

**Changes:**

- **`touchevents.mdx`**: Rewrote the "Tracking Specific Components" section to correctly distinguish between the **label** fallback chain (`sentry-label` > `labelName` > `accessibilityLabel` > `aria-label` > `testID`) and the **name** field (Babel annotation / `displayName`). Updated `labelName` option description.
- **`user-interaction-instrumentation.mdx`**: Updated the label identification description to mention the full fallback chain.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/6103 is released

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)