### PR TITLE
feat(api): derive reference title and slug from summary

### DIFF
--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -130,8 +130,12 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
 
   Object.entries(data.paths).forEach(([apiPath, methods]) => {
     Object.entries(methods).forEach(([method, apiData]) => {
+      // Detect deprecation from either field independently — the (DEPRECATED)
+      // marker may sit on operationId even when a summary is present.
+      const isDeprecated =
+        isDeprecatedOperationId(apiData.operationId) ||
+        isDeprecatedOperationId(apiData.summary);
       const titleSource = apiData.summary || apiData.operationId || '';
-      const isDeprecated = isDeprecatedOperationId(titleSource);
       const cleanName = stripDeprecatedPrefix(titleSource);
 
       let server = 'https://sentry.io';

--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -150,7 +150,9 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
           deprecated: isDeprecated,
           server,
           slug: slugify(cleanName),
-          summary: apiData.summary,
+          summary: apiData.summary
+            ? stripDeprecatedPrefix(apiData.summary)
+            : apiData.summary,
           descriptionMarkdown: apiData.description,
           pathParameters: (apiData.parameters || []).filter(
             p => p.in === 'path'

--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -130,12 +130,6 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
 
   Object.entries(data.paths).forEach(([apiPath, methods]) => {
     Object.entries(methods).forEach(([method, apiData]) => {
-      // Prefer the human-readable `summary` for the rendered title and the URL
-      // slug, falling back to `operationId`. This lets the backend use
-      // `operationId` as a proper machine token (e.g. `addProjectTeam`) without
-      // changing titles or — SEO-critical — slugs, since `summary` carries the
-      // original sentence. The deprecation prefix is detected/stripped from
-      // whichever source wins, so deprecated endpoints keep their exact slug too.
       const titleSource = apiData.summary || apiData.operationId || '';
       const isDeprecated = isDeprecatedOperationId(titleSource);
       const cleanName = stripDeprecatedPrefix(titleSource);

--- a/src/build/resolveOpenAPI.ts
+++ b/src/build/resolveOpenAPI.ts
@@ -130,8 +130,15 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
 
   Object.entries(data.paths).forEach(([apiPath, methods]) => {
     Object.entries(methods).forEach(([method, apiData]) => {
-      const isDeprecated = isDeprecatedOperationId(apiData.operationId);
-      const cleanOperationId = stripDeprecatedPrefix(apiData.operationId ?? '');
+      // Prefer the human-readable `summary` for the rendered title and the URL
+      // slug, falling back to `operationId`. This lets the backend use
+      // `operationId` as a proper machine token (e.g. `addProjectTeam`) without
+      // changing titles or — SEO-critical — slugs, since `summary` carries the
+      // original sentence. The deprecation prefix is detected/stripped from
+      // whichever source wins, so deprecated endpoints keep their exact slug too.
+      const titleSource = apiData.summary || apiData.operationId || '';
+      const isDeprecated = isDeprecatedOperationId(titleSource);
+      const cleanName = stripDeprecatedPrefix(titleSource);
 
       let server = 'https://sentry.io';
       if (apiData.servers && apiData.servers[0]) {
@@ -141,10 +148,10 @@ async function apiCategoriesUncached(): Promise<APICategory[]> {
         categoryMap[tag].apis.push({
           apiPath,
           method,
-          name: cleanOperationId,
+          name: cleanName,
           deprecated: isDeprecated,
           server,
-          slug: slugify(cleanOperationId),
+          slug: slugify(cleanName),
           summary: apiData.summary,
           descriptionMarkdown: apiData.description,
           pathParameters: (apiData.parameters || []).filter(

--- a/src/components/apiPage/index.tsx
+++ b/src/components/apiPage/index.tsx
@@ -137,7 +137,7 @@ export function ApiPage({api}: Props) {
       </div>
       <div className="flex flex-col md:flex-row gap-4">
         <div className="w-full md:w-1/2">
-          {api.summary && <p>{api.summary}</p>}
+          {api.summary && api.summary !== api.name && <p>{api.summary}</p>}
 
           {api.descriptionMarkdown && parseMarkdown(api.descriptionMarkdown)}
 


### PR DESCRIPTION
## Summary

Part of using OpenAPI `operationId` as a proper machine identifier (token) instead of a human sentence. Today the API reference renders the `operationId` as the page title **and** builds the URL slug from it (`slugify(operationId)`), so the misuse is load-bearing for our SEO'd doc URLs.

This makes the reference prefer the human-readable `summary` for both the title and the slug, falling back to `operationId`. It's a **no-op today** (no operations define `summary` yet → falls back to `operationId`, current behavior). Once the backend sets `summary` = the original sentence and `operationId` = a camelCase token, titles and slugs stay **byte-identical** while the operationId becomes a clean token.

Deprecation is encoded as a `(DEPRECATED) ` prefix in the operationId; the strip/detect logic now runs on whichever source wins (`summary || operationId`), so deprecated endpoints keep their exact slug and title too.

## Changes
- `resolveOpenAPI.ts`: title (`name`) and `slug` derive from `summary || operationId`.
- `apiPage`: don't render the summary `<p>` when it already equals the title.

## Test plan
- `pnpm lint:ts` clean for the changed files (pre-existing `instrumentation*.ts` SDK-version errors are unrelated).
- No operation currently defines `summary`, so rendered titles and slugs are unchanged. Verified the slug stays identical once `summary` = the original sentence, since `slugify` runs on the same stripped string.

This is the SEO-foundation PR; the backend operationId→token + summary migration depends on it landing first.