### PR TITLE
fix(a11y): render nav dropdowns inline for correct keyboard tab order

### DIFF
--- a/src/components/TopNavClient.tsx
+++ b/src/components/TopNavClient.tsx
@@ -14,13 +14,7 @@ const mainSections = mainSectionsWithDropdowns;
 // Helper hook for dropdown positioning
 // Returns both absolute (for portals) and fixed (for inline) coordinates
 function useDropdownPosition(triggerRef, open) {
-  const [position, setPosition] = useState({
-    top: 0,
-    left: 0,
-    width: 0,
-    fixedTop: 0,
-    fixedLeft: 0,
-  });
+  const [position, setPosition] = useState<{top: number; left: number; width: number; fixedTop: number; fixedLeft: number} | null>(null);
   useEffect(() => {
     function updatePosition() {
       if (triggerRef.current && open) {
@@ -328,7 +322,7 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
                         />
                       </svg>
                     </button>
-                    {conceptsDropdownOpen && (
+                    {conceptsDropdownOpen && conceptsPosition && (
                       <div
                         ref={conceptsDropdownRef}
                         className="bg-white dark:bg-black border border-[var(--gray-a3)] dark:border-[var(--gray-7)] shadow-lg z-50 min-w-[220px] p-2 rounded-b-md rounded-t-none"
@@ -421,7 +415,7 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
                         />
                       </svg>
                     </button>
-                    {moreDropdownOpen && (
+                    {moreDropdownOpen && morePosition && (
                       <div
                         ref={moreDropdownRef}
                         className="bg-white dark:bg-black border border-[var(--gray-a3)] dark:border-[var(--gray-7)] shadow-lg z-50 min-w-[220px] p-2 rounded-b-md rounded-t-none"
@@ -494,6 +488,7 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
       </div>
       {/* Portal-based dropdowns */}
       {platformDropdownOpen &&
+        sdksPosition &&
         ReactDOM.createPortal(
           <div
             ref={platformDropdownRef}

--- a/src/components/TopNavClient.tsx
+++ b/src/components/TopNavClient.tsx
@@ -342,14 +342,6 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
                           msOverflowStyle: 'none',
                         }}
                         onClick={e => e.stopPropagation()}
-                        onMouseEnter={() => {
-                          clearTimeout(closeTimers.current.concepts);
-                        }}
-                        onMouseLeave={() => {
-                          closeTimers.current.concepts = setTimeout(() => {
-                            setConceptsDropdownOpen(false);
-                          }, 150);
-                        }}
                       >
                         <style>{`
                           .dark .concepts-dropdown-link {
@@ -435,14 +427,6 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
                           msOverflowStyle: 'none',
                         }}
                         onClick={e => e.stopPropagation()}
-                        onMouseEnter={() => {
-                          clearTimeout(closeTimers.current.more);
-                        }}
-                        onMouseLeave={() => {
-                          closeTimers.current.more = setTimeout(() => {
-                            setMoreDropdownOpen(false);
-                          }, 150);
-                        }}
                       >
                         <style>{`
                           .dark .more-dropdown-link {

--- a/src/components/TopNavClient.tsx
+++ b/src/components/TopNavClient.tsx
@@ -14,7 +14,13 @@ const mainSections = mainSectionsWithDropdowns;
 // Helper hook for dropdown positioning
 // Returns both absolute (for portals) and fixed (for inline) coordinates
 function useDropdownPosition(triggerRef, open) {
-  const [position, setPosition] = useState<{top: number; left: number; width: number; fixedTop: number; fixedLeft: number} | null>(null);
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    fixedTop: number;
+    fixedLeft: number;
+  } | null>(null);
   useEffect(() => {
     function updatePosition() {
       if (triggerRef.current && open) {

--- a/src/components/TopNavClient.tsx
+++ b/src/components/TopNavClient.tsx
@@ -14,7 +14,13 @@ const mainSections = mainSectionsWithDropdowns;
 // Helper hook for dropdown positioning
 // Returns both absolute (for portals) and fixed (for inline) coordinates
 function useDropdownPosition(triggerRef, open) {
-  const [position, setPosition] = useState({top: 0, left: 0, width: 0, fixedTop: 0, fixedLeft: 0});
+  const [position, setPosition] = useState({
+    top: 0,
+    left: 0,
+    width: 0,
+    fixedTop: 0,
+    fixedLeft: 0,
+  });
   useEffect(() => {
     function updatePosition() {
       if (triggerRef.current && open) {

--- a/src/components/TopNavClient.tsx
+++ b/src/components/TopNavClient.tsx
@@ -11,9 +11,10 @@ import platformSelectorStyles from './platformSelector/style.module.scss';
 
 const mainSections = mainSectionsWithDropdowns;
 
-// Add a helper hook for portal dropdown positioning
+// Helper hook for dropdown positioning
+// Returns both absolute (for portals) and fixed (for inline) coordinates
 function useDropdownPosition(triggerRef, open) {
-  const [position, setPosition] = useState({top: 0, left: 0, width: 0});
+  const [position, setPosition] = useState({top: 0, left: 0, width: 0, fixedTop: 0, fixedLeft: 0});
   useEffect(() => {
     function updatePosition() {
       if (triggerRef.current && open) {
@@ -22,6 +23,8 @@ function useDropdownPosition(triggerRef, open) {
           top: rect.bottom + window.scrollY,
           left: rect.left + window.scrollX,
           width: rect.width,
+          fixedTop: rect.bottom,
+          fixedLeft: rect.left,
         });
       }
     }
@@ -139,8 +142,29 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
         }
       }
     }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        if (conceptsDropdownOpen) {
+          setConceptsDropdownOpen(false);
+          conceptsBtnRef.current?.focus();
+        }
+        if (moreDropdownOpen) {
+          setMoreDropdownOpen(false);
+          moreBtnRef.current?.focus();
+        }
+        if (platformDropdownOpen) {
+          setPlatformDropdownOpen(false);
+          setPlatformDropdownByClick(false);
+          platformBtnRef.current?.focus();
+        }
+      }
+    }
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
   }, [
     platformDropdownOpen,
     platformDropdownByClick,
@@ -298,6 +322,47 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
                         />
                       </svg>
                     </button>
+                    {conceptsDropdownOpen && (
+                      <div
+                        ref={conceptsDropdownRef}
+                        className="bg-white dark:bg-black border border-[var(--gray-a3)] dark:border-[var(--gray-7)] shadow-lg z-50 min-w-[220px] p-2 rounded-b-md rounded-t-none"
+                        style={{
+                          position: 'fixed',
+                          top: conceptsPosition.fixedTop,
+                          left: conceptsPosition.fixedLeft,
+                          minWidth: conceptsPosition.width,
+                          overflowY: 'auto',
+                          scrollbarWidth: 'none',
+                          msOverflowStyle: 'none',
+                        }}
+                        onClick={e => e.stopPropagation()}
+                        onMouseEnter={() => {
+                          clearTimeout(closeTimers.current.concepts);
+                        }}
+                        onMouseLeave={() => {
+                          closeTimers.current.concepts = setTimeout(() => {
+                            setConceptsDropdownOpen(false);
+                          }, 150);
+                        }}
+                      >
+                        <style>{`
+                          .dark .concepts-dropdown-link {
+                            color: #fff !important;
+                          }
+                        `}</style>
+                        {mainSections
+                          .find(s => s.label === 'Concepts')
+                          ?.dropdown?.map(dropdown => (
+                            <Link
+                              key={dropdown.href}
+                              href={dropdown.href}
+                              className="concepts-dropdown-link block px-4 py-2 text-[var(--gray-12)] dark:text-white hover:bg-[var(--gray-3)] dark:hover:bg-[var(--gray-8)] rounded text-[0.875rem] font-normal font-sans no-underline"
+                            >
+                              {dropdown.label}
+                            </Link>
+                          ))}
+                      </div>
+                    )}
                   </div>
                 ) : section.label === 'Manage' ? (
                   <div
@@ -350,6 +415,47 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
                         />
                       </svg>
                     </button>
+                    {moreDropdownOpen && (
+                      <div
+                        ref={moreDropdownRef}
+                        className="bg-white dark:bg-black border border-[var(--gray-a3)] dark:border-[var(--gray-7)] shadow-lg z-50 min-w-[220px] p-2 rounded-b-md rounded-t-none"
+                        style={{
+                          position: 'fixed',
+                          top: morePosition.fixedTop,
+                          left: morePosition.fixedLeft,
+                          minWidth: morePosition.width,
+                          overflowY: 'auto',
+                          scrollbarWidth: 'none',
+                          msOverflowStyle: 'none',
+                        }}
+                        onClick={e => e.stopPropagation()}
+                        onMouseEnter={() => {
+                          clearTimeout(closeTimers.current.more);
+                        }}
+                        onMouseLeave={() => {
+                          closeTimers.current.more = setTimeout(() => {
+                            setMoreDropdownOpen(false);
+                          }, 150);
+                        }}
+                      >
+                        <style>{`
+                          .dark .more-dropdown-link {
+                            color: #fff !important;
+                          }
+                        `}</style>
+                        {mainSections
+                          .find(s => s.label === 'Manage')
+                          ?.dropdown?.map(dropdown => (
+                            <Link
+                              key={dropdown.href}
+                              href={dropdown.href}
+                              className="more-dropdown-link block px-4 py-2 text-[var(--gray-12)] dark:text-white hover:bg-[var(--gray-3)] dark:hover:bg-[var(--gray-8)] rounded text-[0.875rem] font-normal font-sans no-underline"
+                            >
+                              {dropdown.label}
+                            </Link>
+                          ))}
+                      </div>
+                    )}
                   </div>
                 ) : section.label === 'SDKs' ? (
                   <a
@@ -498,92 +604,6 @@ export default function TopNavClient({platforms}: {platforms: Platform[]}) {
             }
           `}</style>
             <PlatformSelector platforms={platforms} listOnly />
-          </div>,
-          document.body
-        )}
-      {conceptsDropdownOpen &&
-        ReactDOM.createPortal(
-          <div
-            ref={conceptsDropdownRef}
-            className="absolute left-0 bg-white dark:bg-black border border-[var(--gray-a3)] dark:border-[var(--gray-7)] shadow-lg z-50 min-w-[220px] p-2 rounded-b-md rounded-t-none"
-            style={{
-              position: 'absolute',
-              top: conceptsPosition.top,
-              left: conceptsPosition.left,
-              minWidth: conceptsPosition.width,
-              overflowY: 'auto',
-              scrollbarWidth: 'none',
-              msOverflowStyle: 'none',
-            }}
-            onClick={e => e.stopPropagation()}
-            onMouseEnter={() => {
-              clearTimeout(closeTimers.current.concepts);
-            }}
-            onMouseLeave={() => {
-              closeTimers.current.concepts = setTimeout(() => {
-                setConceptsDropdownOpen(false);
-              }, 150);
-            }}
-          >
-            <style>{`
-            .dark .concepts-dropdown-link {
-              color: #fff !important;
-            }
-          `}</style>
-            {mainSections
-              .find(s => s.label === 'Concepts')
-              ?.dropdown?.map(dropdown => (
-                <Link
-                  key={dropdown.href}
-                  href={dropdown.href}
-                  className="concepts-dropdown-link block px-4 py-2 text-[var(--gray-12)] dark:text-white hover:bg-[var(--gray-3)] dark:hover:bg-[var(--gray-8)] rounded text-[0.875rem] font-normal font-sans no-underline"
-                >
-                  {dropdown.label}
-                </Link>
-              ))}
-          </div>,
-          document.body
-        )}
-      {moreDropdownOpen &&
-        ReactDOM.createPortal(
-          <div
-            ref={moreDropdownRef}
-            className="absolute left-0 bg-white dark:bg-black border border-[var(--gray-a3)] dark:border-[var(--gray-7)] shadow-lg z-50 min-w-[220px] p-2 rounded-b-md rounded-t-none"
-            style={{
-              position: 'absolute',
-              top: morePosition.top,
-              left: morePosition.left,
-              minWidth: morePosition.width,
-              overflowY: 'auto',
-              scrollbarWidth: 'none',
-              msOverflowStyle: 'none',
-            }}
-            onClick={e => e.stopPropagation()}
-            onMouseEnter={() => {
-              clearTimeout(closeTimers.current.more);
-            }}
-            onMouseLeave={() => {
-              closeTimers.current.more = setTimeout(() => {
-                setMoreDropdownOpen(false);
-              }, 150);
-            }}
-          >
-            <style>{`
-            .dark .more-dropdown-link {
-              color: #fff !important;
-            }
-          `}</style>
-            {mainSections
-              .find(s => s.label === 'Manage')
-              ?.dropdown?.map(dropdown => (
-                <Link
-                  key={dropdown.href}
-                  href={dropdown.href}
-                  className="more-dropdown-link block px-4 py-2 text-[var(--gray-12)] dark:text-white hover:bg-[var(--gray-3)] dark:hover:bg-[var(--gray-8)] rounded text-[0.875rem] font-normal font-sans no-underline"
-                >
-                  {dropdown.label}
-                </Link>
-              ))}
           </div>,
           document.body
         )}


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Concepts and Manage nav dropdowns were rendered using [ReactDOM.createPortal](https://react.dev/reference/react-dom/createPortal#rendering-to-a-different-part-of-the-dom) to `document.body`, which placed their `<a>` tags at the bottom of the DOM — breaking keyboard tab order. 

### Before 

```typescript
// Dropdown links rendered at bottom of DOM via portal

ReactDOM.createPortal(                                                                  
  <div>               
   <Link href="/concepts/key-terms/">Key Terms</Link>                                  
    ...                                                                                
  </div>,                                                                               
  document.body                                                                        
) 
```
Keyboard users had to tab through the entire page before reaching dropdown items (in the video, you'll see it goes from "Concepts" → "API"). 

https://github.com/user-attachments/assets/4723b17c-8694-41a0-84dc-1ccbe67f1fc7

### After

Dropdowns render inline next to their trigger buttons, using `position: fixed` to escape the parent's `overflow-x: auto` clipping. 

https://github.com/user-attachments/assets/15c92abc-aed4-4bdf-84e5-0d5d8959ab8c

Tab now flows naturally: Concepts → Key Terms → Search → ... → API.                     

Also added Escape key function to exit open dropdowns.

```ts
function handleKeyDown(e: KeyboardEvent) {
 if (e.key === 'Escape') {                                                             
  if (conceptsDropdownOpen) {                                                        
    setConceptsDropdownOpen(false);                                                   
    conceptsBtnRef.current?.focus();
   }      
                                                                             
 if (moreDropdownOpen) {                                                             
   setMoreDropdownOpen(false);
   moreBtnRef.current?.focus();                                                      
  }                                                                                  
 }                                                                                     
}
```

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)