### PR TITLE
fix(react-native): Fix invalid syntax in React Navigation setup example

### DIFF
--- a/includes/react-native-react-navigation-setup.mdx
+++ b/includes/react-native-react-navigation-setup.mdx
@@ -11,7 +11,7 @@ Sentry.init({
   integrations: [navigationIntegration],
 })
 
-function App = () => {
+const App = () => {
   const containerRef = createNavigationContainerRef();
 
   return (


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes a syntax error in the React Navigation setup code snippet that has been present since the file was created (#9442).

`function App = () => {` is invalid JavaScript — changed to `const App = () => {`.

## IS YOUR CHANGE URGENT?  

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)