### PR TITLE
fix(ci): fix pnpm version mismatch in sync-ea-features workflow

### DIFF
--- a/.github/workflows/sync-ea-features.yml
+++ b/.github/workflows/sync-ea-features.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}

--- a/.github/workflows/sync-ea-features.yml
+++ b/.github/workflows/sync-ea-features.yml
@@ -12,19 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Sync EA Features from Flagpole'
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The `sync-ea-features` workflow has never successfully run due to a pnpm version conflict. The workflow specified `version: 9` in the `pnpm/action-setup` step, but `package.json` declares `"packageManager": "pnpm@10.30.0"`. Since `pnpm/action-setup@v4` detects the `packageManager` field, it fails when it conflicts with an explicit version parameter.

**Failed run:** https://github.com/getsentry/sentry-docs/actions/runs/25664433911

## Changes

- **Remove explicit `version: 9`** from `pnpm/action-setup` — the action now reads `pnpm@10.30.0` from `package.json` automatically
- **Bump `actions/checkout`** from `v4.1.1` to `v6` (SHA-pinned), matching other workflows in this repo
- **Bump `actions/create-github-app-token`** from `v2.2.1` to `v3`, matching `bump-api-schema-sha.yml`
- **SHA-pin `pnpm/action-setup`** to match convention used in `test.yml`, `algolia-index.yml`, etc.

These changes also resolve the Node.js 20 deprecation warning for the checkout and app-token actions.

## Verification

After merging, trigger a manual `workflow_dispatch` run to confirm the workflow succeeds:
https://github.com/getsentry/sentry-docs/actions/workflows/sync-ea-features.yml