### PR TITLE
docs(js): Use new split layout in Cloudflare and NestJS quick start guides

### DIFF
--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -19,14 +19,16 @@ Use this guide for general instructions on using the Sentry SDK with Cloudflare.
 - **[Remix](/platforms/javascript/guides/cloudflare/frameworks/remix/)**
 - **[SvelteKit](/platforms/javascript/guides/cloudflare/frameworks/sveltekit/)**
 
-<Alert>
+<Alert level="warning" title="Cloudflare Workers limitations">
   The Cloudflare Workers runtime has some platform-specific limitations that
   affect tracing. See [Known Limitations](#known-limitations) for details.
 </Alert>
 
 <PlatformContent includePath="getting-started-prerequisites" />
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install
 
 Choose the features you want to configure, and this guide will show you how:
 
@@ -38,17 +40,31 @@ Choose the features you want to configure, and this guide will show you how:
 
 ### Install the Sentry SDK
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Run the command for your preferred package manager to add the Sentry SDK to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 <PlatformContent includePath="getting-started-install" />
 
-## Step 2: Configure
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+## Configure
 
 The main Sentry configuration should happen as early as possible in your app's lifecycle.
 
 ### Wrangler Configuration
 
-<PlatformContent includePath="getting-started-config" />
+<PlatformContent
+  includePath="getting-started-config"
+  platform="javascript.cloudflare.splitlayout"
+/>
 
 ### Setup for Cloudflare Workers
 
@@ -59,9 +75,16 @@ The main Sentry configuration should happen as early as possible in your app's l
 
 ### Setup for Cloudflare Pages
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 To use the Sentry SDK, add the `sentryPagesPlugin` as [middleware to your Cloudflare Pages application](https://developers.cloudflare.com/pages/functions/middleware/).
 
 <Include name="cloudflare-pages-middleware-intro.mdx" />
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:functions/_middleware.js}
 import * as Sentry from "@sentry/cloudflare";
@@ -91,8 +114,19 @@ export const onRequest = [
 ];
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <Expandable title="Don't have access to onRequest?">
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you don't have access to the `onRequest` middleware API, you can use the `wrapRequestHandler` API instead. For example:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 // hooks.server.js
@@ -111,13 +145,17 @@ export const handle = ({ event, resolve }) => {
 };
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </Expandable>
 
-## Step 3: Add Readable Stack Traces With Source Maps (Optional)
+### Add Readable Stack Traces With Source Maps (Optional)
 
-<PlatformContent includePath="getting-started-sourcemaps-short-version" />
+<PlatformContent includePath="getting-started-sourcemaps-short-version-splitlayout" />
 
-## Step 4: Verify Your Setup
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 
@@ -127,7 +165,14 @@ First, let's make sure Sentry is correctly capturing errors and creating issues 
 
 #### Cloudflare Workers
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Add the following code snippet to your main worker file to create a `/debug-sentry` route that triggers an error when called:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:index.js}
 export default {
@@ -144,15 +189,30 @@ export default {
 };
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 #### Cloudflare Pages
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Create a new route that throws an error when called by adding the following code snippet to a file in your `functions` directory, such as `functions/debug-sentry.js`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:debug-sentry.js}
 export async function onRequest(context) {
   throw new Error("My first Sentry error!");
 }
 ```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 <OnboardingOption optionId="performance">
 ### Tracing
@@ -205,7 +265,7 @@ export async function onRequest(context) {
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>
 
@@ -225,9 +285,18 @@ This is expected behavior in the Cloudflare Workers environment and affects all 
 
 ### Missing Spans in `waitUntil()`
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you're using Cloudflare's [`waitUntil()`](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#contextwaituntil) to run background tasks, spans created inside `waitUntil()` may not appear in Sentry because the request's root span has already finished before the background work starts.
 
-To capture spans inside `waitUntil()`, wrap your deferred work with `startSpan` and set `forceTransaction: true`. This creates a separate transaction for the background work:
+To capture spans inside `waitUntil()`, wrap your deferred work with `startSpan` and set `forceTransaction: true`. This creates a separate transaction for the background work.
+
+The `forceTransaction: true` option is required because it creates a separate transaction for the `waitUntil()` work. Without it, spans created after the request ends might get lost.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript {filename:index.js}
 import * as Sentry from "@sentry/cloudflare";
@@ -255,7 +324,9 @@ async function updateCacheAndDatabase() {
 }
 ```
 
-The `forceTransaction: true` option is required because it creates a separate transaction for the `waitUntil()` work. Without it, spans created after the request ends might get lost.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 ## Next Steps
 
@@ -276,3 +347,5 @@ Now's a good time to customize your setup and look into more advanced topics. Ou
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>

--- a/docs/platforms/javascript/guides/firebase/index.mdx
+++ b/docs/platforms/javascript/guides/firebase/index.mdx
@@ -171,7 +171,7 @@ exports.onUserCreated = onDocumentCreated("users/{userId}", async (event) => {
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version-splitlayout" />
 
-## Step 4: Verify Your Setup
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 

--- a/docs/platforms/javascript/guides/nestjs/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/index.mdx
@@ -13,15 +13,9 @@ categories:
 
 <PlatformContent includePath="getting-started-prerequisites" />
 
-## Step 1: Install
+<StepConnector selector="h2" showNumbers={true}>
 
-### Install the Sentry SDK
-
-Run the command for your preferred package manager to add the Sentry SDK to your application:
-
-<PlatformContent includePath="getting-started-install" />
-
-## Step 2: Configure
+## Install
 
 Choose the features you want to configure, and this guide will show you how:
 
@@ -31,15 +25,52 @@ Choose the features you want to configure, and this guide will show you how:
 
 <Include name="quick-start-features-expandable" />
 
+### Install the Sentry SDK
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Run the command for your preferred package manager to add the Sentry SDK to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
+
+<PlatformContent includePath="getting-started-install" />
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+## Configure
+
 ### Initialize the Sentry SDK
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
 To import and initialize Sentry, create a file named `instrument.ts` in the root directory of your project and add the following code:
 
+</SplitSectionText>
+<SplitSectionCode>
+
 <PlatformContent includePath="getting-started-config" />
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 ### Apply Instrumentation to Your App
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Make sure to import the `instrument.ts` file before any other modules:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {filename: main.ts} {1-2}
 // Import this first!
@@ -57,7 +88,16 @@ async function bootstrap() {
 bootstrap();
 ```
 
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
 Afterward, add the `SentryModule` as a root module to your main module:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {filename: app.module.ts} {2, 8}
 import { Module } from "@nestjs/common";
@@ -76,24 +116,23 @@ import { AppService } from "./app.service";
 export class AppModule {}
 ```
 
-## Step 3: Capture Nest.js Errors
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+### Add Readable Stack Traces With Source Maps (Optional)
+
+<PlatformContent includePath="getting-started-sourcemaps-short-version-splitlayout" />
+
+## Capture Nest.js Errors
 
 <PlatformContent includePath="getting-started-capture-errors" />
 
-## Step 4: Isolate Async Context for Background Jobs (Optional)
+## Isolate Async Context for Background Jobs (Optional)
 
 If your NestJS app uses background jobs (such as `@Cron()`, `@Interval()`, `@OnEvent()`, or BullMQ), breadcrumbs from those jobs can leak into unrelated HTTP request error events. Wrap your background job handlers with `Sentry.withIsolationScope()` to isolate them. See <PlatformLink to="/features/async-context">Isolate Background Job Scopes</PlatformLink> for details and code examples.
 
-## Step 5: Add Readable Stack Traces With Source Maps (Optional)
-
-The stack traces in your Sentry errors probably won't look like your actual code. To fix this, upload your source maps to Sentry.
-The easiest way to do this is by using the Sentry Wizard:
-
-```bash
-npx @sentry/wizard@latest -i sourcemaps
-```
-
-## Step 6: Verify Your Setup
+## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.
 
@@ -125,3 +164,5 @@ Our next recommended steps for you are:
 - [Get support](https://sentry.zendesk.com/hc/en-us/)
 
 </Expandable>
+
+</StepConnector>

--- a/platform-includes/getting-started-capture-errors/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-capture-errors/javascript.nestjs.mdx
@@ -5,7 +5,14 @@ To make sure Sentry captures all your app's errors, configure error handling bas
 
 ### Using a Custom Global Filter
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you have a global catch-all exception filter, add a `@SentryExceptionCaptured()` decorator to the filter's `catch()` method:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {2, 6}
 import { Catch, ExceptionFilter } from "@nestjs/common";
@@ -20,9 +27,20 @@ export class YourCatchAllExceptionFilter implements ExceptionFilter {
 }
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 ### Not Using a Custom Global Filter
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you don't have a global catch-all exception filter, add the `SentryGlobalFilter` to the providers of your main module, **before** any other exception filters:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {2-3, 7-10}
 import { Module } from "@nestjs/common";
@@ -41,9 +59,20 @@ import { SentryGlobalFilter } from "@sentry/nestjs/setup";
 export class AppModule {}
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 ### Using Error Filters for Specific Exception Types
 
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you have error filters for specific types of exceptions (for example, `@Catch(HttpException)`) and you want to report these errors to Sentry, you need to capture them in the `catch()` handler using `Sentry.captureException()`:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {4,9}
 import { ArgumentsHost, BadRequestException, Catch } from "@nestjs/common";
@@ -60,11 +89,23 @@ export class ExampleExceptionFilter extends BaseExceptionFilter {
 }
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <Expandable title="Are you using Microservices?">
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 If you're using `@nestjs/microservices` make sure to handle errors in RPC contexts correctly by providing your own `RpcExceptionFilter` (see [Nest.js Microservices documentation](https://docs.nestjs.com/microservices/exception-filters)).
 `SentryGlobalFilter` in a [hybrid application](https://docs.nestjs.com/faq/hybrid-application) doesn't extend `BaseRpcExceptionFilter` since this depends on `@nestjs/microservices`.
 
-Use `Sentry.captureException(exception)` in your custom filter in case you want to send these errors to Sentry:
+Use `Sentry.captureException(exception)` in your custom filter in case you want to send these errors to Sentry, as shown in the example on the right.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript
 import { Catch, RpcExceptionFilter, ArgumentsHost } from "@nestjs/common";
@@ -80,5 +121,9 @@ export class ExceptionFilter implements RpcExceptionFilter<RpcException> {
   }
 }
 ```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
 </Expandable>

--- a/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
@@ -1,4 +1,11 @@
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
 Wrap your worker handler with the `withSentry` function, for example, in your `index.ts` file, to initialize the Sentry SDK and hook into the environment:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```typescript {filename:index.ts}
 import * as Sentry from "@sentry/cloudflare";
@@ -31,3 +38,7 @@ export default Sentry.withSentry(
   }
 );
 ```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>

--- a/platform-includes/getting-started-verify/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-verify/javascript.nestjs.mdx
@@ -1,6 +1,13 @@
 ### Issues
 
-First, let's verify that Sentry captures errors and creates issues in your Sentry project. Add the following route to your application, which will trigger an error that Sentry will capture:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+First, let's verify that Sentry captures errors and creates issues in your Sentry project. Add the following route to your application, which will trigger an error that Sentry will capture.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 @Get("/debug-sentry")
@@ -9,10 +16,21 @@ First, let's verify that Sentry captures errors and creates issues in your Sentr
   }
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 <OnboardingOption optionId="performance">
 ### Tracing
 
-To test your tracing configuration, update the previous code snippet by starting a performance trace to measure the time it takes for the execution of your code:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+To test your tracing configuration, update the previous code snippet by starting a performance trace to measure the time it takes for the execution of your code.
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```javascript
 @Get("/debug-sentry")
@@ -31,10 +49,14 @@ To test your tracing configuration, update the previous code snippet by starting
 }
 ```
 
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 </OnboardingOption>
 
 <OnboardingOption optionId="logs">
 
-<Include name="logs/javascript-quick-start-verify-logs" />
+<Include name="logs/javascript-quick-start-verify-logs-splitlayout" />
 
 </OnboardingOption>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
- Updated Cloudflare and NestJS quick start guides to use the new split layout.
- Fixed unnecessary step numbering in the Firebase quick start guide

Closes: #17728

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
