### PR TITLE
docs(unreal): macOS Shipping network entitlements requirement

### DIFF
--- a/docs/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/index.mdx
+++ b/docs/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/index.mdx
@@ -130,7 +130,7 @@ The Sentry Crash Reporter uploads the crash envelope to Sentry, which requires t
 To fix this, override the Shipping entitlements in your project's `Config/DefaultEngine.ini` with either the engine-provided `Sandbox.Server.entitlements` (which includes `network.client` and `network.server`) or your own custom file:
 
 ```ini
-[/Script/MacTargetPlatformSettings.XcodeProjectSettings]
+[/Script/MacTargetPlatform.XcodeProjectSettings]
 ShippingSpecificMacEntitlements=(FilePath="/Game/Build/Mac/Resources/Sandbox.Server.entitlements")
 ```
 

--- a/docs/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/index.mdx
+++ b/docs/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/index.mdx
@@ -116,3 +116,22 @@ After replacing binaries, delete your project's `Build` and `Intermediate` direc
 The `CRASHPAD_ENABLE_STACKTRACE` feature is experimental. On Linux, it requires the `libunwind-ptrace` development package.
 
 </Alert>
+
+## Enabling Network Access on macOS
+
+<Alert>
+
+Applies only to **packaged macOS builds in the Shipping configuration**. Editor and Development/Test/DebugGame builds already include the required network entitlements.
+
+</Alert>
+
+The Sentry Crash Reporter uploads the crash envelope to Sentry, which requires the `com.apple.security.network.client` entitlement. On macOS the Crash Reporter is launched as a child process of the game and inherits its network permissions at runtime, so the entitlement needs to be set on the **game's** entitlements file rather than on the Crash Reporter bundle itself. Unreal's default Shipping entitlements file (`Engine/Build/Mac/Resources/Sandbox.NoNet.entitlements`) does **not** include it, so submissions fail with a DNS resolution error.
+
+To fix this, override the Shipping entitlements in your project's `Config/DefaultEngine.ini` with either the engine-provided `Sandbox.Server.entitlements` (which includes `network.client` and `network.server`) or your own custom file:
+
+```ini
+[/Script/MacTargetPlatformSettings.XcodeProjectSettings]
+ShippingSpecificMacEntitlements=(FilePath="/Game/Build/Mac/Resources/Sandbox.Server.entitlements")
+```
+
+The same setting is available in the Editor under **Project Settings → Platforms → Mac → Entitlements → Mac: Entitlements (Shipping config override)**.

--- a/docs/platforms/unreal/configuration/native-backend/index.mdx
+++ b/docs/platforms/unreal/configuration/native-backend/index.mdx
@@ -62,7 +62,7 @@ The native backend's out-of-process crash daemon uploads crash envelopes to Sent
 To fix this, override the Shipping entitlements in your project's `Config/DefaultEngine.ini` with either the engine-provided `Sandbox.Server.entitlements` (which includes `network.client` and `network.server`) or your own custom file:
 
 ```ini
-[/Script/MacTargetPlatformSettings.XcodeProjectSettings]
+[/Script/MacTargetPlatform.XcodeProjectSettings]
 ShippingSpecificMacEntitlements=(FilePath="/Game/Build/Mac/Resources/Sandbox.Server.entitlements")
 ```
 

--- a/docs/platforms/unreal/configuration/native-backend/index.mdx
+++ b/docs/platforms/unreal/configuration/native-backend/index.mdx
@@ -48,3 +48,22 @@ Available modes:
 - `Minidump` - Write and send a minidump for server-side symbolication. No client-side stack unwinding is performed.
 - `NativeStackwalking` - Walk the stack client-side in the crash daemon and send a JSON event with stack traces. No minidump is generated, resulting in faster uploads and smaller payloads.
 - `NativeStackwalkingWithMinidump` (default) - Perform client-side stack unwinding and also attach a minidump for deep debugging when needed.
+
+### Enabling Network Access on macOS
+
+<Alert>
+
+Applies only to **packaged macOS builds in the Shipping configuration**. Editor and Development/Test/DebugGame builds already include the required network entitlements.
+
+</Alert>
+
+The native backend's out-of-process crash daemon uploads crash envelopes to Sentry from its own process, which requires the `com.apple.security.network.client` entitlement on the packaged macOS game. Unreal's default Shipping entitlements file (`Engine/Build/Mac/Resources/Sandbox.NoNet.entitlements`) does **not** include it, so uploads fail silently with a DNS resolution error.
+
+To fix this, override the Shipping entitlements in your project's `Config/DefaultEngine.ini` with either the engine-provided `Sandbox.Server.entitlements` (which includes `network.client` and `network.server`) or your own custom file:
+
+```ini
+[/Script/MacTargetPlatformSettings.XcodeProjectSettings]
+ShippingSpecificMacEntitlements=(FilePath="/Game/Build/Mac/Resources/Sandbox.Server.entitlements")
+```
+
+The same setting is available in the Editor under **Project Settings → Platforms → Mac → Entitlements → Mac: Entitlements (Shipping config override)**.


### PR DESCRIPTION
This PR adds a "Enabling Network Access on macOS" section to the `Sentry Crash Reporter` and `Native Backend` pages for Unreal SDK, documenting that packaged macOS Shipping builds need `com.apple.security.network.client` (Unreal's default `Sandbox.NoNet.entitlements` omits it, causing silent DNS failures during crash upload) and showing the `DefaultEngine.ini` override that adds it.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1420