### PR TITLE
docs(self-hosted): Add 26.5.1 as a hard stop for upgrades

### DIFF
--- a/develop-docs/self-hosted/releases.mdx
+++ b/develop-docs/self-hosted/releases.mdx
@@ -54,6 +54,7 @@ These are the hard stops that one needs to go through:
 - 23.11.0
 - 24.8.0
 - 25.5.1
+- 26.5.1
 
 Versions to avoid upgrading to:
 - 23.7.0 (issues around database migrations and the Django 3 upgrade)


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds version `26.5.1` to the list of hard stops in the self-hosted upgrading documentation. Users who are upgrading their self-hosted Sentry installation must pass through this version to pick up significant database changes.

I have started squashing migrations, so we need to set some date until which it's safe to squash all the migrations.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)