### PR TITLE
docs(apple): Update SnapshotPreviews repo URL to getsentry org

### DIFF
--- a/docs/platforms/apple/common/snapshots/index.mdx
+++ b/docs/platforms/apple/common/snapshots/index.mdx
@@ -19,7 +19,7 @@ These methods are not mutually exclusive — you can generate and upload snapsho
 
 ### Generate Snapshots From Previews (Recommended)
 
-[SnapshotPreviews](https://github.com/EmergeTools/SnapshotPreviews) automatically turns every `#Preview` and `PreviewProvider` in your project into a snapshot, so you don't have to maintain explicit snapshot tests.
+[SnapshotPreviews](https://github.com/getsentry/SnapshotPreviews) automatically turns every `#Preview` and `PreviewProvider` in your project into a snapshot, so you don't have to maintain explicit snapshot tests.
 
 Create a test that subclasses `SnapshotTest`:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Update the SnapshotPreviews GitHub link from `EmergeTools/SnapshotPreviews` to `getsentry/SnapshotPreviews` in the Apple snapshots documentation.

The repository has moved to the getsentry GitHub organization and the old URL needs to be updated to point to the correct location.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)