### PR TITLE
docs(gitlab): clarify service account vs GitLab Service Account feature

### DIFF
--- a/docs/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/docs/integrations/source-code-mgmt/gitlab/index.mdx
@@ -15,7 +15,7 @@ Sentry owner, manager, or admin permissions and GitLab owner or maintainer permi
 
 <Alert title="Note">
   <p>
-  We recommend creating a dedicated service account on GitLab when installing this integration rather than using a personal user account. The service account should have owner or maintainer permissions in GitLab.
+  We recommend creating a dedicated service account on GitLab when installing this integration rather than using a personal user account. The service account should have owner or maintainer permissions in GitLab. Note: this is a regular GitLab user account dedicated to the integration — do not confuse it with [GitLab's Service Account](https://docs.gitlab.com/user/profile/service_accounts/) feature, which cannot be used with this integration.
   </p>
   <p>
   Since the integration uses personal access tokens for authentication, activities such as comments and work item creation will be attributed to the GitLab user who created the tokens.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a clarifying note to the GitLab integration install docs to prevent confusion between the "service account" recommended for this integration (a plain, dedicated GitLab user account) and GitLab's native [Service Account](https://docs.gitlab.com/user/profile/service_accounts/) feature, which cannot be used with this integration.

The added sentence:
> Note: this is a regular GitLab user account dedicated to the integration — do not confuse it with [GitLab's Service Account](https://docs.gitlab.com/user/profile/service_accounts/) feature, which cannot be used with this integration.

Context: https://sentry.slack.com/archives/C0AKG192UP3/p1781127481303299?thread_ts=1781023041.019729&cid=C0AKG192UP3

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC03R2TP8E2F%3A1781127523.677919%22)
