### PR TITLE
fix(docs): Fix visual spacing bug in Apple install alert

### DIFF
--- a/docs/platforms/apple/common/install/index.mdx
+++ b/docs/platforms/apple/common/install/index.mdx
@@ -14,12 +14,7 @@ This will patch your project and configure the SDK. You'll only need to patch th
 If you prefer, you can choose one of the alternative methods below.
 
 <Alert level="info">
-  If your project uses Objective-C++ or can't enable Clang modules, see the{" "}
-  <PlatformLink to="/install/swift-package-manager/#sentryobjc">
-    SentryObjC
-  </PlatformLink>{" "}
-  section for a pure Objective-C integration that doesn't require Swift headers
-  or semantic imports (`@import`).
+  If your project uses Objective-C++ or can't enable Clang modules, see the <PlatformLink to="/install/swift-package-manager/#sentryobjc">SentryObjC</PlatformLink> section for a pure Objective-C integration that doesn't require Swift headers or semantic imports (`@import`).
 </Alert>
 
 <PageGrid />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## DESCRIBE YOUR PR

Fixes a visual spacing bug in the alert on the Apple installation methods page (`docs/platforms/apple/common/install/index.mdx`).

**Problem:** The alert had extra whitespace appearing around the `PlatformLink` component, making the text look broken/spaced incorrectly.

**Root Cause:** MDX was preserving newlines and indentation within the JSX element. When the link text was on a separate line with indentation, it rendered as actual whitespace in the output.

**Solution:** Changed the `PlatformLink` to inline formatting, matching the pattern used successfully in `cocoapods.mdx` and other files.

### Before/After

| Before | After |
|--------|-------|
| <img width="955" height="162" alt="image" src="https://github.com/user-attachments/assets/f165b1ef-787b-4f49-90f2-f68d6dd906f1" /> [Link](https://docs.sentry.io/platforms/apple/install/) | <img width="959" height="105" alt="Screenshot 2026-06-09 at 09 54 15" src="https://github.com/user-attachments/assets/b4e93236-f541-4f1e-a3b2-49f3d54231d5" /> [Link](https://sentry-docs-git-cursor-fix-apple-install-alert-spacing-4579.sentry.dev/platforms/apple/install/) |

## IS YOUR CHANGE URGENT?  

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/D0AKE11RWSC/p1780990097856769?thread_ts=1780990097.856769&cid=D0AKE11RWSC)

<div><a href="https://cursor.com/agents/bc-5dad39bd-4ff9-54e3-a7da-f9ab412c4579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dad39bd-4ff9-54e3-a7da-f9ab412c4579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

