### PR TITLE
fix: Increase stale workflow operations limit to clear backlog

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -44,4 +44,4 @@ jobs:
           exempt-pr-labels: 'do-not-close,dependencies'
 
           # Processing
-          operations-per-run: 100
+          operations-per-run: 500


### PR DESCRIPTION
## Summary

- Increase `operations-per-run` from 100 to 500

## Problem

The stale PR workflow was running successfully but not closing PRs because it was hitting the operations limit before it could process the full backlog. With 400+ open issues/PRs, 100 operations per run only allows marking ~30-40 PRs as stale, leaving no capacity to close the ones already marked stale from 7+ days ago.

## Solution

Increase to 500 operations, which provides enough headroom to:
1. Process all eligible (non-draft, non-exempt) PRs
2. Both mark new stale PRs AND close previously-staled ones in the same run
3. Leave API capacity for other scheduled workflows (`lock.yml` runs at 3:13 AM)

Once the backlog clears, daily processing load will drop significantly.