### PR TITLE
docs(apple): Document Set as a supported metric attribute type

### DIFF
--- a/platform-includes/metrics/usage/apple.mdx
+++ b/platform-includes/metrics/usage/apple.mdx
@@ -86,6 +86,7 @@ The SDK uses the `SentryAttributeValue` protocol to provide **compile-time type 
 **Supported attribute types:**
 - **Scalar types**: `String`, `Bool`, `Int`, `Double`, `Float`
 - **Array types**: `[String]`, `[Bool]`, `[Int]`, `[Double]`, `[Float]`
+- **Set types**: `Set<String>`, `Set<Bool>`, `Set<Int>`, `Set<Double>`, `Set<Float>`
 
 The protocol automatically handles type conversion and validation, so you can use Swift's native types directly in your code. Invalid types will be caught at compile time, preventing runtime errors.
 
@@ -102,7 +103,8 @@ SentrySDK.metrics.count(
         "build_number": 123,            // Int - passed directly
         "is_premium": true,             // Bool - passed directly
         "success_rate": 0.95,           // Double - passed directly
-        "tags": ["production", "v2"]     // [String] - passed directly
+        "tags": ["production", "v2"],     // [String] - passed directly
+        "features": Set(["darkMode", "beta"])  // Set<String> - passed directly
     ]
 )
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add Set<String>, Set<Bool>, Set<Int>, Set<Double>, and Set<Float> to the list of supported SentryAttributeValue types in the Apple metrics docs, following the addition of Set conformance in sentry-cocoa#7876.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
