### PR TITLE
docs(seer): Fix repository settings links for both Seer billing models

### DIFF
--- a/docs/product/ai-in-sentry/seer/autofix/index.mdx
+++ b/docs/product/ai-in-sentry/seer/autofix/index.mdx
@@ -26,7 +26,7 @@ Set up Issue Autofix in your organization or on specific projects:
 
 1. Connect to GitHub through the [Sentry GitHub integration](/integrations/source-code-mgmt/github/). You can follow the steps in [Seer settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/) to get started. **Note:** Seer can only be integrated with the cloud version of GitHub.
 
-2. Select which repositories you want to connect to Sentry, go to [Seer SCM Settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/scm/) to make sure your repositories are connected.
+2. Select which repositories you want to connect to Sentry, go to [Repositories Settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/repos/) to make sure your repositories are connected.
 
 3. Connect projects to repositories in [Seer Project Settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/projects/). Seer will use the repositories connected to the project to perform Autofix (including Root Cause Analysis and Code Generation).
 

--- a/docs/product/ai-in-sentry/seer/code-review/index.mdx
+++ b/docs/product/ai-in-sentry/seer/code-review/index.mdx
@@ -24,9 +24,9 @@ Set up Code Review in your GitHub organization or on specific repositories:
 
 1. Connect to GitHub through the [Sentry GitHub integration](/integrations/source-code-mgmt/github/). You can follow the steps in [Seer settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/) to get started. **Note:** Seer can only be integrated with the cloud version of GitHub.
 
-2. Select which repositories you want to connect to Sentry, go to [Seer SCM Settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/scm/) to make sure your repositories are connected.
+2. Select which repositories you want to connect to Sentry, go to [Repositories Settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/repos/) to make sure your repositories are connected.
 
-3. Turn on [Code Review](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/repos/) for your repositories and configure the [default setting for new repos](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/#autoEnableCodeReview).
+3. Turn on [Code Review](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/repos/) for your repositories and configure the [default setting for new repos](https://sentry.io/orgredirect/organizations/:orgslug/settings/seer/repos/defaults/).
 
 **Note:** Enabling Code Review for one a repository starts *active contributor pricing*. Learn more about [Seer pricing](/pricing/#seer-pricing).
 


### PR DESCRIPTION
The Autofix and Code Review setup steps linked to a Seer SCM settings page that is not a real route, and the Code Review step used a broken `#autoEnableCodeReview` anchor. Point repository setup to the canonical `/settings/repos/` page (ungated, works for legacy and seat-based Seer) and the default toggle to the `/settings/seer/repos/defaults/` drawer where the field actually lives.