### PR TITLE
docs(replay): Rename Replay Details "Breadcrumbs" section to "Activity"

### DIFF
--- a/docs/product/explore/session-replay/mobile/index.mdx
+++ b/docs/product/explore/session-replay/mobile/index.mdx
@@ -29,19 +29,19 @@ Every replay has a detailed view that contains the embedded video player and ric
 
 The below list shows the breakdown of each component and why it’s valuable:
 
-- **Breadcrumbs:** The replay breadcrumbs show when key user interactions took place, specifically: user taps with the relevant component, navigations, when the user put the app in background or foreground, and [custom breadcrumbs](/product/sentry-basics/integrate-backend/configuration-options/#breadcrumbs) set by your organization. Breadcrumbs also provide insight into the device of a given user session at particular timestamps:
+- **Activity:** The **Activity** tab shows when key user interactions took place, specifically: user taps with the relevant component, navigations, when the user put the app in background or foreground, and [custom breadcrumbs](/product/sentry-basics/integrate-backend/configuration-options/#breadcrumbs) set by your organization. It also provides insight into the device of a given user session at particular timestamps:
       - `device battery` (when battery level or charging status changes)
       - `orientation` (when the user rotates the device)
       - `connectivity` (when this status changes between wifi, cellular, and offline).
 
-These breadcrumbs are synced with the replay player and will auto-scroll as the video plays. Some [breadcrumb types](/product/issues/issue-details/breadcrumbs/) visible in Issue Details are not 1:1 to the replay breadcrumbs list. On the Replay Details page, the trail of events typically seen in the Issue Details page are instead displayed in the Network and Console components.
+Activity entries are synced with the replay player and will auto-scroll as the video plays. Some [breadcrumb types](/product/issues/issue-details/breadcrumbs/) visible in Issue Details are not 1:1 to the Replay Activity list. On the Replay Details page, the trail of events typically seen in the Issue Details page is instead distributed across the Network and Console components.
 
 
 - **Timeline:** This is the section at the bottom of the Replay Details page that illustrates where significant events (such as errors, device battery, and user interactions) happen over the course of the replay. This allows users to easily scrub to key events by dragging across the timeline. It also visually conveys the amount of time that took place between events and has a zoom functionality so you can easily zoom-in to distinguish between events that happened close together.
 
 - **Network:** This is a list of all network requests that were initiated by the app while the replay recording was active. As the video plays, there’s a visual indicator that tracks through the table of network requests, highlighting which requests happened prior to, or next to this point in the video. When a request fails, it is highlighted in red. You can also click the timestamp on the far right of each request to bring yourself to that point in the replay player.
 
-- **Console:** Some debugging messages that don't belong in the breadcrumb list will show up here. For example, a custom `console.log` in React Native. Logs from [Logcat](/platforms/android/integrations/logcat/) and [Timber](/platforms/android/integrations/timber/) are also supported and will show up here.
+- **Console:** Some debugging messages that don't belong in the **Activity** list will show up here. For example, a custom `console.log` in React Native. Logs from [Logcat](/platforms/android/integrations/logcat/) and [Timber](/platforms/android/integrations/timber/) are also supported and will show up here.
 
 - **Errors:** All the errors that occurred in the replay (including in your backend), with links to the corresponding events and [issue(s)](/product/issues/issue-details/error-issues/), as well as the impact these issues have had holistically across all users on your application, seen when you hover over the issue ID.
 

--- a/docs/product/explore/session-replay/replay-details.mdx
+++ b/docs/product/explore/session-replay/replay-details.mdx
@@ -32,26 +32,26 @@ Sentry now provides **AI-powered replay summaries** that automatically analyze w
 - **AI Summary:** An LLM-powered description of the user's journey
 - **Chapters:** Each chapter summarizes related sets of breadcrumbs, network requests, and console logs, ordered by time range. Click a chapter to expand its contents and see the underlying events. Red chapters highlight errors, pink chapters highlight feedback
 
-### Breadcrumbs
+### Activity
 
-The replay breadcrumbs show when key user interactions took place. Breadcrumbs are synced with the replay player and will auto-scroll as the video plays.
+The **Activity** tab shows when key user interactions took place during the replay. Entries are synced with the replay player and will auto-scroll as the video plays.
 
 **Both web and mobile replays include:**
 - **Custom Breadcrumbs:** Learn more about configuring [custom breadcrumbs](/product/sentry-basics/integrate-backend/configuration-options/#breadcrumbs)
 
-**Web-specific breadcrumbs include:**
+**Web-specific activity includes:**
 - **User Clicks:** including [rage clicks](/product/issues/issue-details/replay-issues/rage-clicks/) and [dead clicks](/product/issues/issue-details/replay-issues/rage-clicks/#detection-criteria)
 - **Navigations and Page Loads:** [Learn more about spans](/product/sentry-basics/distributed-tracing/)
 - **Web Vitals:** and an overall performance score [Learn more](/product/dashboards/sentry-dashboards/frontend/web-vitals/)
 
-**Mobile-specific breadcrumbs include:**
+**Mobile-specific activity includes:**
 - Backgrounding and foregrounding
 - Network connectivity changes
 - Battery usage
 
 <Alert>
 
-Some [breadcrumb types](/product/issues/issue-details/breadcrumbs/) visible in **Issue Details** are not a one-to-one representation of the replay breadcrumbs list. The trail of events typically seen in the Issue Details page are now displayed in the Console and Network components of the **Replay Details** page.
+The **Activity** tab on the **Replay Details** page is not a one-to-one representation of the [breadcrumbs](/product/issues/issue-details/breadcrumbs/) shown on the **Issue Details** page. The trail of events typically seen on the **Issue Details** page is instead distributed across the **Activity**, **Console**, and **Network** components of the **Replay Details** page.
 
 </Alert>
 
@@ -61,7 +61,7 @@ The timeline section at the bottom of the **Replay Details** page illustrates wh
 
 ### Console
 
-A list of debugging messages that don't belong in the breadcrumbs list will appear here. For web, this includes `console.log` statements and browser-generated messages to the developer. For React Native, custom `console.log` will appear here, and in Android, logs from [Logcat](/platforms/android/integrations/logcat/) and [Timber](/platforms/android/integrations/timber/) are also supported.
+A list of debugging messages that don't belong in the **Activity** list will appear here. For web, this includes `console.log` statements and browser-generated messages to the developer. For React Native, custom `console.log` will appear here, and in Android, logs from [Logcat](/platforms/android/integrations/logcat/) and [Timber](/platforms/android/integrations/timber/) are also supported.
 
 ### Network
 


### PR DESCRIPTION
## Summary

Companion docs update for the Sentry frontend change that renames the Replay Details "Breadcrumbs" tab to "Activity" (https://github.com/getsentry/sentry/pull/115278)

- Renames the `### Breadcrumbs` section in `replay-details.mdx` to `### Activity` and reworks the surrounding wording (including the alert that contrasts it with Issue Details breadcrumbs).
- Renames the **Breadcrumbs** bullet in the mobile `session-replay/mobile/index.mdx` overview to **Activity** and updates references accordingly.
- Updates the **Console** descriptions to reference the new tab name.

Other mentions of "breadcrumbs" (the SDK concept, performance-overhead pages, and cross-links to Issue Details breadcrumbs) are intentionally left alone since they don't refer to the renamed tab.

Refs [REPLAY-690](https://linear.app/getsentry/issue/REPLAY-690/disparity-between-issue-and-replay-breadcrumbs)