### PR TITLE
docs(react-native): Document touch breadcrumb label improvements

### DIFF
--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -58,11 +58,12 @@ For each component in the touch path, the SDK extracts a **label** and a **name*
 
 The **label** is determined by the first available value from:
 
-1. `sentry-label` prop
+1. `sentry-label` prop (skipped when masked — see [Interaction with Session Replay Masking](#interaction-with-session-replay-masking))
 2. Custom `labelName` prop (if configured on the boundary)
 3. `accessibilityLabel` prop
 4. `aria-label` prop
 5. `testID` prop
+6. Text extracted from children (skipped when masked — see [Automatic Text Extraction from Children](#automatic-text-extraction-from-children))
 
 The **name** comes from the Babel plugin annotation (`data-sentry-component`) or `displayName`. See [Component Names](/platforms/react-native/integrations/component-names/) for details.
 
@@ -83,6 +84,77 @@ const YourCoolComponent = (props) => {
 You don't have to worry about Typescript errors when passing the `sentry-label` prop. [Typescript will not throw an error on props with the '-' character](https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking).
 
 </Alert>
+
+### Automatic `sentry-label` Injection
+
+When [Component Names](/platforms/react-native/integrations/component-names/) are enabled (`annotateReactComponents` option), the Babel plugin automatically injects `sentry-label` props from static text content at build time. This means components like:
+
+```javascript
+function SaveButton() {
+  return (
+    <Pressable>
+      <Text>Save workout</Text>
+    </Pressable>
+  );
+}
+```
+
+will automatically have a `sentry-label="Save workout"` prop added to `Pressable` during the build, without any manual annotation. The injected label:
+
+- Is derived from static string children only (dynamic expressions are skipped)
+- Is capped at 64 characters
+- Does not override an existing `sentry-label` prop
+
+To disable automatic injection while keeping component name annotations:
+
+```javascript {filename:metro.config.js}
+module.exports = withSentryConfig(config, {
+  annotateReactComponents: { autoInjectSentryLabel: false },
+});
+```
+
+### Automatic Text Extraction from Children
+
+When no label is found from props (steps 1–5 above), the SDK attempts to extract text from the touched component's children at runtime. For example, if you touch a button:
+
+```javascript
+<Pressable>
+  <Text>Add to cart</Text>
+</Pressable>
+```
+
+The breadcrumb label will automatically be `"Add to cart"` without needing any props.
+
+Text extraction has the following limits:
+- Traverses up to **3 levels** deep into the component tree
+- Visits up to **5 sibling** nodes at each level
+- Truncates text at **64 characters**
+
+To disable runtime text extraction:
+
+```javascript
+<Sentry.TouchEventBoundary extractTextFromChildren={false}>
+  <RestOfTheApp />
+</Sentry.TouchEventBoundary>
+```
+
+### Interaction with Session Replay Masking
+
+To prevent masked content from leaking into breadcrumbs, the SDK respects [Session Replay](/platforms/react-native/session-replay/) masking boundaries:
+
+- When `maskAllText` is enabled on `mobileReplayIntegration` (the default), `sentry-label` and text extraction from children are both skipped, since they may contain user-visible text content.
+- When the touched element is inside a `Sentry.Mask` boundary, `sentry-label` and text extraction are skipped for that element.
+- Developer-provided labels (`accessibilityLabel`, `aria-label`, `testID`) are never affected by masking.
+
+To enable `sentry-label` and text extraction alongside Session Replay, set `maskAllText: false`:
+
+```javascript
+Sentry.init({
+  integrations: [
+    Sentry.mobileReplayIntegration({ maskAllText: false }),
+  ],
+});
+```
 
 ## Options
 

--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -130,6 +130,12 @@ To prevent masked content from leaking into breadcrumbs, the SDK respects [Sessi
 - When the touched element is inside a `Sentry.Mask` boundary, `sentry-label` and text extraction are skipped for that element.
 - Developer-provided labels (custom `labelName`, `accessibilityLabel`, `aria-label`, `testID`) are never affected by masking.
 
+<Alert level="info">
+
+Currently, both manually set and auto-injected `sentry-label` props are skipped when masking is active, because the SDK cannot distinguish between them at runtime. If you rely on manual `sentry-label` props for tracking, use `accessibilityLabel` or a custom `labelName` instead, which are never affected by masking.
+
+</Alert>
+
 To enable `sentry-label` and text extraction alongside Session Replay, set `maskAllText: false`:
 
 ```javascript

--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -87,6 +87,12 @@ You don't have to worry about Typescript errors when passing the `sentry-label` 
 
 ## Automatic `sentry-label` Injection
 
+<Alert>
+
+Available in SDK version `8.12.0` and above.
+
+</Alert>
+
 When [Component Names](/platforms/react-native/integrations/component-names/) are enabled (`annotateReactComponents` option), the Babel plugin automatically injects `sentry-label` props from static text content at build time. For example, a `<Pressable>` wrapping `<Text>Save workout</Text>` will automatically receive `sentry-label="Save workout"` during the build, without any manual annotation.
 
 See [Component Names — Automatic `sentry-label` Injection](/platforms/react-native/integrations/component-names/#automatic-sentry-label-injection) for configuration details.

--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -141,7 +141,7 @@ Available in SDK version `8.12.0` and above.
 
 </Alert>
 
-When no label is found from props (steps 1–5 above), the SDK attempts to extract text from the touched component's children at runtime. For example, if you touch a button:
+When no label is found from props (steps 1–5 above), the SDK attempts to extract text from the touched component's children at runtime. This complements the [build-time injection](#automatic-sentry-label-injection) — it handles dynamic text, components not processed by the Babel plugin, or cases where `annotateReactComponents` is not enabled. For example, if you touch a button:
 
 ```javascript
 <Pressable>
@@ -164,7 +164,7 @@ To prevent masked content from leaking into breadcrumbs, the SDK respects [Sessi
 
 - When `maskAllText` is enabled on `mobileReplayIntegration` (the default), `sentry-label` and text extraction from children are both skipped, since they may contain user-visible text content.
 - When the touched element is inside a `Sentry.Mask` boundary, `sentry-label` and text extraction are skipped for that element.
-- Developer-provided labels (`accessibilityLabel`, `aria-label`, `testID`) are never affected by masking.
+- Developer-provided labels (custom `labelName`, `accessibilityLabel`, `aria-label`, `testID`) are never affected by masking.
 
 To enable `sentry-label` and text extraction alongside Session Replay, set `maskAllText: false`:
 

--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -85,7 +85,13 @@ You don't have to worry about Typescript errors when passing the `sentry-label` 
 
 </Alert>
 
-### Automatic `sentry-label` Injection
+## Automatic `sentry-label` Injection
+
+<Alert>
+
+Available in SDK version `8.12.0` and above.
+
+</Alert>
 
 When [Component Names](/platforms/react-native/integrations/component-names/) are enabled (`annotateReactComponents` option), the Babel plugin automatically injects `sentry-label` props from static text content at build time. This means components like:
 
@@ -107,13 +113,33 @@ will automatically have a `sentry-label="Save workout"` prop added to `Pressable
 
 To disable automatic injection while keeping component name annotations:
 
-```javascript {filename:metro.config.js}
+```javascript {tabTitle:React Native} {filename:metro.config.js}
+const { getDefaultConfig } = require("@react-native/metro-config");
+const { withSentryConfig } = require('@sentry/react-native/metro');
+
+const config = getDefaultConfig(__dirname);
 module.exports = withSentryConfig(config, {
   annotateReactComponents: { autoInjectSentryLabel: false },
 });
 ```
 
-### Automatic Text Extraction from Children
+```javascript {tabTitle:Expo} {filename:metro.config.js}
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
+
+const config = getSentryExpoConfig(__dirname, {
+  annotateReactComponents: { autoInjectSentryLabel: false },
+});
+```
+
+See [Component Names — Automatic `sentry-label` Injection](/platforms/react-native/integrations/component-names/#automatic-sentry-label-injection) for more details.
+
+## Automatic Text Extraction from Children
+
+<Alert>
+
+Available in SDK version `8.12.0` and above.
+
+</Alert>
 
 When no label is found from props (steps 1–5 above), the SDK attempts to extract text from the touched component's children at runtime. For example, if you touch a button:
 
@@ -130,15 +156,9 @@ Text extraction has the following limits:
 - Visits up to **5 sibling** nodes at each level
 - Truncates text at **64 characters**
 
-To disable runtime text extraction:
+To disable runtime text extraction, set `extractTextFromChildren` to `false` (see [Options](#options)).
 
-```javascript
-<Sentry.TouchEventBoundary extractTextFromChildren={false}>
-  <RestOfTheApp />
-</Sentry.TouchEventBoundary>
-```
-
-### Interaction with Session Replay Masking
+## Interaction with Session Replay Masking
 
 To prevent masked content from leaking into breadcrumbs, the SDK respects [Session Replay](/platforms/react-native/session-replay/) masking boundaries:
 
@@ -201,6 +221,10 @@ _Array&lt;string | RegExp>, Accepts strings and regular expressions_. Component 
 `labelName`
 
 _String_. The name of a custom prop to look for when determining the label of a component. Takes priority over the automatic `accessibilityLabel`, `aria-label`, and `testID` fallbacks.
+
+`extractTextFromChildren`
+
+_boolean, default: true_. When enabled, the SDK extracts text from child components as a label fallback when no explicit label prop is set. Automatically disabled when Session Replay's `maskAllText` is enabled. See [Automatic Text Extraction from Children](#automatic-text-extraction-from-children).
 
 ## Minified Names in Production
 

--- a/docs/platforms/react-native/configuration/touchevents.mdx
+++ b/docs/platforms/react-native/configuration/touchevents.mdx
@@ -58,12 +58,12 @@ For each component in the touch path, the SDK extracts a **label** and a **name*
 
 The **label** is determined by the first available value from:
 
-1. `sentry-label` prop (skipped when masked — see [Interaction with Session Replay Masking](#interaction-with-session-replay-masking))
+1. `sentry-label` prop
 2. Custom `labelName` prop (if configured on the boundary)
 3. `accessibilityLabel` prop
 4. `aria-label` prop
 5. `testID` prop
-6. Text extracted from children (skipped when masked — see [Automatic Text Extraction from Children](#automatic-text-extraction-from-children))
+6. Text extracted from children
 
 The **name** comes from the Babel plugin annotation (`data-sentry-component`) or `displayName`. See [Component Names](/platforms/react-native/integrations/component-names/) for details.
 
@@ -87,51 +87,9 @@ You don't have to worry about Typescript errors when passing the `sentry-label` 
 
 ## Automatic `sentry-label` Injection
 
-<Alert>
+When [Component Names](/platforms/react-native/integrations/component-names/) are enabled (`annotateReactComponents` option), the Babel plugin automatically injects `sentry-label` props from static text content at build time. For example, a `<Pressable>` wrapping `<Text>Save workout</Text>` will automatically receive `sentry-label="Save workout"` during the build, without any manual annotation.
 
-Available in SDK version `8.12.0` and above.
-
-</Alert>
-
-When [Component Names](/platforms/react-native/integrations/component-names/) are enabled (`annotateReactComponents` option), the Babel plugin automatically injects `sentry-label` props from static text content at build time. This means components like:
-
-```javascript
-function SaveButton() {
-  return (
-    <Pressable>
-      <Text>Save workout</Text>
-    </Pressable>
-  );
-}
-```
-
-will automatically have a `sentry-label="Save workout"` prop added to `Pressable` during the build, without any manual annotation. The injected label:
-
-- Is derived from static string children only (dynamic expressions are skipped)
-- Is capped at 64 characters
-- Does not override an existing `sentry-label` prop
-
-To disable automatic injection while keeping component name annotations:
-
-```javascript {tabTitle:React Native} {filename:metro.config.js}
-const { getDefaultConfig } = require("@react-native/metro-config");
-const { withSentryConfig } = require('@sentry/react-native/metro');
-
-const config = getDefaultConfig(__dirname);
-module.exports = withSentryConfig(config, {
-  annotateReactComponents: { autoInjectSentryLabel: false },
-});
-```
-
-```javascript {tabTitle:Expo} {filename:metro.config.js}
-const { getSentryExpoConfig } = require("@sentry/react-native/metro");
-
-const config = getSentryExpoConfig(__dirname, {
-  annotateReactComponents: { autoInjectSentryLabel: false },
-});
-```
-
-See [Component Names — Automatic `sentry-label` Injection](/platforms/react-native/integrations/component-names/#automatic-sentry-label-injection) for more details.
+See [Component Names — Automatic `sentry-label` Injection](/platforms/react-native/integrations/component-names/#automatic-sentry-label-injection) for configuration details.
 
 ## Automatic Text Extraction from Children
 

--- a/docs/platforms/react-native/integrations/component-names.mdx
+++ b/docs/platforms/react-native/integrations/component-names.mdx
@@ -73,7 +73,7 @@ The Sentry browser SDK will pick off the value from these `data` attributes and 
 
 ## Automatic `sentry-label` Injection
 
-When component name capturing is enabled, the Babel plugin also automatically injects `sentry-label` props derived from static text content in your JSX. This provides meaningful labels for [touch event breadcrumbs](/platforms/react-native/configuration/touchevents/) without any manual annotation.
+When component name capturing is enabled, the Babel plugin also automatically injects `sentry-label` props derived from static text content in your JSX. This provides meaningful labels for [touch event breadcrumbs](/platforms/react-native/configuration/touchevents/#automatic-sentry-label-injection) without any manual annotation.
 
 For example, this component:
 
@@ -87,12 +87,7 @@ function SaveButton() {
 }
 ```
 
-will have `sentry-label="Save workout"` added to `Pressable` at build time. The injection:
-
-- Only uses static string children (dynamic expressions like `{variable}` are skipped)
-- Caps the label at 64 characters
-- Skips components that already have an explicit `sentry-label` prop
-- Recognizes `Text` components by default, with support for custom text components via `textComponentNames`
+will have `sentry-label="Save workout"` added to `Pressable` at build time. The injection only uses static string children, caps the label at 64 characters, and skips components that already have an explicit `sentry-label` prop.
 
 To disable automatic label injection while keeping component name annotations:
 

--- a/docs/platforms/react-native/integrations/component-names.mdx
+++ b/docs/platforms/react-native/integrations/component-names.mdx
@@ -71,6 +71,44 @@ Here's what the resulting node would look like if your bundler had applied the p
 
 The Sentry browser SDK will pick off the value from these `data` attributes and collect them when your components are interacted with.
 
+## Automatic `sentry-label` Injection
+
+When component name capturing is enabled, the Babel plugin also automatically injects `sentry-label` props derived from static text content in your JSX. This provides meaningful labels for [touch event breadcrumbs](/platforms/react-native/configuration/touchevents/) without any manual annotation.
+
+For example, this component:
+
+```javascript
+function SaveButton() {
+  return (
+    <Pressable>
+      <Text>Save workout</Text>
+    </Pressable>
+  );
+}
+```
+
+will have `sentry-label="Save workout"` added to `Pressable` at build time. The injection:
+
+- Only uses static string children (dynamic expressions like `{variable}` are skipped)
+- Caps the label at 64 characters
+- Skips components that already have an explicit `sentry-label` prop
+- Recognizes `Text` components by default, with support for custom text components via `textComponentNames`
+
+To disable automatic label injection while keeping component name annotations:
+
+```javascript {tabTitle:React Native} {filename:metro.config.js}
+const config = getDefaultConfig(__dirname);
+module.exports = withSentryConfig(config, {
+  annotateReactComponents: { autoInjectSentryLabel: false },
+});
+```
+
+```javascript {tabTitle:Expo} {filename:metro.config.js}
+const config = getSentryExpoConfig(__dirname, {
+  annotateReactComponents: { autoInjectSentryLabel: false },
+});
+```
+
 ## Options
 
 By default only components located in your project (outside of `node_modules`) are annotated. To avoid annotating other components, use the `ignoredComponents` option. The ignored components won't have `data-sentry-*` annotations added. 

--- a/docs/platforms/react-native/integrations/component-names.mdx
+++ b/docs/platforms/react-native/integrations/component-names.mdx
@@ -73,6 +73,12 @@ The Sentry browser SDK will pick off the value from these `data` attributes and 
 
 ## Automatic `sentry-label` Injection
 
+<Alert>
+
+Available in SDK version `8.12.0` and above.
+
+</Alert>
+
 When component name capturing is enabled, the Babel plugin also automatically injects `sentry-label` props derived from static text content in your JSX. This provides meaningful labels for [touch event breadcrumbs](/platforms/react-native/configuration/touchevents/#automatic-sentry-label-injection) without any manual annotation.
 
 For example, this component:
@@ -92,6 +98,9 @@ will have `sentry-label="Save workout"` added to `Pressable` at build time. The 
 To disable automatic label injection while keeping component name annotations:
 
 ```javascript {tabTitle:React Native} {filename:metro.config.js}
+const { getDefaultConfig } = require("@react-native/metro-config");
+const { withSentryConfig } = require('@sentry/react-native/metro');
+
 const config = getDefaultConfig(__dirname);
 module.exports = withSentryConfig(config, {
   annotateReactComponents: { autoInjectSentryLabel: false },
@@ -99,6 +108,8 @@ module.exports = withSentryConfig(config, {
 ```
 
 ```javascript {tabTitle:Expo} {filename:metro.config.js}
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
+
 const config = getSentryExpoConfig(__dirname, {
   annotateReactComponents: { autoInjectSentryLabel: false },
 });


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents new touch breadcrumb label features in the React Native SDK (v8.12.0):

- **Automatic `sentry-label` injection** — build-time label injection from static text via the Babel plugin, enabled by default with `annotateReactComponents` ([sentry-react-native#6141](https://github.com/getsentry/sentry-react-native/pull/6141))
- **Runtime text extraction from children** — `extractTextFromChildren` prop extracts text from child fiber nodes as a label fallback ([sentry-react-native#6106](https://github.com/getsentry/sentry-react-native/pull/6106))
- **Session Replay masking interaction** — `sentry-label` and text extraction respect `maskAllText` and `Sentry.Mask` boundaries ([sentry-react-native#6142](https://github.com/getsentry/sentry-react-native/pull/6142))
- **Updated label priority chain** — now 6 steps including text extraction and masking notes

### Files changed

- `docs/platforms/react-native/configuration/touchevents.mdx` — new h2 sections for automatic label injection, text extraction, masking interaction; updated label priority; added `extractTextFromChildren` to options
- `docs/platforms/react-native/integrations/component-names.mdx` — new section for `autoInjectSentryLabel` with disable examples

Closes https://github.com/getsentry/sentry-react-native/issues/6113

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

⚠️ Should be merged after the above implementation is shipped in 8.12.0

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)