### PR TITLE
fix(Layout):Cap image max-width at 1000px and remove ultra-wide layout snap

### DIFF
--- a/src/components/developDocsHeader.tsx
+++ b/src/components/developDocsHeader.tsx
@@ -140,32 +140,7 @@ export function DevelopDocsHeader({
           </div>
         </div>
       </nav>
-      <style>{`
-        /* Align header width with content + sidebars at wide screens */
-        @media (min-width: 2057px) {
-          header .nav-inner {
-            /* total layout width = sidebar + gap + content + gap + toc */
-            max-width: calc(
-              var(--sidebar-width, 300px)
-              + var(--gap, 24px)
-              + var(--doc-content-w, 1200px)
-              + var(--gap, 24px)
-              + var(--toc-w, 250px)
-            );
-            margin-left: auto;
-            margin-right: auto;
-            /* center, then compensate if sidebar != toc */
-            transform: translateX(calc((var(--toc-w, 250px) - var(--sidebar-width, 300px)) / 2));
-            /* restore small internal padding (≈ Tailwind px-3) */
-            padding-left: 0.75rem;
-            padding-right: 0.75rem;
-          }
-          /* Ensure the left logo area equals sidebar width */
-          header .nav-inner .logo-slot {
-            width: var(--sidebar-width, 300px);
-          }
-        }
-      `}</style>
+      
     </header>
   );
 }

--- a/src/components/developDocsHeader.tsx
+++ b/src/components/developDocsHeader.tsx
@@ -140,7 +140,14 @@ export function DevelopDocsHeader({
           </div>
         </div>
       </nav>
-      
+      <style>{`
+        /* Fluid centering to match sidebar offset at wide viewports.
+           Use max() to preserve the nav's base 0.75rem (px-3) padding. */
+        header .nav-inner {
+          padding-left: max(0.75rem, var(--layout-offset, 0px));
+          padding-right: max(0.75rem, var(--layout-offset, 0px));
+        }
+      `}</style>
     </header>
   );
 }

--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -141,6 +141,7 @@ export async function DocPage({
           <aside
             data-layout-anchor="right"
             className="sticky h-[calc(100vh-var(--header-height))] top-[var(--header-height)] overflow-y-auto hidden toc:block flex-none w-[250px] min-w-[250px]"
+            style={{marginRight: 'var(--layout-offset, 0px)'}}
           >
             <div className="sidebar">
               <SidebarTableOfContents />
@@ -149,10 +150,18 @@ export async function DocPage({
           </aside>
         )}
       </section>
-      <style>{`:root { --doc-content-w: 1100px; }`}</style>
       <style>{`
+        :root {
+          --doc-content-w: 1100px;
+          --toc-w: 250px;
+          --layout-total: calc(var(--sidebar-width, 300px) + var(--doc-content-w) + var(--toc-w));
+          /* Fluid centering offset: 0 when viewport <= total layout width,
+             grows equally on both sides when viewport > total layout width.
+             This shifts the entire sidebar+content+ToC assembly toward center. */
+          --layout-offset: max(0px, (100vw - var(--layout-total)) / 2);
+        }
         #doc-content {
-          max-width: none;
+          max-width: var(--doc-content-w);
           box-sizing: border-box;
         }
         /* Mobile responsive styles */
@@ -166,14 +175,6 @@ export async function DocPage({
             width: 100%;
             max-width: 100%;
             overflow-x: hidden;
-          }
-        }
-        /* At toc breakpoint (1490px), cap content width at --doc-content-w.
-           Sidebar stays fixed-left; extra space appears on the right at
-           ultra-wide viewports. */
-        @media (min-width: 1490px) {
-          #doc-content {
-            max-width: min(var(--doc-content-w), calc(100vw - 300px - 250px));
           }
         }
       `}</style>

--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -168,40 +168,12 @@ export async function DocPage({
             overflow-x: hidden;
           }
         }
-        /* At toc breakpoint (1490px), constrain content to leave room for TOC */
+        /* At toc breakpoint (1490px), cap content width at --doc-content-w.
+           Sidebar stays fixed-left; extra space appears on the right at
+           ultra-wide viewports. */
         @media (min-width: 1490px) {
           #doc-content {
-            /* Calculate max width: viewport - sidebar - TOC */
-            max-width: calc(100vw - 300px - 250px);
-          }
-        }
-        @media (min-width: 2057px) {
-          :root {
-            --doc-content-w: 1100px;
-            --toc-w: 250px;
-            --gap: 24px;
-          }
-          /* Cap content width and center (reinforced at this breakpoint) */
-          #doc-content {
-            max-width: var(--doc-content-w);
-            padding-left: 2rem;
-            padding-right: 2rem;
-            margin-left: auto;
-            margin-right: auto;
-          }
-          /* Cancel default push so content can center */
-          [data-layout-anchor="left"] + .main-content {
-            margin-left: 0 !important;
-            width: 100% !important;
-          }
-          /* Anchor sidebars to content edges */
-          [data-layout-anchor="left"] {
-            left: calc(50% - (var(--doc-content-w) / 2) - var(--gap) - var(--sidebar-width));
-          }
-          [data-layout-anchor="right"] {
-            position: fixed !important;
-            left: calc(50% + (var(--doc-content-w) / 2) + var(--gap));
-            width: var(--toc-w);
+            max-width: min(var(--doc-content-w), calc(100vw - 300px - 250px));
           }
         }
       `}</style>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -195,7 +195,11 @@ export function Header({
             padding-right: 26px;
           }
         }
-        
+        /* Doc pages: fluid centering to match sidebar offset at wide viewports */
+        .header-content:not(.header-content-home) {
+          padding-left: var(--layout-offset, 0px);
+          padding-right: var(--layout-offset, 0px);
+        }
       `}</style>
       <div
         className={`header-content flex items-center w-full ${isHomePage ? 'header-content-home' : ''}`}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -195,19 +195,7 @@ export function Header({
             padding-right: 26px;
           }
         }
-        /* Doc pages: align header with sidebar and TOC at large viewports */
-        @media (min-width: 2057px) {
-          .header-content:not(.header-content-home) {
-            --sidebar-width: 300px;
-            --doc-content-w: 1100px;
-            --toc-w: 250px;
-            --gap: 24px;
-            /* Match sidebar left edge position */
-            padding-left: calc(50% - (var(--doc-content-w) / 2) - var(--gap) - var(--sidebar-width));
-            /* Match TOC right edge position */
-            padding-right: calc(50% - (var(--doc-content-w) / 2) - var(--gap) - var(--toc-w));
-          }
-        }
+        
       `}</style>
       <div
         className={`header-content flex items-center w-full ${isHomePage ? 'header-content-home' : ''}`}

--- a/src/components/imageLightbox/index.tsx
+++ b/src/components/imageLightbox/index.tsx
@@ -107,9 +107,10 @@ export function ImageLightbox({
         ? {
             width: width != null ? `${width}px` : 'auto',
             height: height != null ? `${height}px` : 'auto',
+            maxWidth: 'min(100%, 1000px)',
             ...style,
           }
-        : {width: '100%', height: 'auto', ...style}
+        : {width: 'auto', maxWidth: 'min(100%, 1000px)', height: 'auto', ...style}
       : {width: 'auto', height: 'auto'};
 
     if (shouldUseNextImage && dimensions) {
@@ -146,7 +147,7 @@ export function ImageLightbox({
         onClick={handleClick}
         onAuxClick={handleClick}
         onKeyDown={handleKeyDown}
-        className="cursor-pointer border-none bg-transparent p-0 block w-full no-underline"
+        className="cursor-pointer border-none bg-transparent p-0 block w-fit no-underline"
         aria-label={`View image: ${alt}`}
       >
         {renderImage()}

--- a/src/components/sidebar/style.module.scss
+++ b/src/components/sidebar/style.module.scss
@@ -52,14 +52,14 @@
 
   @media only screen and (min-width: 768px) {
     position: fixed;
-    left: 0;
+    left: var(--layout-offset, 0px);
     top: var(--header-height, 64px);
     width: var(--sidebar-width);
     display: flex;
 
     & + :global(.main-content) {
-      margin-left: var(--sidebar-width);
-      width: calc(100% - var(--sidebar-width));
+      margin-left: calc(var(--sidebar-width) + var(--layout-offset, 0px));
+      width: calc(100% - var(--sidebar-width) - var(--layout-offset, 0px));
     }
   }
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Doc page images were rendering at full container width (`width: 100%`), making them unnecessarily large and clunky to read around. This PR caps all doc images at 1000px max-width while preserving natural size for smaller images. 

It also removes a jarring layout snap that occurred at the 2057px viewport breakpoint.

Good example page: https://sentry-docs-git-cap-image-max-width-1000.sentry.dev/product/issues/issue-details/

### Image changes (`imageLightbox/index.tsx`)

- **Default images**: Replaced `width: '100%'` with `width: 'auto', maxWidth: 'min(100%, 1000px)'`. Images now render at their natural size, capped at 1000px. On mobile/narrow viewports, `min(100%, 1000px)` ensures they still scale down responsively.
- **Explicit dimension overrides** (e.g. `![alt =1200x800](img.png)`): Added `maxWidth: 'min(100%, 1000px)'` so these are also capped.
- **Click target**: Changed `Lightbox.Trigger` from `w-full` to `w-fit` so the clickable area matches the image width, preventing accidental lightbox triggers when clicking empty space beside narrow images.
- **Lightbox full-screen view**: Unchanged — still uses `max-h-[90vh] max-w-[90vw]` for the expanded view.

All changes are retroactive — every MDX image flows through the `DocImage` → `ImageLightbox` pipeline, so no content files need updating.

### Layout changes (`docPage/index.tsx`, `header.tsx`, `developDocsHeader.tsx`)

- **Removed the 2057px centering breakpoint** from all three files. This breakpoint attempted to center the sidebar + content + ToC assembly at ultra-wide viewports, but caused a jarring width snap as the layout transitioned from left-anchored to centered.
- **Replaced** the 1490px content rule with `max-width: min(var(--doc-content-w), calc(100vw - 300px - 250px))` — content grows fluidly until it hits 1100px, then stops. No discrete layout shifts at any viewport width.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)