### PR TITLE
docs(android): Bump SAGP requirement to 6.8.1 and remove newDsl workaround

### DIFF
--- a/docs/platforms/android/snapshots/index.mdx
+++ b/docs/platforms/android/snapshots/index.mdx
@@ -19,7 +19,7 @@ Snapshots require Android Gradle Plugin (AGP) 8.0 or higher. Earlier AGP version
 
 ## Step 1: Enable Snapshots
 
-Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.6.0 or higher is applied and configured.
+Ensure the [Sentry Android Gradle Plugin](/platforms/android/configuration/gradle/) version 6.8.1 or higher is applied and configured.
 
 Then enable snapshots in your `build.gradle`:
 
@@ -47,16 +47,6 @@ First, choose a Paparazzi version compatible with your project:
 | --------------- | -------------- | ---------- | --- | ------------ |
 | `2.0.0-alpha05` | 9.x+           | 36         | 21+ | > 2025.05.00 |
 | `1.3.5`         | 8.x or 9.x     | ≤ 35       | 17+ | ≤ 2025.04.00 |
-
-<Alert level="warning">
-
-**AGP 9.x**: Paparazzi doesn't support the new Android DSL yet. Add this to your `gradle.properties`:
-
-```properties
-android.newDsl=false
-```
-
-</Alert>
 
 Then apply the plugin:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

- Bump the minimum Sentry Android Gradle Plugin version for snapshots from 6.6.0 to 6.8.1
- Remove the `android.newDsl=false` workaround for Paparazzi on AGP 9.x, which is no longer needed

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)