### PR TITLE
docs(android): Add diffThreshold docs for snapshot previews

### DIFF
--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -189,9 +189,24 @@ sentry {
   If `theme` references a style the renderer can't resolve (typo, wrong prefix, or a theme not on the classpath), neither Sentry nor Paparazzi raises an error or warning. Snapshots still generate, but with incorrect visuals. Double-check the theme string if rendered output looks unexpected.
 </Alert>
 
+### Set a Global Diff Threshold
+
+To ignore small pixel changes across all snapshots, set `diffThreshold` in the plugin configuration:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    diffThreshold = 0.01 // ignore changes of 1% or less
+  }
+}
+```
+
+The `diffThreshold` is a value between `0.0` and `1.0`. Sentry reports a snapshot as changed only when the share of changed pixels exceeds this value. The default is `0.0` (report any difference).
+
 ### Set Diff Thresholds Per Preview
 
-To ignore small pixel changes for specific previews, annotate them with `@SentrySnapshot`. First, add the runtime dependency:
+To override the global threshold for specific previews, annotate them with `@SentrySnapshot` and set a diff threshold. First, add the runtime dependency:
 
 ```kotlin
 dependencies {
@@ -212,6 +227,4 @@ fun BillingPagePreview() {
 }
 ```
 
-The `diffThreshold` is a float between `0.0` and `1.0`. Sentry reports the snapshot as changed only when the share of changed pixels exceeds this value. The default is `0.0` (report any difference).
-
-Per-preview values take precedence over a global `--diff-threshold` set via the CLI. See [Diff Thresholds](/product/snapshots/reviewing-snapshots/#diff-thresholds) for other ways to configure thresholds.
+Per-preview values take precedence over the global `diffThreshold`. See [Diff Thresholds](/product/snapshots/reviewing-snapshots/#diff-thresholds) for other ways to configure thresholds.

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -111,6 +111,33 @@ sentry {
   If `theme` references a style the renderer can't resolve (typo, wrong prefix, or a theme not on the classpath), neither Sentry nor Paparazzi raises an error or warning. Snapshots still generate, but with incorrect visuals. Double-check the theme string if rendered output looks unexpected.
 </Alert>
 
+#### Set Diff Thresholds Per Preview
+
+To ignore small pixel changes for specific previews, annotate them with `@SentrySnapshot`. First, add the runtime dependency:
+
+```kotlin
+dependencies {
+  testImplementation("io.sentry:sentry-snapshots-runtime:{{@inject packages.version('sentry.java.android.gradle-plugin', 'LATEST') }}")
+}
+```
+
+Then annotate any `@Preview` composable:
+
+```kotlin
+import io.sentry.snapshots.runtime.SentrySnapshot
+
+@SentrySnapshot(diffThreshold = 0.01f) // ignore changes of 1% or less
+@Preview
+@Composable
+fun BillingPagePreview() {
+  BillingPage()
+}
+```
+
+The `diffThreshold` is a float between `0.0` and `1.0`. Sentry reports the snapshot as changed only when the share of changed pixels exceeds this value. The default is `0.0` (report any difference).
+
+Per-preview values take precedence over a global `--diff-threshold` set via the CLI. See [Diff Thresholds](/product/snapshots/reviewing-snapshots/#diff-thresholds) for other ways to configure thresholds.
+
 Continue to [Step 3](#step-3-test-locally).
 
 ### Generate Snapshots From an Existing Snapshot Tool

--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -71,73 +71,6 @@ plugins {
 }
 ```
 
-#### Customize Preview Generation
-
-The `previews` block inside `snapshots` exposes options that shape the generated Paparazzi tests. These only apply when `generateTests` is `true` (the default).
-
-```kotlin
-sentry {
-  snapshots {
-    enabled = true
-    previews {
-      theme = "@style/Theme.MyApp"          // optional
-      includePrivatePreviews = false        // optional, defaults to true
-      packageTrees = listOf("com.example")  // optional, defaults to Android namespace
-    }
-  }
-}
-```
-
-| Option                   | Default                                                             | Description                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `theme`                  | Paparazzi default (`android:Theme.Material.NoActionBar.Fullscreen`) | Android theme resource used when rendering previews. Set this if your previews rely on a specific theme.                            |
-| `includePrivatePreviews` | `true`                                                              | Whether `@Preview` composables declared `private` are snapshotted. Set to `false` to exclude in-progress or internal-only previews. |
-| `packageTrees`           | `[]` (falls back to Android namespace)                              | Package prefixes to scan for `@Preview` composables. When empty, the plugin uses the Android namespace from the build variant.      |
-
-If you don't set a `theme`, Paparazzi uses its own default (`android:Theme.Material.NoActionBar.Fullscreen`). If the background of your previews isn't important — for example, when you just want to compare component geometry — you can use a translucent platform theme such as `android:Theme.Translucent.NoTitleBar`:
-
-```kotlin
-sentry {
-  snapshots {
-    enabled = true
-    previews {
-      theme = "android:Theme.Translucent.NoTitleBar"
-    }
-  }
-}
-```
-
-<Alert level="warning">
-  If `theme` references a style the renderer can't resolve (typo, wrong prefix, or a theme not on the classpath), neither Sentry nor Paparazzi raises an error or warning. Snapshots still generate, but with incorrect visuals. Double-check the theme string if rendered output looks unexpected.
-</Alert>
-
-#### Set Diff Thresholds Per Preview
-
-To ignore small pixel changes for specific previews, annotate them with `@SentrySnapshot`. First, add the runtime dependency:
-
-```kotlin
-dependencies {
-  testImplementation("io.sentry:sentry-snapshots-runtime:{{@inject packages.version('sentry.java.android.gradle-plugin', 'LATEST') }}")
-}
-```
-
-Then annotate any `@Preview` composable:
-
-```kotlin
-import io.sentry.snapshots.runtime.SentrySnapshot
-
-@SentrySnapshot(diffThreshold = 0.01f) // ignore changes of 1% or less
-@Preview
-@Composable
-fun BillingPagePreview() {
-  BillingPage()
-}
-```
-
-The `diffThreshold` is a float between `0.0` and `1.0`. Sentry reports the snapshot as changed only when the share of changed pixels exceeds this value. The default is `0.0` (report any difference).
-
-Per-preview values take precedence over a global `--diff-threshold` set via the CLI. See [Diff Thresholds](/product/snapshots/reviewing-snapshots/#diff-thresholds) for other ways to configure thresholds.
-
 Continue to [Step 3](#step-3-test-locally).
 
 ### Generate Snapshots From an Existing Snapshot Tool
@@ -211,3 +144,74 @@ Verify your setup by running:
 ## Step 4: Integrate Into CI
 
 Once the local upload succeeds, wire the same command into your CI. See [Integrating Into CI](/product/snapshots/integrating-into-ci/) for an example GitHub Actions workflow.
+
+## Customize Preview Generation
+
+The options below apply when using the [Compose Previews](#generate-snapshots-from-compose-previews-recommended) path with `generateTests = true` (the default).
+
+### Preview Options
+
+The `previews` block inside `snapshots` exposes options that shape the generated Paparazzi tests.
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    previews {
+      theme = "@style/Theme.MyApp"          // optional
+      includePrivatePreviews = false        // optional, defaults to true
+      packageTrees = listOf("com.example")  // optional, defaults to Android namespace
+    }
+  }
+}
+```
+
+| Option                   | Default                                                             | Description                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `theme`                  | Paparazzi default (`android:Theme.Material.NoActionBar.Fullscreen`) | Android theme resource used when rendering previews. Set this if your previews rely on a specific theme.                            |
+| `includePrivatePreviews` | `true`                                                              | Whether `@Preview` composables declared `private` are snapshotted. Set to `false` to exclude in-progress or internal-only previews. |
+| `packageTrees`           | `[]` (falls back to Android namespace)                              | Package prefixes to scan for `@Preview` composables. When empty, the plugin uses the Android namespace from the build variant.      |
+
+If you don't set a `theme`, Paparazzi uses its own default (`android:Theme.Material.NoActionBar.Fullscreen`). If the background of your previews isn't important — for example, when you just want to compare component geometry — you can use a translucent platform theme such as `android:Theme.Translucent.NoTitleBar`:
+
+```kotlin
+sentry {
+  snapshots {
+    enabled = true
+    previews {
+      theme = "android:Theme.Translucent.NoTitleBar"
+    }
+  }
+}
+```
+
+<Alert level="warning">
+  If `theme` references a style the renderer can't resolve (typo, wrong prefix, or a theme not on the classpath), neither Sentry nor Paparazzi raises an error or warning. Snapshots still generate, but with incorrect visuals. Double-check the theme string if rendered output looks unexpected.
+</Alert>
+
+### Set Diff Thresholds Per Preview
+
+To ignore small pixel changes for specific previews, annotate them with `@SentrySnapshot`. First, add the runtime dependency:
+
+```kotlin
+dependencies {
+  testImplementation("io.sentry:sentry-snapshots-runtime:{{@inject packages.version('sentry.java.android.gradle-plugin', 'LATEST') }}")
+}
+```
+
+Then annotate any `@Preview` composable:
+
+```kotlin
+import io.sentry.snapshots.runtime.SentrySnapshot
+
+@SentrySnapshot(diffThreshold = 0.01f) // ignore changes of 1% or less
+@Preview
+@Composable
+fun BillingPagePreview() {
+  BillingPage()
+}
+```
+
+The `diffThreshold` is a float between `0.0` and `1.0`. Sentry reports the snapshot as changed only when the share of changed pixels exceeds this value. The default is `0.0` (report any difference).
+
+Per-preview values take precedence over a global `--diff-threshold` set via the CLI. See [Diff Thresholds](/product/snapshots/reviewing-snapshots/#diff-thresholds) for other ways to configure thresholds.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the `@SentrySnapshot(diffThreshold = ...)` annotation for setting per-preview diff thresholds in Android snapshot testing.

- Add dependency instructions for `io.sentry:sentry-snapshots-runtime`
- Show usage example annotating a `@Preview` composable
- Explain value range, defaults, and precedence over global CLI `--diff-threshold`

Refs EME-1131

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)