### PR TITLE
fix(md-exports): Return 200 for agent not-found pages so the body survives

### DIFF
--- a/app/md-exports/[...path]/route.test.ts
+++ b/app/md-exports/[...path]/route.test.ts
@@ -61,9 +61,18 @@ describe('md-exports 404 catch-all route', () => {
     return GET(request, {params: Promise.resolve({path: pathSegments})});
   }
 
-  it('returns 404 status', async () => {
+  // Intentionally 200, not 404: agent fetchers (e.g. Claude Code's WebFetch) drop the
+  // response body on non-2xx, which would strip the helpful not-found content. The
+  // not-found signal lives in the body and the X-Sentry-Docs-Not-Found header instead.
+  it('returns 200 status so agent fetchers keep the body', async () => {
     const res = await callRoute(['platforms', 'javascript', 'ai-monitoring.md']);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+  });
+
+  it('marks the soft miss with noindex and a not-found header', async () => {
+    const res = await callRoute(['platforms', 'javascript', 'ai-monitoring.md']);
+    expect(res.headers.get('X-Robots-Tag')).toBe('noindex');
+    expect(res.headers.get('X-Sentry-Docs-Not-Found')).toBe('1');
   });
 
   it('returns text/markdown content type', async () => {
@@ -117,7 +126,7 @@ describe('md-exports 404 catch-all route', () => {
     vi.mocked(readFile).mockRejectedValue(new Error('file not found'));
     const res = await callRoute(['platforms', 'javascript', 'foo.md']);
     const body = await res.text();
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
     expect(body).toContain('Page Not Found');
     expect(body).toContain('llms.txt');
   });

--- a/app/md-exports/[...path]/route.test.ts
+++ b/app/md-exports/[...path]/route.test.ts
@@ -6,6 +6,16 @@ vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
 }));
 
+// Stable mock fn (via vi.hoisted) so assertions survive the vi.resetModules() in
+// beforeEach, which otherwise re-runs the mock factory with a fresh spy.
+const {metricsCount} = vi.hoisted(() => ({
+  metricsCount: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  metrics: {count: metricsCount},
+}));
+
 const SAMPLE_DOCTREE = {
   path: '',
   slug: '',
@@ -52,12 +62,15 @@ const SAMPLE_DOCTREE = {
 describe('md-exports 404 catch-all route', () => {
   beforeEach(() => {
     vi.resetModules();
+    metricsCount.mockClear();
     vi.mocked(readFile).mockResolvedValue(JSON.stringify(SAMPLE_DOCTREE));
   });
 
-  async function callRoute(pathSegments: string[]) {
+  async function callRoute(pathSegments: string[], userAgent?: string) {
     const {GET} = await import('./route');
-    const request = new Request('https://docs.sentry.io/test');
+    const request = new Request('https://docs.sentry.io/test', {
+      headers: userAgent ? {'user-agent': userAgent} : {},
+    });
     return GET(request, {params: Promise.resolve({path: pathSegments})});
   }
 
@@ -137,5 +150,32 @@ describe('md-exports 404 catch-all route', () => {
     expect(body).toMatch(/^---\n/);
     expect(body).toContain('title: "Page Not Found"');
     expect(body).toContain('url: "https://docs.sentry.io/platforms/javascript/foo"');
+  });
+
+  it('emits a not-found metric with the full path and normalized agent', async () => {
+    await callRoute(
+      ['platforms', 'javascript', 'made', 'up', 'page.md'],
+      'Claude-User (claude-code/2.1.165; +https://support.anthropic.com/)'
+    );
+    expect(metricsCount).toHaveBeenCalledWith(
+      'docs.md_export.not_found',
+      1,
+      expect.objectContaining({
+        attributes: {
+          requested_path: 'platforms/javascript/made/up/page',
+          has_suggestions: true,
+          agent: 'claude',
+        },
+      })
+    );
+  });
+
+  it('falls back to "other" for unrecognized agents', async () => {
+    await callRoute(['platforms', 'javascript', 'foo.md'], 'Mozilla/5.0');
+    expect(metricsCount).toHaveBeenCalledWith(
+      'docs.md_export.not_found',
+      1,
+      expect.objectContaining({attributes: expect.objectContaining({agent: 'other'})})
+    );
   });
 });

--- a/app/md-exports/[...path]/route.ts
+++ b/app/md-exports/[...path]/route.ts
@@ -126,11 +126,21 @@ export async function GET(
     ].join('\n');
   }
 
+  // Return 200 (not 404) on purpose. This route serves a Markdown "page not found"
+  // helper that links to real nearby pages so AI agents can self-correct. Many agent
+  // fetchers — including Claude Code's WebFetch (User-Agent "Claude-User") — discard the
+  // response body on any non-2xx status, so a 404 strips exactly the recovery content we
+  // want agents to read, leaving them with "0 bytes". The not-found signal is preserved
+  // in the body ("# Page Not Found"); we mark the response noindex so crawlers don't
+  // treat it as real content, and expose X-Sentry-Docs-Not-Found so monitoring can still
+  // distinguish these soft misses from genuine hits.
   return new Response(body, {
-    status: 404,
+    status: 200,
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
       'Cache-Control': 'public, max-age=300',
+      'X-Robots-Tag': 'noindex',
+      'X-Sentry-Docs-Not-Found': '1',
     },
   });
 }

--- a/app/md-exports/[...path]/route.ts
+++ b/app/md-exports/[...path]/route.ts
@@ -2,6 +2,8 @@ import {readFile} from 'node:fs/promises';
 import {join} from 'node:path';
 
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
+import {AI_AGENT_PATTERN, matchPattern} from 'sentry-docs/lib/trafficClassification';
+import {DocMetrics} from 'sentry-docs/metrics';
 
 interface DocTreeNode {
   path: string;
@@ -65,13 +67,14 @@ function renderSiblingList(siblings: DocTreeNode[], baseUrl: string): string {
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   {params}: {params: Promise<{path: string[]}>}
 ) {
   const {path: pathSegments} = await params;
   const requestedPath = pathSegments.join('/').replace(/\.md$/, '');
 
   let body: string;
+  let hasSuggestions = false;
 
   try {
     const tree = await getDocTree();
@@ -90,6 +93,7 @@ export async function GET(
     ];
 
     if (ancestor && ancestor.children?.length) {
+      hasSuggestions = true;
       const ancestorTitle =
         ancestor.frontmatter?.title || ancestor.slug || 'this section';
       lines.push(`## Pages in ${ancestorTitle}`);
@@ -125,6 +129,15 @@ export async function GET(
       '',
     ].join('\n');
   }
+
+  // Normalize the agent to a low-cardinality name (e.g. "claude", "gptbot") rather
+  // than the raw User-Agent, matching the convention in tracesSampler.ts.
+  const agent =
+    matchPattern(request.headers.get('user-agent') ?? '', AI_AGENT_PATTERN) ?? 'other';
+
+  // Track the full invented URL by agent so we can see which agents make up which
+  // pages most (and whether the soft-404 had suggestions to offer them).
+  DocMetrics.mdExportNotFound(requestedPath.split('/'), hasSuggestions, agent);
 
   // Return 200 (not 404) on purpose. This route serves a Markdown "page not found"
   // helper that links to real nearby pages so AI agents can self-correct. Many agent

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -79,6 +79,31 @@ export const DocMetrics = {
   },
 
   /**
+   * Track requests for Markdown exports that don't exist (agent-facing `.md` route).
+   *
+   * These are almost entirely AI agents guessing URLs. The route returns a soft-404
+   * helper with suggestions so the agent can recover; this metric surfaces exactly
+   * which URLs agents invent most, broken down by agent, plus whether recovery
+   * suggestions were available.
+   *
+   * The full path is intentional here (and safe): metrics are EAP-backed, so
+   * high-cardinality attributes are fine, and an agent-invented not-found path is a
+   * public docs-namespace path, not user PII — unlike the truncation other metrics use.
+   * @param path - Full requested path segments (the invented URL is the signal)
+   * @param hasSuggestions - Whether sibling/section suggestions were returned
+   * @param agent - Normalized agent name (e.g. "claude", "gptbot"), or "other"
+   */
+  mdExportNotFound: (path: string[], hasSuggestions: boolean, agent: string) => {
+    Sentry.metrics.count('docs.md_export.not_found', 1, {
+      attributes: {
+        requested_path: path.join('/'),
+        has_suggestions: hasSuggestions,
+        agent,
+      },
+    });
+  },
+
+  /**
    * Track search queries with zero results (indicates content gaps)
    * @param queryLength - Length of the search query
    * @param attributes - Additional context


### PR DESCRIPTION
The `.md` catch-all (`app/md-exports/[...path]/route.ts`) serves a Markdown "page not found" helper that links to real nearby pages so AI agents can recover from a wrong URL. It was returned as HTTP 404 — but agent fetchers, including Claude Code's WebFetch (User-Agent `Claude-User`), **discard the response body on any non-2xx status**. The agent received "0 bytes" instead of the recovery content, so a guessed URL became a dead end even though the server had useful Markdown to hand back.

This returns the helper with HTTP `200` so the body reaches the agent, and adds a metric so we can see which agents invent which URLs.

**Behavior change**

Before/after for a non-existent page fetched as Markdown (e.g. `/platforms/javascript/guides/vercel-edge.md`):

```text
Before:  404  text/markdown  (agent fetchers drop the body -> "0 bytes")
After:   200  text/markdown  X-Robots-Tag: noindex  X-Sentry-Docs-Not-Found: 1
```

The body is unchanged — same "Page Not Found" heading and the same list of real sibling pages.

**Not-found is still detectable**

`X-Robots-Tag: noindex` keeps crawlers from treating the soft-200 as real content, and `X-Sentry-Docs-Not-Found: 1` lets monitoring distinguish these soft misses from genuine hits even though the status is now 200. This only affects the agent-facing `.md` route; the HTML route still returns a true 404.

**Metric: which agents make up which URLs**

Adds `DocMetrics.mdExportNotFound` → emits `docs.md_export.not_found` with attributes:

- `requested_path` — the **full** invented path (the signal we want). Kept in full because trace metrics are EAP-backed (high cardinality is fine) and an agent-invented docs path isn't PII.
- `agent` — normalized agent name (`claude`, `gptbot`, …) via the same `matchPattern(ua, AI_AGENT_PATTERN)` convention used in `tracesSampler.ts`; `other` when unmatched.
- `has_suggestions` — whether the soft-404 had sibling pages to offer.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+