### PR TITLE
docs(flutter): Move debug symbols from features to configuration sidebar

### DIFF
--- a/docs/platforms/dart/common/debug-symbols/index.mdx
+++ b/docs/platforms/dart/common/debug-symbols/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Debug Symbols
-sidebar_order: 3
+sidebar_order: 50
 sidebar_section: configuration
 ---
 

--- a/docs/platforms/dart/common/debug-symbols/index.mdx
+++ b/docs/platforms/dart/common/debug-symbols/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Debug Symbols
 sidebar_order: 3
-sidebar_section: features
+sidebar_section: configuration
 ---
 
 Sentry currently does not support symbolication or debug symbol uploads for pure Dart applications. 

--- a/docs/platforms/dart/guides/flutter/debug-symbols/index.mdx
+++ b/docs/platforms/dart/guides/flutter/debug-symbols/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Debug Symbols
-description: "Learn how to upload debug symbols so Sentry can show readable stack traces when using Flutter's split-debug-info or obfuscate flags. This is a configuration step, not an optional feature."
+description: "Learn about uploading debug symbols to enable symbolication of stack traces in your Flutter applications."
 sidebar_order: 3
 sidebar_section: configuration
 ---

--- a/docs/platforms/dart/guides/flutter/debug-symbols/index.mdx
+++ b/docs/platforms/dart/guides/flutter/debug-symbols/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Debug Symbols
-description: "Learn about uploading debug symbols to enable symbolication of stack traces in your Flutter applications."
+description: "Learn how to upload debug symbols so Sentry can show readable stack traces when using Flutter's split-debug-info or obfuscate flags. This is a configuration step, not an optional feature."
 sidebar_order: 3
-sidebar_section: features
+sidebar_section: configuration
 ---
 
 Debug symbols are essential for understanding stack traces in your Flutter application when errors occur. Without debug symbols, stack traces from minified or obfuscated code can be difficult or impossible to interpret.

--- a/docs/platforms/dart/guides/flutter/debug-symbols/index.mdx
+++ b/docs/platforms/dart/guides/flutter/debug-symbols/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Debug Symbols
 description: "Learn about uploading debug symbols to enable symbolication of stack traces in your Flutter applications."
-sidebar_order: 3
+sidebar_order: 50
 sidebar_section: configuration
 ---
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Moves Flutter/Dart "Debug Symbols" documentation from the `features` sidebar section to `configuration`, aligning it with how other mobile SDKs (React Native, Apple/Cocoa) categorize their debug symbol upload docs.

**Context:** This came up during testing of the new `sentry init` CLI against Flutter projects ([SDK-1309](https://linear.app/getsentry/issue/SDK-1309)). The tool reads our docs for context and was confused by the categorization.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)