### PR TITLE
docs(azure-devops): correct auth mechanism from PAT to OAuth

### DIFF
--- a/docs/integrations/source-code-mgmt/azure-devops/index.mdx
+++ b/docs/integrations/source-code-mgmt/azure-devops/index.mdx
@@ -16,7 +16,7 @@ Azure DevOps was formerly known as Visual Studio Team Services (VSTS).
   We recommend creating a dedicated service account on Azure DevOps when installing this integration rather than using a personal user account.
   </p>
   <p>
-  Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the Azure DevOps user who created the tokens.
+  Since the integration authenticates via OAuth, activities such as comments and work item creation will be attributed to the Azure DevOps user who authorized the integration.
   </p>
   <p>
   Using a service account helps maintain proper access control, prevents disruption when team members leave, and ensures consistent attribution for all features across your organization.


### PR DESCRIPTION
The install note incorrectly states the integration uses personal access tokens. It actually authenticates via OAuth — the bearer token stored at install time is the OAuth access token from whoever authorized the integration, not a PAT.

The attribution behavior (actions attributed to the authorizing user) is unchanged; only the mechanism description is corrected.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3ACD4NYFD34%3A1780965528.550929%22)