### PR TITLE
Document captureSurfaceViews option for React Native Session Replay

### DIFF
--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -204,7 +204,7 @@ integrations: [
 ]
 ```
 
-## SurfaceView Capture (Android)
+## SurfaceView Capture (Android only)
 
 By default, content rendered inside `SurfaceView` components (e.g. video players, map SDKs) appears as black or transparent regions in Session Replay. You can enable `captureSurfaceViews` to include this content in recordings.
 

--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -210,7 +210,7 @@ By default, content rendered inside `SurfaceView` components (e.g. video players
 
 <Alert level="warning">
 
-This option is **experimental**. Masking granularity is at the `SurfaceView` level only — individual elements inside a `SurfaceView` cannot be masked separately. Only works with the `pixelCopy` screenshot strategy (the default).
+This option is **experimental**. Masking granularity is at the `SurfaceView` level only — individual elements inside a `SurfaceView` cannot be masked separately. Only works with the `pixelCopy` screenshot strategy (the default). See the [Android SurfaceView Capture docs](/platforms/android/session-replay/#surfaceview-capture) for more details.
 
 </Alert>
 

--- a/docs/platforms/react-native/session-replay/index.mdx
+++ b/docs/platforms/react-native/session-replay/index.mdx
@@ -204,6 +204,24 @@ integrations: [
 ]
 ```
 
+## SurfaceView Capture (Android)
+
+By default, content rendered inside `SurfaceView` components (e.g. video players, map SDKs) appears as black or transparent regions in Session Replay. You can enable `captureSurfaceViews` to include this content in recordings.
+
+<Alert level="warning">
+
+This option is **experimental**. Masking granularity is at the `SurfaceView` level only — individual elements inside a `SurfaceView` cannot be masked separately. Only works with the `pixelCopy` screenshot strategy (the default).
+
+</Alert>
+
+```javascript {tabTitle:Mobile}
+integrations: [
+  Sentry.mobileReplayIntegration({
+    captureSurfaceViews: true,
+  }),
+]
+```
+
 ## React Component Names
 
 Sentry helps you capture your React components and unlock additional insights in your application. You can set it up to use React component names.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds documentation for the new `captureSurfaceViews` option in the React Native SDK's `mobileReplayIntegration`. This option bridges the Android SDK's experimental SurfaceView capture support ([sentry-java#5333](https://github.com/getsentry/sentry-java/pull/5333)) to React Native.

- New "SurfaceView Capture (Android)" section with a code example
- Experimental warning noting masking limitations
- Link to the existing [Android SurfaceView Capture docs](/platforms/android/session-replay/#surfaceview-capture)

SDK PR: https://github.com/getsentry/sentry-react-native/pull/6175

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)