### PR TITLE
ci: Replace Bun with tsx in check-redirects-on-rename workflow

### DIFF
--- a/.github/workflows/check-redirects-on-rename.yml
+++ b/.github/workflows/check-redirects-on-rename.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
         with:
-          bun-version: latest
+          node-version-file: 'package.json'
 
       - name: Set up git for diff
         run: |
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          OUTPUT=$(bun scripts/check-redirects-on-rename.ts 2>&1)
+          OUTPUT=$(npx tsx scripts/check-redirects-on-rename.ts 2>&1)
           EXIT_CODE=$?
           set -e
 


### PR DESCRIPTION
Replace `oven-sh/setup-bun` with `actions/setup-node` + `npx tsx` in the
check-redirects-on-rename workflow. The script only uses standard Node.js
APIs (`child_process`, `fs`, `path`).

Part of a series of PRs to remove Bun from all CI workflows.