### PR TITLE
fix(ci): remove NODE_OPTIONS causing OOM in Algolia workflow

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -47,7 +47,7 @@ jobs:
       # without introducing another dependency like ts-node or tsx for everyone else
 
       - name: Build index for user docs
-        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && bun ./scripts/algolia.ts
+        run: pnpm build && bun ./scripts/algolia.ts
         if: steps.filter.outputs.docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
@@ -59,7 +59,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Build index for developer docs
-        run: git submodule init && git submodule update && pnpm enforce-redirects && pnpm generate-doctree && NEXT_PUBLIC_DEVELOPER_DOCS=1 pnpm next build && bun ./scripts/algolia.ts
+        run: pnpm build:developer-docs && bun ./scripts/algolia.ts
         if: steps.filter.outputs.dev-docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}

--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -3,12 +3,15 @@ on:
   push:
     branches:
       - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   index:
     name: Update Algolia index
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4core
     env:
-      NODE_OPTIONS: '--max-old-space-size=6144'
+      NODE_OPTIONS: '--max-old-space-size=12288'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -49,7 +52,7 @@ jobs:
       # without introducing another dependency like ts-node or tsx for everyone else
 
       - name: Build index for user docs
-        run: pnpm enforce-redirects && pnpm generate-og-images && pnpm generate-doctree && pnpm next build && bun ./scripts/algolia.ts
+        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && bun ./scripts/algolia.ts
         if: steps.filter.outputs.docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}

--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -47,7 +47,7 @@ jobs:
       # without introducing another dependency like ts-node or tsx for everyone else
 
       - name: Build index for user docs
-        run: pnpm build && bun ./scripts/algolia.ts
+        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && bun ./scripts/algolia.ts
         if: steps.filter.outputs.docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
@@ -59,7 +59,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Build index for developer docs
-        run: pnpm build:developer-docs && bun ./scripts/algolia.ts
+        run: git submodule init && git submodule update && pnpm enforce-redirects && pnpm generate-doctree && NEXT_PUBLIC_DEVELOPER_DOCS=1 pnpm next build && bun ./scripts/algolia.ts
         if: steps.filter.outputs.dev-docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}

--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -3,15 +3,10 @@ on:
   push:
     branches:
       - master
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   index:
     name: Update Algolia index
-    runs-on: ubuntu-latest-4core
-    env:
-      NODE_OPTIONS: '--max-old-space-size=12288'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Algolia user docs build has been increasingly flaky since late March and is now failing ~100% of the time. All failures show the same pattern: `exit code 143` (SIGTERM) with "runner received shutdown signal" after ~56 minutes — the runner is being OOM-killed.

### Root cause

The `NODE_OPTIONS: '--max-old-space-size=6144'` setting (added in #17283 on April 9 as an attempted fix) tells Node it can allocate up to 6 GB heap on a 7 GB runner, leaving only ~1 GB for the OS/kernel — triggering the OOM killer.

### Evidence

The `lint-404s` workflow does the **same** `pnpm build` → `next build` on the same `ubuntu-latest` runner **without** `NODE_OPTIONS` and has a **0% failure rate**. The algolia workflow — identical build but with `NODE_OPTIONS=6144` — has been failing consistently.

Before April 9 (no `NODE_OPTIONS`, no `.next/cache`), the workflow was already flaky at ~30-40%. The April 9 fix added both cache (which helps) and `NODE_OPTIONS` (which hurts), netting a worse outcome. This PR keeps the cache but removes `NODE_OPTIONS`.

### Timeline
- **Late March**: Failures start appearing (~5-30% rate), no NODE_OPTIONS, no build cache
- **April 9 (#17283)**: Added `NODE_OPTIONS=6144` + `.next/cache` — failure rate increased to ~50-65%
- **Late April–now**: User docs build has not succeeded once since April 28

### What this PR does
- Removes `NODE_OPTIONS: '--max-old-space-size=6144'` (the main culprit)
- Removes unnecessary `generate-og-images` from the user docs build step

### What this does NOT do
- We cannot 100% verify locally because we can't replicate the 7 GB memory constraint of the GitHub Actions runner. The strongest evidence is the `lint-404s` comparison (same build, same runner, no `NODE_OPTIONS`, 0% failure rate).

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [x] Other deadline: Algolia search index for user docs hasn't been updated since April 28
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)