### PR TITLE
docs(tanstackstart-react): Initialize Sentry from a dedicated client init file

### DIFF
--- a/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
@@ -81,16 +81,13 @@ pnpm add @sentry/tanstackstart-react
 <SplitSection>
 <SplitSectionText>
 
-Initialize Sentry in your [client entry point](https://tanstack.com/start/latest/docs/framework/react/guide/client-entry-point) `src/client.tsx`:
+Create an `instrument.client.ts` file in your `src/` directory and initialize Sentry in it.
 
 </SplitSectionText>
 <SplitSectionCode>
 
-```tsx {filename:src/client.tsx}
+```tsx {filename:src/instrument.client.ts}
 import * as Sentry from "@sentry/tanstackstart-react";
-import { StartClient } from "@tanstack/react-start/client";
-import { StrictMode, startTransition } from "react";
-import { hydrateRoot } from "react-dom/client";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -132,6 +129,26 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
 });
+```
+
+</SplitSectionCode>
+</SplitSection>
+
+<SplitSection>
+<SplitSectionText>
+
+Then import this file as the **first import** in your [client entry point](https://tanstack.com/start/latest/docs/framework/react/guide/client-entry-point) `src/client.tsx`. This ensures Sentry initializes before any other code runs, so errors and events before hydration are captured.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```tsx {filename:src/client.tsx}
+// Sentry initialization should be imported first!
+import "./instrument.client";
+
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
 
 startTransition(() => {
   hydrateRoot(


### PR DESCRIPTION
Moves the client `Sentry.init()` into a dedicated `src/instrument.client.ts` file that is imported first in the client entry point. Importing it first ensures Sentry initializes before any other import's side effects (and before hydration).

SDK PR: getsentry/sentry-javascript#21397