### PR TITLE
fix(sdk,python): clarify ignoring loggers

### DIFF
--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -178,6 +178,13 @@ logger.error("hi")  # no error sent to sentry
 You can also use `before-send` and `before-breadcrumb` to ignore
 only certain messages. See <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink> for more information.
 
+<Alert level="success" title="Tip: Ignoring a logger when collecting logs to Sentry">
+
+Using `ignore_logger` removes the entries from specified logger **only** for breadcrumbs and events.
+If you **do not** wish to collect logs from the specified logger altogether, use also `ignore_logger_for_sentry_logs`.
+
+</Alert>
+
 ## Handler classes
 
 Instead of using `LoggingIntegration`, you can use two regular logging `logging.Handler` subclasses that the integration exports.

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -178,7 +178,7 @@ logger.error("hi")  # no error sent to sentry
 You can also use `before-send` and `before-breadcrumb` to ignore
 only certain messages. See <PlatformLink to="/configuration/filtering/">Filtering Events</PlatformLink> for more information.
 
-<Alert level="success" title="Tip: Ignoring a logger when collecting logs to Sentry">
+<Alert level="info" title="Tip: Ignoring a logger when collecting logs to Sentry">
 
 Using `ignore_logger` removes the entries from specified logger **only** for breadcrumbs and events.
 If you **do not** wish to collect logs from the specified logger altogether, use also `ignore_logger_for_sentry_logs`.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add an alert with a tip for ignoring loggers altogether when using the Sentry logs collection. Using only the `ignore_logger` results in behaviour that is described in the docstrings, but not in the official docs themselves which has surprised me at first.

Therefore add a more comprehensive explanation to the docs that are the “first hit” when setting up the Sentry.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
