### PR TITLE
ci: Replace Bun with tsx in algolia-index workflow

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -37,17 +37,10 @@ jobs:
           restore-keys: |
             nextjs-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: '1.1.34'
-
       - run: pnpm install --frozen-lockfile
 
-      # bun seems to be the most straightforward way to run a TypeScript script
-      # without introducing another dependency like ts-node or tsx for everyone else
-
       - name: Build index for user docs
-        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && bun ./scripts/algolia.ts
+        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && npx tsx ./scripts/algolia.ts
         if: steps.filter.outputs.docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
@@ -60,7 +53,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
 
       - name: Build index for developer docs
-        run: git submodule init && git submodule update && pnpm enforce-redirects && pnpm generate-doctree && NEXT_PUBLIC_DEVELOPER_DOCS=1 pnpm next build && bun ./scripts/algolia.ts
+        run: git submodule init && git submodule update && pnpm enforce-redirects && pnpm generate-doctree && NEXT_PUBLIC_DEVELOPER_DOCS=1 pnpm next build && npx tsx ./scripts/algolia.ts
         if: steps.filter.outputs.dev-docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}


### PR DESCRIPTION
Remove `oven-sh/setup-bun` and use `npx tsx` to run the Algolia indexing
script. This workflow already has Node and pnpm set up, so Bun was only
used as a TypeScript runner.

Part of a series of PRs to remove Bun from all CI workflows.