### PR TITLE
fix(api-docs): strip empty HTML comments from markdown exports

### DIFF
--- a/scripts/generate-md-exports.mjs
+++ b/scripts/generate-md-exports.mjs
@@ -32,7 +32,7 @@ import {rehypeExpandCodeTabs} from './rehype-expand-code-tabs.mjs';
 const DOCS_ORIGIN = process.env.NEXT_PUBLIC_DEVELOPER_DOCS
   ? 'https://develop.sentry.dev'
   : 'https://docs.sentry.io';
-const CACHE_VERSION = 9;
+const CACHE_VERSION = 10;
 const CACHE_COMPRESS_LEVEL = 4;
 const R2_BUCKET = process.env.NEXT_PUBLIC_DEVELOPER_DOCS
   ? 'sentry-develop-docs'
@@ -1009,6 +1009,12 @@ async function genMDFromHTML(source, {cacheDir, noCache, usedCacheFiles}) {
       .use(rehypeExpandCodeTabs)
       .use(rehypeRemark, {
         document: false,
+        // Drop React's empty `<!-- -->` text-node separators, which otherwise leak into the
+        // markdown on component-rendered pages like the API docs. Comments dispatch by node
+        // type, so this must live in nodeHandlers rather than handlers.
+        nodeHandlers: {
+          comment() {},
+        },
         handlers: {
           // HACK: Extract the canonical URL during parsing
           link: (_state, node) => {

--- a/scripts/generate-md-exports.test.mjs
+++ b/scripts/generate-md-exports.test.mjs
@@ -15,6 +15,9 @@ function htmlToMarkdown(html) {
       .use(rehypeExpandCodeTabs)
       .use(rehypeRemark, {
         document: false,
+        nodeHandlers: {
+          comment() {},
+        },
         handlers: {
           button() {},
         },
@@ -304,5 +307,25 @@ describe('rehypeExpandCodeTabs', () => {
       expect(codeBlocks).toHaveLength(1);
       expect(codeBlocks[0]).toContain('solo()');
     });
+  });
+});
+
+describe('comment stripping', () => {
+  it('drops React text-node separator comments emitted on component-rendered pages', () => {
+    const html =
+      '<p><code>organization_id_or_slug</code><em> (<!-- -->string<!-- -->)</em></p>';
+
+    const md = htmlToMarkdown(html);
+
+    expect(md).not.toContain('<!--');
+    expect(md).toContain('string');
+  });
+
+  it('drops standalone HTML comments', () => {
+    const md = htmlToMarkdown('<p>before<!-- a real comment -->after</p>');
+
+    expect(md).not.toContain('<!--');
+    expect(md).toContain('before');
+    expect(md).toContain('after');
   });
 });

--- a/src/components/apiPage/index.tsx
+++ b/src/components/apiPage/index.tsx
@@ -20,10 +20,9 @@ function Params({params}) {
           <Fragment key={param.name}>
             <dt>
               <div>
-                <code data-index>{param.name}</code>
+                <code data-index>{param.name}</code>{' '}
                 {!!param.schema?.type && (
                   <em>
-                    {' '}
                     ({param.schema.type}
                     {param.schema.items && `(${param.schema.items.type})`})
                   </em>


### PR DESCRIPTION
Remove extra artifacts in the markdown version of the API docs. We were inserting extra comment markers (`<!-- -->`) and spaces (`&#x20`) within the API docs.

Before:
```
* `status`*&#x20;<!-- -->(<!-- -->string<!-- -->)*
```
After:
```
* `status` *(string)*
```




<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
