### PR TITLE
fix(crons): Correct interval schedule value type from string to integer

### DIFF
--- a/docs/platforms/javascript/common/crons/index.mdx
+++ b/docs/platforms/javascript/common/crons/index.mdx
@@ -166,7 +166,7 @@ This is an object specifying a `schedule_type` of either `crontab` or `interval`
 
 ```json
 {"type": "crontab", "value": "0 * * * *"}
-{"type": "interval", "value": "2", "unit": "hour"}
+{"type": "interval", "value": 2, "unit": "hour"}
 ```
 
 `checkin_margin`:

--- a/docs/product/monitors-and-alerts/monitors/crons/getting-started/http/index.mdx
+++ b/docs/product/monitors-and-alerts/monitors/crons/getting-started/http/index.mdx
@@ -133,7 +133,7 @@ This is an object specifying a `schedule_type` of either `crontab` or `interval`
 
 ```json
 {"type": "crontab", "value": "0 * * * *"}
-{"type": "interval", "value": "2", "unit": "hour"}
+{"type": "interval", "value": 2, "unit": "hour"}
 ```
 
 `checkin_margin`:

--- a/includes/javascript-crons-upsert.mdx
+++ b/includes/javascript-crons-upsert.mdx
@@ -70,7 +70,7 @@ The schedule representation for your monitor, either `crontab` or `interval`. Th
 
 ```json
 {"type": "crontab", "value": "0 * * * *"}
-{"type": "interval", "value": "2", "unit": "hour"}
+{"type": "interval", "value": 2, "unit": "hour"}
 ```
 
 `checkinMargin`:


### PR DESCRIPTION
Correct interval schedule value type from string to integer

The docs showed the interval schedule `value` field as a quoted string (`"2"`) in the JSON examples, but the API expects a numeric integer (`2`). This fixes the example in three places:

- `docs/platforms/javascript/common/crons/index.mdx`
- `docs/product/monitors-and-alerts/monitors/crons/getting-started/http/index.mdx`
- `includes/javascript-crons-upsert.mdx`

Was initially raised in the Python SDK [here](https://github.com/getsentry/sentry-python/issues/6386)