### PR TITLE
docs(search): Add auth token search keyword

### DIFF
--- a/docs/account/auth-tokens/index.mdx
+++ b/docs/account/auth-tokens/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Auth Tokens
+keywords: ["SENTRY_AUTH_TOKEN"]
 sidebar_order: 45
 description: >-
   Learn about the different kinds of Auth Tokens Sentry provides, and when to


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds `SENTRY_AUTH_TOKEN` as a search keyword for the Auth Tokens docs page so docs search can match the environment variable users paste into Command+K.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)