### PR TITLE
feat: Add inline 'Copy Prompt' button to platform links on getting-started pages

### DIFF
--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -14,6 +14,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.browser"
     label="Browser JavaScript"
     url="/platforms/javascript/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.angular"
@@ -44,6 +45,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.cloudflare"
     label="Cloudflare"
     url="/platforms/javascript/guides/cloudflare/logs/"
+    skill="sentry-cloudflare-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.connect"
@@ -99,16 +101,19 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.nestjs"
     label="Nest.js"
     url="/platforms/javascript/guides/nestjs/logs/"
+    skill="sentry-nestjs-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.node"
     label="Node.js"
     url="/platforms/javascript/guides/node/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nextjs"
     label="Next.js"
     url="/platforms/javascript/guides/nextjs/logs/"
+    skill="sentry-nextjs-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nuxt"
@@ -119,11 +124,13 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.react"
     label="React"
     url="/platforms/javascript/guides/react/logs/"
+    skill="sentry-react-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.react-router"
     label="React Router"
     url="/platforms/javascript/guides/react-router/logs/"
+    skill="sentry-react-router-framework-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.remix"
@@ -144,16 +151,19 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.svelte"
     label="Svelte"
     url="/platforms/javascript/guides/svelte/logs/"
+    skill="sentry-svelte-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.sveltekit"
     label="SvelteKit"
     url="/platforms/javascript/guides/sveltekit/logs/"
+    skill="sentry-svelte-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.tanstackstart-react"
     label="TanStack Start"
     url="/platforms/javascript/guides/tanstackstart-react/logs/"
+    skill="sentry-tanstack-start-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.vue"
@@ -190,11 +200,13 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="android"
     label="Android"
     url="/platforms/android/logs/"
+    skill="sentry-android-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple"
     label="Apple"
     url="/platforms/apple/logs/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="capacitor"
@@ -205,16 +217,18 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="dart.flutter"
     label="Flutter"
     url="/platforms/dart/guides/flutter/logs/"
+    skill="sentry-flutter-sdk"
   />
 - <LinkWithPlatformIcon
     platform="react-native"
     label="React Native"
     url="/platforms/react-native/logs/"
+    skill="sentry-react-native-sdk"
   />
 
 ### PHP
 
-- <LinkWithPlatformIcon platform="php" label="PHP" url="/platforms/php/logs/" />
+- <LinkWithPlatformIcon platform="php" label="PHP" url="/platforms/php/logs/" skill="sentry-php-sdk" />
 - <LinkWithPlatformIcon
     platform="php.symfony"
     label="Symfony"
@@ -232,6 +246,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="python"
     label="Python"
     url="/platforms/python/logs/"
+    skill="sentry-python-sdk"
   />
 
 ### Ruby
@@ -240,6 +255,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="ruby"
     label="Ruby"
     url="/platforms/ruby/logs/"
+    skill="sentry-ruby-sdk"
   />
 - <LinkWithPlatformIcon
     platform="ruby.rails"
@@ -249,7 +265,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
 
 ### Go
 
-- <LinkWithPlatformIcon platform="go" label="Go" url="/platforms/go/logs/" />
+- <LinkWithPlatformIcon platform="go" label="Go" url="/platforms/go/logs/" skill="sentry-go-sdk" />
 
 ### Rust
 
@@ -265,6 +281,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="dotnet"
     label=".NET"
     url="/platforms/dotnet/logs/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.aspnetcore"

--- a/src/components/agentSkillsCallout/index.tsx
+++ b/src/components/agentSkillsCallout/index.tsx
@@ -9,10 +9,8 @@ import {DocMetrics} from 'sentry-docs/metrics';
 
 import {CodeBlock} from '../codeBlock';
 import {CodeTabs} from '../codeTabs';
+import {buildDotagentsCommand, buildNpxSkillsCommand, buildPrompt} from './shared';
 import styles from './style.module.scss';
-
-const SKILLS_BASE_URL = 'https://skills.sentry.dev';
-const SKILLS_REPO = 'getsentry/sentry-for-ai';
 
 type Props = {
   /** Display name for the platform, e.g. "Next.js", "Python". Omit for generic. */
@@ -20,32 +18,6 @@ type Props = {
   /** Skill package name, e.g. "sentry-nextjs-sdk". Omit for generic/all skills. */
   skill?: string;
 };
-
-function buildPromptUrl(skill?: string): string {
-  if (!skill) {
-    return SKILLS_BASE_URL + '/';
-  }
-  return `${SKILLS_BASE_URL}/${skill}/SKILL.md`;
-}
-
-function buildPrompt(skill?: string): string {
-  const url = buildPromptUrl(skill);
-  return `Use curl to download, read and follow: ${url}`;
-}
-
-function buildDotagentsCommand(skill?: string): string {
-  if (!skill) {
-    return `npx @sentry/dotagents add ${SKILLS_REPO} --all`;
-  }
-  return `npx @sentry/dotagents add ${SKILLS_REPO} --name ${skill}`;
-}
-
-function buildNpxSkillsCommand(skill?: string): string {
-  if (!skill) {
-    return `npx skills add ${SKILLS_REPO}`;
-  }
-  return `npx skills add ${SKILLS_REPO} --skill ${skill}`;
-}
 
 export function AgentSkillsCallout({skill, platformName}: Props) {
   const [copied, setCopied] = useState(false);

--- a/src/components/agentSkillsCallout/shared.ts
+++ b/src/components/agentSkillsCallout/shared.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared constants and utilities for agent skills prompt building.
+ * Used by AgentSkillsCallout (full banner) and inline copy-prompt buttons.
+ */
+
+export const SKILLS_BASE_URL = 'https://skills.sentry.dev';
+export const SKILLS_REPO = 'getsentry/sentry-for-ai';
+
+export function buildPromptUrl(skill?: string): string {
+  if (!skill) {
+    return SKILLS_BASE_URL + '/';
+  }
+  return `${SKILLS_BASE_URL}/${skill}/SKILL.md`;
+}
+
+export function buildPrompt(skill?: string): string {
+  const url = buildPromptUrl(skill);
+  return `Use curl to download, read and follow: ${url}`;
+}
+
+export function buildDotagentsCommand(skill?: string): string {
+  if (!skill) {
+    return `npx @sentry/dotagents add ${SKILLS_REPO} --all`;
+  }
+  return `npx @sentry/dotagents add ${SKILLS_REPO} --name ${skill}`;
+}
+
+export function buildNpxSkillsCommand(skill?: string): string {
+  if (!skill) {
+    return `npx skills add ${SKILLS_REPO}`;
+  }
+  return `npx skills add ${SKILLS_REPO} --skill ${skill}`;
+}

--- a/src/components/copyPromptButton/index.tsx
+++ b/src/components/copyPromptButton/index.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import * as Tooltip from '@radix-ui/react-tooltip';
+import {Theme} from '@radix-ui/themes';
+import * as Sentry from '@sentry/nextjs';
+import {useTheme} from 'next-themes';
+import {useCallback, useMemo, useState} from 'react';
+import {usePlausibleEvent} from 'sentry-docs/hooks/usePlausibleEvent';
+import {DocMetrics} from 'sentry-docs/metrics';
+
+import {buildPrompt} from '../agentSkillsCallout/shared';
+import styles from './style.module.scss';
+
+type Props = {
+  /** Skill package name, e.g. "sentry-nextjs-sdk". */
+  skill: string;
+};
+
+export function CopyPromptButton({skill}: Props) {
+  const [copied, setCopied] = useState(false);
+  const {emit} = usePlausibleEvent();
+  const {resolvedTheme} = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const prompt = buildPrompt(skill);
+
+  /**
+   * Tooltip styles matching the onboarding tooltip pattern.
+   * Inline styles are required because Radix portals the tooltip to document.body,
+   * outside the Theme wrapper, so CSS module classes don't reliably apply.
+   */
+  const tooltipContentStyle: React.CSSProperties = useMemo(
+    () => ({
+      borderRadius: '4px',
+      padding: '8px 12px',
+      fontSize: '12px',
+      lineHeight: 1.2,
+      textAlign: 'center' as const,
+      color: isDark ? 'var(--foreground)' : 'var(--gray-11)',
+      backgroundColor: isDark ? 'var(--gray-4)' : 'white',
+      boxShadow: '0px 4px 16px 0px rgba(31, 22, 51, 0.1)',
+      zIndex: 9999,
+      position: 'relative' as const,
+      pointerEvents: 'none' as const,
+      userSelect: 'none' as const,
+      whiteSpace: 'nowrap' as const,
+      animationDuration: '100ms',
+      animationTimingFunction: 'ease-in',
+    }),
+    [isDark]
+  );
+
+  const tooltipArrowStyle: React.CSSProperties = useMemo(
+    () => ({
+      fill: isDark ? 'var(--gray-4)' : 'white',
+    }),
+    [isDark]
+  );
+
+  const copyPrompt = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+
+      emit('Copy AI Prompt', {
+        props: {page: window.location.pathname, title: 'Inline Platform Link'},
+      });
+
+      try {
+        setCopied(false);
+        await navigator.clipboard.writeText(prompt);
+        setCopied(true);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch (error) {
+        Sentry.captureException(error);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, false);
+        setCopied(false);
+      }
+    },
+    [prompt, emit, skill]
+  );
+
+  return (
+    <span className={styles.wrapper}>
+      <span className={styles.divider}>|</span>
+      <Tooltip.Provider delayDuration={200}>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              className={styles.button}
+              onClick={copyPrompt}
+              type="button"
+              aria-label="Copy setup prompt for AI agents"
+            >
+              <CopyIcon />
+              <span className={styles.label}>{copied ? 'Copied!' : 'Copy Prompt'}</span>
+            </button>
+          </Tooltip.Trigger>
+          {!copied && (
+            <Tooltip.Portal>
+              <Theme accentColor="iris">
+                <Tooltip.Content style={tooltipContentStyle} sideOffset={6}>
+                  Copy setup prompt for AI agents
+                  <Tooltip.Arrow style={tooltipArrowStyle} />
+                </Tooltip.Content>
+              </Theme>
+            </Tooltip.Portal>
+          )}
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </span>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}

--- a/src/components/copyPromptButton/style.module.scss
+++ b/src/components/copyPromptButton/style.module.scss
@@ -1,0 +1,70 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+
+.divider {
+  color: var(--gray-200);
+  font-size: 0.85rem;
+  margin-right: 0.4rem;
+  user-select: none;
+}
+
+:global(.dark) .divider {
+  color: var(--gray-600);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--accent-purple), transparent 60%);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent-purple), transparent 92%);
+  color: var(--accent-purple);
+  font-size: 0.72rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 150ms,
+    border-color 150ms;
+  line-height: 1.4;
+
+  &:hover {
+    background: color-mix(in srgb, var(--accent-purple), transparent 82%);
+    border-color: color-mix(in srgb, var(--accent-purple), transparent 40%);
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--accent-purple), transparent 72%);
+  }
+}
+
+:global(.dark) .button {
+  background: color-mix(in srgb, var(--accent-purple), transparent 85%);
+  border-color: color-mix(in srgb, var(--accent-purple), transparent 50%);
+  color: var(--accent-purple-light, var(--accent-purple));
+
+  &:hover {
+    background: color-mix(in srgb, var(--accent-purple), transparent 75%);
+    border-color: color-mix(in srgb, var(--accent-purple), transparent 30%);
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--accent-purple), transparent 65%);
+  }
+}
+
+.label {
+  letter-spacing: 0.01em;
+}
+
+

--- a/src/components/linkWithPlatformIcon.tsx
+++ b/src/components/linkWithPlatformIcon.tsx
@@ -1,13 +1,16 @@
+import {CopyPromptButton} from './copyPromptButton';
 import {PlatformIcon} from './platformIcon';
 import {SmartLink} from './smartLink';
 
 type Props = {
   label?: string;
   platform?: string;
+  /** Agent skill name, e.g. "sentry-react-sdk". When provided, renders an inline "Agent Setup" copy-prompt button. */
+  skill?: string;
   url?: string;
 };
 
-export function LinkWithPlatformIcon({platform, label, url}: Props) {
+export function LinkWithPlatformIcon({platform, label, url, skill}: Props) {
   if (!platform) {
     return null;
   }
@@ -27,6 +30,7 @@ export function LinkWithPlatformIcon({platform, label, url}: Props) {
         />
         {label ?? platform}
       </SmartLink>
+      {skill && <CopyPromptButton skill={skill} />}
     </span>
   );
 }


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add an inline "Copy Prompt" button next to platform links on interstitial getting-started pages (starting with Logs). Platforms that have an associated agent-assisted setup skill now show a small purple button that copies the agent setup prompt to the clipboard, giving users immediate access to the AI agent prompt without needing to click through to the platform page first.

### What changed

- **`src/components/agentSkillsCallout/shared.ts`** (new): Extracted shared prompt-building utilities (`buildPrompt`, `buildPromptUrl`, `buildDotagentsCommand`, `buildNpxSkillsCommand`, constants) so both `AgentSkillsCallout` and the new `CopyPromptButton` reuse the same logic.

- **`src/components/copyPromptButton/`** (new): Client component that renders an inline "Copy Prompt" button with:
  - Clipboard copy of the agent setup prompt (e.g., `Use curl to download, read and follow: https://skills.sentry.dev/{skill}/SKILL.md`)
  - Radix tooltip ("Copy setup prompt for AI agents") matching the onboarding tooltip style
  - Plausible analytics + Sentry metrics tracking (reuses existing `Copy AI Prompt` event)
  - Light/dark mode support via `next-themes`
  - Hidden on mobile (< 768px)

- **`src/components/linkWithPlatformIcon.tsx`**: Added optional `skill` prop. When present, renders a `CopyPromptButton` inline after the platform link.

- **`src/components/agentSkillsCallout/index.tsx`**: Refactored to import from `shared.ts` instead of defining utilities locally. No behavioral change.

- **`docs/product/explore/logs/getting-started/index.mdx`**: Added `skill="..."` to 20 platform links that have corresponding agent skills (Browser JS, Cloudflare, Nest.js, Node.js, Next.js, React, React Router, Svelte, SvelteKit, TanStack Start, Android, Apple, Flutter, React Native, PHP, Python, Ruby, Go, .NET).

### How it looks

Platforms **with** a skill:
```
[React icon] React  |  [clipboard] Copy Prompt    ← hover shows tooltip
```

Platforms **without** a skill (unchanged):
```
[Angular icon] Angular
```

### Future work

- Apply same pattern to metrics and profiling getting-started pages
- Consider adding skills for more frameworks (Angular, Astro, Express, etc.)

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)