### PR TITLE
feat(node): Document SEA setup

### DIFF
--- a/docs/platforms/javascript/common/install/esm-without-import.mdx
+++ b/docs/platforms/javascript/common/install/esm-without-import.mdx
@@ -18,7 +18,7 @@ supported:
 </Alert>
 
 
-When running your application in ESM mode, you will most likely want to <PlatformLink to="/install/esm">follow the ESM instructions</PlatformLink>. However, if you can't use the `--import` command line option, you can either use [direct imports](#direct-import-setup) or [SEA bootstrap setup](#nodejs-single-executable-applications) if you are using a Node.js Single Executable Application (SEA).
+When running your application in ESM mode, you will most likely want to <PlatformLink to="/install/esm">follow the ESM instructions</PlatformLink>. However, if you can't use the `--import` command line option, you can either use [direct imports](#direct-imports) or [SEA bootstrap setup](#nodejs-single-executable-applications) if you are using a Node.js Single Executable Application (SEA).
 
 ## Direct Imports
 

--- a/docs/platforms/javascript/common/install/esm-without-import.mdx
+++ b/docs/platforms/javascript/common/install/esm-without-import.mdx
@@ -17,7 +17,11 @@ supported:
   [installation methods](../).
 </Alert>
 
-When running your application in ESM mode, you will most likely want to <PlatformLink to="/install/esm">follow the ESM instructions</PlatformLink>. However, if you want to avoid using the `--import` command line option, for example if you have no way of configuring a CLI flag, you can also follow an alternative setup that involves importing the `instrument.mjs` file directly in your application.
+
+When running your application in ESM mode, you will most likely want to <PlatformLink to="/install/esm">follow the ESM instructions</PlatformLink>. However, if you can't use the `--import` command line option, you can either use [direct imports](#direct-import-setup) or [SEA bootstrap setup](#nodejs-single-executable-applications) if you are using a Node.js Single Executable Application (SEA).
+
+## Direct Imports
+
 
 <Alert level='warning' title='Restrictions of this installation method'>
 
@@ -27,10 +31,7 @@ As a result, the Sentry SDK will not capture data from database calls, queues, O
 
 We recommend using these setups only if the `--import` flag is not an option for you.
 
-This restriction applies when your application statically imports
-`instrument.mjs` from the same ESM module graph. If you use a Node.js Single
-Executable Application (SEA), use the <PlatformLink to="/install/esm-without-import/#nodejs-single-executable-applications">SEA
-bootstrap setup</PlatformLink> instead.
+This restriction applies when your application statically imports `instrument.mjs` from the same ESM module graph. 
 
 </Alert>
 
@@ -110,18 +111,8 @@ cache:
 }
 ```
 
-Keep `sea-bootstrap.cjs`, `instrument.mjs`, and `app.mjs` available on the
-filesystem next to the executable. If you want a fully self-contained
-executable, bundle your instrumentation and app into the SEA main instead.
+Keep `sea-bootstrap.cjs`, `instrument.mjs`, and `app.mjs` available on the filesystem next to the executable. If you want a fully self-contained executable, bundle your instrumentation and app into the SEA main instead.
 
-This setup lets the Sentry SDK register ESM instrumentation hooks before your
-application imports instrumented modules, such as Express or database clients.
-Your instrumentation file and app entrypoint can stay ESM. The verified
-bootstrap pattern shown here uses CommonJS only for the small SEA entry files.
+This setup lets the Sentry SDK register ESM instrumentation hooks before your application imports instrumented modules, such as Express or database clients. Your instrumentation file and app entrypoint can stay ESM. The verified bootstrap pattern shown here uses CommonJS only for the small SEA entry files.
 
-Node.js SEA support is still evolving, including how embedded ESM entrypoints
-and module loading are configured. The embedded SEA main may not be able to
-load filesystem modules with `import()` directly, so the example above uses
-`module.createRequire()` to bridge from the embedded main to a normal
-filesystem bootstrap. The important requirement is startup order: load Sentry
-before loading the application modules you want Sentry to instrument.
+Node.js SEA support is still evolving, including how embedded ESM entrypoints and module loading are configured. The embedded SEA main may not be able to load filesystem modules with `import()` directly, so the example above uses `module.createRequire()` to bridge from the embedded main to a normal filesystem bootstrap. The important requirement is startup order: load Sentry before loading the application modules you want Sentry to instrument.

--- a/docs/platforms/javascript/common/install/esm-without-import.mdx
+++ b/docs/platforms/javascript/common/install/esm-without-import.mdx
@@ -98,16 +98,14 @@ Sentry.init({
 });
 ```
 
-Then configure SEA to use `sea-main.cjs` as its main script and disable code
-cache:
+Then configure SEA to use `sea-main.cjs` as its main script:
 
 ```json {filename: sea-config.json}
 {
   "main": "sea-main.cjs",
   "output": "sea-prep.blob",
   "disableExperimentalSEAWarning": true,
-  "useSnapshot": false,
-  "useCodeCache": false
+  "useSnapshot": false
 }
 ```
 

--- a/docs/platforms/javascript/common/install/esm-without-import.mdx
+++ b/docs/platforms/javascript/common/install/esm-without-import.mdx
@@ -65,13 +65,25 @@ import http from "http";
 
 Node.js Single Executable Applications (SEA) may not load your Sentry instrumentation early enough, so you need to package a small bootstrap file as the SEA main instead of packaging your app entrypoint directly.
 
-The bootstrap imports Sentry first, then imports your real app entrypoint:
+The embedded SEA main should only load a filesystem bootstrap file next to the
+executable:
 
 ```javascript {filename: sea-main.cjs}
-(async () => {
+const { createRequire } = require("node:module");
+
+createRequire(__filename)("./sea-bootstrap.cjs");
+```
+
+The filesystem bootstrap imports Sentry first, then imports your real app
+entrypoint:
+
+```javascript {filename: sea-bootstrap.cjs}
+async function startApp() {
   await import("./instrument.mjs");
   await import("./app.mjs");
-})();
+}
+
+startApp();
 ```
 
 Keep your Sentry setup in `instrument.mjs`:
@@ -85,7 +97,7 @@ Sentry.init({
 });
 ```
 
-Then configure SEA to use the bootstrap as its main script and disable code
+Then configure SEA to use `sea-main.cjs` as its main script and disable code
 cache:
 
 ```json {filename: sea-config.json}
@@ -98,11 +110,18 @@ cache:
 }
 ```
 
+Keep `sea-bootstrap.cjs`, `instrument.mjs`, and `app.mjs` available on the
+filesystem next to the executable. If you want a fully self-contained
+executable, bundle your instrumentation and app into the SEA main instead.
+
 This setup lets the Sentry SDK register ESM instrumentation hooks before your
 application imports instrumented modules, such as Express or database clients.
 Your instrumentation file and app entrypoint can stay ESM. The verified
-bootstrap pattern shown here uses CommonJS only for the small SEA main.
+bootstrap pattern shown here uses CommonJS only for the small SEA entry files.
 
 Node.js SEA support is still evolving, including how embedded ESM entrypoints
-are configured. The important requirement is startup order: load Sentry before
-loading the application modules you want Sentry to instrument.
+and module loading are configured. The embedded SEA main may not be able to
+load filesystem modules with `import()` directly, so the example above uses
+`module.createRequire()` to bridge from the embedded main to a normal
+filesystem bootstrap. The important requirement is startup order: load Sentry
+before loading the application modules you want Sentry to instrument.

--- a/docs/platforms/javascript/common/install/esm-without-import.mdx
+++ b/docs/platforms/javascript/common/install/esm-without-import.mdx
@@ -29,9 +29,7 @@ This installation method has the fundamental restriction that only native Node.j
 
 As a result, the Sentry SDK will not capture data from database calls, queues, ORMs, third-party libraries, or other framework-specific data.
 
-We recommend using these setups only if the `--import` flag is not an option for you.
-
-This restriction applies when your application statically imports `instrument.mjs` from the same ESM module graph. 
+We recommend using this only if the `--import` flag is not an option for you.
 
 </Alert>
 
@@ -109,7 +107,7 @@ Then configure SEA to use `sea-main.cjs` as its main script:
 }
 ```
 
-Keep `sea-bootstrap.cjs`, `instrument.mjs`, and `app.mjs` available on the filesystem next to the executable. If you want a fully self-contained executable, bundle your instrumentation and app into the SEA main instead.
+Keep `sea-bootstrap.cjs`, `instrument.mjs`, and `app.mjs` available on the filesystem next to the executable.
 
 This setup lets the Sentry SDK register ESM instrumentation hooks before your application imports instrumented modules, such as Express or database clients. Your instrumentation file and app entrypoint can stay ESM. The verified bootstrap pattern shown here uses CommonJS only for the small SEA entry files.
 

--- a/docs/platforms/javascript/common/install/esm-without-import.mdx
+++ b/docs/platforms/javascript/common/install/esm-without-import.mdx
@@ -25,7 +25,12 @@ This installation method has the fundamental restriction that only native Node.j
 
 As a result, the Sentry SDK will not capture data from database calls, queues, ORMs, third-party libraries, or other framework-specific data.
 
-We recommend using this only if the `--import` flag is not an option for you.
+We recommend using these setups only if the `--import` flag is not an option for you.
+
+This restriction applies when your application statically imports
+`instrument.mjs` from the same ESM module graph. If you use a Node.js Single
+Executable Application (SEA), use the <PlatformLink to="/install/esm-without-import/#nodejs-single-executable-applications">SEA
+bootstrap setup</PlatformLink> instead.
 
 </Alert>
 
@@ -55,3 +60,49 @@ import http from "http";
 
 // Your application code goes here
 ```
+
+## Node.js Single Executable Applications
+
+Node.js Single Executable Applications (SEA) may not load your Sentry instrumentation early enough, so you need to package a small bootstrap file as the SEA main instead of packaging your app entrypoint directly.
+
+The bootstrap imports Sentry first, then imports your real app entrypoint:
+
+```javascript {filename: sea-main.cjs}
+(async () => {
+  await import("./instrument.mjs");
+  await import("./app.mjs");
+})();
+```
+
+Keep your Sentry setup in `instrument.mjs`:
+
+```javascript {tabTitle:ESM} {filename: instrument.mjs}
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+});
+```
+
+Then configure SEA to use the bootstrap as its main script and disable code
+cache:
+
+```json {filename: sea-config.json}
+{
+  "main": "sea-main.cjs",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "useSnapshot": false,
+  "useCodeCache": false
+}
+```
+
+This setup lets the Sentry SDK register ESM instrumentation hooks before your
+application imports instrumented modules, such as Express or database clients.
+Your instrumentation file and app entrypoint can stay ESM. The verified
+bootstrap pattern shown here uses CommonJS only for the small SEA main.
+
+Node.js SEA support is still evolving, including how embedded ESM entrypoints
+are configured. The important requirement is startup order: load Sentry before
+loading the application modules you want Sentry to instrument.

--- a/docs/platforms/javascript/common/install/esm.mdx
+++ b/docs/platforms/javascript/common/install/esm.mdx
@@ -47,6 +47,10 @@ If it is not possible for you to pass the `--import` flag to the Node.js binary,
 NODE_OPTIONS="--import ./instrument.mjs" npm run start
 ```
 
+If you're building a Node.js Single Executable Application (SEA) and can't rely
+on `--import` or `NODE_OPTIONS`, use the <PlatformLink to="/install/esm-without-import/#nodejs-single-executable-applications">SEA
+bootstrap setup</PlatformLink> instead.
+
 We do not support ESM in Node versions before 18.19.0.
 
 ## Troubleshooting instrumentation


### PR DESCRIPTION
A user asked how to get their instrumentations working in a [Node.js Single Applications](https://nodejs.org/api/single-executable-applications.html) setup, I tried a few things and settled on this as it seems to work best and simplest way to set it up.

Not sure if needs its own dedicated page, but the user did follow the trail of not being able to use `--import`, so it might be an appropriate place for it.