### PR TITLE
feat(android): Add raw tombstone attachment option

### DIFF
--- a/docs/platforms/android/configuration/tombstones.mdx
+++ b/docs/platforms/android/configuration/tombstones.mdx
@@ -100,6 +100,34 @@ It can also make sense if you get recurring reports of native crashes early duri
 
 Other than that, the SDK will always pick up the latest Tombstone from the historical exit reasons list on the next app restart, and there won’t be any historical Tombstones to report. Also keep in mind that historical Tombstones will receive only minimal updates, as the available data is likely out of sync.
 
+#### Attaching Raw Tombstone
+
+<Alert level="info">
+
+Available in Android SDK version `8.42.0` or above.
+
+</Alert>
+
+The SDK can send the raw tombstone data from [ApplicationExitInfo#getTraceInputStream](<https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()>) as an attachment. This is useful for performing deeper investigations using all available information from the OS, in addition to the SDK parsing the tombstone into threads with stack traces:
+
+```xml {filename:AndroidManifest.xml}
+<application>
+    <meta-data android:name="io.sentry.tombstone.attach-raw" android:value="true" />
+</application>
+```
+
+```kotlin
+SentryAndroid.init(context) { options ->
+  options.isAttachRawTombstone = true
+}
+```
+
+```java
+SentryAndroid.init(context, options -> {
+  options.setAttachRawTombstone(true);
+});
+```
+
 #### Interaction with other Options
 
 Similar to ANR, for Tombstone derived events the options `attachThreads` and `attachStacktrace` are currently without effect.

--- a/docs/platforms/android/configuration/tombstones.mdx
+++ b/docs/platforms/android/configuration/tombstones.mdx
@@ -108,7 +108,11 @@ Available in Android SDK version `8.42.0` or above.
 
 </Alert>
 
-The SDK can send the raw tombstone data from [ApplicationExitInfo#getTraceInputStream](<https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()>) as an attachment. This is useful for performing deeper investigations using all available information from the OS, in addition to the SDK parsing the tombstone into threads with stack traces:
+The SDK can send the raw tombstone data from [ApplicationExitInfo#getTraceInputStream](<https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()>) as an attachment. This is useful for performing deeper investigations using all available information from the OS, in addition to the SDK parsing the tombstone into threads with stack traces.
+
+The raw data is a binary protobuf file. To interpret it, you'll need a protobuf decoder and [Android's tombstone schema](https://android.googlesource.com/platform/system/core/+/refs/heads/main/debuggerd/proto/tombstone.proto).
+
+To enable raw tombstone attachments:
 
 ```xml {filename:AndroidManifest.xml}
 <application>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the `isAttachRawTombstone` option for Android SDK 8.42.0+, which allows attaching raw tombstone data from `ApplicationExitInfo#getTraceInputStream()` as an attachment on native crash events.

- Added new "Attaching Raw Tombstone" section to the tombstones configuration page
- Includes AndroidManifest.xml, Kotlin, and Java configuration examples
- Follows the same pattern as the existing ANR thread dump attachment docs

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)