### PR TITLE
docs(attachments): Metadata 

### DIFF
--- a/develop-docs/sdk/telemetry/attachments.mdx
+++ b/develop-docs/sdk/telemetry/attachments.mdx
@@ -193,7 +193,7 @@ SDKs **SHOULD** send placeholders in the same envelope as the event the file is 
         --header "Upload-Metadata: sentry $(echo -n '{"attachment_type":"event.attachment"}' | base64)"
       ```
 
-      The `Upload-Metadata` header follows the [TUS metadata format](https://tus.io/protocols/resumable-upload#upload-metadata). Sentry recognizes a single key, `sentry`, whose value **MUST** be the Base64 encoding of a UTF-8 JSON object describing the attachment:
+      The `Upload-Metadata` header follows the [TUS metadata format](https://tus.io/protocols/resumable-upload#upload-metadata). Sentry recognizes a single key, `sentry`, the value of which **MUST** be the Base64 encoding of a UTF-8 JSON object describing the attachment:
 
       ```json
       {

--- a/develop-docs/sdk/telemetry/attachments.mdx
+++ b/develop-docs/sdk/telemetry/attachments.mdx
@@ -201,9 +201,9 @@ SDKs **SHOULD** send placeholders in the same envelope as the event the file is 
       }
       ```
 
-      | Field             | Type   | Required     | Description                                                                                        |
-      | ----------------- | ------ | ------------ | -------------------------------------------------------------------------------------------------- |
-      | `attachment_type` | String | **REQUIRED** | One of the values listed in [Attachment Types](#attachment-types). Defaults to `event.attachment`. |
+      | Field             | Type   | Required     | Description                                                        |
+      | ----------------- | ------ | ------------ | -------------------------------------------------------------------|
+      | `attachment_type` | String | **REQUIRED** | One of the values listed in [Attachment Types](#attachment-types). |
 
       
    1. Get the location response header:

--- a/develop-docs/sdk/telemetry/attachments.mdx
+++ b/develop-docs/sdk/telemetry/attachments.mdx
@@ -190,7 +190,22 @@ SDKs **SHOULD** send placeholders in the same envelope as the event the file is 
       curl -X POST https://o0.ingest.sentry.io/api/0/upload/ \
         --header "Tus-Resumable: 1.0.0" \
         --header "Upload-Length: ${FILE_SIZE}" \
+        --header "Upload-Metadata: sentry $(echo -n '{"attachment_type":"event.attachment"}' | base64)"
       ```
+
+      The `Upload-Metadata` header follows the [TUS metadata format](https://tus.io/protocols/resumable-upload#upload-metadata). Sentry recognizes a single key, `sentry`, whose value **MUST** be the Base64 encoding of a UTF-8 JSON object describing the attachment:
+
+      ```json
+      {
+        "attachment_type": "event.attachment"
+      }
+      ```
+
+      | Field             | Type   | Required     | Description                                                                                        |
+      | ----------------- | ------ | ------------ | -------------------------------------------------------------------------------------------------- |
+      | `attachment_type` | String | **OPTIONAL** | One of the values listed in [Attachment Types](#attachment-types). Defaults to `event.attachment`. |
+
+      
    1. Get the location response header:
       ```
       HTTP/1.1 201 Created

--- a/develop-docs/sdk/telemetry/attachments.mdx
+++ b/develop-docs/sdk/telemetry/attachments.mdx
@@ -203,7 +203,7 @@ SDKs **SHOULD** send placeholders in the same envelope as the event the file is 
 
       | Field             | Type   | Required     | Description                                                                                        |
       | ----------------- | ------ | ------------ | -------------------------------------------------------------------------------------------------- |
-      | `attachment_type` | String | **OPTIONAL** | One of the values listed in [Attachment Types](#attachment-types). Defaults to `event.attachment`. |
+      | `attachment_type` | String | **REQUIRED** | One of the values listed in [Attachment Types](#attachment-types). Defaults to `event.attachment`. |
 
       
    1. Get the location response header:


### PR DESCRIPTION
Add documentation on the `Upload-Metadata`.

Fix: https://linear.app/getsentry/issue/INGEST-926/document-upload-metadata-in-devdocs