### PR TITLE
docs(python): Add stream_gen_ai_spans to Python AI monitoring docs

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -513,6 +513,14 @@ A number between `0` and `1`, controlling the percentage chance a given session 
 
 </SdkOption>
 
+<SdkOption name="stream_gen_ai_spans" type='bool' defaultValue='False' availableSince='2.60.0'>
+
+When set to `True`, `gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction payload. This prevents AI spans with large inputs and outputs from being dropped due to transaction payload size limits.
+
+Enable this option if you are using AI Agent Monitoring or the Conversations feature.
+
+</SdkOption>
+
 ## Logs Options
 
 <SdkOption name="enable_logs" type='bool' defaultValue='False'>

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -78,6 +78,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         AnthropicIntegration(

--- a/docs/platforms/python/integrations/google-genai/index.mdx
+++ b/docs/platforms/python/integrations/google-genai/index.mdx
@@ -36,6 +36,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         GoogleGenAIIntegration(),
@@ -91,6 +92,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         GoogleGenAIIntegration(

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -30,6 +30,7 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     environment="local",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
 )
 ```
@@ -111,6 +112,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         HuggingfaceHubIntegration(

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -32,6 +32,7 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     environment="local",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     debug=True,
     integrations=[
@@ -49,6 +50,7 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     environment="local",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     debug=True,
     integrations=[
@@ -173,6 +175,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LangchainIntegration(

--- a/docs/platforms/python/integrations/langgraph/index.mdx
+++ b/docs/platforms/python/integrations/langgraph/index.mdx
@@ -104,6 +104,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LanggraphIntegration(

--- a/docs/platforms/python/integrations/litellm/index.mdx
+++ b/docs/platforms/python/integrations/litellm/index.mdx
@@ -36,6 +36,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(),
@@ -55,6 +56,7 @@ import litellm
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(),
@@ -95,6 +97,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(

--- a/docs/platforms/python/integrations/mcp/index.mdx
+++ b/docs/platforms/python/integrations/mcp/index.mdx
@@ -49,6 +49,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(),
@@ -76,6 +77,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(),
@@ -131,6 +133,7 @@ from mcp.types import Tool, TextContent, GetPromptResult, PromptMessage
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(),
@@ -234,6 +237,7 @@ sentry_sdk.init(
     # ...
     # Add data like tool inputs and outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(

--- a/docs/platforms/python/integrations/openai-agents/index.mdx
+++ b/docs/platforms/python/integrations/openai-agents/index.mdx
@@ -69,6 +69,7 @@ async def main() -> None:
         traces_sample_rate=1.0,
         # Add data like LLM and tool inputs/outputs;
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
         send_default_pii=True,
     )
 
@@ -106,6 +107,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         OpenAIAgentsIntegration(

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -89,6 +89,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         OpenAIIntegration(

--- a/docs/platforms/python/integrations/pydantic-ai/index.mdx
+++ b/docs/platforms/python/integrations/pydantic-ai/index.mdx
@@ -42,6 +42,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like LLM and tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         PydanticAIIntegration(),
@@ -58,6 +59,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like LLM and tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         PydanticAIIntegration(),
@@ -119,6 +121,7 @@ async def main() -> None:
         traces_sample_rate=1.0,
         # Add data like LLM and tool inputs/outputs;
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
         send_default_pii=True,
         integrations=[
             PydanticAIIntegration(),
@@ -183,6 +186,7 @@ async def main() -> None:
         traces_sample_rate=1.0,
         # Add data like LLM and tool inputs/outputs;
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
         send_default_pii=True,
         integrations=[
             PydanticAIIntegration(),
@@ -224,6 +228,7 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         PydanticAIIntegration(


### PR DESCRIPTION
Add `stream_gen_ai_spans=True` to all `sentry_sdk.init()` code examples across Python AI integration pages and add the option to the configuration options reference.

**Integration pages updated:** OpenAI, Anthropic, Google GenAI, LangChain, LangGraph, LiteLLM, HuggingFace Hub, OpenAI Agents, Pydantic AI, MCP

**Configuration options page:** Added `stream_gen_ai_spans` as a documented SDK option under Tracing Options with `availableSince: 2.60.0`

Refs TET-2344