### PR TITLE
docs(platforms): Add missing query string clarifications

### DIFF
--- a/docs/platforms/android/data-management/data-collected.mdx
+++ b/docs/platforms/android/data-management/data-collected.mdx
@@ -42,6 +42,8 @@ The full request URL of outgoing and incoming HTTP requests is **always sent to 
 
 The full request query string of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
+Please note that `sendDefaultPii` is not considered for a request query string. We recommend utilizing your own redactions in `beforeSend` or similar hooks.
+
 ## Request and Response Bodies
 
 By default, no request or response bodies are sent to Sentry from the Android SDK. If you want to collect request or response bodies in recorded user sessions, see the Session Replay [network detail configuration docs](/platforms/android/session-replay/configuration/).

--- a/docs/platforms/apple/common/data-management/data-collected.mdx
+++ b/docs/platforms/apple/common/data-management/data-collected.mdx
@@ -36,7 +36,7 @@ When you enable <PlatformLink to="/tracing">tracing</PlatformLink>, which is dis
 
 ## Request Query String
 
-When tracing is enabled, the `http.query` span attribute captures the query string of outgoing HTTP requests and is **always sent to Sentry**. Depending on your application, this could contain PII data.
+The full request query string of outgoing HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
 Please note that `sendDefaultPii` is not considered for a request query string. We recommend utilizing your own redactions in `beforeSend` or similar hooks.
 

--- a/docs/platforms/native/common/data-management/data-collected.mdx
+++ b/docs/platforms/native/common/data-management/data-collected.mdx
@@ -21,6 +21,6 @@ The `inproc` backend stack walks solely in the client and thus only sends the re
 
 ## Request Query String
 
-The `url.query` span attribute captures the query string of HTTP requests and is **always sent to Sentry** when HTTP tracing is enabled. Depending on your application, this could contain PII data.
+The full request query string of HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
 Please note that there is no PII flag that gates the request query string. We recommend utilizing your own redactions in the `before_send` callback or similar hooks.

--- a/docs/platforms/react-native/data-management/data-collected.mdx
+++ b/docs/platforms/react-native/data-management/data-collected.mdx
@@ -46,6 +46,8 @@ The full request URL and Referer of outgoing HTTP requests is **always sent to S
 
 The full request query string of outgoing HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
+Please note that `sendDefaultPii` is not considered for a request query string. We recommend utilizing your own redactions in `beforeSend` or similar hooks.
+
 ## Device Information
 
 By default the Sentry SDK does not send the name of the device on Android.

--- a/docs/platforms/rust/common/data-management/data-collected.mdx
+++ b/docs/platforms/rust/common/data-management/data-collected.mdx
@@ -42,6 +42,8 @@ The full request URL of incoming HTTP requests captured by `sentry-actix` and `s
 The request query string captured by `sentry-actix` and `sentry-tower` (with `http` feature enabled) is **always sent to Sentry**.
 Depending on your application, this could contain PII data.
 
+Please note that `send_default_pii` is not considered for a request query string. We recommend utilizing your own redactions in `before_send` or similar hooks.
+
 ## Request Body
 
 Whether the Rust SDK automatically captures request bodies depends on the HTTP integration and configuration.

--- a/docs/platforms/unity/data-management/data-collected.mdx
+++ b/docs/platforms/unity/data-management/data-collected.mdx
@@ -50,6 +50,8 @@ Depending on your application, this could contain PII data.
 
 The full request query string of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
+Please note that `SendDefaultPii` is not considered for a request query string. We recommend utilizing your own redactions in `SetBeforeSend` or similar hooks.
+
 ## SQL Queries
 
 While SQL queries are sent to Sentry, neither the full SQL query (`SELECT * FROM users WHERE email = 'joe@shmoe.com'`), nor the values of its parameters will ever be sent. A parameterized version of the query (`SELECT * FROM users WHERE email = @email`) is sent instead.


### PR DESCRIPTION
Add the request query string `sendDefaultPii` clarification to Android, React Native, Rust, and Unity data-collected docs.

The parent PR adds this clarification across other platform pages, but these pages already had Request Query String sections and were left out. This keeps the existing query string documentation consistent across the affected SDKs while using the parent PR as the base.