### PR TITLE
docs(slack): Replace Discover with Explore in Slack unfurl references

### DIFF
--- a/develop-docs/integrations/slack/index.mdx
+++ b/develop-docs/integrations/slack/index.mdx
@@ -89,7 +89,7 @@ Add the following scopes to **Bot Scopes**:
 | `im:history`           | Receive `message.im` events for the bot's help responses in DMs, and fetch DM thread context for Seer Agent.                                                                        |
 | `im:read`              | Receive direct-message events and resolve DM channel metadata, enabling slash commands and messages sent directly to the bot.                                                       |
 | `links:read`           | Receive `link_shared` events when a user pastes a Sentry URL in Slack so the integration can generate a rich preview.                                                               |
-| `links:write`          | Attach rich unfurl previews (issues, Discover queries, metric alerts) to Sentry URLs shared in Slack.                                                                               |
+| `links:write`          | Attach rich unfurl previews (issues, explore queries, metric alerts) to Sentry URLs shared in Slack.                                                                               |
 | `team:read`            | Fetch the workspace name and icon during installation for display in the Sentry integration settings page.                                                                          |
 | `users:read`           | Look up workspace users to validate alert-rule recipients, search by username/display name, and automatically link Sentry accounts to Slack identities by email after installation. |
 

--- a/develop-docs/services/chartcuterie.mdx
+++ b/develop-docs/services/chartcuterie.mdx
@@ -11,7 +11,7 @@ application.
 There are however, cases where it would be very valuable to show a chart in
 some context onside of the application. For example
 
- * Slack unfurling of Discover charts, Metric Alert notifications, Issue
+ * Slack unfurling of Explore charts, Metric Alert notifications, Issue
    details, or any other link in Sentry where it may be useful to see a chart
    in Slack.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates docs to mention unfurling works for all areas of explore. Discover is under explore in the sidebar too, so renaming discover -> explore in the docs makes sense.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): May 11
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)