### PR TITLE
feat(tanstackstart-react): Add component tracking

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -53,7 +53,9 @@ export default defineConfig({
 
 The plugin passes through all options to the underlying [`@sentry/vite-plugin`](/platforms/javascript/sourcemaps/uploading/vite/). See the [Sentry Vite Plugin documentation](/platforms/javascript/sourcemaps/uploading/vite/) for the full list of available options.
 
-Additionally, the plugin automatically instruments all TanStack Start middlewares for tracing by default. To disable this behavior:
+### Automatic Middleware Instrumentation
+
+The plugin automatically instruments all TanStack Start middlewares for tracing by default. To disable this behavior:
 
 ```typescript {filename:vite.config.ts}
 sentryTanstackStart({
@@ -62,7 +64,7 @@ sentryTanstackStart({
 }),
 ```
 
-## Component Name Annotation
+### Component Name Annotation
 
 The `reactComponentAnnotation` option annotates your React components with `data-sentry-component` and `data-sentry-source-file` attributes at build time. This lets you see component names instead of generic selectors in Session Replay, breadcrumbs, and performance monitoring.
 
@@ -87,7 +89,7 @@ sentryTanstackStart({
 }),
 ```
 
-## Tunnel Route
+### Tunnel Route
 
 <AvailableSince version="10.51.0" />
 
@@ -95,7 +97,7 @@ The `tunnelRoute` option registers a same-origin TanStack Start server route tha
 
 `tunnelRoute` accepts three shapes:
 
-### `tunnelRoute: true` (recommended)
+#### `tunnelRoute: true` (recommended)
 
 Generates an opaque, unguessable route path for each dev session and production build. Because the path changes between builds, ad blockers can't reliably target it.
 
@@ -105,7 +107,7 @@ sentryTanstackStart({
 }),
 ```
 
-### Static path
+#### Static path
 
 Pass a string to use a fixed route path. This is easier to reason about, but a known path is easier for ad blockers to add to a list.
 
@@ -115,7 +117,7 @@ sentryTanstackStart({
 }),
 ```
 
-### Object form
+#### Object form
 
 Use the object form to control the DSN allowlist or set a static path explicitly:
 

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -62,6 +62,31 @@ sentryTanstackStart({
 }),
 ```
 
+## Component Name Annotation
+
+The `reactComponentAnnotation` option annotates your React components with `data-sentry-component` and `data-sentry-source-file` attributes at build time. This lets you see component names instead of generic selectors in Session Replay, breadcrumbs, and performance monitoring.
+
+```typescript {filename:vite.config.ts}
+sentryTanstackStart({
+  // ...
+  reactComponentAnnotation: {
+    enabled: true,
+  },
+}),
+```
+
+To exclude specific components from annotation:
+
+```typescript {filename:vite.config.ts}
+sentryTanstackStart({
+  // ...
+  reactComponentAnnotation: {
+    enabled: true,
+    ignoredComponents: ["MyInternalComponent"],
+  },
+}),
+```
+
 ## Tunnel Route
 
 <AvailableSince version="10.51.0" />

--- a/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/features/sentryTanstackStart.mdx
@@ -55,6 +55,8 @@ The plugin passes through all options to the underlying [`@sentry/vite-plugin`](
 
 ### Automatic Middleware Instrumentation
 
+<AvailableSince version="10.37.0" />
+
 The plugin automatically instruments all TanStack Start middlewares for tracing by default. To disable this behavior:
 
 ```typescript {filename:vite.config.ts}
@@ -65,6 +67,8 @@ sentryTanstackStart({
 ```
 
 ### Component Name Annotation
+
+<AvailableSince version="10.55.0" />
 
 The `reactComponentAnnotation` option annotates your React components with `data-sentry-component` and `data-sentry-source-file` attributes at build time. This lets you see component names instead of generic selectors in Session Replay, breadcrumbs, and performance monitoring.
 


### PR DESCRIPTION
Adds `reactComponentAnnotation` docs to the `sentryTanstackStart` Vite plugin page. Enabled in the SDK via https://github.com/getsentry/sentry-javascript/pull/21149. This should be merged after the next SDK release (`10.55.0`).

Also changed the structure to have a separate section for each TSS specific option and put them all one level below the `Configuration Options` section.