### PR TITLE
fix: drop browser extension errors instead of just tagging them

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -31,7 +31,7 @@ Sentry.init({
     }),
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ['sentry-docs'],
-      behaviour: 'apply-tag-if-contains-third-party-frames',
+      behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
     }),
     Sentry.browserTracingIntegration({
       linkPreviousTrace: 'session-storage',


### PR DESCRIPTION
## DESCRIBE YOUR PR

Change `thirdPartyErrorFilterIntegration` behaviour from `apply-tag-if-contains-third-party-frames` to `drop-error-if-exclusively-contains-third-party-frames`.

This will filter out noise from browser extensions (LastPass, Honey, ad blockers, etc.) where the entire stack trace is third-party code, rather than just tagging them.

Context: https://sentry.slack.com/archives/CRC3YPFJT/p1778280867611019?thread_ts=1778273682.708329&cid=CRC3YPFJT

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

https://claude.ai/code/session_01YDiRV4Azr5W5ug7GxjTzxi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDiRV4Azr5W5ug7GxjTzxi)_