### PR TITLE
feat(rehype): Conditionally expand code tabs in `.md` with `{mdExpandTabs}`

### DIFF
--- a/.claude/skills/technical-docs/SKILL.md
+++ b/.claude/skills/technical-docs/SKILL.md
@@ -130,11 +130,67 @@ Link to related docs rather than repeating content:
 For automatic tracing, see <PlatformLink to="/configuration/apis/">API Reference</PlatformLink>.
 ```
 
-### Code Block Filenames
+### Code Block Meta Flags
 
 Always include filename when showing file-specific code:
 ```tsx {filename:app/error.tsx}
 ```
+
+Consecutive fenced code blocks are automatically grouped into tabbed code snippets.
+Each tab can have a title and filename:
+
+~~~
+```swift {tabTitle:Swift}
+SentrySDK.capture(error: error)
+```
+
+```objc {tabTitle:Objective-C}
+[SentrySDK captureError:error];
+```
+~~~
+
+#### Markdown Export and `{mdExpandTabs}`
+
+The `.md` export (mainly used by LLMs via the "Copy page" button) **collapses tab groups
+by default**: only the first tab is included, with a note listing the other tabs
+(e.g. *Also available for: yarn, pnpm*). This keeps context lean when tabs show
+trivial variations an LLM can infer on its own.
+
+Add `{mdExpandTabs}` to the first code fence in a group when the tabs contain code an LLM
+**cannot reliably derive** from seeing just one tab. This is rare — most times, adding only
+one tab to the produced `.md` is enough.
+
+~~~
+```swift {tabTitle:Swift} {mdExpandTabs}
+SentrySDK.start { options in
+    options.dsn = "..."
+}
+```
+
+```objc {tabTitle:Objective-C}
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"...";
+}];
+```
+~~~
+
+**Expand** — the code is too different for an LLM to infer:
+- Different languages: Swift / Objective-C, cross-language guides (JS/Python/PHP/Ruby/...)
+- Different setup flows: Hono guide init (Cloudflare vs Node.js `--import` vs Bun)
+- Different APIs or wrappers: GCP Cloud Functions (`wrapHttpFunction` vs `wrapCloudEventFunction`), serverless async/sync handlers
+- Different framework versions with distinct imports: Spring 5/6/7, Spring Boot 2/3/4, Svelte v5+ / v3
+- Client / Server splits: Next.js, Remix, React Router (Replay + browser tracing vs Node integrations)
+- Different platform tooling: KMP (`commonMain` / `iosApp` / `androidApp`), Flutter navigation (Navigator / GoRouter / AutoRoute)
+- Install methods with different patterns: npm (`import`) vs CDN (`<script>`) vs Loader (`sentryOnLoad`)
+- SDK version migration: SDK 2.x vs 1.x when APIs differ
+
+**Collapse** (default) — an LLM can figure it out from one tab:
+- Package managers: npm / yarn / pnpm, pip / uv, .NET CLI / NuGet
+- Module format: ESM / CommonJS (same API, different import syntax)
+- Config file formats: JSON / TOML, properties / yml
+- Java / Kotlin on the same platform (same APIs, syntactic sugar differences)
+- Runtime tabs where only the import path changes (e.g. `@sentry/hono/cloudflare` vs `@sentry/hono/node` in `platform-includes/` snippets)
+- Build tools when only dependency declaration syntax differs: Gradle / Maven / SBT
 
 ## Review Checklist
 

--- a/.claude/skills/technical-docs/SKILL.md
+++ b/.claude/skills/technical-docs/SKILL.md
@@ -153,7 +153,7 @@ SentrySDK.capture(error: error)
 
 The `.md` export (mainly used by LLMs via the "Copy page" button) **collapses tab groups
 by default**: only the first tab is included, with a note listing the other tabs
-(e.g. *Also available for: yarn, pnpm*). This keeps context lean when tabs show
+(e.g. *Other available variations of the above snippet: yarn, pnpm*). This keeps context lean when tabs show
 trivial variations an LLM can infer on its own.
 
 Add `{mdExpandTabs}` to the first code fence in a group when the tabs contain code an LLM

--- a/docs/platforms/javascript/guides/hono/index.mdx
+++ b/docs/platforms/javascript/guides/hono/index.mdx
@@ -247,7 +247,7 @@ Before continuing, make sure you've completed the runtime-specific steps above: 
 </SplitSectionText>
 <SplitSectionCode>
 
-```typescript {tabTitle:Cloudflare Workers} {filename:index.ts}
+```typescript {tabTitle:Cloudflare Workers} {filename:index.ts} {mdExpandTabs}
 import { Hono } from "hono";
 import { sentry } from "@sentry/hono/cloudflare";
 

--- a/scripts/generate-md-exports.mjs
+++ b/scripts/generate-md-exports.mjs
@@ -32,7 +32,7 @@ import {rehypeExpandCodeTabs} from './rehype-expand-code-tabs.mjs';
 const DOCS_ORIGIN = process.env.NEXT_PUBLIC_DEVELOPER_DOCS
   ? 'https://develop.sentry.dev'
   : 'https://docs.sentry.io';
-const CACHE_VERSION = 8;
+const CACHE_VERSION = 9;
 const CACHE_COMPRESS_LEVEL = 4;
 const R2_BUCKET = process.env.NEXT_PUBLIC_DEVELOPER_DOCS
   ? 'sentry-develop-docs'

--- a/scripts/generate-md-exports.test.mjs
+++ b/scripts/generate-md-exports.test.mjs
@@ -69,7 +69,7 @@ describe('rehypeExpandCodeTabs', () => {
       expect(codeBlocks[0]).toContain('npm install @sentry/node');
     });
 
-    it('appends "Also available for" note listing other tab titles', () => {
+    it('appends note listing other tab titles', () => {
       const html = buildCodeTabsHTML([
         {title: 'npm', lang: 'bash', code: 'npm install @sentry/node'},
         {title: 'yarn', lang: 'bash', code: 'yarn add @sentry/node'},
@@ -78,7 +78,9 @@ describe('rehypeExpandCodeTabs', () => {
 
       const md = htmlToMarkdown(html);
 
-      expect(md).toContain('*Also available for: yarn, pnpm*');
+      expect(md).toContain(
+        '*Other available variations of the above snippet: yarn, pnpm*'
+      );
     });
 
     it('omits the note for a single-tab group', () => {
@@ -90,7 +92,7 @@ describe('rehypeExpandCodeTabs', () => {
 
       const codeBlocks = md.match(/```[\s\S]*?```/g);
       expect(codeBlocks).toHaveLength(1);
-      expect(md).not.toContain('Also available for');
+      expect(md).not.toContain('Other available variations of the above snippet');
     });
 
     it('removes the CodeTabs-rendered active tab to avoid duplication', () => {
@@ -252,7 +254,7 @@ describe('rehypeExpandCodeTabs', () => {
       expect(codeBlocks[0]).toContain('npm install');
       expect(codeBlocks[1]).toContain('cf()');
       expect(codeBlocks[2]).toContain('node()');
-      expect(md).toContain('*Also available for: yarn*');
+      expect(md).toContain('*Other available variations of the above snippet: yarn*');
       expect(md).toContain('**\\[Cloudflare Workers] index.ts**');
       expect(md).toContain('**\\[Node.js] app.ts**');
     });
@@ -271,7 +273,7 @@ describe('rehypeExpandCodeTabs', () => {
       expect(codeBlocks).toHaveLength(2);
       expect(codeBlocks[0]).toContain('npm install');
       expect(codeBlocks[1]).toContain('import init');
-      expect(md).toContain('*Also available for: CJS*');
+      expect(md).toContain('*Other available variations of the above snippet: CJS*');
     });
   });
 

--- a/scripts/generate-md-exports.test.mjs
+++ b/scripts/generate-md-exports.test.mjs
@@ -26,7 +26,7 @@ function htmlToMarkdown(html) {
   );
 }
 
-function buildCodeTabsHTML(tabs) {
+function buildCodeTabsHTML(tabs, {expand = false} = {}) {
   const firstTab = tabs[0];
 
   const codeTabsRendered =
@@ -49,169 +49,233 @@ function buildCodeTabsHTML(tabs) {
     })
     .join('');
 
-  return `<div class="code-tabs-wrapper">${codeTabsRendered}${exportBlocks}</div>`;
+  const expandAttr = expand ? ' data-code-tab-md-expand-tabs' : '';
+  return `<div class="code-tabs-wrapper"${expandAttr}>${codeTabsRendered}${exportBlocks}</div>`;
 }
 
 describe('rehypeExpandCodeTabs', () => {
-  it('outputs one fenced code block per tab with "[Title] filename" headings', () => {
-    const html = buildCodeTabsHTML([
-      {
-        title: 'Cloudflare Workers',
-        filename: 'index.ts',
-        lang: 'typescript',
-        code: 'import { sentry } from "@sentry/hono/cloudflare";',
-      },
-      {
-        title: 'Node.js',
-        filename: 'app.ts',
-        lang: 'typescript',
-        code: 'import { sentry } from "@sentry/hono/node";',
-      },
-      {
-        title: 'Bun',
-        filename: 'index.ts',
-        lang: 'typescript',
-        code: 'import { sentry } from "@sentry/hono/bun";',
-      },
-    ]);
+  describe('default (collapsed)', () => {
+    it('outputs only the first tab code block', () => {
+      const html = buildCodeTabsHTML([
+        {title: 'npm', lang: 'bash', code: 'npm install @sentry/node'},
+        {title: 'yarn', lang: 'bash', code: 'yarn add @sentry/node'},
+        {title: 'pnpm', lang: 'bash', code: 'pnpm add @sentry/node'},
+      ]);
 
-    const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(html);
 
-    const codeBlocks = md.match(/```[\s\S]*?```/g);
-    expect(codeBlocks).toHaveLength(3);
-    expect(codeBlocks[0]).toContain('@sentry/hono/cloudflare');
-    expect(codeBlocks[1]).toContain('@sentry/hono/node');
-    expect(codeBlocks[2]).toContain('@sentry/hono/bun');
-    expect(md).toContain('**\\[Cloudflare Workers] index.ts**');
-    expect(md).toContain('**\\[Node.js] app.ts**');
-    expect(md).toContain('**\\[Bun] index.ts**');
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(1);
+      expect(codeBlocks[0]).toContain('npm install @sentry/node');
+    });
+
+    it('appends "Also available for" note listing other tab titles', () => {
+      const html = buildCodeTabsHTML([
+        {title: 'npm', lang: 'bash', code: 'npm install @sentry/node'},
+        {title: 'yarn', lang: 'bash', code: 'yarn add @sentry/node'},
+        {title: 'pnpm', lang: 'bash', code: 'pnpm add @sentry/node'},
+      ]);
+
+      const md = htmlToMarkdown(html);
+
+      expect(md).toContain('*Also available for: yarn, pnpm*');
+    });
+
+    it('omits the note for a single-tab group', () => {
+      const html = buildCodeTabsHTML([
+        {title: 'typescript', lang: 'typescript', code: 'Sentry.init();'},
+      ]);
+
+      const md = htmlToMarkdown(html);
+
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(1);
+      expect(md).not.toContain('Also available for');
+    });
+
+    it('removes the CodeTabs-rendered active tab to avoid duplication', () => {
+      const html = buildCodeTabsHTML([
+        {title: 'ESM', filename: 'instrument.mjs', lang: 'javascript', code: 'import init'},
+        {title: 'CJS', filename: 'instrument.js', lang: 'javascript', code: 'require init'},
+      ]);
+
+      const md = htmlToMarkdown(html);
+
+      expect(md).not.toContain('`instrument.mjs`');
+    });
+
+    it('does not add bold headings to the code block', () => {
+      const html = buildCodeTabsHTML([
+        {title: 'ESM', filename: 'instrument.mjs', lang: 'javascript', code: 'import init'},
+        {title: 'CJS', filename: 'instrument.js', lang: 'javascript', code: 'require init'},
+      ]);
+
+      const md = htmlToMarkdown(html);
+
+      expect(md).not.toMatch(/\*\*.*\*\*/);
+    });
   });
 
-  it('removes the CodeTabs-rendered active tab to avoid duplication', () => {
-    const html = buildCodeTabsHTML([
-      {title: 'ESM', filename: 'instrument.mjs', lang: 'javascript', code: 'import init'},
-      {title: 'CJS', filename: 'instrument.js', lang: 'javascript', code: 'require init'},
-    ]);
+  describe('opt-in expanded ({mdExpandTabs})', () => {
+    it('outputs one fenced code block per tab with "[Title] filename" headings', () => {
+      const html = buildCodeTabsHTML(
+        [
+          {
+            title: 'Cloudflare Workers',
+            filename: 'index.ts',
+            lang: 'typescript',
+            code: 'import { sentry } from "@sentry/hono/cloudflare";',
+          },
+          {
+            title: 'Node.js',
+            filename: 'app.ts',
+            lang: 'typescript',
+            code: 'import { sentry } from "@sentry/hono/node";',
+          },
+          {
+            title: 'Bun',
+            filename: 'index.ts',
+            lang: 'typescript',
+            code: 'import { sentry } from "@sentry/hono/bun";',
+          },
+        ],
+        {expand: true}
+      );
 
-    const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(html);
 
-    expect(md).not.toContain('`instrument.mjs`');
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(3);
+      expect(codeBlocks[0]).toContain('@sentry/hono/cloudflare');
+      expect(codeBlocks[1]).toContain('@sentry/hono/node');
+      expect(codeBlocks[2]).toContain('@sentry/hono/bun');
+      expect(md).toContain('**\\[Cloudflare Workers] index.ts**');
+      expect(md).toContain('**\\[Node.js] app.ts**');
+      expect(md).toContain('**\\[Bun] index.ts**');
+    });
+
+    it('uses tab title alone when filename is absent', () => {
+      const html = buildCodeTabsHTML(
+        [
+          {title: 'Cloudflare Workers', lang: 'javascript', code: 'workers();'},
+          {title: 'Bun', lang: 'javascript', code: 'bun();'},
+        ],
+        {expand: true}
+      );
+
+      const md = htmlToMarkdown(html);
+
+      const headings = md.match(/\*\*.*?\*\*/g);
+      expect(headings).toHaveLength(2);
+      expect(headings[0]).toBe('**Cloudflare Workers**');
+      expect(headings[1]).toBe('**Bun**');
+    });
+
+    it('treats empty filename attribute the same as missing filename', () => {
+      const html =
+        '<div class="code-tabs-wrapper" data-code-tab-md-expand-tabs>' +
+        '<div><button>Tab</button><div class="code-block"><code class="filename"></code>' +
+        '<pre class="language-js"><code>active()</code></pre></div></div>' +
+        '<div hidden data-code-tab-title="JavaScript" data-code-tab-filename="">' +
+        '<pre class="language-js"><code>hello();</code></pre></div>' +
+        '</div>';
+
+      const md = htmlToMarkdown(html);
+
+      const headings = md.match(/\*\*.*?\*\*/g);
+      expect(headings).toHaveLength(1);
+      expect(headings[0]).toBe('**JavaScript**');
+    });
+
+    it('drops export blocks that contain no pre element', () => {
+      const html =
+        '<div class="code-tabs-wrapper" data-code-tab-md-expand-tabs>' +
+        '<div><pre class="language-js"><code>active tab</code></pre></div>' +
+        '<div hidden data-code-tab-title="broken"><p>Not a code block</p></div>' +
+        '<div hidden data-code-tab-title="ok"><pre class="language-js"><code>works();</code></pre></div>' +
+        '</div>';
+
+      const md = htmlToMarkdown(html);
+
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(1);
+      expect(codeBlocks[0]).toContain('works()');
+      expect(md).toContain('**ok**');
+      expect(md).not.toContain('broken');
+      expect(md).not.toContain('active tab');
+    });
   });
 
-  it('uses tab title alone when filename is absent', () => {
-    const html = buildCodeTabsHTML([
-      {title: 'Cloudflare Workers', lang: 'javascript', code: 'workers();'},
-      {title: 'Bun', lang: 'javascript', code: 'bun();'},
-    ]);
+  describe('mixed page', () => {
+    it('collapses and expands groups independently on the same page', () => {
+      const collapsed = buildCodeTabsHTML([
+        {title: 'npm', lang: 'bash', code: 'npm install @sentry/node'},
+        {title: 'yarn', lang: 'bash', code: 'yarn add @sentry/node'},
+      ]);
+      const expanded = buildCodeTabsHTML(
+        [
+          {title: 'Cloudflare Workers', filename: 'index.ts', lang: 'typescript', code: 'cf()'},
+          {title: 'Node.js', filename: 'app.ts', lang: 'typescript', code: 'node()'},
+        ],
+        {expand: true}
+      );
 
-    const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(`<div>${collapsed}${expanded}</div>`);
 
-    const headings = md.match(/\*\*.*?\*\*/g);
-    expect(headings).toHaveLength(2);
-    expect(headings[0]).toBe('**Cloudflare Workers**');
-    expect(headings[1]).toBe('**Bun**');
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(3);
+      expect(codeBlocks[0]).toContain('npm install');
+      expect(codeBlocks[1]).toContain('cf()');
+      expect(codeBlocks[2]).toContain('node()');
+      expect(md).toContain('*Also available for: yarn*');
+      expect(md).toContain('**\\[Cloudflare Workers] index.ts**');
+      expect(md).toContain('**\\[Node.js] app.ts**');
+    });
+
+    it('preserves standalone code blocks alongside tab groups', () => {
+      const standalone =
+        '<pre class="language-bash"><code>npm install @sentry/node</code></pre>';
+      const tabs = buildCodeTabsHTML([
+        {title: 'ESM', lang: 'javascript', code: 'import init'},
+        {title: 'CJS', lang: 'javascript', code: 'require init'},
+      ]);
+
+      const md = htmlToMarkdown(`<div>${standalone}${tabs}</div>`);
+
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(2);
+      expect(codeBlocks[0]).toContain('npm install');
+      expect(codeBlocks[1]).toContain('import init');
+      expect(md).toContain('*Also available for: CJS*');
+    });
   });
 
-  it('treats empty filename attribute the same as missing filename', () => {
-    const html =
-      '<div class="code-tabs-wrapper">' +
-      '<div><button>Tab</button><div class="code-block"><code class="filename"></code>' +
-      '<pre class="language-js"><code>active()</code></pre></div></div>' +
-      '<div hidden data-code-tab-title="JavaScript" data-code-tab-filename="">' +
-      '<pre class="language-js"><code>hello();</code></pre></div>' +
-      '</div>';
+  describe('edge cases', () => {
+    it('does not modify code blocks outside tab wrappers', () => {
+      const html =
+        '<div><pre class="language-bash"><code>curl -sL https://sentry.io/get-cli/ | bash</code></pre></div>';
 
-    const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(html);
 
-    const headings = md.match(/\*\*.*?\*\*/g);
-    expect(headings).toHaveLength(1);
-    expect(headings[0]).toBe('**JavaScript**');
-  });
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(1);
+      expect(codeBlocks[0]).toContain('curl -sL');
+      expect(md).not.toMatch(/\*\*.*\*\*\n/);
+    });
 
-  it('does not modify code blocks outside tab wrappers', () => {
-    const html =
-      '<div><pre class="language-bash"><code>curl -sL https://sentry.io/get-cli/ | bash</code></pre></div>';
+    it('leaves wrapper unchanged when it has no export blocks', () => {
+      const html =
+        '<div class="code-tabs-wrapper">' +
+        '<div><button>Only Tab</button>' +
+        '<div class="code-block"><pre class="language-js"><code>solo();</code></pre></div>' +
+        '</div>' +
+        '</div>';
 
-    const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(html);
 
-    const codeBlocks = md.match(/```[\s\S]*?```/g);
-    expect(codeBlocks).toHaveLength(1);
-    expect(codeBlocks[0]).toContain('curl -sL');
-    expect(md).not.toMatch(/\*\*.*\*\*\n/);
-  });
-
-  it('preserves standalone code blocks when mixed with tab groups', () => {
-    const standalone =
-      '<pre class="language-bash"><code>npm install @sentry/node</code></pre>';
-    const tabs = buildCodeTabsHTML([
-      {
-        title: 'Node.js',
-        filename: 'instrument.mjs',
-        lang: 'javascript',
-        code: 'Sentry.init();',
-      },
-      {title: 'Bun', lang: 'javascript', code: 'init();'},
-    ]);
-
-    const md = htmlToMarkdown(`<div>${standalone}${tabs}</div>`);
-
-    const codeBlocks = md.match(/```[\s\S]*?```/g);
-    expect(codeBlocks).toHaveLength(3);
-    expect(codeBlocks[0]).toContain('npm install');
-    expect(md).toContain('**\\[Node.js] instrument.mjs**');
-    expect(md).toContain('**Bun**');
-  });
-
-  it('expands multiple tab groups independently on the same page', () => {
-    const group1 = buildCodeTabsHTML([
-      {title: 'ESM', filename: 'instrument.mjs', lang: 'javascript', code: 'import init'},
-      {title: 'CJS', filename: 'instrument.js', lang: 'javascript', code: 'require init'},
-    ]);
-    const group2 = buildCodeTabsHTML([
-      {title: 'Python', filename: 'main.py', lang: 'python', code: 'import sentry_sdk'},
-      {title: 'Ruby', filename: 'config.rb', lang: 'ruby', code: 'require "sentry-ruby"'},
-    ]);
-
-    const md = htmlToMarkdown(`<div>${group1}${group2}</div>`);
-
-    const codeBlocks = md.match(/```[\s\S]*?```/g);
-    expect(codeBlocks).toHaveLength(4);
-    expect(codeBlocks[0]).toContain('import init');
-    expect(codeBlocks[1]).toContain('require init');
-    expect(codeBlocks[2]).toContain('import sentry_sdk');
-    expect(codeBlocks[3]).toContain('require "sentry-ruby"');
-  });
-
-  it('drops export blocks that contain no pre element', () => {
-    const html =
-      '<div class="code-tabs-wrapper">' +
-      '<div><pre class="language-js"><code>active tab</code></pre></div>' +
-      '<div hidden data-code-tab-title="broken"><p>Not a code block</p></div>' +
-      '<div hidden data-code-tab-title="ok"><pre class="language-js"><code>works();</code></pre></div>' +
-      '</div>';
-
-    const md = htmlToMarkdown(html);
-
-    const codeBlocks = md.match(/```[\s\S]*?```/g);
-    expect(codeBlocks).toHaveLength(1);
-    expect(codeBlocks[0]).toContain('works()');
-    expect(md).toContain('**ok**');
-    expect(md).not.toContain('broken');
-    expect(md).not.toContain('active tab');
-  });
-
-  it('leaves wrapper unchanged when it has no export blocks', () => {
-    const html =
-      '<div class="code-tabs-wrapper">' +
-      '<div><button>Only Tab</button>' +
-      '<div class="code-block"><pre class="language-js"><code>solo();</code></pre></div>' +
-      '</div>' +
-      '</div>';
-
-    const md = htmlToMarkdown(html);
-
-    const codeBlocks = md.match(/```[\s\S]*?```/g);
-    expect(codeBlocks).toHaveLength(1);
-    expect(codeBlocks[0]).toContain('solo()');
+      const codeBlocks = md.match(/```[\s\S]*?```/g);
+      expect(codeBlocks).toHaveLength(1);
+      expect(codeBlocks[0]).toContain('solo()');
+    });
   });
 });

--- a/scripts/generate-md-exports.test.mjs
+++ b/scripts/generate-md-exports.test.mjs
@@ -95,8 +95,18 @@ describe('rehypeExpandCodeTabs', () => {
 
     it('removes the CodeTabs-rendered active tab to avoid duplication', () => {
       const html = buildCodeTabsHTML([
-        {title: 'ESM', filename: 'instrument.mjs', lang: 'javascript', code: 'import init'},
-        {title: 'CJS', filename: 'instrument.js', lang: 'javascript', code: 'require init'},
+        {
+          title: 'ESM',
+          filename: 'instrument.mjs',
+          lang: 'javascript',
+          code: 'import init',
+        },
+        {
+          title: 'CJS',
+          filename: 'instrument.js',
+          lang: 'javascript',
+          code: 'require init',
+        },
       ]);
 
       const md = htmlToMarkdown(html);
@@ -106,8 +116,18 @@ describe('rehypeExpandCodeTabs', () => {
 
     it('does not add bold headings to the code block', () => {
       const html = buildCodeTabsHTML([
-        {title: 'ESM', filename: 'instrument.mjs', lang: 'javascript', code: 'import init'},
-        {title: 'CJS', filename: 'instrument.js', lang: 'javascript', code: 'require init'},
+        {
+          title: 'ESM',
+          filename: 'instrument.mjs',
+          lang: 'javascript',
+          code: 'import init',
+        },
+        {
+          title: 'CJS',
+          filename: 'instrument.js',
+          lang: 'javascript',
+          code: 'require init',
+        },
       ]);
 
       const md = htmlToMarkdown(html);
@@ -214,7 +234,12 @@ describe('rehypeExpandCodeTabs', () => {
       ]);
       const expanded = buildCodeTabsHTML(
         [
-          {title: 'Cloudflare Workers', filename: 'index.ts', lang: 'typescript', code: 'cf()'},
+          {
+            title: 'Cloudflare Workers',
+            filename: 'index.ts',
+            lang: 'typescript',
+            code: 'cf()',
+          },
           {title: 'Node.js', filename: 'app.ts', lang: 'typescript', code: 'node()'},
         ],
         {expand: true}

--- a/scripts/rehype-expand-code-tabs.mjs
+++ b/scripts/rehype-expand-code-tabs.mjs
@@ -1,7 +1,7 @@
 import {visit} from 'unist-util-visit';
 
 /**
- * Rehype plugin that expands CodeTabs for markdown export.
+ * Rehype plugin that converts CodeTabs export blocks for markdown export.
  *
  * The remark-code-tabs plugin injects hidden <div data-code-tab-title>
  * blocks alongside the interactive <CodeTabs> component inside each
@@ -9,13 +9,12 @@ import {visit} from 'unist-util-visit';
  * tab and are always present in the static HTML (unlike CodeTabs output,
  * which may only include the active tab due to RSC serialization).
  *
- * This plugin:
- *  1. Finds parent elements that contain [data-code-tab-title] children
- *  2. Replaces ALL children with expanded export blocks (removing the
- *     CodeTabs-rendered content to avoid duplication)
- *  3. Each export block becomes a bold heading + fenced code block.
- *     The heading format is "[Tab Title] filename" when both exist,
- *     or just the tab title / filename when only one is present
+ * Behavior depends on whether the wrapper has data-code-tab-md-expand-tabs
+ * (set via {mdExpandTabs} in any code fence of the group):
+ *
+ *  - With flag: all tabs are expanded with "[Title] filename" headings.
+ *  - Without flag (default): only the first tab is kept, plus a note
+ *    listing the other available tab titles.
  */
 export function rehypeExpandCodeTabs() {
   return tree => {
@@ -31,35 +30,80 @@ export function rehypeExpandCodeTabs() {
         return;
       }
 
-      node.children = exportBlocks.flatMap(block => {
-        const title = block.properties.dataCodeTabTitle;
-        const filename = block.properties.dataCodeTabFilename;
-        const label = filename && title ? `[${title}] ${filename}` : filename || title;
+      const expandAll = node.properties?.dataCodeTabMdExpandTabs != null;
 
-        const preElements = collectAll(block, el => el.tagName === 'pre');
-        if (preElements.length === 0) {
-          return [];
-        }
-
-        return [
-          {
-            type: 'element',
-            tagName: 'p',
-            properties: {},
-            children: [
-              {
-                type: 'element',
-                tagName: 'strong',
-                properties: {},
-                children: [{type: 'text', value: label}],
-              },
-            ],
-          },
-          ...preElements,
-        ];
-      });
+      if (expandAll) {
+        node.children = expandAllTabs(exportBlocks);
+      } else {
+        node.children = collapseToFirstTab(exportBlocks);
+      }
     });
   };
+}
+
+function expandAllTabs(exportBlocks) {
+  return exportBlocks.flatMap(block => {
+    const title = block.properties.dataCodeTabTitle;
+    const filename = block.properties.dataCodeTabFilename;
+    const label = filename && title ? `[${title}] ${filename}` : filename || title;
+
+    const preElements = collectAll(block, el => el.tagName === 'pre');
+    if (preElements.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        type: 'element',
+        tagName: 'p',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'strong',
+            properties: {},
+            children: [{type: 'text', value: label}],
+          },
+        ],
+      },
+      ...preElements,
+    ];
+  });
+}
+
+function collapseToFirstTab(exportBlocks) {
+  const first = exportBlocks[0];
+  const preElements = collectAll(first, el => el.tagName === 'pre');
+  if (preElements.length === 0) {
+    return [];
+  }
+
+  const result = [...preElements];
+
+  const otherTitles = exportBlocks
+    .slice(1)
+    .map(block => block.properties.dataCodeTabTitle)
+    .filter(Boolean);
+
+  if (otherTitles.length > 0) {
+    result.push({
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [
+        {
+          type: 'element',
+          tagName: 'em',
+          properties: {},
+          children: [
+            {type: 'text', value: `Also available for: ${otherTitles.join(', ')}`},
+          ],
+        },
+      ],
+    });
+  }
+
+  return result;
 }
 
 function collectAll(node, predicate) {

--- a/scripts/rehype-expand-code-tabs.mjs
+++ b/scripts/rehype-expand-code-tabs.mjs
@@ -96,7 +96,10 @@ function collapseToFirstTab(exportBlocks) {
           tagName: 'em',
           properties: {},
           children: [
-            {type: 'text', value: `Also available for: ${otherTitles.join(', ')}`},
+            {
+              type: 'text',
+              value: `Other available variations of the above snippet: ${otherTitles.join(', ')}`,
+            },
           ],
         },
       ],

--- a/src/remark-code-tabs.js
+++ b/src/remark-code-tabs.js
@@ -32,6 +32,11 @@ function getTabTitle(node) {
   return (match && match[1]) || '';
 }
 
+function getMdExpandTabs(node) {
+  const meta = getFullMeta(node);
+  return /\{mdExpandTabs}/.test(meta || '');
+}
+
 // TODO(dcramer): this should only operate on MDX
 export default function remarkCodeTabs() {
   return markdownAST => {
@@ -84,11 +89,14 @@ export default function remarkCodeTabs() {
         };
       });
 
+      const shouldExpand = pendingCode.some(([node]) => getMdExpandTabs(node));
+
       rootNode.type = 'element';
       rootNode.data = {
         hName: 'div',
         hProperties: {
           className: 'code-tabs-wrapper',
+          ...(shouldExpand && {dataCodeTabMdExpandTabs: true}),
         },
       };
       rootNode.children = [


### PR DESCRIPTION

## DESCRIBE YOUR PR

Improvement of https://github.com/getsentry/sentry-docs/pull/17745

The generated `.md` files are mostly consumed by LLMs. Expanding every tab group floods context with trivial variations (npm/yarn/pnpm, ESM/CJS) that any LLM can infer from a single example.

This PR makes tab expansion opt-in via `{mdExpandTabs}`:

- Default: only the first tab is included, with an "Also available for: yarn, pnpm" note listing the other tabs for completeness
- Opt-in: adding {mdExpandTabs} to any code fence in a group expands all tabs (for cases like Swift/ObjC, different runtime setup flows, client/server splits)
- Skill update: technical-docs now documents when to use `{mdExpandTabs}` vs. when to let tabs collapse

Example page: https://sentry-docs-git-sig-copy-page-all-snippets-conditional.sentry.dev/platforms/javascript/guides/hono.md

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
