### PR TITLE
docs(unreal): Add Session Replay feature

### DIFF
--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -26,6 +26,7 @@ Unreal Engine SDK builds on top of other Sentry SDKs and extends them with Unrea
   - Compatibility with the default [Crash Reporter Client](/platforms/unreal/configuration/crash-reporter/crash-reporter-client/) provided along with Unreal Engine
 - [PlayStation](/platforms/playstation/), [Xbox](/platforms/xbox/) and [Nintendo Switch](/platforms/nintendo-switch/) support
 - [Release health](/platforms/unreal/configuration/releases/) to keep track of crash free users and sessions
+- [Session Replay](/platforms/unreal/session-replay/) (experimental) to attach gameplay video to crash reports on Windows and Xbox, and native session replay on Android
 - [Structured Logging](/platforms/unreal/logs/) to capture and send log messages with additional context
 - [Metrics](/platforms/unreal/metrics/) to track counters, gauges, and distributions
 - [Offline Caching](/platforms/unreal/configuration/options/#EnableOfflineCaching) stores event data to disk in case the device is not online

--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -1,0 +1,97 @@
+---
+title: Set Up Session Replay
+sidebar_title: Session Replay
+description: "Learn how to capture gameplay video and attach it to crash reports with Sentry's Unreal Engine SDK."
+sidebar_order: 5500
+sidebar_section: features
+---
+
+<Alert level="warning">
+
+Session Replay for Unreal Engine is **experimental** and currently limited to a small set of platforms (see [Platform Support](#platform-support)). The API and behavior may change in future releases.
+
+</Alert>
+
+Session Replay records what was happening on screen in the moments leading up to a crash, giving you a visual reproduction to pair with the captured event.
+
+Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/android/session-replay/) Session Replay experiences, which reconstruct the UI from the view hierarchy and aggressively mask text and images by default, the Unreal Engine SDK captures the rendered output of your game directly. On desktop and console, it continuously encodes the rendered frames into a short rolling video clip and attaches that clip to crash reports. On Android, the feature delegates to the underlying [Android SDK's Session Replay](/platforms/android/session-replay/).
+
+## Platform Support
+
+| Platform    | What gets captured                                                              | Requirements                                                                                        |
+| ----------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Windows** | A rolling video clip of the game's backbuffer, attached to crash reports.       | The `AVCodecsCore` and `NVCodecs` plugins enabled, an NVIDIA GPU (NVENC), and a plugin rebuild after enabling (see [below](#windows)). |
+| **Xbox**    | An OS-captured gameplay clip, attached to crash reports.                        | Development kits only.                                                                               |
+| **Android** | A full-session replay via the Android SDK, with default text and image masking. | None beyond the standard Android setup.                                                             |
+
+All other platforms (Linux, macOS, iOS, PlayStation, and Nintendo Switch) are not currently supported. On those platforms the setting is a no-op.
+
+## Enabling Session Replay
+
+To enable Session Replay, navigate to **Project Settings > Plugins > Sentry** and expand the **Session Replay** section, then toggle **Enable session replay (experimental)**.
+
+Alternatively, add the following to your project's configuration `.ini` file:
+
+```ini
+[/Script/Sentry.SentrySettings]
+AttachSessionReplay=True
+```
+
+## Configuration
+
+The following settings are available under the **Session Replay** section in the plugin settings:
+
+- **Enable session replay (experimental)** (`AttachSessionReplay`, default `False`) — Master toggle for the feature.
+- **Replay duration (ms)** (`SessionReplayDurationMs`, default `5000`, range `1000`–`60000`) — The requested length of the retroactive replay window. On Windows this is the rolling clip length kept on disk for crash attachment; on Xbox it's the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). This value is ignored on Android, where the underlying SDK determines the duration.
+
+### Advanced Recording Options (Windows)
+
+The **Advanced recording options (Windows)** group (`SessionReplayOptions`) provides low-level encoder and muxer tuning for the Windows recorder. The defaults are sensible for most projects.
+
+- **Fragment duration (seconds)** (`FragmentSeconds`, default `0.5`, range `0.1`–`2.0`) — Length of each video fragment. Shorter values reduce the worst-case amount of footage lost at crash time, but increase keyframe frequency and lower compression efficiency.
+- **Rotation interval (seconds)** (`RotationIntervalSeconds`, default `1.0`, range `0.25`–`5.0`) — How often the on-disk attachment file is refreshed.
+- **Target framerate** (`Framerate`, default `30`, range `10`–`60`) — Capture framerate. The game can render faster; frames are sampled down to this rate.
+- **Target bitrate (kbps)** (`BitrateKbps`, default `2000`, range `200`–`20000`) — Encoder target bitrate.
+
+```ini
+[/Script/Sentry.SentrySettings]
+AttachSessionReplay=True
+SessionReplayDurationMs=5000
+SessionReplayOptions=(FragmentSeconds=0.500000,RotationIntervalSeconds=1.000000,Framerate=30,BitrateKbps=2000)
+```
+
+## Platform Notes
+
+### Windows
+
+On Windows, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports captured by the native crash handler. It relies on hardware-accelerated H.264 encoding and has the following requirements:
+
+- **The `AVCodecsCore` and `NVCodecs` engine plugins must be enabled** in your project. The Sentry plugin only compiles the recorder when these are present.
+- **An NVIDIA GPU is required.** Encoding goes through NVIDIA NVENC; machines without a compatible NVIDIA GPU fall back to no recording (the feature self-disables and logs a warning).
+- **A plugin rebuild is required after toggling the setting.** Whether Session Replay is compiled in is decided at build time from `AttachSessionReplay`, so after enabling or disabling it, delete your project's `Binaries` and `Intermediate` directories and rebuild.
+
+<Alert>
+
+The most recent fraction of a second of footage (up to one fragment duration) may be missing from the attached clip, since the fragment being encoded at the moment of the crash isn't yet finalized.
+
+</Alert>
+
+### Xbox
+
+On Xbox, Session Replay uses the operating system's game-capture facility to grab a clip of recent gameplay at crash time. This is supported on **development kits only** and is not available in retail builds.
+
+### Android
+
+On Android, enabling the setting turns on the [Android SDK's Session Replay](/platforms/android/session-replay/), recording the full session rather than a crash-attached clip. As with the standalone Android SDK, all text and images are masked by default. See the [Android Session Replay docs](/platforms/android/session-replay/) for details on masking, sampling, and privacy.
+
+## Privacy
+
+<Alert level="warning">
+
+On Windows and Xbox, Session Replay records the rendered game frames as-is — there is **no automatic masking**. Any sensitive information shown on screen (player names, chat, email addresses, in-game purchases, and so on) will be present in the captured video. Only enable this feature if the content rendered by your game is safe to record, and make sure your data-handling and privacy policies account for it.
+
+</Alert>
+
+On Android, the underlying SDK masks all text and images by default. Review the [Android Session Replay privacy documentation](/platforms/android/session-replay/privacy/) before adjusting those defaults.
+
+If you run into issues or have feedback about Session Replay on Unreal Engine, please open a [GitHub issue](https://github.com/getsentry/sentry-unreal/issues).


### PR DESCRIPTION
This PR adds a dedicated "Session Replay" docs page for Unreal SDK.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1404
- https://github.com/getsentry/sentry-unreal/pull/1386
- https://github.com/getsentry/sentry-xbox/pull/136