### PR TITLE
docs(react-native): Restore includeWebFeedback Metro config option

### DIFF
--- a/docs/platforms/react-native/manual-setup/metro.mdx
+++ b/docs/platforms/react-native/manual-setup/metro.mdx
@@ -74,11 +74,12 @@ const config = getSentryExpoConfig(__dirname, {
 
 ### Reduce Bundle Size
 
-If you're not targeting React Native for Web, you can exclude web-only packages like Session Replay from the bundle by opting out via the Metro Plugin options. When set to `false`, the Sentry Metro Plugin resolves the matching Sentry sub-packages to an empty module so they're not included in the output bundle.
+If you're not targeting React Native for Web, you can exclude web-only packages like Session Replay and User Feedback from the bundle by opting out via the Metro Plugin options. When set to `false`, the Sentry Metro Plugin resolves the matching Sentry sub-packages to an empty module so they're not included in the output bundle.
 
 | Option                | Default | Effect when set to `false`                                               |
 | --------------------- | ------- | ------------------------------------------------------------------------ |
 | `includeWebReplay`    | `true`  | Excludes `@sentry/replay` and `@sentry-internal/replay` from the bundle. |
+| `includeWebFeedback`  | `true`  | Excludes `@sentry-internal/feedback` from the bundle.                    |
 
 Note that these options only affect bundling. They do not disable the corresponding native (Android/iOS) integrations.
 
@@ -89,6 +90,7 @@ const { withSentryConfig } = require("@sentry/react-native/metro");
 const config = getDefaultConfig(__dirname);
 module.exports = withSentryConfig(config, {
   includeWebReplay: false,
+  includeWebFeedback: false,
 });
 ```
 
@@ -97,6 +99,7 @@ const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
 const config = getSentryExpoConfig(__dirname, {
   includeWebReplay: false,
+  includeWebFeedback: false,
 });
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Restores the `includeWebFeedback` option to the Metro "Reduce Bundle Size" docs, reverting the removal from https://github.com/getsentry/sentry-docs/pull/17774.

The SDK fix for the crash has landed in https://github.com/getsentry/sentry-react-native/pull/6150.

**Do not merge until the SDK fix is released.**

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline:
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/6150 is released

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)