### PR TITLE
feat: Add Get Started top-level section for onboarding

### DIFF
--- a/docs/get-started/connect-your-tools.mdx
+++ b/docs/get-started/connect-your-tools.mdx
@@ -1,0 +1,67 @@
+---
+title: Connect Your Tools
+sidebar_order: 50
+description: "Link GitHub, Slack, Jira, and other tools to get the most out of Sentry."
+---
+
+Sentry integrates with the tools your team already uses. These integrations unlock features like suspect commits, AI-powered debugging, automated alerts, and issue tracking. Here are the most impactful ones to set up first.
+
+## 1. Source Code Management (GitHub, GitLab, Bitbucket)
+
+Connecting your source code repository unlocks some of Sentry's most powerful features:
+
+- **[Suspect commits](/product/issues/suspect-commits/)** — Sentry identifies the most likely commit that introduced an error
+- **[Seer](/product/ai-in-sentry/seer/)** — AI-powered root cause analysis, automatic fix generation (Autofix), and code review
+- **Stack trace links** — Click from a stack trace directly to the relevant line in your repository
+- **Release tracking** — Associate commits with releases to track regressions
+
+### Set up GitHub
+
+The [GitHub integration](/integrations/source-code-mgmt/github/) is the most popular and enables all of the above. Install it from **Settings > Integrations > GitHub** in Sentry.
+
+Other options: [GitLab](/integrations/source-code-mgmt/gitlab/), [Bitbucket](/integrations/source-code-mgmt/bitbucket/), [Azure DevOps](/integrations/source-code-mgmt/azure-devops/)
+
+## 2. Notifications (Slack, Discord, Microsoft Teams)
+
+Get alerted when Sentry detects issues that match your criteria, directly in the tools your team monitors.
+
+### Set up Slack
+
+The [Slack integration](/integrations/notification-incidents/slack/) lets you:
+
+- Receive alert notifications in specific channels
+- Resolve or assign issues directly from Slack
+- Get weekly reports of new and regressed issues
+
+Other options: [Discord](/integrations/notification-incidents/discord/), [Microsoft Teams](/integrations/notification-incidents/msteams/), [PagerDuty](/integrations/notification-incidents/pagerduty/)
+
+## 3. Issue Tracking (Jira, Linear, GitHub Issues)
+
+Link Sentry issues to your team's project management tool so errors become actionable work items.
+
+### Set up Jira or Linear
+
+The [Jira integration](/integrations/issue-tracking/jira/) and [Linear integration](/integrations/issue-tracking/linear/) let you:
+
+- Create tickets from Sentry issues with one click
+- Sync status between Sentry and your tracker
+- Auto-resolve Sentry issues when tickets are closed
+
+Other options: [Asana](/integrations/issue-tracking/asana/), [ClickUp](/integrations/issue-tracking/clickup/), [Shortcut](/integrations/issue-tracking/shortcut/), [GitHub Issues](/integrations/source-code-mgmt/github/#issue-management)
+
+## 4. AI Coding Assistants
+
+Use Sentry context directly in your development environment:
+
+- **[Claude](/integrations/coding-agents/claude-agent/)** — Reference Sentry issues in Claude conversations
+- **[Cursor](/integrations/coding-agents/cursor-agent/)** — Use Sentry's MCP server in Cursor for context-aware debugging
+
+## All Integrations
+
+Browse the complete list of integrations: **[Integrations →](/integrations/)**
+
+## Next Steps
+
+- **[What to Turn On Next](/get-started/what-to-turn-on-next/)** — Enable additional Sentry features
+- **[Set up Alerts](/product/monitors-and-alerts/alerts/)** — Configure alerting rules for the notifications you just connected
+- **[Guides](/guides/)** — Practical patterns for getting the most out of each feature

--- a/docs/get-started/first-error.mdx
+++ b/docs/get-started/first-error.mdx
@@ -1,0 +1,54 @@
+---
+title: "Your First Error"
+sidebar_order: 30
+description: "See your first error in Sentry and learn how to investigate it."
+---
+
+Once you've [installed the SDK](/get-started/quick-start/), the next step is to trigger a test error and see how Sentry surfaces it. This walkthrough shows you what to expect.
+
+## Trigger a Test Error
+
+Most Sentry SDK setup wizards create a test page or route for you. For example, the Next.js wizard generates a `/sentry-example-page` route. Visit it and click the button to throw a sample error.
+
+If your SDK didn't create a test page, you can trigger an error manually:
+
+```javascript
+// JavaScript
+throw new Error("Sentry test error");
+```
+
+```python
+# Python
+raise Exception("Sentry test error")
+```
+
+## What You'll See in Sentry
+
+### The Issues Page
+
+Open the [**Issues**](https://sentry.io/orgredirect/organizations/:orgslug/issues/) page. Your test error will appear as a new issue with:
+
+- **Title** — The error message (e.g., "Sentry test error")
+- **Stack trace** — The exact file and line where the error occurred
+- **Breadcrumbs** — A timeline of events leading up to the error (console logs, navigation, HTTP requests)
+- **Tags** — Environment, browser, OS, release version, and other metadata
+
+### Issue Details
+
+Click into the issue to see the full detail view. This is where you'll spend most of your debugging time. Key sections:
+
+- **Event details** — The specific error occurrence with its stack trace
+- **Breadcrumbs** — What happened before the error, in chronological order
+- **Tags** — Filter by browser, device, user, or any custom tag you've added
+- **Related traces** — If [tracing](/product/trace-explorer/) is enabled, see the full request path
+- **Replay** — If [Session Replay](/product/session-replay/) is enabled, watch what the user was doing
+
+If you've [connected GitHub](/integrations/source-code-mgmt/github/), Sentry will also show **suspect commits** — the most likely code change that introduced the error — and [Seer](/product/ai-in-sentry/seer/) can analyze the root cause automatically.
+
+## Next Steps
+
+Now that you've seen how Sentry captures and displays errors, consider:
+
+- **[What to Turn On Next](/get-started/what-to-turn-on-next/)** — Enable Logs, Tracing, Session Replay, and more for deeper debugging context
+- **[What to Prioritize guide](/guides/issues-errors/)** — Learn patterns for effective error handling and triage
+- **[Connect Your Tools](/get-started/connect-your-tools/)** — Set up GitHub for suspect commits and Slack for alerts

--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -1,0 +1,28 @@
+---
+title: Get Started
+sidebar_order: 1
+description: "Set up Sentry, discover features, and start fixing issues faster."
+---
+
+Whether you're setting up Sentry for the first time or looking to get more value from your existing setup, start here.
+
+## New to Sentry?
+
+<div className="flex flex-col gap-2">
+
+1. **[Quick Start](/get-started/quick-start/)** — Install the SDK for your platform in minutes.
+2. **[What Sentry Does](/get-started/what-sentry-does/)** — Understand how errors, logs, traces, replays, and metrics all connect.
+3. **[Your First Error](/get-started/first-error/)** — See your first error and learn how to investigate it.
+
+</div>
+
+## Already set up?
+
+<div className="flex flex-col gap-2">
+
+4. **[What to Turn On Next](/get-started/what-to-turn-on-next/)** — Enable Logs, Tracing, Session Replay, and more.
+5. **[Connect Your Tools](/get-started/connect-your-tools/)** — Link GitHub, Slack, Jira, and other tools to your Sentry workflow.
+
+</div>
+
+Then dive into our **[Guides](/guides/)** for practical, real-world patterns that help you get the most from each feature.

--- a/docs/get-started/quick-start.mdx
+++ b/docs/get-started/quick-start.mdx
@@ -1,0 +1,42 @@
+---
+title: Quick Start
+sidebar_order: 10
+description: "Install the Sentry SDK for your platform in minutes."
+---
+
+The fastest way to get started with Sentry is to install the SDK for your platform. Most platforms support a one-command setup wizard that configures error monitoring, tracing, and more automatically.
+
+## Popular Platforms
+
+| Platform | Install Command |
+|---|---|
+| **[Next.js](/platforms/javascript/guides/nextjs/)** | `npx @sentry/wizard@latest -i nextjs` |
+| **[React](/platforms/javascript/guides/react/)** | `npx @sentry/wizard@latest -i react` |
+| **[Node.js](/platforms/javascript/guides/node/)** | `npx @sentry/wizard@latest -i node` |
+| **[Python](/platforms/python/)** | `pip install sentry-sdk` |
+| **[Django](/platforms/python/integrations/django/)** | `pip install sentry-sdk` |
+| **[Laravel](/platforms/php/guides/laravel/)** | `php artisan sentry:publish` |
+| **[Ruby on Rails](/platforms/ruby/guides/rails/)** | `bundle add sentry-ruby sentry-rails` |
+| **[Android](/platforms/android/)** | [Gradle setup](/platforms/android/#install) |
+| **[Apple (iOS)](/platforms/apple/guides/ios/)** | [SPM / CocoaPods setup](/platforms/apple/guides/ios/#install) |
+| **[React Native](/platforms/react-native/)** | `npx @sentry/wizard@latest -i reactNative` |
+| **[Flutter](/platforms/dart/)** | `dart pub add sentry_flutter` |
+| **[.NET](/platforms/dotnet/)** | `dotnet add package Sentry` |
+
+**[See all platforms →](/platforms/)**
+
+## What Happens After Install
+
+Once you've installed the SDK, Sentry will automatically:
+
+- **Capture unhandled errors** and send them to your Sentry project with full stack traces
+- **Create issues** that group similar errors together so you can prioritize
+- **Collect basic performance data** if you've enabled tracing
+
+To verify everything is working, trigger a test error in your app and check the [Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/) page in Sentry.
+
+## Next Steps
+
+- **[What Sentry Does](/get-started/what-sentry-does/)** — Understand the full picture of how Sentry's features connect
+- **[What to Turn On Next](/get-started/what-to-turn-on-next/)** — Enable additional features like Logs, Session Replay, and AI monitoring
+- **[Guides](/guides/)** — Practical patterns for getting the most out of each feature

--- a/docs/get-started/what-sentry-does.mdx
+++ b/docs/get-started/what-sentry-does.mdx
@@ -1,0 +1,44 @@
+---
+title: What Sentry Does
+sidebar_order: 20
+description: "Understand how errors, logs, traces, replays, and metrics connect in Sentry."
+---
+
+Sentry is an application monitoring platform built for developers. It captures errors, logs, traces, replays, and metrics from your application — and connects them all through distributed tracing so you can debug problems with full context.
+
+## The Core Loop: Issue → Context → Fix
+
+When something goes wrong in your application, Sentry's workflow is:
+
+1. **Detect** — Sentry captures errors, performance issues, and anomalies automatically
+2. **Investigate** — Every issue comes with stack traces, breadcrumbs, logs, traces, and (optionally) a video-like replay of the user's session
+3. **Fix** — [Seer](/product/ai-in-sentry/seer/), Sentry's AI, can analyze the root cause and even generate a fix as a pull request
+
+What makes this powerful is that everything is **connected by the same trace**. An error links to the logs that happened around it, the trace that shows the full request path, and the replay that shows what the user saw. No context switching between tools.
+
+## What Sentry Captures
+
+| Feature | What It Does | Effort to Set Up |
+|---|---|---|
+| **[Error Monitoring](/product/issues/)** | Captures unhandled exceptions with full stack traces, groups them into issues | Automatic with SDK |
+| **[Tracing](/product/trace-explorer/)** | Records the full path of requests across services as traces and spans | Auto-instrumented for most frameworks |
+| **[Logs](/product/logs/)** | Structured application logs, correlated with errors and traces | Add `enableLogs: true` to SDK config |
+| **[Session Replay](/product/session-replay/)** | Video-like recordings of user sessions on web and mobile | Enable in SDK config |
+| **[Profiling](/product/profiling/)** | Code-level CPU profiles showing exactly which functions are slow | Enable in SDK config |
+| **[Application Metrics](/product/metrics/)** | Custom counters, gauges, and distributions you define in code | Add metric calls to your code |
+
+## What Sentry Does With That Data
+
+| Feature | What It Does |
+|---|---|
+| **[Issues](/product/issues/)** | Groups errors and performance problems, shows priority, assigns to teams |
+| **[Monitors & Alerts](/product/monitors-and-alerts/)** | Watches for cron failures, uptime issues, and custom conditions — then notifies you |
+| **[Dashboards](/product/dashboards/)** | Visualizes application health across projects with pre-built and custom views |
+| **[Seer (AI)](/product/ai-in-sentry/seer/)** | Analyzes root causes, generates fixes as PRs, reviews code for regressions |
+| **[Releases](/product/releases/)** | Tracks which deploy introduced a problem and measures release health |
+
+## Next Steps
+
+- **[Quick Start](/get-started/quick-start/)** — Install the SDK for your platform
+- **[What to Turn On Next](/get-started/what-to-turn-on-next/)** — Enable features beyond basic error monitoring
+- **[Connect Your Tools](/get-started/connect-your-tools/)** — Link GitHub, Slack, and issue trackers

--- a/docs/get-started/what-to-turn-on-next.mdx
+++ b/docs/get-started/what-to-turn-on-next.mdx
@@ -1,0 +1,82 @@
+---
+title: What to Turn On Next
+sidebar_order: 40
+description: "After basic error monitoring, here's what to enable to get more value from Sentry."
+---
+
+You've installed the SDK and you're capturing errors. Here's the recommended order for enabling additional features, prioritized by the context and value they add to your debugging workflow.
+
+## 1. Logs
+
+<span className="badge badge-new">NEW</span>
+
+Structured logs let you see what your application was doing around the time of an error. Logs are correlated with errors and traces automatically via the same trace context.
+
+**Why turn this on:** When an error happens, you'll see the logs that led up to it — no more switching to a separate logging tool.
+
+**Set up:** Enable `enableLogs: true` in your SDK configuration, or select Logs during the SDK setup wizard.
+
+- **[What to Log guide](/guides/logs/)** — Practical patterns for what to log in auth flows, payments, API calls, and more
+- **[Logs product docs](/product/logs/)** — Full reference for searching, filtering, and alerting on logs
+- **SDK setup:** Find your platform's Logs documentation in the [SDK docs](/platforms/)
+
+## 2. Tracing
+
+Tracing records the full path of requests across your services as traces and spans. Most SDK integrations auto-instrument common operations (HTTP requests, database queries, framework rendering) without any code changes.
+
+**Why turn this on:** See exactly where time is spent in a request, identify slow database queries and N+1 problems, and trace errors across microservices.
+
+**Set up:** Enable `tracesSampleRate` in your SDK configuration, or select Tracing during the SDK setup wizard.
+
+- **[Querying Traces guide](/guides/querying-traces/)** — Five practical queries for finding slow pages, API calls, and bottlenecks
+- **[Adding Custom Spans guide](/guides/custom-spans/)** — Instrument your own code for visibility beyond auto-instrumentation
+- **[Traces & Spans product docs](/product/trace-explorer/)** — Full reference for the Trace Explorer
+
+## 3. Session Replay
+
+Session Replay captures video-like recordings of user sessions in your web or mobile app. When an error happens, you can watch what the user was doing before, during, and after the error.
+
+**Why turn this on:** Reproduce bugs without asking users "what did you click?" See rage clicks, dead clicks, and slow interactions.
+
+**Set up:** Enable `replaysSessionSampleRate` and `replaysOnErrorSampleRate` in your SDK configuration.
+
+- **[Using Session Replay guide](/guides/session-replay/)** — Five debugging workflows for using replays effectively
+- **[Session Replay product docs](/product/session-replay/)** — Full reference for replay search, filters, and privacy controls
+
+## 4. AI Agent Monitoring
+
+If you're building AI-powered features, Sentry can trace LLM calls, agent tool executions, and AI pipelines with the same trace context as the rest of your app.
+
+**Why turn this on:** Track token usage, model costs, tool execution failures, and latency across your AI features.
+
+- **[AI monitoring docs](/ai/monitoring/)** — Set up monitoring for OpenAI, Anthropic, Vercel AI, LangChain, and more
+
+## 5. Application Metrics
+
+Define custom counters, gauges, and distributions to track business and application health metrics. Metrics are trace-connected, so you can drill from an anomalous metric value down to the specific traces and spans that caused it.
+
+**Why turn this on:** Track business KPIs (signups, purchases, API usage), system health (queue depth, cache hit rates), and performance budgets alongside your errors and traces.
+
+- **[What to Track guide](/guides/metrics/)** — Practical patterns for choosing what to measure
+- **[Application Metrics product docs](/product/metrics/)** — Full reference for counters, gauges, distributions, and dashboards
+
+## 6. Profiling
+
+Continuous profiling captures CPU profiles from your production application, showing exactly which functions are consuming time.
+
+**Why turn this on:** Go beyond "this endpoint is slow" to "this specific function on line 42 is slow." Profiling adds code-level visibility without custom instrumentation.
+
+- **[Profiling product docs](/product/profiling/)** — Set up and interpret flame graphs and profiles
+
+## 7. Cron & Uptime Monitoring
+
+Track scheduled jobs (crons) and endpoint availability (uptime) to catch failures in background processes and external dependencies.
+
+**Why turn this on:** Know immediately when a cron job fails to run or an endpoint goes down, before your users notice.
+
+- **[Monitors & Alerts product docs](/product/monitors-and-alerts/)** — Set up cron monitors, uptime checks, and alerting rules
+
+## Next Steps
+
+- **[Connect Your Tools](/get-started/connect-your-tools/)** — Link GitHub for suspect commits and Seer, Slack for alerts, and Jira for issue tracking
+- **[Guides](/guides/)** — Hands-on patterns for each feature

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -102,6 +102,13 @@ export async function Home() {
                   identify and debug performance issues and errors across their systems
                   and services.
                 </p>
+                <a
+                  href="/get-started/"
+                  className="mb-4 inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-white no-underline hover:opacity-90 transition-opacity text-sm"
+                  style={{backgroundColor: '#8b5cf6'}}
+                >
+                  Get Started
+                </a>
                 <HomeSearchObserver>
                   <div className="home-search-bar relative z-50 self-stretch">
                     <Search

--- a/src/components/navigationData.ts
+++ b/src/components/navigationData.ts
@@ -30,6 +30,7 @@ export const moreSections: NavSection[] = [
 // Main navigation sections with dropdowns (used in TopNavClient)
 // Labels use title case with proper acronym handling (SDKs, API stay uppercase)
 export const mainSectionsWithDropdowns: NavSection[] = [
+  {label: 'Get Started', href: '/get-started/'},
   {label: 'SDKs', href: '/platforms/'},
   {label: 'Product', href: '/product/'},
   {label: 'AI', href: '/ai/'},
@@ -42,6 +43,7 @@ export const mainSectionsWithDropdowns: NavSection[] = [
 // Main navigation sections as simple links (used in mobile nav, header, sidebar)
 // Labels are title case for mobile/sidebar display
 export const mainSections: NavSection[] = [
+  {label: 'Get Started', href: '/get-started/'},
   {label: 'SDKs', href: '/platforms/'},
   {label: 'Product', href: '/product/'},
   {label: 'AI', href: '/ai/'},

--- a/src/components/sidebar/sidebarNavigation.tsx
+++ b/src/components/sidebar/sidebarNavigation.tsx
@@ -11,6 +11,16 @@ import {docNodeToNavNode, getNavNodes} from './utils';
 export async function SidebarNavigation({path}: {path: string[]}) {
   const rootNode = await getDocsRootNode();
 
+  // Get Started section
+  if (path[0] === 'get-started') {
+    return (
+      <ProductSidebar
+        rootNode={rootNode}
+        items={[{title: 'Get Started', root: 'get-started'}]}
+      />
+    );
+  }
+
   // Product section: just show the sidebar for /product/ and its children
   if (path[0] === 'product') {
     return (


### PR DESCRIPTION
## Summary

Creates a new top-level `/get-started/` section that provides a clear onboarding funnel for new and existing users. Added as the first item in the top navigation.

### New pages

| Page | Purpose |
|---|---|
| `/get-started/` | Landing page with paths for new and existing users |
| `/get-started/quick-start/` | SDK install shortcuts for 12 popular platforms |
| `/get-started/what-sentry-does/` | Connected platform overview (errors, logs, traces, replays, metrics) |
| `/get-started/first-error/` | Guided walkthrough of seeing and investigating your first error |
| `/get-started/what-to-turn-on-next/` | Feature adoption ladder: Logs → Tracing → Replay → AI → Metrics → Profiling → Crons |
| `/get-started/connect-your-tools/` | Top integrations to set up (GitHub, Slack, Jira, AI coding assistants) |

### Other changes
- Added 'Get Started' as first item in top nav (`navigationData.ts`)
- Added sidebar routing for `/get-started/` (`sidebarNavigation.tsx`)
- Added 'Get Started' CTA button on docs homepage

### Design decisions
- All content **links to existing docs** — no content was moved from its current home
- Pages are concise (50-80 lines each) and serve as shortcuts/overviews
- The 'What to Turn On Next' page establishes a recommended feature adoption order aligned with company priorities (Logs and AI are #1 and #4)

### Merge order
PR 3 of 4. Base: pr/2-fix-stale-content
1. pr/1-flatten-explore
2. pr/2-fix-stale-content
3. **This PR** (get started) ← merge third
4. pr/4-guide-crosslinks