### PR TITLE
docs(unreal): Crash Reporter cache mode setting

### DIFF
--- a/docs/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/index.mdx
+++ b/docs/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/index.mdx
@@ -38,6 +38,7 @@ You can customize the appearance of the Sentry Crash Reporter directly from the 
 - **Cancel button label** - Label for the cancel button. Set to empty string to hide the button.
 - **Accent color** - Primary accent color used for the crash reporter UI elements.
 - **Window closable** - When disabled, the user cannot close the crash reporter window without submitting the report. The native close button is disabled and the cancel button is hidden. Enabled by default.
+- **Cache mode** - Initial cache mode shown to the user in the crash reporter when they have not selected one. The user can still override this at runtime. `None` never keeps envelopes after submission, `Offline` keeps them only while the host is offline, `Always` keeps them regardless of submission outcome. Leave as `Default` to let the crash reporter use its built-in default.
 - **App logo** - Replace the default crash reporter logo with a custom PNG image. Enable the override toggle, then use the image picker to select a file. The image is copied into your project's `Build/SentryCrashReporter/` folder and staged alongside the plugin during packaging.
 
 These settings are applied each time the SDK initializes. Properties that are not overridden will use the crash reporter's built-in defaults.


### PR DESCRIPTION
This PR documents the new `Cache mode` option which exposes the Sentry Crash Reporter's `CacheKeep` preference through the Unreal SDK settings.

Related items:
- https://github.com/getsentry/sentry-desktop-crash-reporter/pull/211
- https://github.com/getsentry/sentry-unreal/pull/1408