### PR TITLE
docs(react-native): document .env.local for Expo auth token

### DIFF
--- a/docs/platforms/react-native/index.mdx
+++ b/docs/platforms/react-native/index.mdx
@@ -46,7 +46,7 @@ npx @sentry/wizard@latest -i reactNative
 - Wrap the _Bundle React Native code and images_ Xcode project build phase script to upload generated source maps and collect bundled node modules.
 - Add _Upload Debug Symbols to Sentry_ Xcode project build phase.
 - Run `pod install`.
-- Store build credentials in _*ios/sentry.properties*_, _*android/sentry.properties*_ and _*env.local*_.
+- Store build credentials in _*ios/sentry.properties*_, _*android/sentry.properties*_ and _*.env.local*_.
 - Configure Sentry for the supplied DSN in your _*layout.tsx*_/_*App.tsx*_file.
 
 </Expandable>

--- a/docs/platforms/react-native/manual-setup/expo.mdx
+++ b/docs/platforms/react-native/manual-setup/expo.mdx
@@ -29,7 +29,7 @@ npx @sentry/wizard@latest -i reactNative
 - Wrap the _Bundle React Native code and images_ Xcode project build phase script to upload generated source maps and collect bundled node modules.
 - Add _Upload Debug Symbols to Sentry_ Xcode project build phase.
 - Run `pod install`.
-- Store build credentials in _*ios/sentry.properties*_, _*android/sentry.properties*_ and _*env.local*_.
+- Store build credentials in _*ios/sentry.properties*_, _*android/sentry.properties*_ and _*.env.local*_.
 - Configure Sentry for the supplied DSN in your _*layout.tsx*_ file.
 
 </Expandable>
@@ -165,6 +165,6 @@ To verify that everything is working as expected, build the `Release` version of
 
 ## Notes
 
-- Don't commit your auth token. Instead, use an environment variable like `SENTRY_AUTH_TOKEN`.
+- Don't commit your auth token. Store it in `.env.local` as `SENTRY_AUTH_TOKEN` for local builds, and as an [EAS secret](https://docs.expo.dev/eas/environment-variables/) for EAS builds.
 - Source maps for the `Release` version of your application are uploaded automatically during the native application build.
 - During development, the source code is resolved using the Metro Server and source maps aren't used. This currently doesn't work on web.

--- a/includes/react-native-expo-plugin-code-snippet.mdx
+++ b/includes/react-native-expo-plugin-code-snippet.mdx
@@ -55,9 +55,15 @@ export default withSentry(config, {
 
 </Alert>
 
-Add auth token to your environment:
+Add your auth token to a `.env.local` file in the root of your project:
 
-```bash
+```properties {filename:.env.local}
 # DO NOT COMMIT YOUR AUTH TOKEN
-export SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 ```
+
+<Alert>
+
+Do not commit your auth token. Add `.env.local` to your `.gitignore`. For EAS builds, add `SENTRY_AUTH_TOKEN` as an [EAS secret](https://docs.expo.dev/eas/environment-variables/) instead of using a `.env.local` file.
+
+</Alert>


### PR DESCRIPTION
The wizard listed `.env.local` as a file it creates, but never showed what goes in it. The Expo plugin snippet also showed a bare `export` shell command, which doesn't work for EAS builds.

**What changed:**

- `react-native-expo-plugin-code-snippet.mdx`: replaced the shell `export` command with a proper `.env.local` code block (format that actually works for local builds), and added a note directing EAS users to add `SENTRY_AUTH_TOKEN` as an EAS secret instead
- `expo.mdx` Notes: replaced vague "use an environment variable like `SENTRY_AUTH_TOKEN`" with explicit `.env.local` and EAS secret guidance
- `index.mdx` + `expo.mdx`: fixed typo `env.local` → `.env.local` in the wizard task expandables

Feedback from Antonis Lilis testing `sentry init` on Expo — the missing `.env.local` meant EAS builds couldn't upload source maps.