### PR TITLE
fix(deno): Preserve npm: specifier in ___SDK_PACKAGE___ for Deno

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/postgresjs.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/postgresjs.mdx
@@ -36,7 +36,7 @@ export default Sentry.withSentry((env) => ({ dsn: "__DSN__" }), {
 <PlatformSection supported={["javascript.deno"]}>
 
 ```javascript
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 import postgres from "npm:postgres";
 
 const sql = Sentry.instrumentPostgresJsSql(

--- a/docs/platforms/javascript/common/configuration/integrations/supabase.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/supabase.mdx
@@ -39,15 +39,16 @@ You need to have both the Sentry SDK and the Supabase library installed. For Sup
 
 ## Configuration
 
-This is the preferred method for most use cases. and follows Sentry's standard integration pattern.
+This is the preferred method for most use cases and follows Sentry's standard integration pattern.
 
 ```javascript
+import * as Sentry from "___SDK_PACKAGE___";
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseClient = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_KEY');
 
 Sentry.init({
-  dsn: 'YOUR_DSN',
+  dsn: "___PUBLIC_DSN___",
   integrations: [
     Sentry.supabaseIntegration({ supabaseClient })
   ],

--- a/docs/platforms/javascript/guides/deno/index.mdx
+++ b/docs/platforms/javascript/guides/deno/index.mdx
@@ -41,7 +41,7 @@ Import the Sentry Deno SDK directly from the npm registry, before importing any 
 <SplitSectionCode>
 
 ```javascript {filename: main.ts}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 // your other imports
 ```
 
@@ -63,7 +63,7 @@ Initialize Sentry as early as possible in your app:
 <SplitSectionCode>
 
 ```javascript {filename: main.ts}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 // your other imports
 
 Sentry.init({

--- a/platform-includes/configuration/capture-console/javascript.deno.mdx
+++ b/platform-includes/configuration/capture-console/javascript.deno.mdx
@@ -1,5 +1,5 @@
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/contextlines/javascript.deno.mdx
+++ b/platform-includes/configuration/contextlines/javascript.deno.mdx
@@ -1,5 +1,5 @@
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/dedupe/javascript.deno.mdx
+++ b/platform-includes/configuration/dedupe/javascript.deno.mdx
@@ -1,5 +1,5 @@
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/extra-error-data/javascript.deno.mdx
+++ b/platform-includes/configuration/extra-error-data/javascript.deno.mdx
@@ -1,5 +1,5 @@
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/configuration/rewrite-frames/javascript.deno.mdx
+++ b/platform-includes/configuration/rewrite-frames/javascript.deno.mdx
@@ -1,5 +1,5 @@
 ```javascript {tabTitle: JavaScript}
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/crons/setup/javascript.deno.mdx
+++ b/platform-includes/crons/setup/javascript.deno.mdx
@@ -5,7 +5,7 @@ _requires SDK version 7.88.0 or higher_
 Use the `DenoCron` integration to monitor your [`Deno.cron`](https://deno.com/blog/cron) calls and get notified when a schedule job is missed (or doesn't start when expected), if it fails due to a problem in the runtime (such as an error), or if it fails by exceeding its maximum runtime.
 
 ```TypeScript
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/platform-includes/performance/configure-sample-rate/javascript.deno.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.deno.mdx
@@ -1,5 +1,5 @@
 ```javascript
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "___SDK_PACKAGE___";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",

--- a/src/components/platformSdkPackageName.tsx
+++ b/src/components/platformSdkPackageName.tsx
@@ -34,6 +34,10 @@ export async function getSdkPackageName(
     return null;
   }
 
+  const useNpmSpecifier = platformOrGuide.name === 'deno';
+  if (useNpmSpecifier && sdkData.canonical.startsWith('npm:')) {
+    return sdkData.canonical;
+  }
   return sdkData.canonical.replace(/^npm:/, '') || null;
 }
 
@@ -47,6 +51,7 @@ export async function PlatformSdkPackageName({fallback}: PlatformSdkPackageNameP
   const platformOrGuide = getCurrentPlatformOrGuide(rootNode, path);
 
   const sdkPackage = await getSdkPackageName(platformOrGuide);
+  const displayName = sdkPackage?.replace(/^npm:/, '') || fallbackName;
 
-  return <code>{sdkPackage || fallbackName} </code>;
+  return <code>{displayName} </code>;
 }


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes the root cause of why Deno docs hardcode `import * as Sentry from "npm:@sentry/deno"` instead of using the `___SDK_PACKAGE___` placeholder like all other platforms.

The issue: `getSdkPackageName()` strips the `npm:` prefix from the registry canonical value for all platforms. This is correct for Node/Browser/etc (they import from `@sentry/node`), but Deno requires the `npm:` prefix in its import specifiers.

- Preserve the `npm:` prefix in `getSdkPackageName` when the platform is Deno
- Strip `npm:` in the `PlatformSdkPackageName` display component so prose still shows `@sentry/deno`
- Replace all hardcoded `npm:@sentry/deno` imports with `___SDK_PACKAGE___` across 10 content files
- Add Sentry import + DSN placeholder to the Supabase integration snippet
- Fix typo in Supabase docs ("most use cases. and" → "most use cases and")

Supersedes #17562 with a systemic fix instead of a per-page workaround.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)