### PR TITLE
docs(apple): Document SentrySPM and clarify CocoaPods deprecation

### DIFF
--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -5,7 +5,7 @@ sidebar_order: 2000
 ---
 
 <Alert level="warning" title="Deprecated">
-We will stop publishing to CocoaPods at the end of June 2026. We recommend migrating to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually installing the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases).
+We will stop publishing to CocoaPods at the end of June 2026. We recommend migrating to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually installing the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases). All versions published before that date will remain available on CocoaPods.
 </Alert>
 
 To integrate Sentry into your Xcode project using CocoaPods, specify it in your _Podfile_:

--- a/docs/platforms/apple/common/install/swift-package-manager.mdx
+++ b/docs/platforms/apple/common/install/swift-package-manager.mdx
@@ -11,11 +11,12 @@ https://github.com/getsentry/sentry-cocoa.git
 ```
 
 You can define your dependency rule by selecting the SDK version (or branch), and then click the "Add Package" button.
-You will then be prompted to choose one of the options `Sentry`, `Sentry-Dynamic` or `SentrySwiftUI`.
+You will then be prompted to choose one of the options `Sentry`, `Sentry-Dynamic`, `SentrySwiftUI`, or `SentrySPM`.
 
-- `Sentry` is the static framework, which is the recommended option if you prefer a fast app start time.
-- `Sentry-Dynamic` is the dynamic framework.
+- `Sentry` is the static pre-built framework, which is the recommended option if you prefer a fast app start time.
+- `Sentry-Dynamic` is the dynamic pre-built framework.
 - `SentrySwiftUI` is used to track performance of SwiftUI views, see more information in the [docs](/platforms/apple/guides/ios/tracing/instrumentation/swiftui-instrumentation/).
+- `SentrySPM` compiles the SDK from source as part of your project build instead of using a pre-built binary. This is useful if you want to step through SDK code while debugging. Not all product variants are available yet with this option.
 
 <Alert>
   Xcode allows you to choose many options, but you should choose only one of the


### PR DESCRIPTION
## DESCRIBE YOUR PR

Prepares the Apple SDK install docs for the CocoaPods end-of-life (end of June 2026):

- **SPM page**: Add `SentrySPM` as a documented product option alongside `Sentry`, `Sentry-Dynamic`, and `SentrySwiftUI`. It compiles from source and is useful for stepping through SDK code while debugging.
- **CocoaPods page**: Clarify in the deprecation alert that all versions published before the cutoff will remain available on CocoaPods.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)