### PR TITLE
docs(snapshots): Document selective uploads for subset/sharded CI runs

### DIFF
--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -59,7 +59,7 @@ sentry-cli build snapshots ./shard-1 --app-id web-frontend --selective
 sentry-cli build snapshots ./shard-2 --app-id web-frontend --selective
 ```
 
-Sentry merges selective uploads that share the same commit SHA and `app-id`. Removals and renames cannot be detected on PRs when using `--selective`, because Sentry cannot distinguish an intentionally deleted snapshot from one that simply wasn't part of this shard.
+Sentry merges selective uploads that share the same commit SHA and `app-id`. Removals and renames cannot be detected when using `--selective`, because Sentry cannot distinguish an intentionally deleted snapshot from one that simply wasn't part of this shard.
 
 ## Diff Threshold
 

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -65,4 +65,21 @@ Snapshots supports the following image formats:
 - PNG
 - JPEG
 
+## Selective Uploads
+
+If you only generate a subset of your snapshots per CI run — for example, because you shard tests across parallel jobs or run only affected tests — pass the `--selective` flag on each upload:
+
+```bash
+sentry-cli build snapshots ./shard-1 --app-id web-frontend --selective
+sentry-cli build snapshots ./shard-2 --app-id web-frontend --selective
+```
+
+When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as **unchanged** (skipped) rather than removed. Sentry merges selective uploads that share the same commit SHA and `app-id`, so you can upload shards independently and they combine into a single build.
+
+<Alert level="warning">
+  Because Sentry cannot distinguish a deliberately deleted snapshot from one
+  that was not part of the subset, removals and renames cannot be detected when
+  using `--selective`.
+</Alert>
+
 For the full `sentry-cli build snapshots` flag reference, see [Snapshots (CLI)](/cli/snapshots/).

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -65,9 +65,9 @@ Snapshots supports the following image formats:
 - PNG
 - JPEG
 
-## Selective Uploads
+## Selective Testing
 
-If you only generate a subset of your snapshots per CI run — for example, because you shard tests across parallel jobs or run only affected tests — pass the `--selective` flag on each upload:
+If you only generate a subset of your snapshots per CI run — for example, because you run only affected tests or shard across parallel jobs — pass the `--selective` flag on each upload:
 
 ```bash
 sentry-cli build snapshots ./shard-1 --app-id web-frontend --selective


### PR DESCRIPTION
Add a "Selective Uploads" section to the [uploading snapshots](/product/snapshots/uploading-snapshots/) product docs explaining the `--selective` flag added in [getsentry/sentry-cli#3268](https://github.com/getsentry/sentry-cli/pull/3268).

The new section covers:
- When to use `--selective` (sharding tests across parallel CI jobs, running only affected tests)
- How Sentry treats missing snapshots as unchanged/skipped rather than removed
- Merging behavior for selective uploads sharing the same commit SHA and app-id
- Trade-off: removals and renames cannot be detected

The CLI reference at `/cli/snapshots/` already documents the flag — this adds the conceptual explanation in the product docs where users discover the feature.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)