### PR TITLE
feat: Add inline 'Copy Prompt' button to platform links on getting-started pages

### DIFF
--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -20,6 +20,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.angular"
     label="Angular"
     url="/platforms/javascript/guides/angular/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.astro"
@@ -30,16 +31,19 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.aws-lambda"
     label="AWS Lambda"
     url="/platforms/javascript/guides/aws-lambda/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.azure-functions"
     label="Azure Functions"
     url="/platforms/javascript/guides/azure-functions/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.bun"
     label="Bun"
     url="/platforms/javascript/guides/bun/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.cloudflare"
@@ -51,6 +55,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.connect"
     label="Connect"
     url="/platforms/javascript/guides/connect/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.electron"
@@ -61,41 +66,49 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.ember"
     label="Ember"
     url="/platforms/javascript/guides/ember/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.express"
     label="Express"
     url="/platforms/javascript/guides/express/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.fastify"
     label="Fastify"
     url="/platforms/javascript/guides/fastify/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.gatsby"
     label="Gatsby"
     url="/platforms/javascript/guides/gatsby/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.gcp-functions"
     label="Google Cloud Functions"
     url="/platforms/javascript/guides/gcp-functions/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.hapi"
     label="Hapi"
     url="/platforms/javascript/guides/hapi/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.hono"
     label="Hono"
     url="/platforms/javascript/guides/hono/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.koa"
     label="Koa"
     url="/platforms/javascript/guides/koa/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nestjs"
@@ -141,6 +154,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.solid"
     label="Solid"
     url="/platforms/javascript/guides/solid/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.solidstart"
@@ -168,12 +182,14 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
 - <LinkWithPlatformIcon
     platform="javascript.vue"
     label="Vue"
+    skill="sentry-browser-sdk"
     url="/platforms/javascript/guides/vue/logs/"
   />
 - <LinkWithPlatformIcon
     platform="javascript.wasm"
     label="Wasm"
     url="/platforms/javascript/guides/wasm/logs/"
+    skill="sentry-browser-sdk"
   />
 
 ### Java

--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -14,6 +14,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.browser"
     label="Browser JavaScript"
     url="/platforms/javascript/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.angular"
@@ -44,6 +45,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.cloudflare"
     label="Cloudflare"
     url="/platforms/javascript/guides/cloudflare/logs/"
+    skill="sentry-cloudflare-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.connect"
@@ -99,16 +101,19 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.nestjs"
     label="Nest.js"
     url="/platforms/javascript/guides/nestjs/logs/"
+    skill="sentry-nestjs-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.node"
     label="Node.js"
     url="/platforms/javascript/guides/node/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nextjs"
     label="Next.js"
     url="/platforms/javascript/guides/nextjs/logs/"
+    skill="sentry-nextjs-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nuxt"
@@ -119,11 +124,13 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.react"
     label="React"
     url="/platforms/javascript/guides/react/logs/"
+    skill="sentry-react-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.react-router"
     label="React Router"
     url="/platforms/javascript/guides/react-router/logs/"
+    skill="sentry-react-router-framework-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.remix"
@@ -144,16 +151,19 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.svelte"
     label="Svelte"
     url="/platforms/javascript/guides/svelte/logs/"
+    skill="sentry-svelte-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.sveltekit"
     label="SvelteKit"
     url="/platforms/javascript/guides/sveltekit/logs/"
+    skill="sentry-svelte-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.tanstackstart-react"
     label="TanStack Start"
     url="/platforms/javascript/guides/tanstackstart-react/logs/"
+    skill="sentry-tanstack-start-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.vue"
@@ -190,11 +200,13 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="android"
     label="Android"
     url="/platforms/android/logs/"
+    skill="sentry-android-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple"
     label="Apple"
     url="/platforms/apple/logs/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="capacitor"
@@ -205,16 +217,18 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="dart.flutter"
     label="Flutter"
     url="/platforms/dart/guides/flutter/logs/"
+    skill="sentry-flutter-sdk"
   />
 - <LinkWithPlatformIcon
     platform="react-native"
     label="React Native"
     url="/platforms/react-native/logs/"
+    skill="sentry-react-native-sdk"
   />
 
 ### PHP
 
-- <LinkWithPlatformIcon platform="php" label="PHP" url="/platforms/php/logs/" />
+- <LinkWithPlatformIcon platform="php" label="PHP" url="/platforms/php/logs/" skill="sentry-php-sdk" />
 - <LinkWithPlatformIcon
     platform="php.symfony"
     label="Symfony"
@@ -232,6 +246,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="python"
     label="Python"
     url="/platforms/python/logs/"
+    skill="sentry-python-sdk"
   />
 
 ### Ruby
@@ -240,6 +255,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="ruby"
     label="Ruby"
     url="/platforms/ruby/logs/"
+    skill="sentry-ruby-sdk"
   />
 - <LinkWithPlatformIcon
     platform="ruby.rails"
@@ -249,7 +265,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
 
 ### Go
 
-- <LinkWithPlatformIcon platform="go" label="Go" url="/platforms/go/logs/" />
+- <LinkWithPlatformIcon platform="go" label="Go" url="/platforms/go/logs/" skill="sentry-go-sdk" />
 
 ### Rust
 
@@ -265,6 +281,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="dotnet"
     label=".NET"
     url="/platforms/dotnet/logs/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.aspnetcore"

--- a/docs/product/explore/logs/getting-started/index.mdx
+++ b/docs/product/explore/logs/getting-started/index.mdx
@@ -26,6 +26,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.astro"
     label="Astro"
     url="/platforms/javascript/guides/astro/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.aws-lambda"
@@ -61,6 +62,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.electron"
     label="Electron"
     url="/platforms/javascript/guides/electron/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.ember"
@@ -132,6 +134,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.nuxt"
     label="Nuxt"
     url="/platforms/javascript/guides/nuxt/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.react"
@@ -149,6 +152,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.remix"
     label="Remix"
     url="/platforms/javascript/guides/remix/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.solid"
@@ -160,6 +164,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="javascript.solidstart"
     label="SolidStart"
     url="/platforms/javascript/guides/solidstart/logs/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.svelte"
@@ -228,6 +233,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="capacitor"
     label="Capacitor"
     url="/platforms/javascript/guides/capacitor/logs/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dart.flutter"
@@ -249,11 +255,13 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="php.symfony"
     label="Symfony"
     url="/platforms/php/guides/symfony/logs/"
+    skill="sentry-php-sdk"
   />
 - <LinkWithPlatformIcon
     platform="php.laravel"
     label="Laravel"
     url="/platforms/php/guides/laravel/logs/"
+    skill="sentry-php-sdk"
   />
 
 ### Python
@@ -277,6 +285,7 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="ruby.rails"
     label="Rails"
     url="/platforms/ruby/guides/rails/logs/"
+    skill="sentry-ruby-sdk"
   />
 
 ### Go
@@ -303,21 +312,25 @@ To set up Sentry Logs, use the links below for supported SDKs. After it's been s
     platform="dotnet.aspnetcore"
     label="ASP.NET Core"
     url="/platforms/dotnet/guides/aspnetcore/logs/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.maui"
     label="MAUI"
     url="/platforms/dotnet/guides/maui/logs/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.extensions-logging"
     label="Microsoft.Extensions.Logging"
     url="/platforms/dotnet/guides/extensions-logging/logs/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.serilog"
     label="Serilog"
     url="/platforms/dotnet/guides/serilog/logs/"
+    skill="sentry-dotnet-sdk"
   />
 
 ### Native

--- a/docs/product/explore/metrics/getting-started/index.mdx
+++ b/docs/product/explore/metrics/getting-started/index.mdx
@@ -26,6 +26,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.astro"
     label="Astro"
     url="/platforms/javascript/guides/astro/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.aws-lambda"
@@ -61,6 +62,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.electron"
     label="Electron"
     url="/platforms/javascript/guides/electron/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.ember"
@@ -132,6 +134,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.nuxt"
     label="Nuxt"
     url="/platforms/javascript/guides/nuxt/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.react"
@@ -149,6 +152,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.remix"
     label="Remix"
     url="/platforms/javascript/guides/remix/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.solid"
@@ -160,6 +164,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.solidstart"
     label="SolidStart"
     url="/platforms/javascript/guides/solidstart/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.svelte"
@@ -333,11 +338,13 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="php.symfony"
     label="Symfony"
     url="/platforms/php/guides/symfony/metrics/"
+    skill="sentry-php-sdk"
   />
 - <LinkWithPlatformIcon
     platform="php.laravel"
     label="Laravel"
     url="/platforms/php/guides/laravel/metrics/"
+    skill="sentry-php-sdk"
   />
 
 ### Ruby
@@ -370,86 +377,103 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="dotnet.android"
     label=".NET for Android"
     url="/platforms/dotnet/guides/android/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.apple"
     label=".NET for iOS, macOS, and Mac Catalyst"
     url="/platforms/dotnet/guides/apple/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.aspnet"
     label="ASP.NET"
     url="/platforms/dotnet/guides/aspnet/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.aspnetcore"
     label="ASP.NET Core"
     url="/platforms/dotnet/guides/aspnetcore/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.aws-lambda"
     label="AWS Lambda"
     url="/platforms/dotnet/guides/aws-lambda/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.azure-functions-worker"
     label="Azure Functions"
     url="/platforms/dotnet/guides/azure-functions-worker/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.blazor-webassembly"
     label="Blazor WebAssembly"
     url="/platforms/dotnet/guides/blazor-webassembly/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.entityframework"
     label="Entity Framework"
     url="/platforms/dotnet/guides/entityframework/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.extensions-logging"
     label="Microsoft.Extensions.Logging"
     url="/platforms/dotnet/guides/extensions-logging/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.google-cloud-functions"
     label="Google Cloud Functions"
     url="/platforms/dotnet/guides/google-cloud-functions/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.log4net"
     label="log4net"
     url="/platforms/dotnet/guides/log4net/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.maui"
     label="MAUI"
     url="/platforms/dotnet/guides/maui/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.nlog"
     label="NLog"
     url="/platforms/dotnet/guides/nlog/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.serilog"
     label="Serilog"
     url="/platforms/dotnet/guides/serilog/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.winforms"
     label="Windows Forms"
     url="/platforms/dotnet/guides/winforms/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.winui"
     label="WinUI"
     url="/platforms/dotnet/guides/winui/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.wpf"
     label="WPF"
     url="/platforms/dotnet/guides/wpf/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 
 ### Native

--- a/docs/product/explore/metrics/getting-started/index.mdx
+++ b/docs/product/explore/metrics/getting-started/index.mdx
@@ -14,11 +14,13 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.browser"
     label="Browser JavaScript"
     url="/platforms/javascript/metrics/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.angular"
     label="Angular"
     url="/platforms/javascript/guides/angular/metrics/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.astro"
@@ -29,26 +31,31 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.aws-lambda"
     label="AWS Lambda"
     url="/platforms/javascript/guides/aws-lambda/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.azure-functions"
     label="Azure Functions"
     url="/platforms/javascript/guides/azure-functions/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.bun"
     label="Bun"
     url="/platforms/javascript/guides/bun/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.cloudflare"
     label="Cloudflare"
     url="/platforms/javascript/guides/cloudflare/metrics/"
+    skill="sentry-cloudflare-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.connect"
     label="Connect"
     url="/platforms/javascript/guides/connect/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.electron"
@@ -59,56 +66,67 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.ember"
     label="Ember"
     url="/platforms/javascript/guides/ember/metrics/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.express"
     label="Express"
     url="/platforms/javascript/guides/express/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.fastify"
     label="Fastify"
     url="/platforms/javascript/guides/fastify/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.gatsby"
     label="Gatsby"
     url="/platforms/javascript/guides/gatsby/metrics/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.gcp-functions"
     label="Google Cloud Functions"
     url="/platforms/javascript/guides/gcp-functions/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.hapi"
     label="Hapi"
     url="/platforms/javascript/guides/hapi/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.hono"
     label="Hono"
     url="/platforms/javascript/guides/hono/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.koa"
     label="Koa"
     url="/platforms/javascript/guides/koa/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nestjs"
     label="Nest.js"
     url="/platforms/javascript/guides/nestjs/metrics/"
+    skill="sentry-nestjs-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.node"
     label="Node.js"
     url="/platforms/javascript/guides/node/metrics/"
+    skill="sentry-node-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nextjs"
     label="Next.js"
     url="/platforms/javascript/guides/nextjs/metrics/"
+    skill="sentry-nextjs-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.nuxt"
@@ -119,11 +137,13 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.react"
     label="React"
     url="/platforms/javascript/guides/react/metrics/"
+    skill="sentry-react-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.react-router"
     label="React Router"
     url="/platforms/javascript/guides/react-router/metrics/"
+    skill="sentry-react-router-framework-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.remix"
@@ -134,6 +154,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.solid"
     label="Solid"
     url="/platforms/javascript/guides/solid/metrics/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.solidstart"
@@ -144,26 +165,31 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="javascript.svelte"
     label="Svelte"
     url="/platforms/javascript/guides/svelte/metrics/"
+    skill="sentry-svelte-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.sveltekit"
     label="SvelteKit"
     url="/platforms/javascript/guides/sveltekit/metrics/"
+    skill="sentry-svelte-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.tanstackstart-react"
     label="TanStack Start"
     url="/platforms/javascript/guides/tanstackstart-react/metrics/"
+    skill="sentry-tanstack-start-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.vue"
     label="Vue"
     url="/platforms/javascript/guides/vue/metrics/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.wasm"
     label="Wasm"
     url="/platforms/javascript/guides/wasm/metrics/"
+    skill="sentry-browser-sdk"
   />
 
 ### Java
@@ -190,6 +216,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="elixir"
     label="Elixir"
     url="/platforms/elixir/metrics/"
+    skill="sentry-elixir-sdk"
   />
 
 ### Mobile
@@ -198,41 +225,49 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="android"
     label="Android"
     url="/platforms/android/metrics/"
+    skill="sentry-android-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple.ios"
     label="iOS"
     url="/platforms/apple/guides/ios/metrics/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple.macos"
     label="macOS"
     url="/platforms/apple/guides/macos/metrics/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple.tvos"
     label="tvOS"
     url="/platforms/apple/guides/tvos/metrics/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple.watchos"
     label="watchOS"
     url="/platforms/apple/guides/watchos/metrics/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="apple.visionos"
     label="visionOS"
     url="/platforms/apple/guides/visionos/metrics/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dart.flutter"
     label="Flutter"
     url="/platforms/dart/guides/flutter/metrics/"
+    skill="sentry-flutter-sdk"
   />
 - <LinkWithPlatformIcon
     platform="react-native"
     label="React Native"
     url="/platforms/react-native/metrics/"
+    skill="sentry-react-native-sdk"
   />
 
 ### Python
@@ -241,41 +276,49 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="python"
     label="Python"
     url="/platforms/python/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.django"
     label="Django"
     url="/platforms/python/guides/django/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.flask"
     label="Flask"
     url="/platforms/python/guides/flask/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.fastapi"
     label="FastAPI"
     url="/platforms/python/guides/fastapi/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.starlette"
     label="Starlette"
     url="/platforms/python/guides/starlette/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.celery"
     label="Celery"
     url="/platforms/python/guides/celery/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.aws-lambda"
     label="AWS Lambda"
     url="/platforms/python/guides/aws-lambda/metrics/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="python.gcp-functions"
     label="Google Cloud Functions"
     url="/platforms/python/guides/gcp-functions/metrics/"
+    skill="sentry-python-sdk"
   />
 
 ### PHP
@@ -284,6 +327,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="php"
     label="PHP"
     url="/platforms/php/metrics/"
+    skill="sentry-php-sdk"
   />
 - <LinkWithPlatformIcon
     platform="php.symfony"
@@ -302,6 +346,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="ruby"
     label="Ruby (incl. Rails)"
     url="/platforms/ruby/metrics/"
+    skill="sentry-ruby-sdk"
   />
 
 ### Go
@@ -310,6 +355,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="go"
     label="Go"
     url="/platforms/go/metrics/"
+    skill="sentry-go-sdk"
   />
 
 ### .NET
@@ -318,6 +364,7 @@ To set up Sentry's Application Metrics, use the links below for supported SDKs. 
     platform="dotnet"
     label=".NET"
     url="/platforms/dotnet/metrics/"
+    skill="sentry-dotnet-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.android"

--- a/docs/product/explore/profiling/getting-started.mdx
+++ b/docs/product/explore/profiling/getting-started.mdx
@@ -26,11 +26,13 @@ Continuous Profiling can be used both independently and as a complement to the t
     platform="python"
     label="Python (since version 2.24.1)"
     url="/platforms/python/profiling/"
+    skill="sentry-python-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.node"
     label="Node.js (since version 9.8.0)"
     url="/platforms/javascript/guides/node/profiling/"
+    skill="sentry-node-sdk"
   />
 
 ### UI Profiling
@@ -45,16 +47,19 @@ UI Profiling can be used both independently and as a complement to the tracing p
     platform="apple"
     label="iOS & macOS (since version 8.49.0)"
     url="/platforms/apple/profiling/"
+    skill="sentry-cocoa-sdk"
   />
 - <LinkWithPlatformIcon
     platform="android"
     label="Android (Java & Kotlin only) (since version 8.5.0)"
     url="/platforms/android/profiling/"
+    skill="sentry-android-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.browser"
     label="Browser JavaScript (since version 10.27.0)"
     url="/platforms/javascript/profiling/"
+    skill="sentry-browser-sdk"
   />
 - <LinkWithPlatformIcon
     platform="javascript.electron"
@@ -78,16 +83,19 @@ Transaction-based Profiling requires Sentry's tracing product being enabled befo
     platform="react-native"
     label="React Native (beta)"
     url="/platforms/react-native/profiling/"
+    skill="sentry-react-native-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dart.flutter"
     label="Flutter (experimental, iOS and macOS only)"
     url="/platforms/dart/guides/flutter/profiling/"
+    skill="sentry-flutter-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet.maui"
     label=".NET (experimental, iOS only)"
     url="/platforms/dotnet/guides/maui/profiling/"
+    skill="sentry-dotnet-sdk"
   />
 
 #### Standalone and server apps
@@ -96,14 +104,17 @@ Transaction-based Profiling requires Sentry's tracing product being enabled befo
     platform="php"
     label="PHP"
     url="/platforms/php/profiling/"
+    skill="sentry-php-sdk"
   />
 - <LinkWithPlatformIcon
     platform="ruby"
     label="Ruby (beta)"
     url="/platforms/ruby/profiling/"
+    skill="sentry-ruby-sdk"
   />
 - <LinkWithPlatformIcon
     platform="dotnet"
     label=".NET (experimental)"
     url="/platforms/dotnet/profiling/"
+    skill="sentry-dotnet-sdk"
   />

--- a/docs/product/explore/profiling/getting-started.mdx
+++ b/docs/product/explore/profiling/getting-started.mdx
@@ -65,6 +65,7 @@ UI Profiling can be used both independently and as a complement to the tracing p
     platform="javascript.electron"
     label="Electron (since version 7.4.0)"
     url="/platforms/javascript/guides/electron/profiling/"
+    skill="sentry-node-sdk"
   />
 
 ### Transaction-based Profiling

--- a/src/components/agentSkillsCallout/index.tsx
+++ b/src/components/agentSkillsCallout/index.tsx
@@ -9,10 +9,8 @@ import {DocMetrics} from 'sentry-docs/metrics';
 
 import {CodeBlock} from '../codeBlock';
 import {CodeTabs} from '../codeTabs';
+import {buildDotagentsCommand, buildNpxSkillsCommand, buildPrompt} from './shared';
 import styles from './style.module.scss';
-
-const SKILLS_BASE_URL = 'https://skills.sentry.dev';
-const SKILLS_REPO = 'getsentry/sentry-for-ai';
 
 type Props = {
   /** Display name for the platform, e.g. "Next.js", "Python". Omit for generic. */
@@ -20,32 +18,6 @@ type Props = {
   /** Skill package name, e.g. "sentry-nextjs-sdk". Omit for generic/all skills. */
   skill?: string;
 };
-
-function buildPromptUrl(skill?: string): string {
-  if (!skill) {
-    return SKILLS_BASE_URL + '/';
-  }
-  return `${SKILLS_BASE_URL}/${skill}/SKILL.md`;
-}
-
-function buildPrompt(skill?: string): string {
-  const url = buildPromptUrl(skill);
-  return `Use curl to download, read and follow: ${url}`;
-}
-
-function buildDotagentsCommand(skill?: string): string {
-  if (!skill) {
-    return `npx @sentry/dotagents add ${SKILLS_REPO} --all`;
-  }
-  return `npx @sentry/dotagents add ${SKILLS_REPO} --name ${skill}`;
-}
-
-function buildNpxSkillsCommand(skill?: string): string {
-  if (!skill) {
-    return `npx skills add ${SKILLS_REPO}`;
-  }
-  return `npx skills add ${SKILLS_REPO} --skill ${skill}`;
-}
 
 export function AgentSkillsCallout({skill, platformName}: Props) {
   const [copied, setCopied] = useState(false);

--- a/src/components/agentSkillsCallout/shared.ts
+++ b/src/components/agentSkillsCallout/shared.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared constants and utilities for agent skills prompt building.
+ * Used by AgentSkillsCallout (full banner) and inline copy-prompt buttons.
+ */
+
+export const SKILLS_BASE_URL = 'https://skills.sentry.dev';
+export const SKILLS_REPO = 'getsentry/sentry-for-ai';
+
+export function buildPromptUrl(skill?: string): string {
+  if (!skill) {
+    return SKILLS_BASE_URL + '/';
+  }
+  return `${SKILLS_BASE_URL}/${skill}/SKILL.md`;
+}
+
+export function buildPrompt(skill?: string): string {
+  const url = buildPromptUrl(skill);
+  return `Use curl to download, read and follow: ${url}`;
+}
+
+export function buildDotagentsCommand(skill?: string): string {
+  if (!skill) {
+    return `npx @sentry/dotagents add ${SKILLS_REPO} --all`;
+  }
+  return `npx @sentry/dotagents add ${SKILLS_REPO} --name ${skill}`;
+}
+
+export function buildNpxSkillsCommand(skill?: string): string {
+  if (!skill) {
+    return `npx skills add ${SKILLS_REPO}`;
+  }
+  return `npx skills add ${SKILLS_REPO} --skill ${skill}`;
+}

--- a/src/components/copyPromptButton/index.tsx
+++ b/src/components/copyPromptButton/index.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import * as Tooltip from '@radix-ui/react-tooltip';
+import {Theme} from '@radix-ui/themes';
+import * as Sentry from '@sentry/nextjs';
+import {useTheme} from 'next-themes';
+import {useCallback, useMemo, useState} from 'react';
+import {usePlausibleEvent} from 'sentry-docs/hooks/usePlausibleEvent';
+import {DocMetrics} from 'sentry-docs/metrics';
+
+import {buildPrompt} from '../agentSkillsCallout/shared';
+import styles from './style.module.scss';
+
+type Props = {
+  /** Skill package name, e.g. "sentry-nextjs-sdk". */
+  skill: string;
+};
+
+export function CopyPromptButton({skill}: Props) {
+  const [copied, setCopied] = useState(false);
+  const {emit} = usePlausibleEvent();
+  const {resolvedTheme} = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const prompt = buildPrompt(skill);
+
+  /**
+   * Tooltip styles matching the onboarding tooltip pattern.
+   * Inline styles are required because Radix portals the tooltip to document.body,
+   * outside the Theme wrapper, so CSS module classes don't reliably apply.
+   */
+  const tooltipContentStyle: React.CSSProperties = useMemo(
+    () => ({
+      borderRadius: '4px',
+      padding: '8px 12px',
+      fontSize: '12px',
+      lineHeight: 1.2,
+      textAlign: 'center' as const,
+      color: isDark ? 'var(--foreground)' : 'var(--gray-11)',
+      backgroundColor: isDark ? 'var(--gray-4)' : 'white',
+      boxShadow: '0px 4px 16px 0px rgba(31, 22, 51, 0.1)',
+      zIndex: 9999,
+      position: 'relative' as const,
+      pointerEvents: 'none' as const,
+      userSelect: 'none' as const,
+      whiteSpace: 'nowrap' as const,
+      animationDuration: '100ms',
+      animationTimingFunction: 'ease-in',
+    }),
+    [isDark]
+  );
+
+  const tooltipArrowStyle: React.CSSProperties = useMemo(
+    () => ({
+      fill: isDark ? 'var(--gray-4)' : 'white',
+    }),
+    [isDark]
+  );
+
+  const copyPrompt = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+
+      emit('Copy AI Prompt', {
+        props: {page: window.location.pathname, title: 'Inline Platform Link'},
+      });
+
+      try {
+        setCopied(false);
+        await navigator.clipboard.writeText(prompt);
+        setCopied(true);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch (error) {
+        Sentry.captureException(error);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, false);
+        setCopied(false);
+      }
+    },
+    [prompt, emit, skill]
+  );
+
+  return (
+    <span className={styles.wrapper}>
+      <span className={styles.divider}>|</span>
+      <Tooltip.Provider delayDuration={200}>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              className={styles.button}
+              onClick={copyPrompt}
+              type="button"
+              aria-label="Copy setup prompt for AI agents"
+            >
+              <CopyIcon />
+              <span className={styles.label}>{copied ? 'Copied!' : 'Copy Prompt'}</span>
+            </button>
+          </Tooltip.Trigger>
+          {!copied && (
+            <Tooltip.Portal>
+              <Theme accentColor="iris">
+                <Tooltip.Content style={tooltipContentStyle} sideOffset={6}>
+                  Copy setup prompt for AI agents
+                  <Tooltip.Arrow style={tooltipArrowStyle} />
+                </Tooltip.Content>
+              </Theme>
+            </Tooltip.Portal>
+          )}
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </span>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}

--- a/src/components/copyPromptButton/index.tsx
+++ b/src/components/copyPromptButton/index.tsx
@@ -70,11 +70,11 @@ export function CopyPromptButton({skill}: Props) {
         setCopied(false);
         await navigator.clipboard.writeText(prompt);
         setCopied(true);
-        DocMetrics.copyAIPrompt(window.location.pathname, skill, true);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, true, 'inline_link');
         setTimeout(() => setCopied(false), 1500);
       } catch (error) {
         Sentry.captureException(error);
-        DocMetrics.copyAIPrompt(window.location.pathname, skill, false);
+        DocMetrics.copyAIPrompt(window.location.pathname, skill, false, 'inline_link');
         setCopied(false);
       }
     },

--- a/src/components/copyPromptButton/style.module.scss
+++ b/src/components/copyPromptButton/style.module.scss
@@ -1,0 +1,70 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+
+.divider {
+  color: var(--gray-200);
+  font-size: 0.85rem;
+  margin-right: 0.4rem;
+  user-select: none;
+}
+
+:global(.dark) .divider {
+  color: var(--gray-600);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--accent-purple), transparent 60%);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent-purple), transparent 92%);
+  color: var(--accent-purple);
+  font-size: 0.72rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 150ms,
+    border-color 150ms;
+  line-height: 1.4;
+
+  &:hover {
+    background: color-mix(in srgb, var(--accent-purple), transparent 82%);
+    border-color: color-mix(in srgb, var(--accent-purple), transparent 40%);
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--accent-purple), transparent 72%);
+  }
+}
+
+:global(.dark) .button {
+  background: color-mix(in srgb, var(--accent-purple), transparent 85%);
+  border-color: color-mix(in srgb, var(--accent-purple), transparent 50%);
+  color: var(--accent-purple-light, var(--accent-purple));
+
+  &:hover {
+    background: color-mix(in srgb, var(--accent-purple), transparent 75%);
+    border-color: color-mix(in srgb, var(--accent-purple), transparent 30%);
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--accent-purple), transparent 65%);
+  }
+}
+
+.label {
+  letter-spacing: 0.01em;
+}
+
+

--- a/src/components/linkWithPlatformIcon.tsx
+++ b/src/components/linkWithPlatformIcon.tsx
@@ -1,13 +1,16 @@
+import {CopyPromptButton} from './copyPromptButton';
 import {PlatformIcon} from './platformIcon';
 import {SmartLink} from './smartLink';
 
 type Props = {
   label?: string;
   platform?: string;
+  /** Agent skill name, e.g. "sentry-react-sdk". When provided, renders an inline "Agent Setup" copy-prompt button. */
+  skill?: string;
   url?: string;
 };
 
-export function LinkWithPlatformIcon({platform, label, url}: Props) {
+export function LinkWithPlatformIcon({platform, label, url, skill}: Props) {
   if (!platform) {
     return null;
   }
@@ -27,6 +30,7 @@ export function LinkWithPlatformIcon({platform, label, url}: Props) {
         />
         {label ?? platform}
       </SmartLink>
+      {skill && <CopyPromptButton skill={skill} />}
     </span>
   );
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -166,13 +166,20 @@ export const DocMetrics = {
    * @param pathname - Page where the prompt was copied
    * @param skill - Skill name if present (e.g., "sentry-nextjs-sdk")
    * @param success - Whether the clipboard copy succeeded
+   * @param source - Where the copy was triggered from ('callout' for the full banner, 'inline_link' for platform list buttons)
    */
-  copyAIPrompt: (pathname: string, skill: string | undefined, success: boolean) => {
+  copyAIPrompt: (
+    pathname: string,
+    skill: string | undefined,
+    success: boolean,
+    source: 'callout' | 'inline_link' = 'callout'
+  ) => {
     Sentry.metrics.count('docs.copy_ai_prompt', 1, {
       attributes: {
         page_path: pathname.split('/').slice(0, 3).join('/'), // First 3 segments
         skill: skill || 'generic',
         success,
+        source,
       },
     });
   },


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add an inline "Copy Prompt" button next to platform links on interstitial getting-started pages (Logs, Metrics, Profiling). Platforms that have an associated agent-assisted setup skill now show a small purple button that copies the agent setup prompt to the clipboard, giving users immediate access to the AI agent prompt without needing to click through to the platform page first.

### What changed

- **`src/components/agentSkillsCallout/shared.ts`** (new): Extracted shared prompt-building utilities (`buildPrompt`, `buildPromptUrl`, `buildDotagentsCommand`, `buildNpxSkillsCommand`, constants) so both `AgentSkillsCallout` and the new `CopyPromptButton` reuse the same logic.

- **`src/components/copyPromptButton/`** (new): Client component that renders an inline "Copy Prompt" button with:
  - Clipboard copy of the agent setup prompt
  - Radix tooltip ("Copy setup prompt for AI agents") matching the onboarding tooltip style
  - Plausible analytics + Sentry metrics tracking (reuses existing `Copy AI Prompt` event)
  - Light/dark mode support via `next-themes`
  - Hidden on mobile (< 768px)

- **`src/components/linkWithPlatformIcon.tsx`**: Added optional `skill` prop. When present, renders a `CopyPromptButton` inline after the platform link.

- **`src/components/agentSkillsCallout/index.tsx`**: Refactored to import from `shared.ts`. No behavioral change.

- **`docs/product/explore/logs/getting-started/index.mdx`**: Added `skill` props to platform links.
- **`docs/product/explore/metrics/getting-started/index.mdx`**: Added `skill` props to platform links.
- **`docs/product/explore/profiling/getting-started.mdx`**: Added `skill` props to platform links.

### Skill mapping

- Server-side JS frameworks -> `sentry-node-sdk`
- Browser-only JS frameworks -> `sentry-browser-sdk`
- Framework-specific skills where they exist (Next.js, Nest.js, React, Svelte, Cloudflare, React Router, TanStack Start)
- Non-JS platforms: Python, Ruby, Go, PHP, .NET, Android, Apple, Flutter, React Native, Elixir
- Intentionally omitted: Astro, Nuxt, Remix, SolidStart, Electron, Capacitor (ambiguous SDK mapping), Java, Native, Gaming (no skills exist)

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)