### PR TITLE
docs(snapshots): Clarify main snapshot uploads

### DIFF
--- a/docs/product/snapshots/integrating-into-ci.mdx
+++ b/docs/product/snapshots/integrating-into-ci.mdx
@@ -31,6 +31,11 @@ If you have previously installed the Sentry App, ensure you have accepted the la
 
 3. Modify an existing workflow or create a new workflow to upload snapshots on pushes to your main branch and on pull requests:
 
+<Alert>
+  Upload snapshots on every commit to main to ensure the base build is always
+  available.
+</Alert>
+
 ```yml {filename:sentry_snapshots.yml}
 name: Sentry Snapshots Upload
 


### PR DESCRIPTION
Clarify that snapshot uploads should run on every commit to main.

This makes the CI integration guidance explicit that the main branch base build must always be available for snapshot comparisons. Without current uploads from main, pull request snapshot comparisons can lack the baseline they need.

Refs EME-1143
