### PR TITLE
docs(js): Update "Scrubbing Data" guide for span streaming, logs and metrics

### DIFF
--- a/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
@@ -36,9 +36,23 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ## Scrubbing Data
 
-### <PlatformIdentifier name="before-send" /> & <PlatformIdentifier name="before-send-transaction" />
+### `beforeSend`, `beforeSendSpan`, & `beforeSendTransaction`
 
-SDKs provide a <PlatformIdentifier name="before-send" /> hook, which is invoked before an error or message event is sent and can be used to modify event data to remove sensitive information. Some SDKs also provide a <PlatformIdentifier name="before-send-transaction" /> hook which does the same thing for transactions. We recommend using <PlatformIdentifier name="before-send" /> and <PlatformIdentifier name="before-send-transaction" /> in the SDKs to **scrub any data before it is sent**, to ensure that sensitive data never leaves the local environment.
+SDKs provide various `beforeSend*` hooks, which are invoked before an errors, messages, spans, logs or metrics are sent and can be used to modify event data to remove sensitive information. The following hooks are available:
+
+- `beforeSend` applies to error and message events
+- `beforeSendSpan` applies to spans
+- `beforeSendLog` applies to logs
+- `beforeSendMetric` applies to metrics
+- `beforeSendTransaction` applies to transactions (only in transaction mode)
+
+<Alert>
+
+If you're using <PlatformLink to="/tracing/new-spans/">Span Stream Mode</PlatformLink>, `beforeSendTransaction` has no effect. Instead, use `beforeSendSpan` with the `withStreamedSpan` helper to modify streamed spans directly.
+
+</Alert>
+
+We recommend using these hooks in the SDKs to **scrub any data before it is sent**, to ensure that sensitive data never leaves the local environment.
 
 <PlatformContent includePath="configuration/before-send/" />
 
@@ -50,6 +64,7 @@ Sensitive data may appear in the following areas:
 - HTTP context → Query strings may be picked up in some frameworks as part of the HTTP request context.
 - Transaction Names → In certain situations, transaction names might contain sensitive data. For example, a browser's pageload transaction might have a raw URL like `/users/1234/details` as its name (where `1234` is a user id, which may be considered PII). In most cases, our SDKs can parameterize URLs and routes successfully, that is, turn `/users/1234/details` into `/users/:userid/details`. However, depending on the framework, your routing configuration, race conditions, and a few other factors, the SDKs might not be able to completely parameterize all of your URLs.
 - HTTP Spans → Most SDKs will include the HTTP query string and fragment as a data attribute, which means the HTTP span may need to be scrubbed.
+- Attributes → Attributes can be scrubbed using the `beforeSendSpan`, `beforeSendLog`, and `beforeSendMetric` hooks for the respective telemetry types.
 
 For more details and data filtering instructions, see <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink>.
 

--- a/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
@@ -36,7 +36,7 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ## Scrubbing Data
 
-### Scrubbing in `beforeSend*` SDK hooks
+### Scrubbing in `beforeSend*` SDK Hooks
 
 SDKs provide various `beforeSend*` hooks, which are invoked before an errors, messages, spans, logs or metrics are sent and can be used to modify event data to remove sensitive information. The following hooks are available:
 
@@ -48,7 +48,7 @@ SDKs provide various `beforeSend*` hooks, which are invoked before an errors, me
 
 <Alert>
 
-If you're using <PlatformLink to="/tracing/new-spans/">Span Stream Mode</PlatformLink>, `beforeSendTransaction` has no effect. Instead, use `beforeSendSpan` with the `withStreamedSpan` helper to modify streamed spans directly.
+If you're using <PlatformLink to="/tracing/new-spans/">stream mode</PlatformLink>, `beforeSendTransaction` has no effect. Instead, use `beforeSendSpan` with the `withStreamedSpan` helper to modify streamed spans directly.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
@@ -40,11 +40,11 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 SDKs provide various `beforeSend*` hooks, which are invoked before an errors, messages, spans, logs or metrics are sent and can be used to modify event data to remove sensitive information. The following hooks are available:
 
-- `beforeSend` applies to error and message events
-- `beforeSendSpan` applies to spans
-- `beforeSendLog` applies to logs
-- `beforeSendMetric` applies to metrics
-- `beforeSendTransaction` applies to transactions (only in transaction mode)
+- <PlatformLink to="/configuration/options/#beforeSend">`beforeSend`</PlatformLink> applies to error and message events
+- <PlatformLink to="/configuration/options/#beforeSendSpan">`beforeSendSpan`</PlatformLink> applies to spans
+- <PlatformLink to="/configuration/options/#beforeSendLog">`beforeSendLog`</PlatformLink> applies to logs
+- <PlatformLink to="/configuration/options/#beforeSendMetric">`beforeSendMetric`</PlatformLink> applies to metrics
+- <PlatformLink to="/configuration/options/#beforeSendTransaction">`beforeSendTransaction`</PlatformLink> applies to transactions (only in transaction mode)
 
 <Alert>
 

--- a/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
+++ b/docs/platforms/javascript/common/data-management/sensitive-data/index.mdx
@@ -36,7 +36,7 @@ If you _do not_ wish to use the default PII behavior, you can also choose to ide
 
 ## Scrubbing Data
 
-### `beforeSend`, `beforeSendSpan`, & `beforeSendTransaction`
+### Scrubbing in `beforeSend*` SDK hooks
 
 SDKs provide various `beforeSend*` hooks, which are invoked before an errors, messages, spans, logs or metrics are sent and can be used to modify event data to remove sensitive information. The following hooks are available:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This PR updates the "Scrubbing Data" section in two regards:

1. Adds `beforeSendSpan` as a hook to scrub span data and adds a note that for stream mode, `beforeSendTransaction` is no longer invoked
2. Adds `beforeSendMetric` and `beforeSendLog` APIs which can be used to scrub metrics and logs respectively. 

⚠️ https://github.com/getsentry/sentry-docs/pull/17834 must be merged first. The 404 lint job currently fails because of the missing links only introduced with this PR.

Note: I also decided to remove the `PlatformIdentifier` components since this page is already JS-specific. No need to worry about case-ing.

h/t @s1gr1d for flagging this page

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: Mid June
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/) 