### PR TITLE
feat(AI prompts): add AgentSkillsCallout to missing SDK quickstart pages

### DIFF
--- a/docs/platforms/dotnet/common/index.mdx
+++ b/docs/platforms/dotnet/common/index.mdx
@@ -1,3 +1,5 @@
+<AgentSkillsCallout skill="sentry-dotnet-sdk" platformName=".NET" />
+
 <PlatformContent includePath="getting-started-primer" />
 
 On this page, we get you up and running with Sentry's SDK.

--- a/docs/platforms/elixir/index.mdx
+++ b/docs/platforms/elixir/index.mdx
@@ -9,10 +9,13 @@ categories:
   - server
 ---
 
+<AgentSkillsCallout skill="sentry-elixir-sdk" platformName="Elixir" />
+
 On this page, we get you up and running with Sentry's SDK.
 
 <Alert>
-  You don't have an account and Sentry project established? Head over to [sentry.io](https://sentry.io/signup/), then return to this page.
+  You don't have an account and Sentry project established? Head over to
+  [sentry.io](https://sentry.io/signup/), then return to this page.
 </Alert>
 
 ## Install

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -9,6 +9,8 @@ categories:
   - serverless
 ---
 
+<AgentSkillsCallout skill="sentry-cloudflare-sdk" platformName="Cloudflare" />
+
 Use this guide for general instructions on using the Sentry SDK with Cloudflare. If you're using any of the listed frameworks, follow their specific setup instructions:
 
 - **[Astro](/platforms/javascript/guides/cloudflare/frameworks/astro/)**

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -9,6 +9,11 @@ categories:
   - server-node
 ---
 
+<AgentSkillsCallout
+  skill="sentry-react-router-framework-sdk"
+  platformName="React Router"
+/>
+
 <Alert level="warning" title="Important">
   This SDK is currently in **beta**. Beta features are still in progress and may
   have bugs. Please reach out on

--- a/docs/platforms/python/index.mdx
+++ b/docs/platforms/python/index.mdx
@@ -10,6 +10,8 @@ categories:
   - serverless
 ---
 
+<AgentSkillsCallout skill="sentry-python-sdk" platformName="Python" />
+
 ## Prerequisites
 
 - You need a Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)

--- a/docs/platforms/ruby/common/index.mdx
+++ b/docs/platforms/ruby/common/index.mdx
@@ -1,9 +1,11 @@
+<AgentSkillsCallout skill="sentry-ruby-sdk" platformName="Ruby" />
+
 <PlatformContent includePath="alert-using-a-framework" noGuides />
 
 ## Prerequisites
 
-* You need a Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
-* Ruby 2.4+ or any of the most recent JRuby versions
+- You need a Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Ruby 2.4+ or any of the most recent JRuby versions
 
 ## Features
 

--- a/platform-includes/llm-rules-platform/javascript.mdx
+++ b/platform-includes/llm-rules-platform/javascript.mdx
@@ -1,0 +1,4 @@
+<AgentSkillsCallout
+  skill="sentry-browser-sdk"
+  platformName="Browser JavaScript"
+/>


### PR DESCRIPTION
## DESCRIBE YOUR PR
Add the Agent-Assisted Setup banner to SDK quickstart pages that have a corresponding skill on getsentry/sentry-for-ai but were missing the callout:

- Python (sentry-python-sdk)
- Ruby (sentry-ruby-sdk)
- .NET (sentry-dotnet-sdk)
- Cloudflare (sentry-cloudflare-sdk)
- Elixir (sentry-elixir-sdk)
- React Router Framework (sentry-react-router-framework-sdk)
- Browser JavaScript (sentry-browser-sdk) — new platform-include override replacing the generic fallback

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)