### PR TITLE
ci: Replace Bun with tsx in enforce-version-convention workflow

### DIFF
--- a/.github/workflows/enforce-version-convention.yml
+++ b/.github/workflows/enforce-version-convention.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
         with:
-          bun-version: latest
+          node-version-file: 'package.json'
 
       - name: Run script for checking conventions
-        run: bun scripts/check-version-conventions.ts
+        run: npx tsx scripts/check-version-conventions.ts


### PR DESCRIPTION
Replace `oven-sh/setup-bun` with `actions/setup-node` + `npx tsx` in the
enforce-version-convention workflow. The script only uses standard Node.js
APIs and local project imports.

Part of a series of PRs to remove Bun from all CI workflows.