### PR TITLE
docs(cocoa): Clarify profiling session sampling lifecycle

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -900,7 +900,7 @@ The mode for starting and stopping the profiler:
 
 The percentage of profile sessions to sample. Specifying `0` means no profiles are collected, `1.0` means all sessions are profiled.
 
-The sample decision is evaluated when the SDK starts and on each subsequent foreground event. Backgrounding and foregrounding the app starts a new profile session.
+The SDK evaluates the sample decision when profiling is configured at SDK start, and then only when a new Sentry user session starts. Foregrounding the app keeps the same profile sampling decision unless it starts a new session.
 
 </SdkOption>
 

--- a/docs/platforms/apple/common/profiling/index.mdx
+++ b/docs/platforms/apple/common/profiling/index.mdx
@@ -49,7 +49,7 @@ SentrySDK.start { options in
 }];
 ```
 
-By default, `sessionSampleRate` is `0`, so you'll need to set it to a higher value to receive profile data. `sessionSampleRate` is evaluated once per user session and applies to any attempt to start a profile until the next user session starts. See <PlatformLink to="/configuration/releases/#sessions">user session documentation</PlatformLink> for more information on user sessions.
+By default, `sessionSampleRate` is `0`, so you'll need to set it to a higher value to receive profile data. The SDK evaluates `sessionSampleRate` once per Sentry user session, and foregrounding the app only reevaluates it if a new session starts. See <PlatformLink to="/configuration/releases/#sessions">user session documentation</PlatformLink> for more information on user sessions.
 
 See the subsections below to learn about the various ways the profiler can be started and stopped.
 
@@ -160,7 +160,7 @@ The SDK must have been started in order to stop a running launch profiler. If a 
 </Alert>
 
 <Alert>
-Every time the SDK is started with app start profiling configured, a separate sample decision is generated with `sessionSampleRate` and stored until the next app launch (as well as `tracesSampleRate` if trace profile lifecycle is configured). The same sample decision will apply for the remainder of the profile session following that subsequent launch.
+Every time the SDK starts with app start profiling configured, it generates a sample decision with `sessionSampleRate` and stores it until the next app launch (as well as `tracesSampleRate` if trace profile lifecycle is configured). That decision is used for the launch profile on the next launch and remains active until a new session starts.
 </Alert>
 
 ## Transaction-based Profiling (removed in 9.0.0)


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Clarify Apple profiling docs after sentry-cocoa changed when profile session sampling is reevaluated.

Profile `sessionSampleRate` is now documented as evaluated once per Sentry user session. Foregrounding the app keeps the existing profile sampling decision unless it starts a new session. The app-start profiling note now matches that lifecycle too.

This aligns the Apple docs with the Android profiling docs, which describe profiling sampling as a once-per-session decision.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

Refs getsentry/sentry-cocoa#7927
Refs getsentry/sentry-cocoa#7944
