### PR TITLE
docs(agent-monitoring): Mention conversation IDs in setup

### DIFF
--- a/docs/ai/monitoring/agents/getting-started.mdx
+++ b/docs/ai/monitoring/agents/getting-started.mdx
@@ -20,6 +20,8 @@ keywords:
 
 Sentry AI Agent Monitoring helps you track and debug AI agent applications using our supported SDKs and integrations. Monitor your complete agent workflows from user interaction to final response, including tool calls, model interactions, and custom logic.
 
+To use [Conversations](/ai/monitoring/conversations/), set a conversation ID for each chat. Sentry uses the `gen_ai.conversation.id` attribute to group related AI spans, and some SDK integrations set it automatically.
+
 To start sending AI agent data to Sentry, make sure you've created a Sentry project for your AI-enabled repository and follow one of the guides below:
 
 - [Python](/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module)


### PR DESCRIPTION
Add the conversation ID prerequisite to the top-level AI Agent Monitoring getting-started page.

This makes the Conversations dependency visible before users branch into platform-specific setup docs.

Refs TET-2442