### PR TITLE
docs(go): Recommend SCM source context for Go

### DIFF
--- a/docs/platforms/go/common/configuration/options.mdx
+++ b/docs/platforms/go/common/configuration/options.mdx
@@ -116,8 +116,6 @@ By default, no errors are ignored.
 
 </SdkOption>
 
-
-
 <SdkOption name="MaxErrorDepth" type="int" defaultValue="100">
 
 This is the maximum number of errors reported in a chain of errors. This protects the SDK from an arbitrarily long chain of wrapped errors.
@@ -177,7 +175,6 @@ Maximum number of spans that can be attached to a transaction.
 See https://develop.sentry.dev/sdk/envelopes/#size-limits for size limits applied during event ingestion. Events that exceed these limits might get dropped.
 
 </SdkOption>
-
 
 <SdkOption name="IgnoreTransactions" type="[]string">
 
@@ -331,7 +328,6 @@ When set to `true`, disables the telemetry buffer layer for prioritizing events 
 
 By default, TLS uses the host's root CA set. If you don't have `ca-certificates` (which should be your go-to way of fixing the issue of the missing certificates) and want to use `gocertifi` instead, you can provide pre-loaded cert files as one of the options to the `sentry.Init` call:
 
-
 ```go
 sentryClientOptions := sentry.ClientOptions{
 	Dsn: "___PUBLIC_DSN___",
@@ -361,7 +357,7 @@ sentry.Init(sentry.ClientOptions{
 	Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 		var filteredIntegrations []sentry.Integration
 		for _, integration := range integrations {
-			if integration.Name() == "ContextifyFrames" {
+			if integration.Name() == "GlobalTags" {
 				continue
 			}
 			filteredIntegrations = append(filteredIntegrations, integration)

--- a/docs/platforms/go/common/index.mdx
+++ b/docs/platforms/go/common/index.mdx
@@ -10,7 +10,7 @@ Check out the other SDKs we support in the left-hand dropdown.
 
 ## Prerequisites
 
-* If you don't have an account and Sentry project established already, please head over to [Sentry](https://sentry.io/signup/), and then return to this page.
+- If you don't have an account and Sentry project established already, please head over to [Sentry](https://sentry.io/signup/), and then return to this page.
 
 ## Install
 
@@ -38,4 +38,5 @@ To view and resolve the recorded error, log into [sentry.io](https://sentry.io) 
 
 ## Next Steps
 
+- Learn how to set up [Source Context](/platforms/go/source-context/) for readable stack traces
 - Explore [practical guides](/guides/) on what to monitor, log, track, and investigate after setup

--- a/docs/platforms/go/common/integrations/index.mdx
+++ b/docs/platforms/go/common/integrations/index.mdx
@@ -36,24 +36,20 @@ This integration allows you to ignore certain error patterns using regular expre
 
 This integration lets you ignore specific transactions that match the provided patterns. This is useful when certain transaction names should not be captured.
 
-### ContextifyFramesIntegration
-
-This integration captures context around lines of code that caused an error. It provides a snapshot of source code, including lines before and after the error, for better debugging.
-
 ### GlobalTagsIntegration
 
 This integration adds global tags to all events. These can be defined as environment variables using the `SENTRY_TAGS_` prefix or within the client options.
 
 ### Disabling certain Integrations
 
-You can customize the list of integrations without disabling all the default ones using the Integrations option. In the example below, all integrations are enabled except the ContextifyFrames Integration:
+You can customize the list of integrations without disabling all the default ones using the Integrations option. In the example below, all integrations are enabled except the `GlobalTags` Integration:
 
 ```go
 sentry.Init(sentry.ClientOptions{
 	Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 		var filteredIntegrations []sentry.Integration
 		for _, integration := range integrations {
-			if integration.Name() == "ContextifyFrames" {
+			if integration.Name() == "GlobalTags" {
 				continue
 			}
 			filteredIntegrations = append(filteredIntegrations, integration)

--- a/docs/platforms/go/common/source-context/index.mdx
+++ b/docs/platforms/go/common/source-context/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Source Context
+sidebar_order: 90
+sidebar_section: configuration
+description: Learn how to show source lines in Go stack traces.
+---
+
+Source context shows the lines around a frame in a stack trace so you can see the code that failed without leaving Sentry.
+
+For Go, source context is provided through [SCM Source Context](/integrations/source-code-mgmt/source-context/) with code mappings.
+
+The Go SDK no longer reads local source files at runtime to populate source context. If you want source lines in stack traces, set up SCM Source Context instead of bundling source files with your deployed binary.
+
+## Setup
+
+To use source context with Go:
+
+1. Set up a supported SCM integration.
+2. Configure code mappings for your project.
+3. Enable source context for the project.
+
+For setup details, see [SCM Source Context](/integrations/source-code-mgmt/source-context/).
+
+## Troubleshooting Missing Source Context
+
+If stack traces are missing source lines, check the following:
+
+- Your project has a supported SCM integration installed
+- Your project has code mappings configured correctly
+- Source context is enabled for the project
+- The event is associated with a release or branch that Sentry can resolve through your code mappings

--- a/docs/platforms/go/common/source-context/index.mdx
+++ b/docs/platforms/go/common/source-context/index.mdx
@@ -21,7 +21,7 @@ For setup details, see [SCM Source Context](/integrations/source-code-mgmt/sourc
 
 ## Troubleshooting Missing Source Context
 
-If stack traces are missing source lines, check the following:
+If stack traces are missing source lines, make sure that:
 
 - Your project has a supported SCM integration installed
 - Your project has code mappings configured correctly

--- a/docs/platforms/go/common/source-context/index.mdx
+++ b/docs/platforms/go/common/source-context/index.mdx
@@ -9,8 +9,6 @@ Source context shows the lines around a frame in a stack trace so you can see th
 
 For Go, source context is provided through [SCM Source Context](/integrations/source-code-mgmt/source-context/) with code mappings.
 
-The Go SDK no longer reads local source files at runtime to populate source context. If you want source lines in stack traces, set up SCM Source Context instead of bundling source files with your deployed binary.
-
 ## Setup
 
 To use source context with Go:

--- a/docs/platforms/go/common/troubleshooting.mdx
+++ b/docs/platforms/go/common/troubleshooting.mdx
@@ -14,13 +14,18 @@ supported:
   - go.negroni
 ---
 
-## Missing Stack Trace
+## Missing Source Context
 
-Since the Go SDK tries to read the source files from your local disk, it's possible that you’re compiling your binary and deploying it in a manner that makes the source code inaccessible.
+If your Go stack traces are missing source lines, the most common cause is that SCM Source Context isn't fully set up for the project.
 
-This is common in Go because you can compile the binary, and then have no more need for the source code. Without access to the source code, however, we can’t map anything back, and we don’t support uploading Go source code with a release to stitch this data on.
+Check that:
 
-You can see [in the Serverless section](/platforms/go/serverless/#source-context) how to bundle the source code with the binary, which applies to other forms of deployment as well.
+- your project has a supported SCM integration installed
+- your code mappings point to the correct repository paths
+- source context is enabled for the project
+- the event is associated with a release or branch that Sentry can resolve through your code mappings
+
+For the full setup, see [Source Context](/platforms/go/source-context/).
 
 ## Avoiding Temporary File Leaks In File Upload Handlers
 

--- a/docs/platforms/go/common/usage/serverless.mdx
+++ b/docs/platforms/go/common/usage/serverless.mdx
@@ -4,42 +4,13 @@ description: "Learn more about serverless support, which is available out of the
 sidebar_order: 6
 ---
 
-### Source Context
+## Source Context
 
-`sentry-go` SDK comes with the support for serverless solutions out of the box.
-However, to get the source contexts right, you need to bundle your source code with the binary itself.
+`sentry-go` works with serverless runtimes out of the box.
 
-For example, when using **AWS Lambda** and given this tree structure:
+If you want source lines in stack traces, see [Source Context](/platforms/go/source-context/).
 
-```bash
-.
-├── bin
-│   └── upload-image
-│   └── process-image
-│   └── create-thumbnails
-├── functions
-│   └── upload-image
-│       └── main.go
-│   └── process-image
-│       └── main.go
-│   └── create-thumbnails
-│       └── main.go
-├── helper
-│   ├── foo.go
-│   └── bar.go
-├── util
-│   ├── baz.go
-│   └── qux.go
-
-```
-
-You can build one of the binaries and bundle them with the necessary source files with this command:
-
-```bash
-GOOS=linux go build -o bin/upload-image functions/upload-image/main.go && zip -r handler.zip bin/upload-image functions/upload-image/ helper/ util/
-```
-
-The only requirement is that you locate the source code on the deployed machine. Everything else should be done automatically by the SDK.
+This guidance is the same for serverless and non-serverless Go deployments.
 
 ### Events Delivery
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
This updates the Go serverless and troubleshooting docs to recommend SCM Source Context as the preferred way to get source lines in stack traces when a supported SCM integration is available.

It also expands the SCM Source Context page to explain why this is often a better default than bundling repository source into deployed binaries, especially for Go serverless deployments.

## IS YOUR CHANGE URGENT?
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA
- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST
- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

## EXTRA RESOURCES
- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
