### PR TITLE
docs(snapshots): Add local testing page for download and diff commands

### DIFF
--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -97,3 +97,43 @@ sentry-cli build snapshots [OPTIONS] --app-id <APP_ID> <PATH>
 | `--force-git-metadata`          | Force git metadata collection outside CI.                                                                                                                                      |
 | `--log-level <LEVEL>`           | Logging verbosity: `trace`, `debug`, `info`, `warn`, or `error`.                                                                                                               |
 | `--quiet`                       | Suppress output while preserving exit codes. Alias: `--silent`.                                                                                                                |
+
+## Download Baselines
+
+`sentry-cli snapshots download` downloads baseline snapshot images from Sentry to a local directory.
+
+```bash
+sentry-cli snapshots download --app-id web-frontend
+```
+
+| Flag                        | Description                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--app-id <APP_ID>`         | Resolve the latest baseline snapshot for this app. Mutually exclusive with `--snapshot-id`.           |
+| `--snapshot-id <ID>`        | Download a specific snapshot by artifact ID. Mutually exclusive with `--app-id`.                      |
+| `--branch <BRANCH>`         | Filter by git branch when using `--app-id`.                                                           |
+| `--output <DIR>`            | Destination directory for extracted images. Default: `./snapshots-base/`.                             |
+| `-o`, `--org <ORG>`         | Sentry organization slug. Can also be set via `SENTRY_ORG`.                                           |
+| `-p`, `--project <PROJECT>` | Sentry project slug (numeric ID required with org auth tokens). Can also be set via `SENTRY_PROJECT`. |
+| `--auth-token <TOKEN>`      | Sentry auth token. Can also be set via `SENTRY_AUTH_TOKEN`.                                           |
+| `--quiet`                   | Suppress output while preserving exit codes.                                                          |
+
+## Local Diff
+
+`sentry-cli snapshots diff` compares two directories of snapshot images locally using [odiff](https://github.com/nicolo-ribaudo/odiff-bin) and outputs JSON with per-image results.
+
+```bash
+sentry-cli snapshots diff ./snapshots-base ./snapshots-head
+```
+
+On first run, `sentry-cli` downloads the `odiff` binary and caches it at `~/.sentry-cli/odiff/`.
+
+| Flag                  | Description                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `<BASE_DIR>`          | Path to the baseline image directory.                                                       |
+| `<HEAD_DIR>`          | Path to the head image directory.                                                           |
+| `--output <DIR>`      | Directory for diff mask PNGs. Default: `./diff-output/`.                                    |
+| `--threshold <FLOAT>` | Pixel color difference threshold (`0.0`–`1.0`). Default: `0.01`.                            |
+| `--fail-on-diff`      | Exit with code 1 if any differences are found.                                              |
+| `--no-antialiasing`   | Disable antialiasing detection.                                                             |
+| `--selective`         | Treat images in the base directory but missing from head as `skipped` instead of `removed`. |
+| `--quiet`             | Suppress output while preserving exit codes.                                                |

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -119,7 +119,7 @@ sentry-cli snapshots download --app-id web-frontend
 
 ## Local Diff
 
-`sentry-cli snapshots diff` compares two directories of snapshot images locally using [odiff](https://github.com/nicolo-ribaudo/odiff-bin) and outputs JSON with per-image results.
+`sentry-cli snapshots diff` compares two directories of snapshot images locally using [odiff](https://github.com/dmtrKovalenko/odiff) and outputs JSON with per-image results.
 
 ```bash
 sentry-cli snapshots diff ./snapshots-base ./snapshots-head
@@ -131,7 +131,7 @@ On first run, `sentry-cli` downloads the `odiff` binary and caches it at `~/.sen
 | --------------------- | ------------------------------------------------------------------------------------------- |
 | `<BASE_DIR>`          | Path to the baseline image directory.                                                       |
 | `<HEAD_DIR>`          | Path to the head image directory.                                                           |
-| `--output <DIR>`      | Directory for diff mask PNGs. Default: `./diff-output/`.                                    |
+| `--output <DIR>`      | Directory for diff mask images. Default: `./diff-output/`.                                  |
 | `--threshold <FLOAT>` | Pixel color difference threshold (`0.0`–`1.0`). Default: `0.01`.                            |
 | `--fail-on-diff`      | Exit with code 1 if any differences are found.                                              |
 | `--no-antialiasing`   | Disable antialiasing detection.                                                             |

--- a/docs/product/snapshots/local-testing/index.mdx
+++ b/docs/product/snapshots/local-testing/index.mdx
@@ -30,17 +30,17 @@ sentry-cli snapshots download --app-id web-frontend --branch main
 sentry-cli snapshots download --snapshot-id 259299
 ```
 
-Use `--output` to change the destination directory.
+Use `--output` to change the destination directory. See the [full download reference](/cli/snapshots/#download-baselines) for all available flags.
 
 ## Diffing Locally
 
-Use `sentry-cli snapshots diff` to compare two directories of images:
+Use `sentry-cli snapshots diff` to compare two directories of images. See the [full diff reference](/cli/snapshots/#local-diff) for all available flags.
 
 ```bash
 sentry-cli snapshots diff ./snapshots-base ./snapshots-head
 ```
 
-This outputs JSON with per-image results (`changed`, `unchanged`, `added`, `removed`) and writes diff mask PNGs to `./diff-output/`. Use `--fail-on-diff` to exit with code 1 when any differences are found — useful in CI or pre-push hooks:
+This outputs JSON with per-image results (`changed`, `unchanged`, `added`, `removed`) and writes diff mask images to `./diff-output/`. Use `--fail-on-diff` to exit with code 1 when any differences are found — useful in CI or pre-push hooks:
 
 ```bash
 sentry-cli snapshots diff ./snapshots-base ./snapshots-head --fail-on-diff
@@ -52,8 +52,8 @@ Pass `--threshold` to ignore sub-pixel noise (default `0.01`), or `--selective` 
 
 ```bash
 sentry-cli snapshots download --app-id web-frontend
-pnpm run snapshots
-sentry-cli snapshots diff ./snapshots-base ./artifacts/snapshots --fail-on-diff
+# (Run your snapshot generation command here -> saved into ./path/to/snapshots)
+sentry-cli snapshots diff ./snapshots-base ./path/to/snapshots --fail-on-diff
 ```
 
 For the full flag reference, see the [Snapshots CLI reference](/cli/snapshots/).

--- a/docs/product/snapshots/local-testing/index.mdx
+++ b/docs/product/snapshots/local-testing/index.mdx
@@ -1,0 +1,59 @@
+---
+title: Local Testing
+sidebar_order: 25
+description: Download baseline snapshots and diff images locally with sentry-cli.
+---
+
+<Include name="feature-available-for-user-group-early-adopter" />
+
+You can download baseline snapshots from Sentry and diff them against local images without leaving your machine. This is useful for fast iteration during development or for AI-assisted visual regression workflows.
+
+<Alert level="warning">
+  `sentry-cli snapshots download` and `sentry-cli snapshots diff` are
+  experimental. These commands are subject to breaking changes, including
+  removal, in any Sentry CLI release.
+</Alert>
+
+## Downloading Baselines
+
+Use `sentry-cli snapshots download` to pull baseline images from Sentry to a local directory:
+
+```bash
+sentry-cli snapshots download --app-id web-frontend
+```
+
+This resolves the latest baseline snapshot for the given `app-id` and extracts images to `./snapshots-base/`. You can also target a specific branch or snapshot:
+
+```bash
+sentry-cli snapshots download --app-id web-frontend --branch main
+
+sentry-cli snapshots download --snapshot-id 259299
+```
+
+Use `--output` to change the destination directory.
+
+## Diffing Locally
+
+Use `sentry-cli snapshots diff` to compare two directories of images:
+
+```bash
+sentry-cli snapshots diff ./snapshots-base ./snapshots-head
+```
+
+This outputs JSON with per-image results (`changed`, `unchanged`, `added`, `removed`) and writes diff mask PNGs to `./diff-output/`. Use `--fail-on-diff` to exit with code 1 when any differences are found — useful in CI or pre-push hooks:
+
+```bash
+sentry-cli snapshots diff ./snapshots-base ./snapshots-head --fail-on-diff
+```
+
+Pass `--threshold` to ignore sub-pixel noise (default `0.01`), or `--selective` to treat missing base images as skipped instead of removed.
+
+## End-to-End Workflow
+
+```bash
+sentry-cli snapshots download --app-id web-frontend
+pnpm run snapshots
+sentry-cli snapshots diff ./snapshots-base ./artifacts/snapshots --fail-on-diff
+```
+
+For the full flag reference, see the [Snapshots CLI reference](/cli/snapshots/).


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new `sentry-cli snapshots download` and `sentry-cli snapshots diff` commands added in [sentry-cli#3306](https://github.com/getsentry/sentry-cli/pull/3306) and [sentry-cli#3310](https://github.com/getsentry/sentry-cli/pull/3310).

- New "Local Testing" product docs page covering the workflow: download baselines → run tests → diff locally
- CLI reference sections for `snapshots download` and `snapshots diff` with flag tables

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [x] Other deadline:
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)