### PR TITLE
docs(tanstackstart-react): Update TanStack Start SDK status from alpha to beta

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -9,9 +9,9 @@ categories:
   - browser
 ---
 
-<Alert level="warning">
+<Alert level="warning" title="Beta">
 
-This SDK is compatible with TanStack Start 1.0 RC and is currently in **ALPHA**. Alpha features are still in progress, may have bugs and might include breaking changes.
+This SDK is compatible with TanStack Start 1.0 RC and is currently in **beta**. Beta features are still in progress and may have bugs.
 Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns.
 
 </Alert>

--- a/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
@@ -16,9 +16,9 @@ For the fastest setup, we recommend using the [installation wizard](/platforms/j
 
 </Alert>
 
-<Alert level="warning">
+<Alert level="warning" title="Beta">
 
-This SDK is compatible with TanStack Start 1.0 RC and is currently in **ALPHA**. Alpha features are still in progress, may have bugs and might include breaking changes.
+This SDK is compatible with TanStack Start 1.0 RC and is currently in **beta**. Beta features are still in progress and may have bugs.
 Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns.
 
 </Alert>


### PR DESCRIPTION
Promote the tanstackstart-react SDK from alpha to beta in the docs. SDK change in https://github.com/getsentry/sentry-javascript/pull/21175. Merge after the `10.55.0` release of the javascript SDKs.