### PR TITLE
docs(js): Add `streamGenAiSpans` option

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -121,6 +121,8 @@ Sentry.init({
 
 AI spans with large inputs and outputs can hit transaction payload size limits. Set `streamGenAiSpans` to `true` to send `gen_ai` spans as standalone envelope items instead of bundling them in the transaction.
 
+Enable this option if `gen_ai` spans are being dropped because the transaction payload exceeds size limits.
+
 </SplitSectionText>
 <SplitSectionCode>
 

--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -113,6 +113,31 @@ Sentry.init({
 </SplitSection>
 </SplitLayout>
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+### Streaming Gen AI Spans
+
+AI spans with large inputs and outputs can hit transaction payload size limits. Set `streamGenAiSpans` to `true` to send `gen_ai` spans as standalone envelope items instead of bundling them in the transaction.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```javascript
+import * as Sentry from "___SDK_PACKAGE___";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
+});
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 ## Tracking Conversations
 
 <Alert level="info">


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new streamGenAiSpans option for JavaScript AI Agent Monitoring ([getsentry/sentry-javascript#20785](https://github.com/getsentry/sentry-javascript/pull/20785)).

Should not be merged before [10.53.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.53.0) exists. 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)