### PR TITLE
docs(github-enterprise): note github.com webhook URL for custom GitHub Apps

### DIFF
--- a/docs/integrations/source-code-mgmt/github/index.mdx
+++ b/docs/integrations/source-code-mgmt/github/index.mdx
@@ -121,7 +121,11 @@ Occasionally, Sentry will request additional permissions to your GitHub account 
       </tr>
       <tr>
         <th>Webhook URL </th>
-        <td>https://sentry.io/extensions/github-enterprise/webhook/ </td>
+        <td>
+          https://sentry.io/extensions/github-enterprise/webhook/
+          <br />
+          <small>If you're configuring a custom GitHub App on github.com (instead of GitHub Enterprise Server or GitHub Enterprise Cloud), use `https://sentry.io/extensions/github-enterprise/webhook/github-com/` instead.</small>
+        </td>
       </tr>
       <tr>
         <th>Webhook secret </th>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a small footnote under the existing Webhook URL row in the GitHub Enterprise setup table, directing customers configuring a custom GitHub App on github.com (rather than GHE Server or GHE Cloud) to the dedicated `/extensions/github-enterprise/webhook/github-com/` endpoint.

Backing code change: getsentry/sentry#115599 added the dedicated route because github.com doesn't send the `X-GitHub-Enterprise-Host` or `X-Github-Tenant` headers that GHES and GHE Cloud use for host identification. The feature is now GA (getsentry/sentry-options-automator#7866).

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)