### PR TITLE
docs: use eas env instead of secret

### DIFF
--- a/docs/platforms/react-native/manual-setup/expo/eas-build-hooks.mdx
+++ b/docs/platforms/react-native/manual-setup/expo/eas-build-hooks.mdx
@@ -25,7 +25,7 @@ EAS Build automatically runs `package.json` scripts with these names at the corr
 Set your DSN as an EAS secret or environment variable so it's available during builds:
 
 ```bash
-eas secret:create --scope project --name SENTRY_DSN --value <your-dsn>
+eas env:create --name SENTRY_DSN --value <your-dsn> --visibility secret --scope project
 ```
 
 ## What Gets Captured


### PR DESCRIPTION
## DESCRIBE YOUR PR
Use non-deprecated eas CLI command for creating secret.

<img width="1126" height="145" alt="image" src="https://github.com/user-attachments/assets/80603634-85d6-42f4-b82b-3f8dd281f9e4" />
https://docs.expo.dev/eas/cli/#eas-env-create-environment

## IS YOUR CHANGE URGENT?  
- [x] None: Not urgent, can wait up to 1 week+

## LEGAL BOILERPLATE
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
