### PR TITLE
docs(nuxt): add sentry init setup

### DIFF
--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -16,7 +16,7 @@ categories:
 
 <Alert level="warning">
 
-The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard below or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
 
 </Alert>
 
@@ -38,6 +38,18 @@ npx sentry@latest init
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+<Alert level="info" title="Prefer the existing framework wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i nuxt
+```
+
+To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+
+</Alert>
 
 <Expandable title="How does the wizard work?">
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -16,7 +16,7 @@ categories:
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, run the existing framework-specific wizard with `npx @sentry/wizard@latest -i nuxt`, or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard option below, or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -14,35 +14,43 @@ categories:
 
 ## Install
 
+<Alert level="warning">
+
+The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+
+</Alert>
+
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>
 
-To install Sentry using the installation wizard, run the following command within your project:
+Run the Sentry init command in your project directory to automatically configure Sentry in your Nuxt application.
 
-The wizard then guides you through the setup process, asking you to enable additional (optional) Sentry features for your application beyond error monitoring.
+The wizard guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
 
 </SplitSectionText>
 <SplitSectionCode>
 
 ```bash
-npx @sentry/wizard@latest -i nuxt
+npx sentry@latest init
 ```
 
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
 
-<Include name="quick-start-features-expandable" />
+<Expandable title="How does the wizard work?">
 
-This guide assumes that you enable all features and allow the wizard to create an example page or component. You can add or remove features at any time, but setting them up now will save you the effort of configuring them manually later.
+The Sentry init wizard is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
 
-<Expandable title="What does the installation wizard change inside your application?">
-- Creates `sentry.(client|server).config.ts` to initialize the SDK
-- Creates or updates your `nuxt.config.ts` to add build options to add source maps upload and auto-instrumentation via Vite plugins
-- Creates `.env.sentry-build-plugin` with an auth token to upload source maps (this file is automatically added to `.gitignore`)
-- Adds an example page and route to your application to help verify your Sentry setup
-  - If it couldn't create a page, the wizard adds an example component instead
+- **Analyzes your project** — reads project files and manifests to understand your Nuxt app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies Nuxt and selects the `@sentry/nuxt` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/nuxt` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, Nuxt module configuration, and other selected features based on your project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
+
+For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
 
 </Expandable>
 
@@ -52,17 +60,21 @@ This guide assumes that you enable all features and allow the wizard to create a
 
 ## Verify Your Setup
 
-If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard.
+The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
 
-<Expandable level="warning" title="The wizard created an example component instead of a page.">
-The wizard creates a `SentryErrorButton` component when it fails to add an example page to your project. This usually happens if you don't have a `app.vue` file or if that file does not contain the `NuxtPage` component. To verify your setup, follow these steps before continuing with the next section, "View Captured Data in Sentry":
+<OnboardingOptionButtons
+  options={[
+    "error-monitoring",
+    "performance",
+    "session-replay",
+    "user-feedback",
+    "logs",
+  ]}
+/>
 
-1. Add the `SentryErrorButton` component to a page and open it in your browser. For most Nuxt applications, this will be at localhost.
-2. Click the "Throw Sample Error" button, which triggers an error and starts a performance trace on the client side.
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
-To test the server side as well, refer to the "Verify" section in the [Manual setup guide](/platforms/javascript/guides/nuxt/manual-setup/).
-
-</Expandable>
+If you haven't tested your Sentry configuration yet, let's do it now. Add a test button to one of your pages to confirm that Sentry is working properly and sending data to your Sentry project.
 
 To test Sentry, you can run your Nuxt application in either production or development mode.
 We **recommend testing in production mode** as it most closely resembles your deployed application's environment.
@@ -116,26 +128,58 @@ NODE_OPTIONS='--import ./.nuxt/dev/sentry.server.config.mjs' nuxt dev
 </SplitSection>
 </SplitLayout>
 
-After building and running your project:
+After building and running your project, add the button to one of your pages and click it:
 
-1.  Open the example page `/sentry-example-page` in your browser. For most Nuxt applications, this will be at localhost.
-2.  Click the "Throw sample error" button. This triggers two errors:
-    - a frontend error
-    - an error within the API route
+```vue
+<template>
+  <button
+    type="button"
+    @click="
+      () => {
+        throw new Error('Sentry Test Error');
+      }
+    "
+  >
+    Break the world
+  </button>
+</template>
+```
 
-Sentry captures both of these errors for you. Additionally, the button click starts a performance trace to measure the time it takes for the API request to complete.
+Sentry captures the error for you. If the wizard added verification files to your project, you can use those instead of adding a temporary test button.
 
-### View Captured Data in Sentry
+### Check Your Data in Sentry
 
-Now, head over to your project on [Sentry.io](https://sentry.io/) to view the collected data (it takes a couple of moments for the data to appear).
+**Errors** — [Open Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/)
 
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+You should see "Sentry Test Error" with a full stack trace pointing to your source code.
 
-<Include name="quick-start-locate-data-expandable" />
+<OnboardingOption optionId="performance">
+
+**Tracing** — [Open Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/)
+
+You should see route and request traces. Learn more about [Nuxt tracing](/platforms/javascript/guides/nuxt/tracing/).
+
+</OnboardingOption>
+
+<OnboardingOption optionId="session-replay">
+
+**Session Replay** — [Open Replays](https://sentry.io/orgredirect/organizations/:orgslug/replays/)
+
+Watch a video-like recording of your session, including the moment the error occurred. Learn more about [Session Replay configuration](/platforms/javascript/guides/nuxt/session-replay/).
+
+</OnboardingOption>
+
+<OnboardingOption optionId="logs">
+
+**Logs** — [Open Logs](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) <FeatureBadge type="new" />
+
+See structured log entries from your application. Learn more about [Logs configuration](/platforms/javascript/guides/nuxt/logs/).
+
+</OnboardingOption>
 
 ## Next Steps
 
-At this point, you should have integrated Sentry into your Nuxt application and should already be sending error and performance data to your Sentry project.
+At this point, you should have integrated Sentry into your Nuxt application and should already be sending data to your Sentry project.
 
 Now's a good time to customize your setup and look into more advanced topics. Our next recommended steps for you are:
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -39,18 +39,6 @@ npx sentry@latest init
 </SplitSection>
 </SplitLayout>
 
-<Alert level="info" title="Prefer the existing framework wizard?">
-
-If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
-
-```bash
-npx @sentry/wizard@latest -i nuxt
-```
-
-To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
-
-</Alert>
-
 <Expandable title="How does sentry init work?">
 
 The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
@@ -63,6 +51,18 @@ The `sentry init` command is AI-powered. It analyzes your project and generates 
 - **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
 
 For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+
+</Expandable>
+
+<Expandable title="Prefer the existing Nuxt wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i nuxt
+```
+
+To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
 
 </Expandable>
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -16,7 +16,7 @@ categories:
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard option below, or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
 
 </Alert>
 
@@ -26,7 +26,7 @@ The AI-powered `sentry init` flow is currently experimental. If you don't want t
 
 Run the Sentry init command in your project directory to automatically configure Sentry in your Nuxt application.
 
-The wizard guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
+The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -51,9 +51,9 @@ To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javas
 
 </Alert>
 
-<Expandable title="How does the wizard work?">
+<Expandable title="How does sentry init work?">
 
-The Sentry init wizard is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
 
 - **Analyzes your project** — reads project files and manifests to understand your Nuxt app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
 - **Detects your framework** — identifies Nuxt and selects the `@sentry/nuxt` SDK.
@@ -72,7 +72,7 @@ For full details on what each file does, see the [Manual Setup](/platforms/javas
 
 ## Verify Your Setup
 
-The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
+The command will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
 
 <OnboardingOptionButtons
   options={[
@@ -157,7 +157,7 @@ After building and running your project, add the button to one of your pages and
 </template>
 ```
 
-Sentry captures the error for you. If the wizard added verification files to your project, you can use those instead of adding a temporary test button.
+Sentry captures the error for you. If the command you ran added verification files to your project, you can use those instead of adding a temporary test button.
 
 ### Check Your Data in Sentry
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -16,7 +16,7 @@ categories:
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard below or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, run the existing framework-specific wizard with `npx @sentry/wizard@latest -i nuxt`, or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -72,7 +72,9 @@ To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/gu
 
 ## Verify Your Setup
 
-If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard.
+The `sentry init` command checks the integration files it creates or modifies before it finishes. To confirm runtime events are reaching Sentry, start your Nuxt app, exercise the parts of your app that should send events, and then check your Sentry project.
+
+If you used the Nuxt installation wizard instead, you can also verify your setup with the example page or component it creates.
 
 <Expandable level="warning" title="The wizard created an example component instead of a page.">
 The wizard creates a `SentryErrorButton` component when it fails to add an example page to your project. This usually happens if you don't have a `app.vue` file or if that file does not contain the `NuxtPage` component. To verify your setup, follow these steps before continuing with the next section, "View Captured Data in Sentry":
@@ -136,7 +138,7 @@ NODE_OPTIONS='--import ./.nuxt/dev/sentry.server.config.mjs' nuxt dev
 </SplitSection>
 </SplitLayout>
 
-After building and running your project:
+If you used the Nuxt installation wizard, after building and running your project:
 
 1.  Open the example page `/sentry-example-page` in your browser. For most Nuxt applications, this will be at localhost.
 2.  Click the "Throw sample error" button. This triggers two errors:

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -72,21 +72,17 @@ For full details on what each file does, see the [Manual Setup](/platforms/javas
 
 ## Verify Your Setup
 
-The command will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
+If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard.
 
-<OnboardingOptionButtons
-  options={[
-    "error-monitoring",
-    "performance",
-    "session-replay",
-    "user-feedback",
-    "logs",
-  ]}
-/>
+<Expandable level="warning" title="The wizard created an example component instead of a page.">
+The wizard creates a `SentryErrorButton` component when it fails to add an example page to your project. This usually happens if you don't have a `app.vue` file or if that file does not contain the `NuxtPage` component. To verify your setup, follow these steps before continuing with the next section, "View Captured Data in Sentry":
 
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+1. Add the `SentryErrorButton` component to a page and open it in your browser. For most Nuxt applications, this will be at localhost.
+2. Click the "Throw Sample Error" button, which triggers an error and starts a performance trace on the client side.
 
-If you haven't tested your Sentry configuration yet, let's do it now. Add a test button to one of your pages to confirm that Sentry is working properly and sending data to your Sentry project.
+To test the server side as well, refer to the "Verify" section in the [Manual setup guide](/platforms/javascript/guides/nuxt/manual-setup/).
+
+</Expandable>
 
 To test Sentry, you can run your Nuxt application in either production or development mode.
 We **recommend testing in production mode** as it most closely resembles your deployed application's environment.
@@ -140,58 +136,26 @@ NODE_OPTIONS='--import ./.nuxt/dev/sentry.server.config.mjs' nuxt dev
 </SplitSection>
 </SplitLayout>
 
-After building and running your project, add the button to one of your pages and click it:
+After building and running your project:
 
-```vue
-<template>
-  <button
-    type="button"
-    @click="
-      () => {
-        throw new Error('Sentry Test Error');
-      }
-    "
-  >
-    Break the world
-  </button>
-</template>
-```
+1.  Open the example page `/sentry-example-page` in your browser. For most Nuxt applications, this will be at localhost.
+2.  Click the "Throw sample error" button. This triggers two errors:
+    - a frontend error
+    - an error within the API route
 
-Sentry captures the error for you. If the command you ran added verification files to your project, you can use those instead of adding a temporary test button.
+Sentry captures both of these errors for you. Additionally, the button click starts a performance trace to measure the time it takes for the API request to complete.
 
-### Check Your Data in Sentry
+### View Captured Data in Sentry
 
-**Errors** — [Open Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/)
+Now, head over to your project on [Sentry.io](https://sentry.io/) to view the collected data (it takes a couple of moments for the data to appear).
 
-You should see "Sentry Test Error" with a full stack trace pointing to your source code.
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
-<OnboardingOption optionId="performance">
-
-**Tracing** — [Open Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/)
-
-You should see route and request traces. Learn more about [Nuxt tracing](/platforms/javascript/guides/nuxt/tracing/).
-
-</OnboardingOption>
-
-<OnboardingOption optionId="session-replay">
-
-**Session Replay** — [Open Replays](https://sentry.io/orgredirect/organizations/:orgslug/replays/)
-
-Watch a video-like recording of your session, including the moment the error occurred. Learn more about [Session Replay configuration](/platforms/javascript/guides/nuxt/session-replay/).
-
-</OnboardingOption>
-
-<OnboardingOption optionId="logs">
-
-**Logs** — [Open Logs](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) <FeatureBadge type="new" />
-
-See structured log entries from your application. Learn more about [Logs configuration](/platforms/javascript/guides/nuxt/logs/).
-
-</OnboardingOption>
+<Include name="quick-start-locate-data-expandable" />
 
 ## Next Steps
 
-At this point, you should have integrated Sentry into your Nuxt application and should already be sending data to your Sentry project.
+At this point, you should have integrated Sentry into your Nuxt application and should already be sending error and performance data to your Sentry project.
 
 Now's a good time to customize your setup and look into more advanced topics. Our next recommended steps for you are:
 

--- a/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
@@ -5,18 +5,8 @@ description: "Learn how to manually set up Sentry in your Nuxt app and capture y
 ---
 
 <Alert level="info">
-  For automated setup, run the experimental AI-powered `sentry init` command:
-
-  ```bash
-  npx sentry@latest init
-  ```
-
-  If you'd rather use the existing Nuxt installation wizard, run:
-
-  ```bash
-  npx @sentry/wizard@latest -i nuxt
-  ```
-
+  Looking for automatic setup with `sentry init` or the Nuxt wizard? Follow the
+  [Nuxt quickstart](/platforms/javascript/guides/nuxt/) instead.
   Continue with this guide to set up Sentry manually.
 </Alert>
 

--- a/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
@@ -5,7 +5,14 @@ description: "Learn how to manually set up Sentry in your Nuxt app and capture y
 ---
 
 <Alert level="info">
-  For the fastest setup, we recommend using [`sentry init`](/platforms/javascript/guides/nuxt).
+  For automated setup, start with the experimental AI-powered [`sentry init`](/platforms/javascript/guides/nuxt) flow.
+  If you'd rather use the existing Nuxt installation wizard, run:
+
+  ```bash
+  npx @sentry/wizard@latest -i nuxt
+  ```
+
+  Continue with this guide to set up Sentry manually.
 </Alert>
 
 <PlatformContent includePath="getting-started-complete" />

--- a/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
@@ -5,8 +5,7 @@ description: "Learn how to manually set up Sentry in your Nuxt app and capture y
 ---
 
 <Alert level="info">
-  For the fastest setup, we recommend using the [wizard
-  installer](/platforms/javascript/guides/nuxt).
+  For the fastest setup, we recommend using [`sentry init`](/platforms/javascript/guides/nuxt).
 </Alert>
 
 <PlatformContent includePath="getting-started-complete" />

--- a/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
@@ -5,7 +5,12 @@ description: "Learn how to manually set up Sentry in your Nuxt app and capture y
 ---
 
 <Alert level="info">
-  For automated setup, start with the experimental AI-powered [`sentry init`](/platforms/javascript/guides/nuxt) flow.
+  For automated setup, run the experimental AI-powered `sentry init` command:
+
+  ```bash
+  npx sentry@latest init
+  ```
+
   If you'd rather use the existing Nuxt installation wizard, run:
 
   ```bash


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds the experimental `sentry init` path to the Nuxt docs, following the TanStack Start setup pattern. The quick start now points users at `npx sentry@latest init`, explains how the AI-powered command works, and keeps manual setup as the detailed fallback.

The existing `@sentry/wizard` command remains available as the non-AI framework wizard path.

This follows the merged TanStack Start docs PR [#17693](https://github.com/getsentry/sentry-docs/pull/17693) for the experimental `sentry init` flow, AI-powered command explanation, and manual-setup fallback pattern.

This also updates the manual setup callout while preserving the Nuxt-specific dev and production verification notes.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## TEST PLAN

- `git diff --check`
- `pnpm generate-doctree`
- Reviewed final diff to confirm wizard-generated example-page instructions are scoped to the existing wizard and next-step content is unchanged
- Not run: `pnpm lint:typos` (`typos` binary unavailable in this checkout)
- Not run: `pnpm build` (local build requires `NEXT_PUBLIC_SENTRY_DSN`)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

