### PR TITLE
Add .devcontainer/devcontainer.json reference config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,20 @@
 {
-  // Dev Container config for sentry-docs.
+  // Environment config for Sentry's coding-agent sandbox (Per-Repo Environments).
   //
-  // Standard devcontainer.json (VS Code Dev Containers / GitHub Codespaces) that
-  // also serves as the source-of-truth environment config for Sentry's
-  // coding-agent sandbox (Per-Repo Environments).
+  // The sandbox honors only the lifecycle commands + env below. It deliberately
+  // does NOT accept a repo-provided base image or tooling — `image`,
+  // `build`/`dockerfile`, and `features` are intentionally omitted, because the
+  // sandbox runs on its own hardened, multi-language base (Python + Node) and
+  // provisions runtime versions via `mise`, not via a repo image.
   //
-  // What the coding-agent sandbox honors vs ignores:
-  //   honored: onCreateCommand / updateContentCommand / postCreateCommand,
-  //            containerEnv, remoteEnv
-  //   ignored (by design, for security): image, build/dockerfile, features
-  //
-  // The sandbox runs on its own hardened, multi-language base image; the image
-  // + features below only apply to local Dev Containers / Codespaces. The repo
-  // pins node 22.16.0 / pnpm 10.30.0 via package.json (volta + packageManager).
+  // honored: onCreateCommand / updateContentCommand / postCreateCommand,
+  //          containerEnv, remoteEnv
   "name": "Sentry Docs",
 
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-
-  // Honored everywhere. Next.js builds are memory-hungry; give node headroom.
-  // next.config.ts requires NEXT_PUBLIC_SENTRY_DSN to be set for a production
-  // build — it's a public client-side key, so a placeholder is fine for dev/CI
-  // builds (override with the real DSN for a production deploy).
+  // NODE_OPTIONS gives the memory-hungry Next.js build headroom.
+  // next.config.ts requires NEXT_PUBLIC_SENTRY_DSN for a production build — it's
+  // a public client-side key, so a placeholder is fine for dev/CI builds
+  // (override with the real DSN for a production deploy).
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=8192",
     "NEXT_PUBLIC_SENTRY_DSN": "https://examplePublicKey@o0.ingest.sentry.io/0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  // Dev Container config for sentry-docs.
+  //
+  // Standard devcontainer.json (VS Code Dev Containers / GitHub Codespaces) that
+  // also serves as the source-of-truth environment config for Sentry's
+  // coding-agent sandbox (Per-Repo Environments).
+  //
+  // What the coding-agent sandbox honors vs ignores:
+  //   honored: onCreateCommand / updateContentCommand / postCreateCommand,
+  //            containerEnv, remoteEnv
+  //   ignored (by design, for security): image, build/dockerfile, features
+  //
+  // The sandbox runs on its own hardened, multi-language base image; the image
+  // + features below only apply to local Dev Containers / Codespaces. The repo
+  // pins node 22.16.0 / pnpm 10.30.0 via package.json (volta + packageManager).
+  "name": "Sentry Docs",
+
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+
+  // Honored everywhere. Next.js builds are memory-hungry; give node headroom.
+  // next.config.ts requires NEXT_PUBLIC_SENTRY_DSN to be set for a production
+  // build — it's a public client-side key, so a placeholder is fine for dev/CI
+  // builds (override with the real DSN for a production deploy).
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=8192",
+    "NEXT_PUBLIC_SENTRY_DSN": "https://examplePublicKey@o0.ingest.sentry.io/0"
+  },
+
+  // One-time, cacheable setup: activate the pinned pnpm (from package.json's
+  // packageManager field) via corepack, then install with the committed lockfile.
+  "onCreateCommand": "corepack enable && pnpm install --frozen-lockfile",
+
+  // Re-run on repo content changes (e.g. lockfile drift).
+  "updateContentCommand": "corepack enable && pnpm install --frozen-lockfile",
+
+  "postCreateCommand": "echo 'sentry-docs dev environment ready: pnpm deps installed (run: pnpm dev)'"
+}


### PR DESCRIPTION
## Summary

Adds a Dev Container config for sentry-docs. Standard `devcontainer.json` (VS Code Dev Containers / GitHub Codespaces) that **also** serves as the source-of-truth environment config for Sentry's coding-agent sandbox (**Per-Repo Environments**, part of [AIML-2937](https://linear.app/getsentry/issue/AIML-2937)).

## What the coding-agent sandbox honors vs ignores

- **Honored:** `onCreateCommand` / `updateContentCommand` / `postCreateCommand`, `containerEnv`, `remoteEnv`
- **Ignored (by design, for security):** `image`, `build`/`dockerfile`, `features`

The sandbox runs on its own hardened, multi-language base image; the `image` + node version here only apply to local Dev Containers / Codespaces. The repo pins node 22.16.0 / pnpm 10.30.0 via `package.json` (`volta` + `packageManager`).

## Lifecycle

- `onCreateCommand` / `updateContentCommand`: `corepack enable && pnpm install --frozen-lockfile`
- `containerEnv`: `NODE_OPTIONS` (build headroom) + `NEXT_PUBLIC_SENTRY_DSN` (a public client key; `next.config.ts` requires it for a production build — placeholder for dev/CI, override for prod deploy)

## Verified in the universal sandbox image

- `pnpm install --frozen-lockfile` resolves the lockfile and installs cleanly; pnpm auto-pinned to 10.30.0 via `packageManager`.
- `pnpm build` runs end to end — `enforce-redirects`, `generate-og-images` (2541 files scanned), `generate-doctree`, then `next build` static generation across ~10k pages — once `NEXT_PUBLIC_SENTRY_DSN` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/tehgJLfYHA86brLj-Cn-6jy-b5NcSf3HK_3KeckRulA