### PR TITLE
docs(snapshots): Remove sharding references from selective testing docs

### DIFF
--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -52,14 +52,13 @@ For PRs from forks, set `--base-repo-name` to the upstream repository so Sentry 
 
 ## Selective Uploads
 
-If you shard snapshot generation across parallel CI jobs and upload each shard separately, pass `--selective` on every upload:
+If you only upload a subset of your snapshots per CI run — for example, because you run only affected tests — pass `--selective`:
 
 ```bash
-sentry-cli build snapshots ./shard-1 --app-id web-frontend --selective
-sentry-cli build snapshots ./shard-2 --app-id web-frontend --selective
+sentry-cli build snapshots ./snapshots --app-id web-frontend --selective
 ```
 
-Sentry merges selective uploads that share the same commit SHA and `app-id`. Removals and renames cannot be detected when using `--selective`, because Sentry cannot distinguish an intentionally deleted snapshot from one that simply wasn't part of this shard.
+When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as unchanged rather than removed. Removals and renames cannot be detected when using `--selective`, because Sentry cannot distinguish a deliberately deleted snapshot from one that was not part of the subset.
 
 ## Diff Threshold
 
@@ -84,7 +83,7 @@ sentry-cli build snapshots [OPTIONS] --app-id <APP_ID> <PATH>
 | `--auth-token <TOKEN>`          | Sentry auth token. Can also be set via `SENTRY_AUTH_TOKEN`.                                                                                                                    |
 | `-o`, `--org <ORG>`             | Sentry organization slug. Can also be set via `SENTRY_ORG`.                                                                                                                    |
 | `-p`, `--project <PROJECT>`     | Sentry project slug. Can also be set via `SENTRY_PROJECT`.                                                                                                                     |
-| `--selective`                   | Mark the upload as a subset. Use when sharding snapshot generation across parallel jobs.                                                                                       |
+| `--selective`                   | Mark the upload as a subset. Use when uploading only a portion of your snapshots (for example, affected tests only).                                                           |
 | `--diff-threshold <THRESHOLD>`  | Float between `0.0` and `1.0`. Sentry only reports images as changed if the percentage of changed pixels exceeds this value.                                                   |
 | `--head-sha <SHA>`              | Commit SHA for the upload. Auto-detected in CI.                                                                                                                                |
 | `--base-sha <SHA>`              | Base commit SHA for comparison (PR only). Auto-detected from merge-base.                                                                                                       |

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -21,7 +21,7 @@ sentry-cli build snapshots <output-dir> \
   --project <project-slug> \
 ```
 
-For the full command reference, including auto-detected git metadata and sharding behavior, see [Snapshots (CLI)](/cli/snapshots/). For an end-to-end CI setup, see [Integrating Into CI](/product/snapshots/integrating-into-ci/).
+For the full command reference, including auto-detected git metadata, see [Snapshots (CLI)](/cli/snapshots/). For an end-to-end CI setup, see [Integrating Into CI](/product/snapshots/integrating-into-ci/).
 
 ### Upload Structure
 
@@ -67,14 +67,13 @@ Snapshots supports the following image formats:
 
 ## Selective Testing
 
-If you only generate a subset of your snapshots per CI run — for example, because you run only affected tests or shard across parallel jobs — pass the `--selective` flag on each upload:
+If you only generate a subset of your snapshots per CI run — for example, because you run only affected tests — pass the `--selective` flag:
 
 ```bash
-sentry-cli build snapshots ./shard-1 --app-id web-frontend --selective
-sentry-cli build snapshots ./shard-2 --app-id web-frontend --selective
+sentry-cli build snapshots ./snapshots --app-id web-frontend --selective
 ```
 
-When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as **unchanged** (skipped) rather than removed. Sentry merges selective uploads that share the same commit SHA and `app-id`, so you can upload shards independently and they combine into a single build.
+When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as **unchanged** (skipped) rather than removed.
 
 <Alert level="warning">
   Because Sentry cannot distinguish a deliberately deleted snapshot from one


### PR DESCRIPTION
Remove sharding/parallel-job references from the selective testing
section of the snapshots upload docs. Sharding support isn't ready
to document yet — keep the section focused on the affected-tests
use case only.

Changes:
- Remove "shard across parallel jobs" from the intro sentence
- Replace multi-shard CLI example with a single upload example
- Remove sentence about merging selective uploads across shards
- Drop "sharding behavior" mention from the upload command intro

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)