### PR TITLE
fix(develop): Clarify `add_feature_flag` API value type requirements

### DIFF
--- a/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
+++ b/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
@@ -8,7 +8,7 @@ spec_depends_on:
   - id: sdk/foundations/client/integrations
     version: ">=1.0.0"
 spec_changelog:
-  - version 1.0.1
+  - version: 1.0.1
     date: 2026-06-05
     summary: Fixed `add_feature_flag` API specifying unsupported feature flag value types
   - version: 1.0.0

--- a/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
+++ b/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
@@ -2,7 +2,7 @@
 title: Feature Flags
 description: Guidelines for tracking feature flag evaluations — scope storage, span attributes, the add_feature_flag API, and third-party integrations.
 spec_id: sdk/foundations/client/integrations/feature-flags
-spec_version: 1.0.0
+spec_version: 1.0.1
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/client/integrations

--- a/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
+++ b/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
@@ -8,6 +8,9 @@ spec_depends_on:
   - id: sdk/foundations/client/integrations
     version: ">=1.0.0"
 spec_changelog:
+  - version 1.0.1
+    date: 2026-06-05
+    summary: Fixed `add_feature_flag` API specifying unsupported feature flag value types
   - version: 1.0.0
     date: 2025-02-24
     summary: Initial spec, extracted from expected features
@@ -40,7 +43,7 @@ When tracking on error feature flag evaluations, we record the 100 most recent, 
 
 ### The `add_feature_flag` API
 
-If an SDK supports feature flags it must expose a function `add_feature_flag` which has similar behavior to the `set_tag` function. It must accept a key of type string and a value which is a union of string, boolean, integer, float, and structure.
+If an SDK supports feature flags it MUST expose a function `add_feature_flag` which has similar behavior to the `set_tag` function. It MUST accept a key of type string and a value of type `boolean`. Non-boolean values MUST be rejected.
 
 </SpecSection>
 


### PR DESCRIPTION

## DESCRIBE YOUR PR

Update the `add_feature_flag` API documentation to specify that only boolean values are accepted.

Looks like the initial spec was too broad, as our product currently only supports boolean feature flags.
This was raised in https://github.com/getsentry/sentry-javascript/issues/21157.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
