### PR TITLE
docs(metrics): Remove guidance discouraging infrastructure metrics

### DIFF
--- a/docs/product/explore/metrics/index.mdx
+++ b/docs/product/explore/metrics/index.mdx
@@ -190,8 +190,7 @@ Application Metrics are best for **application and code-based health signals**, 
 - User action counts
 - Success/failure rates
 
-**Not ideal for Application Metrics:**
-- Infrastructure metrics (CPU, memory, disk) - a tool purpose-built for this, like Prometheus, is a better fit
+**Other Sentry features that may be a better fit:**
 - Log aggregation - use [Logs](/product/explore/logs/)
 - Full request tracing - use [Traces](/product/explore/trace-explorer/)
 


### PR DESCRIPTION
Remove the line that told users infrastructure metrics (CPU, memory, disk) are "not ideal" for Application Metrics. The page itself lists `memory.usage` as a gauge example, so the guidance was contradictory. Users should track whatever signals are useful to them.