### PR TITLE
docs(react-router): add sentry init setup

### DIFF
--- a/docs/platforms/javascript/guides/react-router/features/instrumentation-api.mdx
+++ b/docs/platforms/javascript/guides/react-router/features/instrumentation-api.mdx
@@ -197,7 +197,7 @@ export async function action({ request }) {
 
 If you're not seeing spans for your loaders and actions:
 
-1. Check that the React Router version is 7.9.5 or later
+1. Check that the React Router version is 7.15 or later
 2. Make sure `instrumentations` is exported from `entry.server.tsx`
 3. Verify `tracesSampleRate` is set in your server configuration
 

--- a/docs/platforms/javascript/guides/react-router/features/instrumentation-api.mdx
+++ b/docs/platforms/javascript/guides/react-router/features/instrumentation-api.mdx
@@ -4,7 +4,9 @@ description: "Automatic tracing for loaders, actions, middleware, navigations, f
 sidebar_order: 10
 ---
 
-React Router 7.15+ provides an [instrumentation API](https://reactrouter.com/how-to/instrumentation) that enables automatic span creation for loaders, actions, middleware, navigations, fetchers, lazy routes, and request handlers without the need for manual wrapper functions. Transaction names (for HTTP requests, pageloads, and navigations) use parameterized route patterns, such as `/users/:id`, and errors are automatically captured with proper context.
+React Router 7.15+ provides the stable [instrumentation API](https://reactrouter.com/how-to/instrumentation) used in this guide. React Router 7.9.5 introduced an earlier unstable version of the API with `unstable_*` names, so upgrade to 7.15+ before using the stable `instrumentations` examples below.
+
+The instrumentation API enables automatic span creation for loaders, actions, middleware, navigations, fetchers, lazy routes, and request handlers without the need for manual wrapper functions. Transaction names (for HTTP requests, pageloads, and navigations) use parameterized route patterns, such as `/users/:id`, and errors are automatically captured with proper context.
 
 ## Server-Side Setup
 
@@ -197,7 +199,7 @@ export async function action({ request }) {
 
 If you're not seeing spans for your loaders and actions:
 
-1. Check that the React Router version is 7.15 or later
+1. Check that the React Router version is 7.15 or later for the stable `instrumentations` API. React Router 7.9.5 includes the earlier unstable API, which uses `unstable_*` names.
 2. Make sure `instrumentations` is exported from `entry.server.tsx`
 3. Verify `tracesSampleRate` is set in your server configuration
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -35,7 +35,7 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard option below, or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
 
 </Alert>
 
@@ -45,7 +45,7 @@ The AI-powered `sentry init` flow is currently experimental. If you don't want t
 
 Run the Sentry init command in your project directory to automatically configure Sentry in your React Router v7 Framework Mode application.
 
-The wizard guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
+The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -71,9 +71,9 @@ To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javas
 
 </Alert>
 
-<Expandable title="How does the wizard work?">
+<Expandable title="How does sentry init work?">
 
-The Sentry init wizard is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
 
 - **Analyzes your project** — reads project files and manifests to understand your React Router Framework app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
 - **Detects your framework** — identifies React Router v7 Framework Mode and selects the `@sentry/react-router` SDK.
@@ -88,7 +88,7 @@ For full details on what each file does, see the [Manual Setup](/platforms/javas
 
 ## Verify Your Setup
 
-The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
+The command will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
 
 <OnboardingOptionButtons
   options={[

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -35,7 +35,7 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, run the existing framework-specific wizard with `npx @sentry/wizard@latest -i reactRouter`, or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard option below, or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -253,7 +253,9 @@ Sentry.init({
 
 ## Verify Your Setup
 
-If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard:
+The `sentry init` command checks the integration files it creates or modifies before it finishes. To confirm runtime events are reaching Sentry, start your React Router app, exercise the parts of your app that should send events, and then check your Sentry project.
+
+If you used the React Router Framework Mode installation wizard instead, you can also verify your setup with the example page it creates:
 
 1. Open the example page `/sentry-example-page` in your browser. For most React Router applications, this will be at localhost.
 2. Observe the example page with a button that triggers test errors.
@@ -264,7 +266,7 @@ Clicking the button triggers an error that Sentry captures for you. The example 
 
 <Alert level="success" title="Tip">
 
-Don't forget to explore the example files' code in your project to understand what's happening after your button click.
+If you used the React Router Framework Mode installation wizard, explore the example files' code in your project to understand what's happening after your button click.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -296,4 +296,4 @@ Our next recommended steps for you are:
 
 </Expandable>
 
-</StepConnector>
+</StepComponent>

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -35,7 +35,7 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard below or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, run the existing framework-specific wizard with `npx @sentry/wizard@latest -i reactRouter`, or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -59,18 +59,6 @@ npx sentry@latest init
 </SplitSection>
 </SplitLayout>
 
-<Alert level="info" title="Prefer the existing framework wizard?">
-
-If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
-
-```bash
-npx @sentry/wizard@latest -i reactRouter
-```
-
-To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
-
-</Alert>
-
 <Expandable title="How does sentry init work?">
 
 The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
@@ -83,6 +71,18 @@ The `sentry init` command is AI-powered. It analyzes your project and generates 
 - **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
 
 For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+
+</Expandable>
+
+<Expandable title="Prefer the existing React Router wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i reactRouter
+```
+
+To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
 
 </Expandable>
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -35,7 +35,7 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <Alert level="warning">
 
-The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard below or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
 
 </Alert>
 
@@ -58,6 +58,18 @@ npx sentry@latest init
 
 </SplitSection>
 </SplitLayout>
+
+<Alert level="info" title="Prefer the existing framework wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i reactRouter
+```
+
+To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+
+</Alert>
 
 <Expandable title="How does the wizard work?">
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -29,23 +29,29 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 <PlatformContent includePath="getting-started-prerequisites" />
 
-<StepConnector selector="h2" showNumbers={true}>
+<StepComponent>
 
 ## Install
+
+<Alert level="warning">
+
+The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+
+</Alert>
 
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>
 
-To install Sentry using the installation wizard, run the command on the right within your project directory.
+Run the Sentry init command in your project directory to automatically configure Sentry in your React Router v7 Framework Mode application.
 
-The wizard guides you through the setup process, asking you to enable additional (optional) Sentry features for your application beyond error monitoring.
+The wizard guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
 
 </SplitSectionText>
 <SplitSectionCode>
 
 ```bash
-npx @sentry/wizard@latest -i reactRouter
+npx sentry@latest init
 ```
 
 </SplitSectionCode>
@@ -53,28 +59,24 @@ npx @sentry/wizard@latest -i reactRouter
 </SplitSection>
 </SplitLayout>
 
-This guide assumes that you enable all features and allow the wizard to create an example page and route. You can add or remove features at any time, but setting them up now will save you the effort of configuring them manually later.
+<Expandable title="How does the wizard work?">
 
-<Expandable title="What does the installation wizard change inside your application?">
+The Sentry init wizard is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
 
-- Installs the `@sentry/react-router` package (and optionally `@sentry/profiling-node`)
-- Reveals React Router entry point files (`entry.client.tsx` and `entry.server.tsx`) if not already visible
-- Initializes Sentry in your client and server entry files with default configuration
-- Creates `instrument.server.mjs` for server-side instrumentation
-- Updates your `app/root.tsx` to capture errors in the error boundary
-- Configures source map upload in `vite.config.ts` and `react-router.config.ts`
-- Creates `.env.sentry-build-plugin` with an auth token to upload source maps (this file is automatically added to `.gitignore`)
-- Creates example page and API route to help verify your Sentry setup
+- **Analyzes your project** — reads project files and manifests to understand your React Router Framework app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies React Router v7 Framework Mode and selects the `@sentry/react-router` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/react-router` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, error capture, tracing, and other selected features based on your existing project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
+
+For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
 
 </Expandable>
 
-## Configure
+## Verify Your Setup
 
-If you prefer to configure Sentry manually, here are the configuration files the wizard would create:
-
-In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also get to the root of an error or performance issue faster, by watching a video-like reproduction of a user session with [session replay](/product/explore/session-replay/web/getting-started/).
-
-Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
+The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
 
 <OnboardingOptionButtons
   options={[
@@ -83,178 +85,55 @@ Select which Sentry features you'd like to install in addition to Error Monitori
     "session-replay",
     "user-feedback",
     "logs",
-    {
-      id: "profiling",
-      checked: false,
-    },
   ]}
 />
 
-<Include name="quick-start-features-expandable" />
-
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
-### Client-Side Configuration
-
-The wizard creates a client configuration file that initializes the Sentry SDK in your browser.
-
-The configuration includes your DSN (Data Source Name), which connects your app to your Sentry project, and enables the features you selected during installation.
-
-</SplitSectionText>
-<SplitSectionCode>
-
-```tsx {tabTitle:Client} {filename:entry.client.tsx}
-import * as Sentry from "@sentry/react-router";
-import { startTransition, StrictMode } from "react";
-import { hydrateRoot } from "react-dom/client";
-import { HydratedRouter } from "react-router/dom";
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // To disable sending user data, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
-
-  integrations: [
-    // ___PRODUCT_OPTION_START___ performance
-    // Registers and configures the Tracing integration,
-    // which automatically instruments your application to monitor its
-    // performance, including custom React Router routing instrumentation
-    Sentry.reactRouterTracingIntegration(),
-    // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ session-replay
-    // Registers the Replay integration,
-    // which automatically captures Session Replays
-    Sentry.replayIntegration(),
-    // ___PRODUCT_OPTION_END___ session-replay
-    // ___PRODUCT_OPTION_START___ user-feedback
-    Sentry.feedbackIntegration({
-      // Additional SDK configuration goes in here, for example:
-      colorScheme: "system",
-    }),
-    // ___PRODUCT_OPTION_END___ user-feedback
-  ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
-  // ___PRODUCT_OPTION_START___ performance
-
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for tracing.
-  // We recommend adjusting this value in production
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#traces-sample-rate
-  tracesSampleRate: 1.0,
-
-  // Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled
-  tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
-  // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ session-replay
-
-  // Capture Replay for 10% of all sessions,
-  // plus 100% of sessions with an error
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/configuration/#general-integration-configuration
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  // ___PRODUCT_OPTION_END___ session-replay
-});
-
-startTransition(() => {
-  hydrateRoot(
-    document,
-    <StrictMode>
-      <HydratedRouter />
-    </StrictMode>
-  );
-});
-```
-
-</SplitSectionCode>
-</SplitSection>
-
-<SplitSection>
-<SplitSectionText>
-
-### Server-Side Configuration
-
-The wizard also creates a server configuration file for Node.js runtime.
-
-For more advanced configuration options or to set up Sentry manually, check out our [manual setup guide](/platforms/javascript/guides/react-router/manual-setup/).
-
-</SplitSectionText>
-<SplitSectionCode>
-
-```js {tabTitle:Server} {filename:instrument.server.mjs}
-import * as Sentry from "@sentry/react-router";
-// ___PRODUCT_OPTION_START___ profiling
-import { nodeProfilingIntegration } from "@sentry/profiling-node";
-// ___PRODUCT_OPTION_END___ profiling
-
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-
-  // To disable sending user data, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
-  // ___PRODUCT_OPTION_START___ profiling
-
-  // Add our Profiling integration
-  integrations: [nodeProfilingIntegration()],
-  // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ performance
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for tracing.
-  // We recommend adjusting this value in production
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#tracesSampleRate
-  tracesSampleRate: 1.0,
-  // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ profiling
-  // Enable profiling for a percentage of sessions
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
-  profileSessionSampleRate: 1.0,
-  // ___PRODUCT_OPTION_END___ profiling
-});
-```
-
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
-
-## Verify Your Setup
-
-If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard:
-
-1. Open the example page `/sentry-example-page` in your browser. For most React Router applications, this will be at localhost.
-2. Observe the example page with a button that triggers test errors.
-
 <PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
-Clicking the button triggers an error that Sentry captures for you. The example also demonstrates how to test performance tracing.
+Add a test button to one of your routes to trigger an error:
 
-<Alert level="success" title="Tip">
+```tsx
+<button
+  type="button"
+  onClick={() => {
+    throw new Error("Sentry Test Error");
+  }}
+>
+  Break the world
+</button>
+```
 
-Don't forget to explore the example files' code in your project to understand what's happening after your button click.
+Start your app and click the button.
 
-</Alert>
+### Check Your Data in Sentry
 
-### View Captured Data in Sentry
+**Errors** — [Open Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/)
 
-Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
+You should see "Sentry Test Error" with a full stack trace pointing to your source code.
 
-<Include name="quick-start-locate-data-expandable" />
+<OnboardingOption optionId="performance">
+
+**Tracing** — [Open Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/)
+
+You should see route and request traces. Learn more about the [Instrumentation API](/platforms/javascript/guides/react-router/features/instrumentation-api/).
+
+</OnboardingOption>
+
+<OnboardingOption optionId="session-replay">
+
+**Session Replay** — [Open Replays](https://sentry.io/orgredirect/organizations/:orgslug/replays/)
+
+Watch a video-like recording of your session, including the moment the error occurred. Learn more about [Session Replay configuration](/platforms/javascript/guides/react-router/session-replay/).
+
+</OnboardingOption>
+
+<OnboardingOption optionId="logs">
+
+**Logs** — [Open Logs](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) <FeatureBadge type="new" />
+
+See structured log entries from your application. Learn more about [Logs configuration](/platforms/javascript/guides/react-router/logs/).
+
+</OnboardingOption>
 
 ## Next Steps
 
@@ -276,4 +155,4 @@ Our next recommended steps for you are:
 
 </Expandable>
 
-</StepConnector>
+</StepComponent>

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -86,9 +86,13 @@ For full details on what each file does, see the [Manual Setup](/platforms/javas
 
 </Expandable>
 
-## Verify Your Setup
+## Configure
 
-The command will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
+If you prefer to configure Sentry manually, here are the configuration files the wizard would create:
+
+In addition to capturing errors, you can monitor interactions between multiple services or applications by [enabling tracing](/concepts/key-terms/tracing/). You can also get to the root of an error or performance issue faster, by watching a video-like reproduction of a user session with [session replay](/product/explore/session-replay/web/getting-started/).
+
+Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
 <OnboardingOptionButtons
   options={[
@@ -97,55 +101,178 @@ The command will have prompted you to select which features to enable. Select th
     "session-replay",
     "user-feedback",
     "logs",
+    {
+      id: "profiling",
+      checked: false,
+    },
   ]}
 />
 
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+<Include name="quick-start-features-expandable" />
 
-Add a test button to one of your routes to trigger an error:
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
-```tsx
-<button
-  type="button"
-  onClick={() => {
-    throw new Error("Sentry Test Error");
-  }}
->
-  Break the world
-</button>
+### Client-Side Configuration
+
+The wizard creates a client configuration file that initializes the Sentry SDK in your browser.
+
+The configuration includes your DSN (Data Source Name), which connects your app to your Sentry project, and enables the features you selected during installation.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```tsx {tabTitle:Client} {filename:entry.client.tsx}
+import * as Sentry from "@sentry/react-router";
+import { startTransition, StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { HydratedRouter } from "react-router/dom";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+
+  // To disable sending user data, uncomment the line below. For more info visit:
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+  // dataCollection: { userInfo: false },
+
+  integrations: [
+    // ___PRODUCT_OPTION_START___ performance
+    // Registers and configures the Tracing integration,
+    // which automatically instruments your application to monitor its
+    // performance, including custom React Router routing instrumentation
+    Sentry.reactRouterTracingIntegration(),
+    // ___PRODUCT_OPTION_END___ performance
+    // ___PRODUCT_OPTION_START___ session-replay
+    // Registers the Replay integration,
+    // which automatically captures Session Replays
+    Sentry.replayIntegration(),
+    // ___PRODUCT_OPTION_END___ session-replay
+    // ___PRODUCT_OPTION_START___ user-feedback
+    Sentry.feedbackIntegration({
+      // Additional SDK configuration goes in here, for example:
+      colorScheme: "system",
+    }),
+    // ___PRODUCT_OPTION_END___ user-feedback
+  ],
+  // ___PRODUCT_OPTION_START___ logs
+
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+  // ___PRODUCT_OPTION_END___ logs
+  // ___PRODUCT_OPTION_START___ performance
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for tracing.
+  // We recommend adjusting this value in production
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#traces-sample-rate
+  tracesSampleRate: 1.0,
+
+  // Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled
+  tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
+  // ___PRODUCT_OPTION_END___ performance
+  // ___PRODUCT_OPTION_START___ session-replay
+
+  // Capture Replay for 10% of all sessions,
+  // plus 100% of sessions with an error
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/configuration/#general-integration-configuration
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ session-replay
+});
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <HydratedRouter />
+    </StrictMode>
+  );
+});
 ```
 
-Start your app and click the button.
+</SplitSectionCode>
+</SplitSection>
 
-### Check Your Data in Sentry
+<SplitSection>
+<SplitSectionText>
 
-**Errors** — [Open Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/)
+### Server-Side Configuration
 
-You should see "Sentry Test Error" with a full stack trace pointing to your source code.
+The wizard also creates a server configuration file for Node.js runtime.
 
-<OnboardingOption optionId="performance">
+For more advanced configuration options or to set up Sentry manually, check out our [manual setup guide](/platforms/javascript/guides/react-router/manual-setup/).
 
-**Tracing** — [Open Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/)
+</SplitSectionText>
+<SplitSectionCode>
 
-You should see route and request traces. Learn more about the [Instrumentation API](/platforms/javascript/guides/react-router/features/instrumentation-api/).
+```js {tabTitle:Server} {filename:instrument.server.mjs}
+import * as Sentry from "@sentry/react-router";
+// ___PRODUCT_OPTION_START___ profiling
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+// ___PRODUCT_OPTION_END___ profiling
 
-</OnboardingOption>
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
 
-<OnboardingOption optionId="session-replay">
+  // To disable sending user data, uncomment the line below. For more info visit:
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+  // dataCollection: { userInfo: false },
+  // ___PRODUCT_OPTION_START___ logs
 
-**Session Replay** — [Open Replays](https://sentry.io/orgredirect/organizations/:orgslug/replays/)
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+  // ___PRODUCT_OPTION_END___ logs
+  // ___PRODUCT_OPTION_START___ profiling
 
-Watch a video-like recording of your session, including the moment the error occurred. Learn more about [Session Replay configuration](/platforms/javascript/guides/react-router/session-replay/).
+  // Add our Profiling integration
+  integrations: [nodeProfilingIntegration()],
+  // ___PRODUCT_OPTION_END___ profiling
+  // ___PRODUCT_OPTION_START___ performance
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for tracing.
+  // We recommend adjusting this value in production
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#tracesSampleRate
+  tracesSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ performance
+  // ___PRODUCT_OPTION_START___ profiling
+  // Enable profiling for a percentage of sessions
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
+  profileSessionSampleRate: 1.0,
+  // ___PRODUCT_OPTION_END___ profiling
+});
+```
 
-</OnboardingOption>
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-<OnboardingOption optionId="logs">
+## Verify Your Setup
 
-**Logs** — [Open Logs](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) <FeatureBadge type="new" />
+If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard:
 
-See structured log entries from your application. Learn more about [Logs configuration](/platforms/javascript/guides/react-router/logs/).
+1. Open the example page `/sentry-example-page` in your browser. For most React Router applications, this will be at localhost.
+2. Observe the example page with a button that triggers test errors.
 
-</OnboardingOption>
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
+
+Clicking the button triggers an error that Sentry captures for you. The example also demonstrates how to test performance tracing.
+
+<Alert level="success" title="Tip">
+
+Don't forget to explore the example files' code in your project to understand what's happening after your button click.
+
+</Alert>
+
+### View Captured Data in Sentry
+
+Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
+
+<Include name="quick-start-locate-data-expandable" />
 
 ## Next Steps
 
@@ -167,4 +294,4 @@ Our next recommended steps for you are:
 
 </Expandable>
 
-</StepComponent>
+</StepConnector>

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -12,8 +12,7 @@ description: "Learn how to manually set up Sentry in your React Router v7 app an
 </Alert>
 
 <Alert level="info">
-  For the fastest setup, we recommend using the [wizard
-  installer](/platforms/javascript/guides/react-router).
+  For the fastest setup, we recommend using [`sentry init`](/platforms/javascript/guides/react-router).
 </Alert>
 
 <PlatformContent includePath="getting-started-prerequisites" />
@@ -205,7 +204,7 @@ Automatic server-side instrumentation is currently only supported on:
 
 If you're on a different version, you have two options:
 
-1. **Recommended**: Use the <PlatformLink to="/features/instrumentation-api/">Instrumentation API</PlatformLink> (React Router 7.9.5+) for automatic tracing without Node version restrictions
+1. **Recommended**: Use the <PlatformLink to="/features/instrumentation-api/">Instrumentation API</PlatformLink> (React Router 7.15+) for automatic tracing without Node version restrictions
 2. **Alternative**: Use our manual server wrappers (shown below)
 
 For server loaders use `wrapServerLoader`:

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -211,7 +211,7 @@ Automatic server-side instrumentation is currently only supported on:
 
 If you're on a different version, you have two options:
 
-1. **Recommended**: Use the <PlatformLink to="/features/instrumentation-api/">Instrumentation API</PlatformLink> (React Router 7.15+) for automatic tracing without Node version restrictions
+1. **Recommended**: Use the stable <PlatformLink to="/features/instrumentation-api/">Instrumentation API</PlatformLink> (React Router 7.15+) for automatic tracing without Node version restrictions. React Router 7.9.5 introduced an earlier unstable API with `unstable_*` names.
 2. **Alternative**: Use our manual server wrappers (shown below)
 
 For server loaders use `wrapServerLoader`:

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -12,18 +12,9 @@ description: "Learn how to manually set up Sentry in your React Router v7 app an
 </Alert>
 
 <Alert level="info">
-  For automated setup, run the experimental AI-powered `sentry init` command:
-
-  ```bash
-  npx sentry@latest init
-  ```
-
-  If you'd rather use the existing React Router Framework Mode installation wizard, run:
-
-  ```bash
-  npx @sentry/wizard@latest -i reactRouter
-  ```
-
+  Looking for automatic setup with `sentry init` or the React Router Framework
+  Mode wizard? Follow the [React Router quickstart](/platforms/javascript/guides/react-router/)
+  instead.
   Continue with this guide to set up Sentry manually.
 </Alert>
 

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -12,7 +12,14 @@ description: "Learn how to manually set up Sentry in your React Router v7 app an
 </Alert>
 
 <Alert level="info">
-  For the fastest setup, we recommend using [`sentry init`](/platforms/javascript/guides/react-router).
+  For automated setup, start with the experimental AI-powered [`sentry init`](/platforms/javascript/guides/react-router) flow.
+  If you'd rather use the existing React Router Framework Mode installation wizard, run:
+
+  ```bash
+  npx @sentry/wizard@latest -i reactRouter
+  ```
+
+  Continue with this guide to set up Sentry manually.
 </Alert>
 
 <PlatformContent includePath="getting-started-prerequisites" />

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -12,7 +12,12 @@ description: "Learn how to manually set up Sentry in your React Router v7 app an
 </Alert>
 
 <Alert level="info">
-  For automated setup, start with the experimental AI-powered [`sentry init`](/platforms/javascript/guides/react-router) flow.
+  For automated setup, run the experimental AI-powered `sentry init` command:
+
+  ```bash
+  npx sentry@latest init
+  ```
+
   If you'd rather use the existing React Router Framework Mode installation wizard, run:
 
   ```bash


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds the experimental `sentry init` path to the React Router Framework Mode docs, following the TanStack Start setup pattern. The quick start now points users at `npx sentry@latest init`, explains how the AI-powered command works, and keeps manual setup as the detailed fallback.

The existing `@sentry/wizard` command remains available as the non-AI framework wizard path.

This follows the merged TanStack Start docs PR [#17693](https://github.com/getsentry/sentry-docs/pull/17693) for the experimental `sentry init` flow, AI-powered command explanation, and manual-setup fallback pattern.

This also updates the manual setup callout and standardizes React Router Instrumentation API wording on `7.15+`.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## TEST PLAN

- `git diff --check`
- `pnpm generate-doctree`
- Reviewed final diff to confirm wizard-generated example-page instructions are scoped to the existing wizard and next-step content is unchanged
- Not run: `pnpm lint:typos` (`typos` binary unavailable in this checkout)
- Not run: `pnpm build` (local build requires `NEXT_PUBLIC_SENTRY_DSN`)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

