### PR TITLE
docs(otel): Add Apple platform to traceparent propagation list

### DIFF
--- a/docs/concepts/otlp/sentry-with-otel.mdx
+++ b/docs/concepts/otlp/sentry-with-otel.mdx
@@ -63,6 +63,7 @@ The following SDKs support the `propagateTraceparent` option:
   ### Mobile
 
   - <LinkWithPlatformIcon platform="android" label="Android" url="/platforms/android/configuration/options/#propagateTraceparent" />
+  - <LinkWithPlatformIcon platform="apple" label="Apple" url="/platforms/apple/configuration/options/#enablePropagateTraceparent" />
   - <LinkWithPlatformIcon platform="dart.flutter" label="Flutter" url="/platforms/dart/guides/flutter/configuration/options/#propagateTraceparent" />
   - <LinkWithPlatformIcon platform="native" label="Native" url="/platforms/native/configuration/options/#propagate_traceparent" />
   - <LinkWithPlatformIcon platform="react-native" label="React Native" url="/platforms/react-native/configuration/options/#propagateTraceparent" />


### PR DESCRIPTION
Adds the Apple/Cocoa SDK to the W3C traceparent propagation list on the `sentry-with-otel` concepts page.

Support was added in getsentry/sentry-cocoa#6356 and the option is documented at https://docs.sentry.io/platforms/apple/tracing/trace-propagation/#basic-example — it was just missing from the central SDK list.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC09MQRJGBU2%3A1781075156.454069%22)