### PR TITLE
docs(platforms): Generalize query string collection wording

### DIFF
--- a/docs/platforms/apple/common/data-management/data-collected.mdx
+++ b/docs/platforms/apple/common/data-management/data-collected.mdx
@@ -36,7 +36,7 @@ When you enable <PlatformLink to="/tracing">tracing</PlatformLink>, which is dis
 
 ## Request Query String
 
-When tracing is enabled, the `http.query` span attribute captures the query string of outgoing HTTP requests and is **always sent to Sentry**. Depending on your application, this could contain PII data.
+The full request query string of outgoing HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
 Please note that `sendDefaultPii` is not considered for a request query string. We recommend utilizing your own redactions in `beforeSend` or similar hooks.
 

--- a/docs/platforms/native/common/data-management/data-collected.mdx
+++ b/docs/platforms/native/common/data-management/data-collected.mdx
@@ -21,6 +21,6 @@ The `inproc` backend stack walks solely in the client and thus only sends the re
 
 ## Request Query String
 
-The `url.query` span attribute captures the query string of HTTP requests and is **always sent to Sentry** when HTTP tracing is enabled. Depending on your application, this could contain PII data.
+The full request query string of HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
 
 Please note that there is no PII flag that gates the request query string. We recommend utilizing your own redactions in the `before_send` callback or similar hooks.


### PR DESCRIPTION
Generalize the Apple and Native request query string descriptions so they do not imply query strings are only sent through tracing span attributes.

The data-collected pages should describe the data category rather than a single transport path. Query strings can also appear through other data paths such as breadcrumbs or event request data, so this switches those sections to the same path-agnostic wording used by the other SDK docs.