### PR TITLE
docs(flagpole): Add sentry_cell context property and deprecate sentry_region

### DIFF
--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -121,9 +121,13 @@ Here are some common properties we surface via our Sentry and GetSentry context 
 
 **System Context Properties**
 
-`sentry_region` [str]
+`sentry_cell` [str]
 
-: The sentry region or single-tenant the flag check is being performed in.
+: The sentry cell or single-tenant the flag check is being performed in.
+
+`sentry_region` [str] *(deprecated — use `sentry_cell` instead)*
+
+: The sentry region or single-tenant the flag check is being performed in. This property is deprecated in favor of `sentry_cell` and will be removed in a future release.
 
 `sentry_singletenant` [bool]
 
@@ -227,8 +231,20 @@ options:
     flagpole.allowed_features: ["organizations:is_sentry"]
 ```
 
-You can also use the `sentry_singletenant` and `sentry_region` context values in
-your feature conditions as required.
+You can also use the `sentry_singletenant` and `sentry_cell` context values in
+your feature conditions as required. For example, to roll out a feature to
+specific cells:
+
+```yaml
+- conditions:
+  - operator: in
+    value:
+      - us
+      - de
+    property: sentry_cell
+  name: multi-region rollout
+  rollout: 100
+```
 
 ## Testing a Flagpole feature locally
 


### PR DESCRIPTION
Update flagpole documentation to add `sentry_cell` as a system context property and deprecate `sentry_region`.

- Add `sentry_cell` [str] as a new system context property
- Mark `sentry_region` as deprecated with a note to use `sentry_cell` instead
- Update the "Using Flagpole in single-tenants" section to reference `sentry_cell`
- Add example YAML condition using `sentry_cell` for multi-region rollout

Refs LINEAR-INFRENG-327 (parent: INFREG-326)

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)