### PR TITLE
fix(docs): Fix typos & minor errors in strict TypeScript settings guide

### DIFF
--- a/develop-docs/frontend/strict-typescript-settings-guide.mdx
+++ b/develop-docs/frontend/strict-typescript-settings-guide.mdx
@@ -48,7 +48,7 @@ This obviously isn't great, but since we had 3k+ errors, this was the fastest wa
 // ✅
 - const handleClick = (event: any) => {
 + const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-  e.stopPropagation()
+  event.stopPropagation()
   props.onClick()
 }
 ```
@@ -80,7 +80,7 @@ for (const child of collection) {
 }
 ```
 
-There is also a stylistic [typescript-eslint](https://typescript-eslint.io/rules/prefer-for-of/) rule that can catch those cases, as this arguably easier to read, too.
+There is also a stylistic [typescript-eslint](https://typescript-eslint.io/rules/prefer-for-of/) rule that can catch those cases, as this is arguably easier to read, too.
 
 #### Functional Access
 
@@ -93,7 +93,7 @@ collection.forEach(child => {
 })
 ```
 
-Whether or not this is a good approach depends on what's actually happening in the body of the function, as well as the size of the collection and how much you're concerned bout performance.
+Whether or not this is a good approach depends on what's actually happening in the body of the function, as well as the size of the collection and how much you're concerned about performance.
 
 ### Accessing a Specific Element of an Array
 
@@ -186,7 +186,7 @@ function doSomething(input: Record<string, unknown>) {
   Object.keys(input).forEach(key => {
     const item = input[key]!
     // ...
-  }
+  })
 }
 ```
 
@@ -199,7 +199,7 @@ The best solution here would be to switch to `Object.entries` or `Object.values`
 function doSomething(input: Record<string, unknown>) {
   Object.entries(input).forEach(([key, item]) => {
     // ...
-  }
+  })
 }
 ```
 
@@ -263,7 +263,7 @@ function printKey(person: Person, key: keyof Person) {
 }
 ```
 
-Of course, this might lead to errors on the call-sides if we have strings there that might potentially not be a valid key.
+Of course, this might lead to errors on the call-sites if we have strings there that might potentially not be a valid key.
 
 ### Fallback Lookups
 
@@ -378,7 +378,7 @@ function getProduct(category: DataCategory) {
 <Alert level="warning">
 TS7053: Element implicitly has an any type because expression of type DataCategory can't be used to index type
 
-Property '[DataCategory. PROFILE_DURATION]' does not exist on type ...
+Property '[DataCategory.PROFILE_DURATION]' does not exist on type ...
 </Alert>
 
 ### Solution 1: Make the Mapping Exhaustive


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes typos and a few minor errors in the **Strict TypeScript Settings Guide** (`develop-docs/frontend/strict-typescript-settings-guide.mdx`). Content/meaning is unchanged — these are copy and example-code corrections only.

- "concerned **bout** performance" → "concerned **about** performance"
- "errors on the **call-sides**" → "errors on the **call-sites**"
- "as this **arguably easier** to read" → "as this **is arguably easier** to read" (missing word)
- ✅ `handleClick` example: body called `e.stopPropagation()` after the param was renamed to `event` → now `event.stopPropagation()`
- Two `forEach` snippets were missing the closing `)` on the callback (`}` → `})`)
- Stray space in a simulated TS error: `DataCategory. PROFILE_DURATION` → `DataCategory.PROFILE_DURATION`

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)