### PR TITLE
feat: add Sentry metric for Copy Prompt button clicks

### DIFF
--- a/src/components/agentSkillsCallout/index.tsx
+++ b/src/components/agentSkillsCallout/index.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/nextjs';
 import Link from 'next/link';
 import {useCallback, useState} from 'react';
 import {usePlausibleEvent} from 'sentry-docs/hooks/usePlausibleEvent';
+import {DocMetrics} from 'sentry-docs/metrics';
 
 import {CodeBlock} from '../codeBlock';
 import {CodeTabs} from '../codeTabs';
@@ -66,13 +67,15 @@ export function AgentSkillsCallout({skill, platformName}: Props) {
         setCopied(false);
         await navigator.clipboard.writeText(prompt);
         setCopied(true);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, true);
         setTimeout(() => setCopied(false), 1500);
       } catch (error) {
         Sentry.captureException(error);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, false);
         setCopied(false);
       }
     },
-    [prompt, emit]
+    [prompt, emit, skill]
   );
 
   const description = platformName

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -135,6 +135,22 @@ export const DocMetrics = {
       },
     });
   },
+
+  /**
+   * Track "Copy Prompt" button clicks in the Agent Skills Callout
+   * @param pathname - Page where the prompt was copied
+   * @param skill - Skill name if present (e.g., "sentry-nextjs-sdk")
+   * @param success - Whether the clipboard copy succeeded
+   */
+  copyAIPrompt: (pathname: string, skill: string | undefined, success: boolean) => {
+    Sentry.metrics.count('docs.copy_ai_prompt', 1, {
+      attributes: {
+        page_path: pathname.split('/').slice(0, 3).join('/'), // First 3 segments
+        skill: skill || 'generic',
+        success,
+      },
+    });
+  },
 };
 
 /**


### PR DESCRIPTION
## DESCRIBE YOUR PR

- **Preview has been validated**
- **Sentry data has been validated (see vercel preview in Sentry!)****

Track "Copy Prompt" button clicks in the Agent Skills Callout as a Sentry application metric (`docs.copy_ai_prompt` counter).

**Metric attributes:**
- `page_path` -- first 3 URL segments (privacy-safe, matches existing metrics)
- `skill` -- skill name (e.g. `sentry-nextjs-sdk`) or `generic` if no skill specified
- `success` -- whether the clipboard copy succeeded

**Changes (2 files):**
- `src/metrics.ts` -- Add `copyAIPrompt` method to `DocMetrics`, following the same pattern as existing metrics (`copyPage`, `snippetCopy`, etc.)
- `src/components/agentSkillsCallout/index.tsx` -- Import `DocMetrics` and call `copyAIPrompt` on success/failure in the click handler. Also fixes `useCallback` dependency array to include `skill`.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)