### PR TITLE
fix(drains): Redirect old integration/ drain paths and fix Vercel tab name

### DIFF
--- a/docs/product/drains/vercel.mdx
+++ b/docs/product/drains/vercel.mdx
@@ -56,13 +56,13 @@ After selecting the Logs data type, you'll need to configure the drain to send d
 3. Select which log sources to collect. See [Log Source Details](#log-source-details) for more information.
 
 4. Select which environments to drain from. You can choose to drain from all environments or select specific ones.
-5. Under the custom endpoint tab add the Sentry Vercel Log Drain Endpoint in the URL field. You can find the endpoint in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **Vercel**. You can select either JSON or NDJSON encoding.
+5. Under the custom endpoint tab add the Sentry Vercel Log Drain Endpoint in the URL field. You can find the endpoint in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **Vercel Drains**. You can select either JSON or NDJSON encoding.
 
 ```bash
 ___VERCEL_LOG_DRAIN_URL___
 ```
 
-6. Click the Custom Headers toggle and add the Sentry Authentication Header. You'll also find the header value in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **Vercel**.
+6. Click the Custom Headers toggle and add the Sentry Authentication Header. You'll also find the header value in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **Vercel Drains**.
 
 ```
 x-sentry-auth: sentry sentry_key=___PUBLIC_KEY___

--- a/redirects.js
+++ b/redirects.js
@@ -2407,6 +2407,15 @@ const userDocsRedirects = [
     source: '/product/alerts/:path*',
     destination: '/product/monitors-and-alerts/alerts/',
   },
+  // Drains reorg: integration/ subfolder flattened, OTLP collector moved to concepts
+  {
+    source: '/product/drains/integration/opentelemetry-collector/',
+    destination: '/concepts/otlp/forwarding/pipelines/collector/',
+  },
+  {
+    source: '/product/drains/integration/:path*',
+    destination: '/product/drains/:path*',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

The OTLP consolidation in #16297 (Feb 11, 2026) flattened `/product/drains/integration/` into `/product/drains/` and moved the OTLP Collector page to `/concepts/otlp/forwarding/pipelines/collector/`, but **no redirects were added**. Old URLs — including "Learn more" links shipped in the Sentry app — now 404.

This came out of ramp-up on [CW-1434 — Fix incorrect Vercel Drains docs page](https://linear.app/getsentry/issue/CW-1434/fix-incorrect-vercel-drains-docs-page).

## Changes

**Redirects** (`redirects.js`):
- `/product/drains/integration/opentelemetry-collector/` → `/concepts/otlp/forwarding/pipelines/collector/`
- `/product/drains/integration/:path*` → `/product/drains/:path*` (covers vercel, cloudflare, heroku, openrouter, shopify-hydrogen, supabase)

**Vercel page** (`docs/product/drains/vercel.mdx`):
- Manual setup steps referenced the **Client Keys (DSN) > Vercel** tab, but the app labels it **Vercel Drains**. Updated to match.

## Companion PR

The in-app links that were pointing at the now-dead paths are fixed in getsentry/sentry#116716. This PR additionally protects external links/bookmarks via redirects.