### PR TITLE
feat: Add httpx2 integration page

### DIFF
--- a/docs/platforms/python/integrations/httpx2/index.mdx
+++ b/docs/platforms/python/integrations/httpx2/index.mdx
@@ -1,0 +1,48 @@
+---
+title: HTTPX2
+description: "Learn about the HTTPX2 integration and how it adds support for the HTTPX2 HTTP client."
+---
+
+The [HTTPX2](https://httpx2.pydantic.dev/) integration instruments outgoing HTTP requests using either the sync or the async HTTPX2 clients.
+
+Use this integration to create spans for outgoing requests and ensure traces are properly propagated to downstream services.
+
+## Install
+
+Install `sentry-sdk` from PyPI:
+
+```bash {tabTitle:pip}
+pip install sentry-sdk
+```
+```bash {tabTitle:uv}
+uv add sentry-sdk
+```
+
+## Configure
+
+The HTTPX2 integration is enabled automatically if you have the `httpx2` package installed.
+
+<PlatformContent includePath="getting-started-config" />
+
+## Verify
+
+```python
+import httpx2
+
+def main():
+    sentry_init(...)  # same as above
+    with sentry_sdk.start_transaction(name="testing_sentry"):
+        r1 = httpx2.get("https://sentry.io/")
+        r2 = httpx2.post("http://httpbin.org/post")
+
+main()
+```
+
+This will create a transaction called `testing_sentry` in the Performance section of [sentry.io](https://sentry.io), and create spans for the outgoing HTTP requests.
+
+It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+
+## Supported Versions
+
+- HTTPX2: 2.0+
+- Python: 3.10+

--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -93,6 +93,7 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 | ------------------------------------------------------------------------------------------------------------------------------ | :--------------: |
 | <LinkWithPlatformIcon platform="python.aiohttp" label="AIOHTTP" url="/platforms/python/integrations/aiohttp/aiohttp-client" /> |        ✓         |
 | <LinkWithPlatformIcon platform="python.httpx"   label="HTTPX"   url="/platforms/python/integrations/httpx" />                  |        ✓         |
+| <LinkWithPlatformIcon platform="python"         label="HTTPX2"  url="/platforms/python/integrations/httpx2" />                  |        ✓         |
 | <LinkWithPlatformIcon platform="python"         label="pyreqwest"   url="/platforms/python/integrations/pyreqwest" />          |                  |
 | Python standard HTTP client (in the [Default Integrations](default-integrations/#stdlib))                                      |        ✓         |
 | `Requests` HTTP instrumentation is done via the [Default Integrations](default-integrations/#stdlib).                          |        ✓         |


### PR DESCRIPTION
We've added a new integration to the Python SDK in https://github.com/getsentry/sentry-python/pull/6463. This adds the docs page for it. Note: It's just a copy of the existing HTTPX page as the new package (HTTPX2) is a fork.

Preview:
- integrations table: https://sentry-docs-git-ivana-add-httpx2-integration.sentry.dev/platforms/python/integrations/#http-clients
- integrations page: https://sentry-docs-git-ivana-add-httpx2-integration.sentry.dev/platforms/python/integrations/httpx2/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): June 8
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
