### PR TITLE
fix(react-native): Remove broken includeWebFeedback option from Metro docs

### DIFF
--- a/docs/platforms/react-native/manual-setup/metro.mdx
+++ b/docs/platforms/react-native/manual-setup/metro.mdx
@@ -74,12 +74,11 @@ const config = getSentryExpoConfig(__dirname, {
 
 ### Reduce Bundle Size
 
-If you're not targeting React Native for Web, you can exclude web-only packages like Session Replay and User Feedback from the bundle by opting out via the Metro Plugin options. When set to `false`, the Sentry Metro Plugin resolves the matching Sentry sub-packages to an empty module so they're not included in the output bundle.
+If you're not targeting React Native for Web, you can exclude web-only packages like Session Replay from the bundle by opting out via the Metro Plugin options. When set to `false`, the Sentry Metro Plugin resolves the matching Sentry sub-packages to an empty module so they're not included in the output bundle.
 
 | Option                | Default | Effect when set to `false`                                               |
 | --------------------- | ------- | ------------------------------------------------------------------------ |
 | `includeWebReplay`    | `true`  | Excludes `@sentry/replay` and `@sentry-internal/replay` from the bundle. |
-| `includeWebFeedback`  | `true`  | Excludes `@sentry-internal/feedback` from the bundle.                    |
 
 Note that these options only affect bundling. They do not disable the corresponding native (Android/iOS) integrations.
 
@@ -90,7 +89,6 @@ const { withSentryConfig } = require("@sentry/react-native/metro");
 const config = getDefaultConfig(__dirname);
 module.exports = withSentryConfig(config, {
   includeWebReplay: false,
-  includeWebFeedback: false,
 });
 ```
 
@@ -99,7 +97,6 @@ const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
 const config = getSentryExpoConfig(__dirname, {
   includeWebReplay: false,
-  includeWebFeedback: false,
 });
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Removes `includeWebFeedback: false` from the "Reduce Bundle Size" Metro config examples and the options table.

The `includeWebFeedback: false` option causes a crash at app startup:

```
TypeError: buildFeedbackIntegration is not a function (it is undefined)
```

**Root cause:** When the option stubs `@sentry-internal/feedback` to an empty module, `@sentry/browser`'s barrel file still imports `feedbackSync.js` and `feedbackAsync.js`, which **call** `buildFeedbackIntegration()` at module evaluation time. Unlike `@sentry-internal/replay` (which is just re-exported without being called), the feedback package has intermediate wrapper files that eagerly invoke the stubbed export.

This is a temporary docs fix until the SDK-side fix lands in `sentry-react-native`.

Fixes https://github.com/getsentry/sentry-react-native/issues/6149

## IS YOUR CHANGE URGENT?

- [x] Urgent deadline: Users following the docs hit a crash at startup
- [ ] Other deadline:
- [ ] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)