### PR TITLE
docs(contributing): Add `new`, `beta`, and `early_access` frontmatter fields

### DIFF
--- a/docs/contributing/pages/frontmatter.mdx
+++ b/docs/contributing/pages/frontmatter.mdx
@@ -28,6 +28,18 @@ Set this to true to disable indexing (robots, algolia) of this content.
 
 Set this to true to disable page-level table of contents rendering.
 
+`new` (false)
+
+Set this to true to show a "NEW" badge next to the title in the sidebar.
+
+`beta` (false)
+
+Set this to true to show a "BETA" badge next to the title in the sidebar.
+
+`early_access` (false)
+
+Set this to true to show an "EA" (early access) badge next to the title in the sidebar.
+
 `draft` (false)
 
 Set this to true to mark this page as a draft, and hide it from various other components (such as the PageGrid).


### PR DESCRIPTION
Document the three badge-related frontmatter fields (new, beta, early_access) that were missing from the contributing docs page.

Comparison
- old Frontmatter page https://docs.sentry.io/contributing/pages/frontmatter/
- updated one https://sentry-docs-git-joshua-fixdocumentfrontmatterfields.sentry.dev/contributing/pages/frontmatter/

## DESCRIBE YOUR PR
From `types/frontmatter.ts` https://github.com/getsentry/sentry-docs/blob/master/src/types/frontmatter.ts , we have these badges that show up nicely in the sidebar. They weren't documented yet, so wasn't directly clear which ones were available.

<img width="42" height="23" alt="Screenshot 2026-05-28 at 15 04 53" src="https://github.com/user-attachments/assets/c969dc22-9608-4ecc-99fc-9c778f34edff" />

<img width="47" height="21" alt="Screenshot 2026-05-28 at 15 05 14" src="https://github.com/user-attachments/assets/60365d96-0cc6-4e96-9462-23d7393e8712" />

<img width="37" height="22" alt="Screenshot 2026-05-28 at 15 04 37" src="https://github.com/user-attachments/assets/d96ca5e6-ef15-4f3a-99e8-d5fbb5f151ae" />


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
