### PR TITLE
remove zendesk help article results from SentryGlobalSearch

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -43,11 +43,7 @@ const randomUserToken = (() => {
 // this type is not exported from the global-search package
 type SentryGlobalSearchConfig = ConstructorParameters<typeof SentryGlobalSearch>[0];
 
-const developerDocsSites: SentryGlobalSearchConfig = [
-  'develop',
-  'docs',
-  'blog',
-];
+const developerDocsSites: SentryGlobalSearchConfig = ['develop', 'docs', 'blog'];
 
 const userDocsSites: SentryGlobalSearchConfig = [
   {

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -45,7 +45,6 @@ type SentryGlobalSearchConfig = ConstructorParameters<typeof SentryGlobalSearch>
 
 const developerDocsSites: SentryGlobalSearchConfig = [
   'develop',
-  'zendesk_sentry_articles',
   'docs',
   'blog',
 ];

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -52,7 +52,6 @@ const userDocsSites: SentryGlobalSearchConfig = [
     platformBias: true,
     legacyBias: true,
   },
-  'zendesk_sentry_articles',
   'develop',
   'blog',
 ];


### PR DESCRIPTION
SentryGlobalSearch uses zendesk_sentry_articles index in Algolia which is now outdated

The new help center will need to be indexed and added back

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
