### PR TITLE
docs(dataCollection): Clarify URL handling in data collection spec

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -144,6 +144,21 @@ init({
 })
 ```
 
+#### URLs
+
+URL strings in span descriptions follow the format defined in [Structuring Data](/sdk/telemetry/traces/structuring-data/): `METHOD scheme://host/path` — query strings and fragments are excluded. Authority credentials (`userinfo@`) are always replaced with `[Filtered]@`.
+
+The `queryParams` option controls query parameter filtering wherever query strings appear — including `url.full`, `url.query`, and `event.request.query_string`. `url.path` and the span description are unaffected since they never contain query strings.
+
+**Example:** Given a request to `https://user:pass@example.com/api/users?token=abc123&page=5`:
+
+| Attribute | `queryParams` enabled | `queryParams` off |
+|---|---|---|
+| Span description | `GET https://[Filtered]:[Filtered]@example.com/api/users` | same |
+| `url.full` | `https://example.com/api/users?token=[Filtered]&page=5` | `https://example.com/api/users` |
+| `url.path` | `/api/users` | same |
+| `url.query` | `token=[Filtered]&page=5` | not collected |
+
 #### Cookies and Query Params
 
 Cookies and query params may arrive as a single unparsed string (e.g., `Cookie: user_session=abc; theme=dark-mode`) rather than pre-split key-value pairs. SDKs **MAY** handle both cases:

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -148,7 +148,7 @@ init({
 
 URL strings in span descriptions follow the format defined in [Structuring Data](/sdk/telemetry/traces/structuring-data/): `METHOD scheme://host/path` — query strings and fragments are excluded. Authority credentials (`userinfo@`) are always replaced with `[Filtered]@`.
 
-The `queryParams` option controls query parameter filtering wherever query strings appear — including `url.full`, `url.query`, and `event.request.query_string`. `url.path` and the span description are unaffected since they never contain query strings.
+The `queryParams` option controls query parameter filtering wherever query strings appear — including `url.full`, `url.query`, and [`request.query_string`](/sdk/foundations/envelopes/event-payloads/request/). `url.path` and the span description are unaffected since they never contain query strings. For general data scrubbing rules (variable size limits, structuring for server-side scrubbing), see [Data Scrubbing](/sdk/foundations/data-scrubbing/).
 
 **Example:** Given a request to `https://user:pass@example.com/api/users?token=abc123&page=5`:
 
@@ -158,6 +158,7 @@ The `queryParams` option controls query parameter filtering wherever query strin
 | `url.full` | `https://example.com/api/users?token=[Filtered]&page=5` | `https://example.com/api/users` |
 | `url.path` | `/api/users` | same |
 | `url.query` | `token=[Filtered]&page=5` | not collected |
+| `request.query_string` | `token=[Filtered]&page=5` | not collected |
 
 #### Cookies and Query Params
 

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -146,15 +146,15 @@ init({
 
 #### URLs
 
-URL strings in span descriptions follow the format defined in [Structuring Data](/sdk/telemetry/traces/structuring-data/): `METHOD scheme://host/path` — query strings and fragments are excluded. Authority credentials (`userinfo@`) are always replaced with `[Filtered]@`.
+URL strings in span descriptions follow the format defined in [Structuring Data](/sdk/telemetry/traces/structuring-data/): `METHOD scheme://host/path` — query strings and fragments are excluded.
 
 The `queryParams` option controls query parameter filtering wherever query strings appear — including `url.full`, `url.query`, and [`request.query_string`](/sdk/foundations/envelopes/event-payloads/request/). `url.path` and the span description are unaffected since they never contain query strings. For general data scrubbing rules (variable size limits, structuring for server-side scrubbing), see [Data Scrubbing](/sdk/foundations/data-scrubbing/).
 
-**Example:** Given a request to `https://user:pass@example.com/api/users?token=abc123&page=5`:
+**Example:** Given a request to `https://example.com/api/users?token=abc123&page=5`:
 
 | Attribute | `queryParams` enabled | `queryParams` off |
 |---|---|---|
-| Span description | `GET https://[Filtered]:[Filtered]@example.com/api/users` | same |
+| Span description | `GET https://example.com/api/users` | same |
 | `url.full` | `https://example.com/api/users?token=[Filtered]&page=5` | `https://example.com/api/users` |
 | `url.path` | `/api/users` | same |
 | `url.query` | `token=[Filtered]&page=5` | not collected |

--- a/develop-docs/sdk/foundations/data-scrubbing.mdx
+++ b/develop-docs/sdk/foundations/data-scrubbing.mdx
@@ -18,6 +18,7 @@ The normative rules for sensitive data, PII, cookies, request bodies, and user-s
 - SDKs should not include PII or other sensitive data in the payload by default. The legacy option [_send-default-pii_](https://docs.sentry.io/platforms/python/configuration/options/#send-default-pii) is **disabled by default**; the replacement is `dataCollection.includeUserInfo` and `dataCollection.collect` (see [Data Collection](/sdk/foundations/client/data-collection/)).
 - Certain sensitive data must never be sent through SDK instrumentation: header/cookie/query values matching the default denylist are replaced with `"[Filtered]"`. User-set data is always attached; only automatically gathered data is scrubbed. Users can use `beforeSend` / event processors to remove or redact any data.
 - For the exact default denylist (partial, case-insensitive match), PII denylist (`x-forwarded-`, `-user`), cookies when unparsable, and raw request bodies, see [Data Collection — Default Denylist](/sdk/foundations/client/data-collection/#default-denylist) and [User-Set Data and Scrubbing](/sdk/foundations/client/data-collection/#user-set-data-scrubbing).
+- For how `queryParams` filtering applies to URL attributes, see [Data Collection — URLs](/sdk/foundations/client/data-collection/#urls).
 
 ### Application State
 


### PR DESCRIPTION
Add a URLs section to the data collection spec clarifying how `queryParams` interacts with URL attributes.