### PR TITLE
fix(docs): Remove stale JS logs loader warning

### DIFF
--- a/platform-includes/logs/requirements/javascript.mdx
+++ b/platform-includes/logs/requirements/javascript.mdx
@@ -2,10 +2,6 @@ Logs for JavaScript are supported in Sentry JavaScript SDK version `9.41.0` and 
 
 <PlatformSection supported={["javascript"]}>
 
-<Alert level="warning">
-
-Logging is not supported in the [loader or CDN script](/platforms/javascript/install/loader/) for browser JavaScript. We recommend installing the SDK via [NPM](/platforms/javascript/install/npm/) to use logging. We are tracking support for the loader and CDN script in [this GitHub issue](https://github.com/getsentry/sentry-javascript/issues/16314).
-
-</Alert>
+Logging is also supported via [CDN bundles and the Loader Script](/platforms/javascript/install/loader/). Use a bundle that includes logs, such as `bundle.logs.metrics.min.js`.
 
 </PlatformSection>


### PR DESCRIPTION
Fixes #17124 where the `/platforms/javascript/logs/` page still showed a warning saying:

 >  Logging is not supported via the loader or CDN. 

That guidance _appears_ to be outdated, As the loader/CDN bundles with logs support according to this comment 

[Support Sentry Logging in the JS Loader and CDN · Issue \#16314 · getsentry/sentry-javascript](https://github.com/getsentry/sentry-javascript/issues/16314#issuecomment-3896193327)

This will remove the stale warning and replace pointing to the Loader Script docs.

```mdx
<PlatformSection supported={["javascript"]}>

Logging is also supported via [CDN bundles and the Loader Script](/platforms/javascript/install/loader/). Use a bundle that includes logs, such as `bundle.logs.metrics.min.js`.

</PlatformSection>
```

[Capacitor](https://docs.sentry.io/platforms/javascript/guides/capacitor/logs/) was left unchanged on purpose. Since it uses [javascript.capacitor.mdx](https://github.com/getsentry/sentry-docs/blob/c41d1fb8b8bbb27e9a3cca64a6f7fd75437ca093/platform-includes/logs/requirements/javascript.capacitor.mdx?plain=1#L4), and the stale warning there is wrapped in `<PlatformSection supported={["javascript"]}>`, so it does not render on Capacitor pages since it's checking for: 

```mdx
<PlatformSection supported={["javascript"]}>
```

not 

```mdx
<PlatformSection supported={["javascript.capacitor"]}>
```

It’s gated by the wrong key for that page. But I think that's by design, should be safe to leave that file alone for now.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+