### PR TITLE
docs(build-distribution): Replace Early Adopter callout with BETA nav badge

### DIFF
--- a/docs/platforms/android/build-distribution/auto-update.mdx
+++ b/docs/platforms/android/build-distribution/auto-update.mdx
@@ -5,8 +5,6 @@ sidebar_order: 10
 description: Enable automatic update checks and installations for internal Android builds using the Sentry Auto-Update SDK.
 ---
 
-<Include name="feature-available-for-user-group-early-adopter" />
-
 <Alert level="warning">
 
 The Auto-Update SDK is designed for **internal builds only** and should never be used in production builds distributed through the Google Play Store or other public app stores.

--- a/docs/platforms/android/build-distribution/index.mdx
+++ b/docs/platforms/android/build-distribution/index.mdx
@@ -4,9 +4,8 @@ sidebar_title: Build Distribution
 sidebar_order: 5250
 sidebar_section: features
 description: Upload Android builds to Sentry for distribution to internal teams and beta testers.
+beta: true
 ---
-
-<Include name="feature-available-for-user-group-early-adopter" />
 
 [Build Distribution](/product/build-distribution) helps you securely distribute Android builds to your internal teams and beta testers.
 

--- a/docs/platforms/android/build-distribution/install-groups.mdx
+++ b/docs/platforms/android/build-distribution/install-groups.mdx
@@ -4,8 +4,6 @@ sidebar_order: 20
 description: Control which Android builds can see updates for each other using install groups.
 ---
 
-<Include name="feature-available-for-user-group-early-adopter" />
-
 Install groups let you tag builds with one or more group names to control update visibility between builds. See the [product documentation](/product/build-distribution/#install-groups) for a full explanation of how install groups work.
 
 ## Uploading With Install Groups

--- a/docs/platforms/apple/guides/ios/build-distribution/auto-update.mdx
+++ b/docs/platforms/apple/guides/ios/build-distribution/auto-update.mdx
@@ -5,8 +5,6 @@ sidebar_order: 10
 description: Enable automatic update checks and installations for internal iOS builds using the Sentry Auto-Update SDK.
 ---
 
-<Include name="feature-available-for-user-group-early-adopter" />
-
 <Alert level="warning">
 
 The Auto-Update SDK is designed for **internal builds only** and should never be used in production builds distributed through the App Store.

--- a/docs/platforms/apple/guides/ios/build-distribution/index.mdx
+++ b/docs/platforms/apple/guides/ios/build-distribution/index.mdx
@@ -3,9 +3,8 @@ title: Build Distribution
 sidebar_order: 4950
 sidebar_section: features
 description: Upload iOS builds to Sentry for distribution to internal teams and beta testers.
+beta: true
 ---
-
-<Include name="feature-available-for-user-group-early-adopter" />
 
 [Build Distribution](/product/build-distribution) helps you securely distribute iOS builds to your internal teams and beta testers.
 Streamline your distribution workflow with automated uploads from CI.

--- a/docs/platforms/apple/guides/ios/build-distribution/install-groups.mdx
+++ b/docs/platforms/apple/guides/ios/build-distribution/install-groups.mdx
@@ -4,8 +4,6 @@ sidebar_order: 20
 description: Control which iOS builds can see updates for each other using install groups.
 ---
 
-<Include name="feature-available-for-user-group-early-adopter" />
-
 Install groups let you tag builds with one or more group names to control update visibility between builds. See the [product documentation](/product/build-distribution/#install-groups) for a full explanation of how install groups work.
 
 ## Uploading With Install Groups

--- a/docs/platforms/dart/guides/flutter/build-distribution/index.mdx
+++ b/docs/platforms/dart/guides/flutter/build-distribution/index.mdx
@@ -3,9 +3,8 @@ title: Build Distribution
 sidebar_order: 5250
 sidebar_section: features
 description: Upload Flutter builds to Sentry for distribution to internal teams and beta testers.
+beta: true
 ---
-
-<Include name="feature-available-for-user-group-early-adopter" />
 
 <Include name="build-distribution/intro" />
 

--- a/docs/platforms/react-native/build-distribution/index.mdx
+++ b/docs/platforms/react-native/build-distribution/index.mdx
@@ -4,9 +4,8 @@ sidebar_title: Build Distribution
 sidebar_order: 10
 sidebar_section: configuration
 description: Upload React Native iOS and Android builds to Sentry for distribution to internal teams and beta testers.
+beta: true
 ---
-
-<Include name="feature-available-for-user-group-early-adopter" />
 
 <Include name="build-distribution/intro" />
 

--- a/docs/product/build-distribution/index.mdx
+++ b/docs/product/build-distribution/index.mdx
@@ -2,9 +2,8 @@
 title: Build Distribution
 sidebar_order: 137
 description: Distribute app builds to internal teams and beta testers.
+beta: true
 ---
-
-<Include name="feature-available-for-user-group-early-adopter" />
 
 Build Distribution enables you to securely distribute app builds to your internal teams and beta testers. Upload builds from CI to streamline your distribution workflow, manage access control, and track installation analytics.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Replaces the in-page Early Adopter callout on Build Distribution docs with a BETA badge on the sidebar nav item, so the feature's status is signaled in navigation rather than via a repeated in-page Include.

- Removed `<Include name="feature-available-for-user-group-early-adopter" />` from all 9 Build Distribution pages (Android, iOS, React Native, Flutter, and the product section).
- Added `beta: true` to the 5 section `index.mdx` pages, which renders a BETA badge next to the "Build Distribution" nav item.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)