### PR TITLE
docs(react-native): Clarify profiling platform support

### DIFF
--- a/docs/platforms/react-native/profiling/index.mdx
+++ b/docs/platforms/react-native/profiling/index.mdx
@@ -8,6 +8,17 @@ sidebar_section: features
 
 <PlatformContent includePath="profiling/index/why-profiling" />
 
+## Platform Support
+
+React Native profiling captures two levels of data:
+
+- **JavaScript profiling** — Profiles JS code executed in the Hermes engine. Available on all platforms that use Hermes (iOS, Android).
+- **Native profiling** — Profiles platform-specific code using the native SDK profilers. When enabled (the default), native profiling captures:
+  - **iOS and macOS**: Swift and Objective-C code (via [sentry-cocoa](https://docs.sentry.io/platforms/apple/profiling/))
+  - **Android**: Kotlin and Java code (via [sentry-java](https://docs.sentry.io/platforms/android/profiling/))
+
+Native profiling is not available on other platforms (for example, tvOS or visionOS). On unsupported platforms, only JavaScript profiling is active.
+
 ## Enable Tracing
 
 Profiling depends on Sentry’s Tracing product being enabled beforehand. To enable tracing in the SDK:

--- a/docs/platforms/react-native/profiling/index.mdx
+++ b/docs/platforms/react-native/profiling/index.mdx
@@ -14,8 +14,8 @@ React Native profiling captures two levels of data:
 
 - **JavaScript profiling** — Profiles JS code executed in the Hermes engine. Available on all platforms that use Hermes (iOS, Android).
 - **Native profiling** — Profiles platform-specific code using the native SDK profilers. When enabled (the default), native profiling captures:
-  - **iOS and macOS**: Swift and Objective-C code (via [sentry-cocoa](https://docs.sentry.io/platforms/apple/profiling/))
-  - **Android**: Kotlin and Java code (via [sentry-java](https://docs.sentry.io/platforms/android/profiling/))
+  - **iOS and macOS**: Swift and Objective-C code (via <Link to="/platforms/apple/profiling/">sentry-cocoa</Link>)
+  - **Android**: Kotlin and Java code (via <Link to="/platforms/android/profiling/">sentry-java</Link>)
 
 Native profiling is not available on other platforms (for example, tvOS or visionOS). On unsupported platforms, only JavaScript profiling is active.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a "Platform Support" section to the React Native profiling docs that clarifies which profiling levels are available on which platforms:

- **JavaScript profiling** (Hermes) works on iOS and Android
- **Native profiling** captures Swift/ObjC on iOS/macOS (via sentry-cocoa) and Kotlin/Java on Android (via sentry-java)
- Other platforms (tvOS, visionOS) only get JS profiling

Resolves https://github.com/getsentry/sentry-react-native/issues/3973
Related to https://github.com/getsentry/team-mobile/issues/191

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)