### PR TITLE
Update media queries to avoid horizontal scroll when side menu appears

### DIFF
--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -164,6 +164,13 @@ export async function DocPage({
           max-width: var(--doc-content-w);
           box-sizing: border-box;
         }
+        /* When the TOC is visible but the full layout doesn't fit yet, shrink content
+           to fill available space rather than overflowing. */
+        @media (min-width: 1490px) and (max-width: 1649px) {
+          #doc-content {
+            max-width: calc(100vw - var(--sidebar-width, 300px) - var(--toc-w) - 2rem);
+          }
+        }
         /* Mobile responsive styles */
         @media (max-width: 768px) {
           .main-content {

--- a/src/components/docPage/index.tsx
+++ b/src/components/docPage/index.tsx
@@ -72,7 +72,7 @@ export async function DocPage({
   const leafNode = nodeForPath(rootNode, unversionedPath);
 
   return (
-    <div className="tw-app">
+    <div className={`tw-app${hasToc ? ' has-toc' : ''}`}>
       {isDeveloperDocs ? (
         <DevelopDocsHeader pathname={pathname} searchPlatforms={searchPlatforms} />
       ) : (
@@ -165,9 +165,10 @@ export async function DocPage({
           box-sizing: border-box;
         }
         /* When the TOC is visible but the full layout doesn't fit yet, shrink content
-           to fill available space rather than overflowing. */
+           to fill available space rather than overflowing. Only applies when the TOC
+           is actually rendered (has-toc class). */
         @media (min-width: 1490px) and (max-width: 1649px) {
-          #doc-content {
+          .has-toc #doc-content {
             max-width: calc(100vw - var(--sidebar-width, 300px) - var(--toc-w) - 2rem);
           }
         }


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

See https://sentry-docs-git-coolguyzone-fixscroll-bug.sentry.dev/platforms/android/logs/ at widths 1490+, there shouldn't be any more horizontal scrolling.

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
