### PR TITLE
docs(sveltekit): add sentry init setup

### DIFF
--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -18,7 +18,7 @@ categories:
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard below or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, run the existing framework-specific wizard with `npx @sentry/wizard@latest -i sveltekit`, or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -42,18 +42,6 @@ npx sentry@latest init
 </SplitSection>
 </SplitLayout>
 
-<Alert level="info" title="Prefer the existing framework wizard?">
-
-If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
-
-```bash
-npx @sentry/wizard@latest -i sveltekit
-```
-
-To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
-
-</Alert>
-
 <Expandable title="How does sentry init work?">
 
 The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
@@ -66,6 +54,18 @@ The `sentry init` command is AI-powered. It analyzes your project and generates 
 - **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
 
 For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+
+</Expandable>
+
+<Expandable title="Prefer the existing SvelteKit wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i sveltekit
+```
+
+To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
 
 </Expandable>
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -75,74 +75,32 @@ For full details on what each file does, see the [Manual Setup](/platforms/javas
 
 ## Verify Your Setup
 
-The command will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
+If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page and route created by the installation wizard:
 
-<OnboardingOptionButtons
-  options={[
-    "error-monitoring",
-    "performance",
-    "session-replay",
-    "user-feedback",
-    "logs",
-  ]}
-/>
+1. Open the example page `/sentry-example-page` in your browser
+2. Click the "Throw Sample Error" button. This triggers two errors:
+   - a frontend error
+   - an error within the API route
 
-<PlatformContent includePath="getting-started-browser-sandbox-warning" />
-
-Add a test button to one of your pages to trigger an error:
-
-```svelte
-<button
-  type="button"
-  on:click={() => {
-    throw new Error("Sentry Test Error");
-  }}
->
-  Break the world
-</button>
-```
-
-Start your dev server and click the button.
+Sentry captures both of these errors for you. Additionally, the button click starts a trace to measure the time it takes for the API request to complete.
 
 <Alert level="success" title="Tip">
 
-If the command you ran added verification files to your project, you can use those instead of adding a temporary test button.
+Don't forget to explore the example files' code in your project to understand what's happening after your button click.
 
 </Alert>
 
-### Check Your Data in Sentry
+### View Captured Data in Sentry
 
-**Errors** — [Open Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/)
+Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
 
-You should see "Sentry Test Error" with a full stack trace pointing to your source code.
+<PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
-<OnboardingOption optionId="performance">
-
-**Tracing** — [Open Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/)
-
-You should see request and route traces. Learn more about [SvelteKit tracing](/platforms/javascript/guides/sveltekit/tracing/).
-
-</OnboardingOption>
-
-<OnboardingOption optionId="session-replay">
-
-**Session Replay** — [Open Replays](https://sentry.io/orgredirect/organizations/:orgslug/replays/)
-
-Watch a video-like recording of your session, including the moment the error occurred. Learn more about [Session Replay configuration](/platforms/javascript/guides/sveltekit/session-replay/).
-
-</OnboardingOption>
-
-<OnboardingOption optionId="logs">
-
-**Logs** — [Open Logs](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) <FeatureBadge type="new" />
-
-See structured log entries from your application. Learn more about [Logs configuration](/platforms/javascript/guides/sveltekit/logs/).
-
-</OnboardingOption>
+<Include name="quick-start-locate-data-expandable" />
 
 ## Next Steps
 
-At this point, you should have integrated Sentry into your SvelteKit application and should already be sending data to your Sentry project.
+At this point, you should have integrated Sentry into your SvelteKit application and should already be sending error and performance data to your Sentry project.
 
 Now's a good time to customize your setup and look into more advanced topics.
 Our next recommended steps for you are:
@@ -150,7 +108,7 @@ Our next recommended steps for you are:
 - Explore [practical guides](/guides/) on what to monitor, log, track, and investigate after setup
 - Learn how to [manually capture errors](/platforms/javascript/guides/sveltekit/usage/)
 - Continue to [customize your configuration](/platforms/javascript/guides/sveltekit/configuration/)
-- Learn how to [manually instrument](/platforms/javascript/guides/sveltekit/configuration/build/#load-function-instrumentation) SvelteKit-specific features
+- Learn how to [manually instrument](/platforms/javascript/guides/sveltekit/apis#load-function-instrumentation) SvelteKit-specific features
 - Learn more about [deploying SvelteKit apps to Cloudflare Pages](/platforms/javascript/guides/cloudflare/frameworks/sveltekit/)
 - Get familiar with [Sentry's product features](/product) like tracing, insights, and alerts
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -18,7 +18,7 @@ categories:
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard option below, or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
 
 </Alert>
 
@@ -28,7 +28,7 @@ The AI-powered `sentry init` flow is currently experimental. If you don't want t
 
 Run the Sentry init command in your project directory to automatically configure Sentry in your SvelteKit application.
 
-The wizard guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
+The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
 
 </SplitSectionText>
 
@@ -54,9 +54,9 @@ To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javas
 
 </Alert>
 
-<Expandable title="How does the wizard work?">
+<Expandable title="How does sentry init work?">
 
-The Sentry init wizard is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
 
 - **Analyzes your project** — reads project files and manifests to understand your SvelteKit app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
 - **Detects your framework** — identifies SvelteKit and selects the `@sentry/sveltekit` SDK.
@@ -75,7 +75,7 @@ For full details on what each file does, see the [Manual Setup](/platforms/javas
 
 ## Verify Your Setup
 
-The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
+The command will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
 
 <OnboardingOptionButtons
   options={[
@@ -106,7 +106,7 @@ Start your dev server and click the button.
 
 <Alert level="success" title="Tip">
 
-If the wizard added verification files to your project, you can use those instead of adding a temporary test button.
+If the command you ran added verification files to your project, you can use those instead of adding a temporary test button.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -16,37 +16,44 @@ categories:
 <StepComponent>
 ## Install
 
+<Alert level="warning">
+
+The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+
+</Alert>
+
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>
 
-Run the Sentry wizard to automatically configure Sentry in your SvelteKit application. It will then guide you through the setup process, asking you to enable additional (optional) Sentry features for your application beyond error monitoring.
+Run the Sentry init command in your project directory to automatically configure Sentry in your SvelteKit application.
+
+The wizard guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
 
 </SplitSectionText>
 
 <SplitSectionCode>
 
 ```bash
-npx @sentry/wizard@latest -i sveltekit
+npx sentry@latest init
 ```
 
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
 
-<Include name="quick-start-features-expandable" />
+<Expandable title="How does the wizard work?">
 
-This guide assumes that you enable all features and allow the wizard to create an example page. You can add or remove features at any time, but setting them up now will save you the effort of configuring them manually later.
+The Sentry init wizard is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
 
-<Expandable title="What does the installation wizard change inside your application?">
+- **Analyzes your project** — reads project files and manifests to understand your SvelteKit app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies SvelteKit and selects the `@sentry/sveltekit` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/sveltekit` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, SvelteKit hooks or instrumentation, and other selected features based on your SvelteKit version and project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
 
-- Creates or updates `hooks.(client|server).js` to initialize the SDK and instrument [SvelteKit's hooks](https://kit.svelte.dev/docs/hooks)
-- Creates or updates `vite.config.js` to add source maps upload and auto-instrumentation via Vite plugins
-- If you're on SvelteKit `2.31.0` or higher:
-  - Creates `instrumentation.server.js` to initialize the server-side SDK
-  - Enables server-side instrumentation and tracing in `svelte.config.js`
-- Creates `.env.sentry-build-plugin` with an auth token to upload source maps (this file is automatically added to `.gitignore`)
-- Adds an example page to your application to help verify your Sentry setup
+For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
 
 </Expandable>
 
@@ -56,32 +63,74 @@ This guide assumes that you enable all features and allow the wizard to create a
 
 ## Verify Your Setup
 
-If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page and route created by the installation wizard:
+The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:
 
-1. Open the example page `/sentry-example-page` in your browser
-2. Click the "Throw Sample Error" button. This triggers two errors:
-   - a frontend error
-   - an error within the API route
-
-Sentry captures both of these errors for you. Additionally, the button click starts a trace to measure the time it takes for the API request to complete.
-
-<Alert level="success" title="Tip">
-
-Don't forget to explore the example files' code in your project to understand what's happening after your button click.
-
-</Alert>
-
-### View Captured Data in Sentry
-
-Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
+<OnboardingOptionButtons
+  options={[
+    "error-monitoring",
+    "performance",
+    "session-replay",
+    "user-feedback",
+    "logs",
+  ]}
+/>
 
 <PlatformContent includePath="getting-started-browser-sandbox-warning" />
 
-<Include name="quick-start-locate-data-expandable" />
+Add a test button to one of your pages to trigger an error:
+
+```svelte
+<button
+  type="button"
+  on:click={() => {
+    throw new Error("Sentry Test Error");
+  }}
+>
+  Break the world
+</button>
+```
+
+Start your dev server and click the button.
+
+<Alert level="success" title="Tip">
+
+If the wizard added verification files to your project, you can use those instead of adding a temporary test button.
+
+</Alert>
+
+### Check Your Data in Sentry
+
+**Errors** — [Open Issues](https://sentry.io/orgredirect/organizations/:orgslug/issues/)
+
+You should see "Sentry Test Error" with a full stack trace pointing to your source code.
+
+<OnboardingOption optionId="performance">
+
+**Tracing** — [Open Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/)
+
+You should see request and route traces. Learn more about [SvelteKit tracing](/platforms/javascript/guides/sveltekit/tracing/).
+
+</OnboardingOption>
+
+<OnboardingOption optionId="session-replay">
+
+**Session Replay** — [Open Replays](https://sentry.io/orgredirect/organizations/:orgslug/replays/)
+
+Watch a video-like recording of your session, including the moment the error occurred. Learn more about [Session Replay configuration](/platforms/javascript/guides/sveltekit/session-replay/).
+
+</OnboardingOption>
+
+<OnboardingOption optionId="logs">
+
+**Logs** — [Open Logs](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) <FeatureBadge type="new" />
+
+See structured log entries from your application. Learn more about [Logs configuration](/platforms/javascript/guides/sveltekit/logs/).
+
+</OnboardingOption>
 
 ## Next Steps
 
-At this point, you should have integrated Sentry into your SvelteKit application and should already be sending error and performance data to your Sentry project.
+At this point, you should have integrated Sentry into your SvelteKit application and should already be sending data to your Sentry project.
 
 Now's a good time to customize your setup and look into more advanced topics.
 Our next recommended steps for you are:
@@ -89,7 +138,7 @@ Our next recommended steps for you are:
 - Explore [practical guides](/guides/) on what to monitor, log, track, and investigate after setup
 - Learn how to [manually capture errors](/platforms/javascript/guides/sveltekit/usage/)
 - Continue to [customize your configuration](/platforms/javascript/guides/sveltekit/configuration/)
-- Learn how to [manually instrument](/platforms/javascript/guides/sveltekit/apis#load-function-instrumentation) SvelteKit-specific features
+- Learn how to [manually instrument](/platforms/javascript/guides/sveltekit/configuration/build/#load-function-instrumentation) SvelteKit-specific features
 - Learn more about [deploying SvelteKit apps to Cloudflare Pages](/platforms/javascript/guides/cloudflare/frameworks/sveltekit/)
 - Get familiar with [Sentry's product features](/product) like tracing, insights, and alerts
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -18,7 +18,7 @@ categories:
 
 <Alert level="warning">
 
-The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard below or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
 
 </Alert>
 
@@ -41,6 +41,18 @@ npx sentry@latest init
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+<Alert level="info" title="Prefer the existing framework wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i sveltekit
+```
+
+To configure Sentry without a wizard, follow the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+
+</Alert>
 
 <Expandable title="How does the wizard work?">
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -18,7 +18,7 @@ categories:
 
 <Alert level="warning">
 
-The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, run the existing framework-specific wizard with `npx @sentry/wizard@latest -i sveltekit`, or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+The AI-powered `sentry init` flow is currently experimental. If you don't want to use it, use the existing framework-specific wizard option below, or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -75,7 +75,9 @@ To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/gu
 
 ## Verify Your Setup
 
-If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page and route created by the installation wizard:
+The `sentry init` command checks the integration files it creates or modifies before it finishes. To confirm runtime events are reaching Sentry, start your SvelteKit app, exercise the parts of your app that should send events, and then check your Sentry project.
+
+If you used the SvelteKit installation wizard instead, you can also verify your setup with the example page and route it creates:
 
 1. Open the example page `/sentry-example-page` in your browser
 2. Click the "Throw Sample Error" button. This triggers two errors:
@@ -86,7 +88,7 @@ Sentry captures both of these errors for you. Additionally, the button click sta
 
 <Alert level="success" title="Tip">
 
-Don't forget to explore the example files' code in your project to understand what's happening after your button click.
+If you used the SvelteKit installation wizard, explore the example files' code in your project to understand what's happening after your button click.
 
 </Alert>
 

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -5,7 +5,12 @@ description: "Learn how to manually set up Sentry in your SvelteKit app and capt
 ---
 
 <Alert level="info">
-  For automated setup, start with the experimental AI-powered [`sentry init`](/platforms/javascript/guides/sveltekit) flow.
+  For automated setup, run the experimental AI-powered `sentry init` command:
+
+  ```bash
+  npx sentry@latest init
+  ```
+
   If you'd rather use the existing SvelteKit installation wizard, run:
 
   ```bash

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -5,7 +5,14 @@ description: "Learn how to manually set up Sentry in your SvelteKit app and capt
 ---
 
 <Alert level="info">
-  For the fastest setup, we recommend using [`sentry init`](/platforms/javascript/guides/sveltekit).
+  For automated setup, start with the experimental AI-powered [`sentry init`](/platforms/javascript/guides/sveltekit) flow.
+  If you'd rather use the existing SvelteKit installation wizard, run:
+
+  ```bash
+  npx @sentry/wizard@latest -i sveltekit
+  ```
+
+  Continue with this guide to set up Sentry manually.
 </Alert>
 
 <PlatformContent includePath="getting-started-complete" />

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -5,18 +5,8 @@ description: "Learn how to manually set up Sentry in your SvelteKit app and capt
 ---
 
 <Alert level="info">
-  For automated setup, run the experimental AI-powered `sentry init` command:
-
-  ```bash
-  npx sentry@latest init
-  ```
-
-  If you'd rather use the existing SvelteKit installation wizard, run:
-
-  ```bash
-  npx @sentry/wizard@latest -i sveltekit
-  ```
-
+  Looking for automatic setup with `sentry init` or the SvelteKit wizard? Follow
+  the [SvelteKit quickstart](/platforms/javascript/guides/sveltekit/) instead.
   Continue with this guide to set up Sentry manually.
 </Alert>
 

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -5,8 +5,7 @@ description: "Learn how to manually set up Sentry in your SvelteKit app and capt
 ---
 
 <Alert level="info">
-  For the fastest setup, we recommend using the [wizard
-  installer](/platforms/javascript/guides/sveltekit).
+  For the fastest setup, we recommend using [`sentry init`](/platforms/javascript/guides/sveltekit).
 </Alert>
 
 <PlatformContent includePath="getting-started-complete" />


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds the experimental `sentry init` path to the SvelteKit docs, following the TanStack Start setup pattern. The quick start now points users at `npx sentry@latest init`, explains how the AI-powered command works, and keeps manual setup as the detailed fallback.

The existing `@sentry/wizard` command remains available as the non-AI framework wizard path.

This follows the merged TanStack Start docs PR [#17693](https://github.com/getsentry/sentry-docs/pull/17693) for the experimental `sentry init` flow, AI-powered command explanation, and manual-setup fallback pattern.

This also updates the manual setup callout and fixes a stale SvelteKit manual instrumentation link on the root guide.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## TEST PLAN

- `git diff --check`
- `pnpm generate-doctree`
- Reviewed final diff to confirm verification/next-step content is restored from base
- Not run: `pnpm lint:typos` (`typos` binary unavailable in this checkout)
- Not run: `pnpm build` (local build requires `NEXT_PUBLIC_SENTRY_DSN`)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
