### PR TITLE
chore(search): Tune Algolia ranking to favor title and relevance

### DIFF
--- a/scripts/algolia.ts
+++ b/scripts/algolia.ts
@@ -203,7 +203,13 @@ const frameworkPopularity: Record<string, number> = {
   unity: 17,
 };
 
-const PRODUCT_DOC_PREFIXES = ['product/', 'concepts/', 'cli/', 'guides/', 'integrations/'];
+const PRODUCT_DOC_PREFIXES = [
+  'product/',
+  'concepts/',
+  'cli/',
+  'guides/',
+  'integrations/',
+];
 
 const getPopularity = (
   slug: string,

--- a/scripts/algolia.ts
+++ b/scripts/algolia.ts
@@ -203,12 +203,21 @@ const frameworkPopularity: Record<string, number> = {
   unity: 17,
 };
 
-const getPopularity = (sdk: string | undefined, framework: string | undefined) => {
+const PRODUCT_DOC_PREFIXES = ['product/', 'concepts/', 'cli/', 'guides/', 'integrations/'];
+
+const getPopularity = (
+  slug: string,
+  sdk: string | undefined,
+  framework: string | undefined
+) => {
   if (sdk && frameworkPopularity[sdk]) {
     return frameworkPopularity[sdk];
   }
   if (framework && frameworkPopularity[framework]) {
     return frameworkPopularity[framework];
+  }
+  if (PRODUCT_DOC_PREFIXES.some(prefix => slug.startsWith(prefix))) {
+    return 0;
   }
   return Number.MAX_SAFE_INTEGER;
 };
@@ -238,7 +247,7 @@ async function getRecords(
       keywords: pageFm.keywords,
       sdk,
       framework,
-      ...(!isDeveloperDocs && {popularity: getPopularity(sdk, framework)}),
+      ...(!isDeveloperDocs && {popularity: getPopularity(pageFm.slug, sdk, framework)}),
     };
 
     const cacheFileName = `v${CACHE_VERSION}_${md5(html + JSON.stringify(meta))}.json`;

--- a/scripts/algolia.ts
+++ b/scripts/algolia.ts
@@ -105,7 +105,26 @@ async function indexAndUpload() {
   }
 
   if (!isDeveloperDocs) {
-    await index.setSettings(sentryAlgoliaIndexSettings);
+    await index.setSettings({
+      ...sentryAlgoliaIndexSettings,
+      searchableAttributes: [
+        'unordered(title)',
+        'unordered(section)',
+        'unordered(keywords)',
+        'text',
+      ],
+      ranking: [
+        'filters',
+        'typo',
+        'words',
+        'attribute',
+        'exact',
+        'proximity',
+        'desc(sectionRank)',
+        'asc(position)',
+        'asc(popularity)',
+      ],
+    });
   }
 
   const totalSeconds = (performance.now() - startTime) / 1000;


### PR DESCRIPTION
## DESCRIBE YOUR PR

Tune Algolia docs search so it leans on titles and textual relevance over SDK popularity, and so SDK-agnostic product docs surface above individual SDK pages on broad queries.

### Commit 1 — Ranking and searchable-attributes override

Override the index settings pushed by `scripts/algolia.ts` on top of the defaults from `@sentry-internal/global-search`:

- **Add `title` as the first searchable attribute.** The package's default `searchableAttributes` only includes `section`, `keywords`, and `text` — so page titles never contributed to matching unless they happened to also be a heading on the page. With `title` first, title matches outrank section and body matches via Algolia's `attribute` ranking criterion.
- **Move `asc(popularity)` to the last position in the `ranking` array.** It was running ahead of `attribute`, `exact`, and `proximity`, which meant a popular SDK page with a `## Tracing` heading would outrank the actual Tracing product page on a "Tracing" query. Textual relevance now decides first; popularity is a final tiebreaker.

### Commit 2 — Boost SDK-agnostic product docs

Pages outside `platforms/` previously fell back to `Number.MAX_SAFE_INTEGER` for the `popularity` field, so they always *lost* the `asc(popularity)` tiebreaker to any SDK page. Pages whose slug starts with `product/`, `concepts/`, `cli/`, `guides/`, or `integrations/` now get `popularity: 0` — better than every individual SDK — so they surface above SDK pages on broad queries.

This composes correctly with platform filtering: the platform `optionalFilters` boost runs at the `filters` ranking criterion, which sits ahead of `asc(popularity)`. So a user with Python selected still gets Python-relevant pages first; product pages come second (and only beat *non-matching* SDK pages).

Left `attributeForDistinct: 'section'` unchanged for now — the above should be enough on its own, and changing distinct behavior is a bigger behavior shift worth testing separately if needed.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

### Testing note

The ranking-settings override (commit 1) only takes effect when `scripts/algolia.ts` runs at deploy time against the production Algolia index, so a Vercel preview won't exercise it — preview deploys point at the existing index. To validate before merge, either tweak the index's "Searchable attributes" and "Ranking and Sorting" settings directly in the Algolia dashboard (non-destructive, easy to revert) or stand up a one-off staging index by overriding `DOCS_INDEX_NAME`.

The popularity boost (commit 2) changes per-record data, so it'll only fully take effect after the next full reindex on master.
