### PR TITLE
docs(snapshots): Document SnapshotPreviews selective testing

### DIFF
--- a/docs/platforms/apple/common/snapshots/index.mdx
+++ b/docs/platforms/apple/common/snapshots/index.mdx
@@ -42,6 +42,10 @@ Set `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` before running the tests so SnapshotPrevi
 export TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="$PWD/snapshot-images"
 ```
 
+SnapshotPreviews emits logical, unprefixed `.png` names. If you render the same logical snapshot on multiple simulators, prefix or directory-scope those files in CI before uploading them to Sentry.
+
+For large suites where you only want to render affected preview groups in a given CI run, see [Selective Testing with SnapshotPreviews](/platforms/apple/snapshots/selective-testing/).
+
 To customize per-preview metadata in those sidecars, see [SnapshotPreviews Metadata](/platforms/apple/snapshots/snapshotpreviews-metadata/).
 
 Continue to [Step 2](#step-2-test-locally).

--- a/docs/platforms/apple/common/snapshots/selective-testing.mdx
+++ b/docs/platforms/apple/common/snapshots/selective-testing.mdx
@@ -4,9 +4,8 @@ sidebar_title: Selective Testing
 sidebar_order: 4952
 sidebar_section: features
 description: Render only selected SnapshotPreviews groups in CI while keeping Sentry aware of the full tracked image set.
+early_access: true
 ---
-
-<Include name="feature-available-for-user-group-early-adopter" />
 
 Selective testing is an advanced workflow for large suites where rendering every preview on every pull request is too expensive. On each run you render and upload only a subset of your previews, and Sentry diffs that subset against the baseline.
 
@@ -15,7 +14,7 @@ There are two approaches:
 - **Approach A — upload just the subset.** Simplest to set up. Any image you don't upload counts as skipped, so Sentry can't detect deletions or renames.
 - **Approach B — upload the subset plus the full list of tracked image names.** Sentry can then tell apart snapshots that were rendered, skipped, or removed/renamed.
 
-Either way, you first organize snapshots into selectable groups and upload a baseline build, covered in the next two sections. The approaches differ only in the final render-and-upload step.
+For both implementations, you first organize snapshots into groups and upload a baseline build, covered in the next two sections. The approaches differ only in the final render-and-upload step.
 
 ## Organize Snapshots Into Selectable Groups
 

--- a/docs/platforms/apple/common/snapshots/selective-testing.mdx
+++ b/docs/platforms/apple/common/snapshots/selective-testing.mdx
@@ -1,0 +1,148 @@
+---
+title: Selective Testing with SnapshotPreviews
+sidebar_title: Selective Testing
+sidebar_order: 4952
+sidebar_section: features
+description: Render only selected SnapshotPreviews groups in CI while keeping Sentry aware of the full tracked image set.
+early_access: true
+---
+
+<Include name="feature-available-for-user-group-early-adopter" />
+
+Selective testing is an advanced SnapshotPreviews workflow for large suites. Use it when rendering every preview on every pull request is too expensive, but you still want Sentry to tell apart:
+
+- snapshots rendered in this run;
+- snapshots skipped because their group wasn't selected;
+- snapshots intentionally removed from the tracked set.
+
+The idea is to separate **name generation** from **image rendering**. First, write the complete list of image names for the full tracked suite. Then render only the groups selected for this CI run and upload those images with the complete image-name file.
+
+## Organize snapshots into selectable groups
+
+Create one `SnapshotTest` subclass per group CI can select. Inclusion filters, such as `snapshotPreviewModules()` or `snapshotPreviews()`, define what a group renders. Exclusion filters, such as `excludedSnapshotPreviews()`, remove snapshots from the tracked set entirely.
+
+```swift
+import SnapshottingTests
+
+final class ModuleASnapshots: SnapshotTest {
+  override class func snapshotPreviewModules() -> [String]? {
+    ["ModuleA"]
+  }
+
+  override class func excludedSnapshotPreviews() -> [String]? {
+    ["ModuleA/LoadingView.swift:Loading"]
+  }
+}
+
+final class ModuleBCSnapshots: SnapshotTest {
+  override class func snapshotPreviewModules() -> [String]? {
+    ["ModuleB", "ModuleC"]
+  }
+}
+```
+
+Together, these groups cover every tracked snapshot in Module A, Module B, and Module C. `ModuleA/LoadingView.swift:Loading` is excluded, so it is not part of the tracked set. If that snapshot existed in the base build, Sentry can report it as removed instead of skipped.
+
+Use class-level `-only-testing:<test-target>/<class-name>` selectors. Do not shard by generated preview method selectors; those selectors are runtime-generated implementation details.
+
+## Step 1: Upload a complete baseline build
+
+On your base branch, render and upload the full snapshot suite. This is a normal, complete upload. Do not pass an image-name file on the baseline upload.
+
+```bash
+TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/private/tmp/base_snapshots/iphone" \
+xcodebuild test \
+  -project MyApp.xcodeproj \
+  -scheme MyApp \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'
+
+sentry-cli build snapshots "/private/tmp/base_snapshots/iphone" \
+  --app-id com.example.MyApp
+```
+
+## Step 2: Build the pull request test bundle
+
+On the pull request, build the test bundle once and reuse it for name generation and rendering.
+
+```bash
+xcodebuild build-for-testing \
+  -project MyApp.xcodeproj \
+  -scheme MyApp \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -derivedDataPath /private/tmp/snapshotpreviews_root/DerivedData
+```
+
+Use the `.xctestrun` file generated under the derived data directory for the following `test-without-building` commands:
+
+```bash
+/private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun
+```
+
+## Step 3: Generate image names for every selectable group
+
+Generate the image-name file for each group in its own run. Setting `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` puts SnapshotPreviews in name-only mode: it writes names and returns without rendering or exporting PNG/JSON files.
+
+Run each class separately and merge the files in CI. Do not rely on passing multiple dynamic `SnapshotTest` classes to one name-generation invocation.
+
+```bash
+TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="/private/tmp/snapshotpreviews_root/all-image-file-names_1.txt" \
+xcodebuild test-without-building \
+  -xctestrun /private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:MyAppTests/ModuleASnapshots
+
+TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="/private/tmp/snapshotpreviews_root/all-image-file-names_2.txt" \
+xcodebuild test-without-building \
+  -xctestrun /private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:MyAppTests/ModuleBCSnapshots
+```
+
+Combine the per-group files into one de-duplicated image-name file:
+
+```bash
+cat /private/tmp/snapshotpreviews_root/all-image-file-names_1.txt \
+    /private/tmp/snapshotpreviews_root/all-image-file-names_2.txt \
+  | sort -u > /private/tmp/snapshotpreviews_root/all-image-file-names_all.txt
+```
+
+## Step 4: Render only the selected group
+
+Render only the group selected for this run. Your CI can decide which groups to render using whatever rules make sense for your project, such as changed files, ownership, or shard assignment. This example renders Module A and skips the Module B/C group.
+
+```bash
+TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/private/tmp/head_snapshots/iphone" \
+xcodebuild test-without-building \
+  -xctestrun /private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:MyAppTests/ModuleASnapshots
+```
+
+## Step 5: Upload the selective build
+
+Upload the rendered image directory with the complete image-name file. Passing `--all-image-file-names-file` tells Sentry this is a selective upload, so listed images that were not uploaded are treated as skipped rather than removed.
+
+```bash
+sentry-cli build snapshots "/private/tmp/head_snapshots/iphone" \
+  --app-id com.example.MyApp \
+  --all-image-file-names-file /private/tmp/snapshotpreviews_root/all-image-file-names_all.txt
+```
+
+With this example:
+
+- rendered Module A snapshots are reported as changed or unchanged;
+- Module B/C snapshots are listed but not uploaded, so they are reported as skipped;
+- `ModuleA/LoadingView.swift:Loading` is excluded and not listed, so if it existed in the base build, Sentry can report it as removed.
+
+## Notes
+
+- `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` and `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` are mutually exclusive. One run writes names; another run renders images.
+- `--all-image-file-names-file` marks the upload as selective. You do not need to also pass `--selective`.
+- SnapshotPreviews writes logical, unprefixed image names. If you upload from a parent directory that groups images by simulator, prefix every entry in the image-name file with the same upload-root-relative path.
+
+## Complete example
+
+For a complete working example, see the SnapshotPreviews MultiModuleDemo app and CI workflow:
+
+- [MultiModuleDemo snapshot test groups](https://github.com/getsentry/SnapshotPreviews/blob/main/Examples/MultiModuleDemo/MultiModuleDemoTests/MultiModuleDemoSnapshotTests.swift)
+- [MultiModuleDemo Sentry Snapshots workflow](https://github.com/getsentry/SnapshotPreviews/blob/main/docs/examples/ios_sentry_upload_snapshots.yml)

--- a/docs/platforms/apple/common/snapshots/selective-testing.mdx
+++ b/docs/platforms/apple/common/snapshots/selective-testing.mdx
@@ -253,7 +253,8 @@ final class ModuleASnapshots: SnapshotTest {
 
 ## Complete Example
 
-For a complete working example, see the SnapshotPreviews MultiModuleDemo app and CI workflow:
+For a complete working example, see the SnapshotPreviews MultiModuleDemo app, CI workflow, and a pull request that triggers a selective run:
 
 - [MultiModuleDemo snapshot test groups](https://github.com/getsentry/SnapshotPreviews/blob/main/Examples/MultiModuleDemo/MultiModuleDemoTests/MultiModuleDemoSnapshotTests.swift)
 - [MultiModuleDemo Sentry Snapshots workflow](https://github.com/getsentry/SnapshotPreviews/blob/main/.github/workflows/ios_sentry_upload_snapshots.yml)
+- [Example pull request: a selective Module A–only run](https://github.com/getsentry/SnapshotPreviews/pull/269)

--- a/docs/platforms/apple/common/snapshots/selective-testing.mdx
+++ b/docs/platforms/apple/common/snapshots/selective-testing.mdx
@@ -4,145 +4,257 @@ sidebar_title: Selective Testing
 sidebar_order: 4952
 sidebar_section: features
 description: Render only selected SnapshotPreviews groups in CI while keeping Sentry aware of the full tracked image set.
-early_access: true
 ---
 
 <Include name="feature-available-for-user-group-early-adopter" />
 
-Selective testing is an advanced SnapshotPreviews workflow for large suites. Use it when rendering every preview on every pull request is too expensive, but you still want Sentry to tell apart:
+Selective testing is an advanced workflow for large suites where rendering every preview on every pull request is too expensive. On each run you render and upload only a subset of your previews, and Sentry diffs that subset against the baseline.
 
-- snapshots rendered in this run;
-- snapshots skipped because their group wasn't selected;
-- snapshots intentionally removed from the tracked set.
+There are two approaches:
 
-The idea is to separate **name generation** from **image rendering**. First, write the complete list of image names for the full tracked suite. Then render only the groups selected for this CI run and upload those images with the complete image-name file.
+- **Approach A — upload just the subset.** Simplest to set up. Any image you don't upload counts as skipped, so Sentry can't detect deletions or renames.
+- **Approach B — upload the subset plus the full list of tracked image names.** Sentry can then tell apart snapshots that were rendered, skipped, or removed/renamed.
 
-## Organize snapshots into selectable groups
+Either way, you first organize snapshots into selectable groups and upload a baseline build, covered in the next two sections. The approaches differ only in the final render-and-upload step.
 
-Create one `SnapshotTest` subclass per group CI can select. Inclusion filters, such as `snapshotPreviewModules()` or `snapshotPreviews()`, define what a group renders. Exclusion filters, such as `excludedSnapshotPreviews()`, remove snapshots from the tracked set entirely.
+## Organize Snapshots Into Selectable Groups
 
-```swift
+Create one `SnapshotTest` subclass per group CI can select. Inclusion filters (`snapshotPreviewModules()`, `snapshotPreviews()`) define what each group renders.
+
+```swift {filename:MyAppSnapshotTests.swift}
 import SnapshottingTests
 
 final class ModuleASnapshots: SnapshotTest {
   override class func snapshotPreviewModules() -> [String]? {
     ["ModuleA"]
   }
-
-  override class func excludedSnapshotPreviews() -> [String]? {
-    ["ModuleA/LoadingView.swift:Loading"]
-  }
 }
 
-final class ModuleBCSnapshots: SnapshotTest {
+final class ModuleBSnapshots: SnapshotTest {
   override class func snapshotPreviewModules() -> [String]? {
-    ["ModuleB", "ModuleC"]
+    ["ModuleB"]
   }
 }
 ```
 
-Together, these groups cover every tracked snapshot in Module A, Module B, and Module C. `ModuleA/LoadingView.swift:Loading` is excluded, so it is not part of the tracked set. If that snapshot existed in the base build, Sentry can report it as removed instead of skipped.
+## Upload a Baseline Build
 
-Use class-level `-only-testing:<test-target>/<class-name>` selectors. Do not shard by generated preview method selectors; those selectors are runtime-generated implementation details.
-
-## Step 1: Upload a complete baseline build
-
-On your base branch, render and upload the full snapshot suite. This is a normal, complete upload. Do not pass an image-name file on the baseline upload.
+Render and upload the full suite on your base branch — typically via a CI workflow that runs on every merge.
 
 ```bash
-TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/private/tmp/base_snapshots/iphone" \
+TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/tmp/base_snapshots" \
 xcodebuild test \
   -project MyApp.xcodeproj \
   -scheme MyApp \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'
 
-sentry-cli build snapshots "/private/tmp/base_snapshots/iphone" \
+sentry-cli build snapshots "/tmp/base_snapshots" \
   --app-id com.example.MyApp
 ```
 
-## Step 2: Build the pull request test bundle
+In this example, the full suite produces this set of tracked images:
 
-On the pull request, build the test bundle once and reuse it for name generation and rendering.
+```text
+/tmp/base_snapshots/
+├── ModuleA_HomeView.swift_Light.png
+├── ModuleA_HomeView.swift_Dark.png
+├── ModuleA_ProfileView.swift_Profile.png
+├── ModuleB_CartView.swift_Cart.png
+├── ModuleB_CheckoutView.swift_Checkout.png
+└── ModuleB_SettingsView.swift_Settings.png
+```
+
+Note that we also have a `.json` sidecar for each image (not shown here for brevity).
+
+## Upload the Pull Request Build
+
+On each pull request, render the selected subset of previews and upload it. Your CI decides which groups to render — by changed files, code ownership, shard assignment, or whatever fits your project. In the examples below, we render the Module A group and skip Module B.
+
+Pick one of the two approaches below, depending on whether you need removal and rename detection.
+
+### Approach A: Subset Only
+
+Render the selected group with `xcodebuild test`:
+
+```bash
+TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/tmp/head_snapshots" \
+xcodebuild test \
+  -project MyApp.xcodeproj \
+  -scheme MyApp \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:MyAppTests/ModuleASnapshots
+```
+
+This produces a set of only Module A's rendered images:
+
+```text
+/tmp/head_snapshots/
+├── ModuleA_HomeView.swift_Light.png
+├── ModuleA_HomeView.swift_Dark.png
+└── ModuleA_ProfileView.swift_Profile.png
+```
+
+Upload the subset with the `--selective` flag:
+
+```bash
+sentry-cli build snapshots "/tmp/head_snapshots" \
+  --app-id com.example.MyApp \
+  --selective
+```
+
+<Alert>
+  With `--selective`, Sentry reports every tracked image you didn't upload as
+  skipped — including ones that might have been removed or renamed.
+</Alert>
+
+### Approach B: Subset and Image-Name File
+
+Alongside the rendered subset, upload a file listing every tracked image name. With that image-name file, Sentry distinguishes images you **rendered** (diffed against the baseline) from ones **skipped** this run, and flags any baseline image absent from the file as **removed or renamed**.
+
+#### Step 1: Build the Test Bundle
+
+Rendering and name generation can't share a run, so in this example we compile the app once up front with `build-for-testing`:
 
 ```bash
 xcodebuild build-for-testing \
   -project MyApp.xcodeproj \
   -scheme MyApp \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
-  -derivedDataPath /private/tmp/snapshotpreviews_root/DerivedData
+  -derivedDataPath /tmp/DerivedData
 ```
 
-Use the `.xctestrun` file generated under the derived data directory for the following `test-without-building` commands:
+Steps 2 and 3 then run against the generated `.xctestrun` with `test-without-building`, so neither recompiles:
 
 ```bash
-/private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun
+/tmp/DerivedData/Build/Products/<generated>.xctestrun
 ```
 
-## Step 3: Generate image names for every selectable group
+#### Step 2: Render the Selected Group
 
-Generate the image-name file for each group in its own run. Setting `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` puts SnapshotPreviews in name-only mode: it writes names and returns without rendering or exporting PNG/JSON files.
-
-Run each class separately and merge the files in CI. Do not rely on passing multiple dynamic `SnapshotTest` classes to one name-generation invocation.
+Render the selected group with `test-without-building`:
 
 ```bash
-TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="/private/tmp/snapshotpreviews_root/all-image-file-names_1.txt" \
+TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/tmp/head_snapshots" \
 xcodebuild test-without-building \
-  -xctestrun /private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
-  -only-testing:MyAppTests/ModuleASnapshots
-
-TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="/private/tmp/snapshotpreviews_root/all-image-file-names_2.txt" \
-xcodebuild test-without-building \
-  -xctestrun /private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
-  -only-testing:MyAppTests/ModuleBCSnapshots
-```
-
-Combine the per-group files into one de-duplicated image-name file:
-
-```bash
-cat /private/tmp/snapshotpreviews_root/all-image-file-names_1.txt \
-    /private/tmp/snapshotpreviews_root/all-image-file-names_2.txt \
-  | sort -u > /private/tmp/snapshotpreviews_root/all-image-file-names_all.txt
-```
-
-## Step 4: Render only the selected group
-
-Render only the group selected for this run. Your CI can decide which groups to render using whatever rules make sense for your project, such as changed files, ownership, or shard assignment. This example renders Module A and skips the Module B/C group.
-
-```bash
-TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="/private/tmp/head_snapshots/iphone" \
-xcodebuild test-without-building \
-  -xctestrun /private/tmp/snapshotpreviews_root/DerivedData/Build/Products/<generated>.xctestrun \
+  -xctestrun /tmp/DerivedData/Build/Products/<generated>.xctestrun \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
   -only-testing:MyAppTests/ModuleASnapshots
 ```
 
-## Step 5: Upload the selective build
+This produces a set of only Module A's rendered images:
 
-Upload the rendered image directory with the complete image-name file. Passing `--all-image-file-names-file` tells Sentry this is a selective upload, so listed images that were not uploaded are treated as skipped rather than removed.
+```text
+/tmp/head_snapshots/
+├── ModuleA_HomeView.swift_Light.png
+├── ModuleA_HomeView.swift_Dark.png
+└── ModuleA_ProfileView.swift_Profile.png
+```
+
+#### Step 3: Generate the Image-Name File
+
+Run each group in name-only mode by setting the environment variable `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` to point to a file in the path you want to write the names to. Run each group in its own invocation — passing multiple `SnapshotTest` classes to a single name-generation run isn't supported.
+
+In the example below, we generate a name file for each group — including Module B, which we didn't render — so the list covers every tracked image, not just the rendered subset.
 
 ```bash
-sentry-cli build snapshots "/private/tmp/head_snapshots/iphone" \
+TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="/tmp/names_1.txt" \
+xcodebuild test-without-building \
+  -xctestrun /tmp/DerivedData/Build/Products/<generated>.xctestrun \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:MyAppTests/ModuleASnapshots
+
+TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="/tmp/names_2.txt" \
+xcodebuild test-without-building \
+  -xctestrun /tmp/DerivedData/Build/Products/<generated>.xctestrun \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:MyAppTests/ModuleBSnapshots
+```
+
+```text
+# names_1.txt
+ModuleA_HomeView.swift_Light.png
+ModuleA_HomeView.swift_Dark.png
+ModuleA_ProfileView.swift_Profile.png
+
+# names_2.txt
+ModuleB_CartView.swift_Cart.png
+ModuleB_CheckoutView.swift_Checkout.png
+ModuleB_SettingsView.swift_Settings.png
+```
+
+Next we need to combine the per-group files into one de-duplicated list; here we join them with `cat` and sort them with `sort -u`:
+
+```bash
+cat /tmp/names_1.txt \
+    /tmp/names_2.txt \
+  | sort -u > /tmp/names_all.txt
+```
+
+The result is a single file containing the full tracked set of image names:
+
+```text {filename:names_all.txt}
+ModuleA_HomeView.swift_Dark.png
+ModuleA_HomeView.swift_Light.png
+ModuleA_ProfileView.swift_Profile.png
+ModuleB_CartView.swift_Cart.png
+ModuleB_CheckoutView.swift_Checkout.png
+ModuleB_SettingsView.swift_Settings.png
+```
+
+#### Step 4: Upload With the Image-Name File
+
+Add the flag `--all-image-file-names-file <path>` with your image-name file when uploading.
+
+```bash
+sentry-cli build snapshots "/tmp/head_snapshots" \
   --app-id com.example.MyApp \
-  --all-image-file-names-file /private/tmp/snapshotpreviews_root/all-image-file-names_all.txt
+  --all-image-file-names-file /tmp/names_all.txt
 ```
 
-With this example:
+Alternatively you can pass the image filenames as a comma-separated list by using `--all-image-file-names <names>` instead of `--all-image-file-names-file <path>`.
 
-- rendered Module A snapshots are reported as changed or unchanged;
-- Module B/C snapshots are listed but not uploaded, so they are reported as skipped;
-- `ModuleA/LoadingView.swift:Loading` is excluded and not listed, so if it existed in the base build, Sentry can report it as removed.
+```bash
+sentry-cli build snapshots "/tmp/head_snapshots" \
+  --app-id com.example.MyApp \
+  --all-image-file-names "ModuleA_HomeView.swift_Light.png, ModuleA_HomeView.swift_Dark.png, ModuleA_ProfileView.swift_Profile.png, ModuleB_CartView.swift_Cart.png, ModuleB_CheckoutView.swift_Checkout.png, ModuleB_SettingsView.swift_Settings.png"
+```
+
+And that's it! Sentry will now diff the uploaded subset against the baseline and report any changes.
+
+## Exclude Previews From the Tracked Set
+
+The inclusion overrides (`snapshotPreviews()`, `snapshotPreviewModules()`) choose what each group renders — use them to shard your suite. The exclusion overrides (`excludedSnapshotPreviews()`, `excludedSnapshotPreviewModules()`) remove matching previews from the tracked set entirely, both from the rendered images and from the image-name file. Use them to drop previews you don't want tracked, such as flaky ones or whole modules.
+
+For example, to stop tracking a flaky Module A preview:
+
+```swift {filename:MyAppSnapshotTests.swift}
+final class ModuleASnapshots: SnapshotTest {
+  override class func snapshotPreviewModules() -> [String]? {
+    ["ModuleA"]
+  }
+
+  override class func excludedSnapshotPreviews() -> [String]? {
+    ["ModuleA/HomeView.swift:Dark"]
+  }
+}
+```
+
+<Alert>
+  Because exclusions drop previews from the image-name file too, a preview
+  that's in the baseline but excluded on a pull request is reported as
+  **removed** under Approach B. (Approach A has no image-name file, so it's
+  reported as skipped instead.)
+</Alert>
 
 ## Notes
 
-- `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` and `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` are mutually exclusive. One run writes names; another run renders images.
-- `--all-image-file-names-file` marks the upload as selective. You do not need to also pass `--selective`.
-- SnapshotPreviews writes logical, unprefixed image names. If you upload from a parent directory that groups images by simulator, prefix every entry in the image-name file with the same upload-root-relative path.
+- `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` and `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` are mutually exclusive. One run writes names; another renders images.
+- Passing an image-name file (`--all-image-file-names-file`, or `--all-image-file-names` for an inline list) marks the upload as selective on its own, so you don't also pass `--selective`.
+- SnapshotPreviews writes each image as `<Module>_<File>.swift_<Preview>.png` with no directory prefix. If your upload root nests images in per-simulator subfolders (for example `iphone/` and `ipad/`), prefix every entry in the image-name file with that subfolder.
 
-## Complete example
+## Complete Example
 
 For a complete working example, see the SnapshotPreviews MultiModuleDemo app and CI workflow:
 
 - [MultiModuleDemo snapshot test groups](https://github.com/getsentry/SnapshotPreviews/blob/main/Examples/MultiModuleDemo/MultiModuleDemoTests/MultiModuleDemoSnapshotTests.swift)
-- [MultiModuleDemo Sentry Snapshots workflow](https://github.com/getsentry/SnapshotPreviews/blob/main/docs/examples/ios_sentry_upload_snapshots.yml)
+- [MultiModuleDemo Sentry Snapshots workflow](https://github.com/getsentry/SnapshotPreviews/blob/main/.github/workflows/ios_sentry_upload_snapshots.yml)

--- a/docs/platforms/apple/common/snapshots/snapshotpreviews-metadata.mdx
+++ b/docs/platforms/apple/common/snapshots/snapshotpreviews-metadata.mdx
@@ -4,7 +4,6 @@ sidebar_title: SnapshotPreviews Metadata
 sidebar_order: 4951
 sidebar_section: features
 description: Add tags, context, and diff thresholds to SnapshotPreviews sidecar metadata.
-early_access: true
 ---
 
 <Include name="feature-available-for-user-group-early-adopter" />


### PR DESCRIPTION
Add an Apple Snapshots guide for using SnapshotPreviews with Sentry selective testing.

**What Changed**

This adds a dedicated selective testing page under the Apple Snapshots docs and links to it from the Apple Snapshots setup guide.

The new page explains how to:

- organize SnapshotPreviews into selectable `SnapshotTest` groups;
- generate image-name manifests for the groups that participate in selective testing;
- merge those manifests into one complete tracked image-name file;
- render only the group selected for the current CI run;
- upload the rendered subset with `--all-image-file-names-file`.

**Why This Exists**

Selective Sentry uploads need to distinguish images that were skipped in the current run from images that were removed from the snapshot suite. SnapshotPreviews provides the image-name manifest; Sentry uses that manifest to treat listed-but-missing images as skipped rather than removed.

**Workflow Constraints**

The page documents the constraints users need to account for:

- name generation and image rendering are separate, mutually exclusive SnapshotPreviews modes;
- manifest generation must run once per participating `SnapshotTest` group;
- CI is responsible for merging the per-group manifest files before upload;
- inclusion filters define selectable groups;
- exclusion filters remove snapshots from the tracked set entirely.

**Examples**

The examples use placeholder project, scheme, and test class names so readers can adapt the workflow to their own app. The page links to the SnapshotPreviews MultiModuleDemo workflow as a complete reference implementation.

Refs EME-1182