### PR TITLE
fix(search): Skip stored SDK bias on SDK-agnostic doc pages

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -74,6 +74,18 @@ type Props = {
 
 const STORAGE_KEY = 'sentry-docs-search-platforms';
 
+// Paths outside `/platforms/` whose pages are not about any specific SDK.
+// Restoring the user's last-used SDK on these pages biases query results
+// toward irrelevant SDK pages instead of the product/concept docs they're
+// actually reading. Mirrors PRODUCT_DOC_PREFIXES in scripts/algolia.ts.
+const SDK_AGNOSTIC_PATH_PREFIXES = [
+  '/product/',
+  '/concepts/',
+  '/cli/',
+  '/guides/',
+  '/integrations/',
+];
+
 export function Search({
   path,
   autoFocus,
@@ -91,6 +103,9 @@ export function Search({
 
   // Load stored platforms on mount
   useEffect(() => {
+    const isSdkAgnosticPath = SDK_AGNOSTIC_PATH_PREFIXES.some(prefix =>
+      pathname?.startsWith(prefix)
+    );
     const storedPlatforms = localStorage.getItem(STORAGE_KEY) ?? '[]';
     if (!storedPlatforms) {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(searchPlatforms));
@@ -99,10 +114,14 @@ export function Search({
       searchPlatforms.length === 0 &&
       useStoredSearchPlatforms
     ) {
-      const platforms = JSON.parse(storedPlatforms);
-      setCurrentSearchPlatforms(platforms);
+      if (isSdkAgnosticPath) {
+        setCurrentSearchPlatforms([]);
+      } else {
+        const platforms = JSON.parse(storedPlatforms);
+        setCurrentSearchPlatforms(platforms);
+      }
     }
-  }, [useStoredSearchPlatforms, searchPlatforms]);
+  }, [useStoredSearchPlatforms, searchPlatforms, pathname]);
 
   // Update stored platforms when they change
   useEffect(() => {


### PR DESCRIPTION
## DESCRIBE YOUR PR

Right now if you visit a non-SDK page (e.g. /product/...) after visiting an SDK page, your search results will still be weighted towards content relevant to that SDK. With this fix, you will only see SDK-specific results when you are in the SDK docs.

This adds an 'SDK_AGNOSTIC_PATH_PREFIXES' array which lets the search component know when you are not on an SDK page. Homepage behavior is unchanged. See video for an example of the fix:


https://github.com/user-attachments/assets/6a157b79-1217-45d6-b4f2-680305c6e937



## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)