### PR TITLE
docs(js): Correct `propagateTraceparent` availableSince version to 10.31.0

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -585,7 +585,7 @@ Sentry.init({
 
 </SdkOption>
 
-<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false' availableSince='10.10.0'>
+<SdkOption name="propagateTraceparent" type='boolean' defaultValue='false' availableSince='10.31.0'>
 
 If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/) to outgoing Http requests made via `fetch` or `XMLHttpRequest`.
 This header is attached in addition to the `sentry-trace` and `baggage` headers.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Corrects the `availableSince` version for the `propagateTraceparent` option in the JavaScript SDK configuration docs from `10.10.0` to `10.31.0`. On `10.10.0` it became available for browsers, but not generally in JS. [Release with the general JS availability](https://github.com/getsentry/sentry-javascript/releases/tag/10.31.0#:~:text=feat(node)%3A%20Support%20propagateTraceparent%20option%20(%2318476))

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)