### PR TITLE
ci: Replace Bun with tsx in lint-404s workflow

### DIFF
--- a/.github/workflows/lint-404s.yml
+++ b/.github/workflows/lint-404s.yml
@@ -35,10 +35,6 @@ jobs:
               - 'scripts/lint-404s/**'
             dev-docs:
               - 'develop-docs/**'
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
-
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
@@ -69,7 +65,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Lint 404s
-        run: bun ./scripts/lint-404s/main.ts
+        run: npx tsx ./scripts/lint-404s/main.ts
         if: steps.filter.outputs.docs == 'true' || steps.filter.outputs.dev-docs == 'true'
 
       - name: Kill Http Server


### PR DESCRIPTION
Remove `oven-sh/setup-bun` and use `npx tsx` to run the lint script.
This workflow already has Node and pnpm set up, so Bun was only used
as a TypeScript runner for the final script invocation.

Part of a series of PRs to remove Bun from all CI workflows.