### PR TITLE
chore(dynamic-sampling): add notice about contacting account managers for am3

### DIFF
--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -95,7 +95,7 @@ Here you can configure a fixed sample rate for each project in your organization
 
 When you edit the sample rates for individual projects, an estimated overall sample rate for your organization will also be calculated. This is a weighted average based on the volume of traffic for each project. Keep in mind that this value is an estimate and may change as the volume of traffic fluctuates.
 
-To adjust the sample rates of all your projects at once, edit the overall sample rate for your organization by going to the [Dynamic Sampling settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/dynamic-sampling/). This will proportionally update each project's sample rate to meet your chosen target. The maximum rate is 100%, and adjustments will be made to balance the rates across projects. You'll be able to review and finalize the updated sample rates before saving. Make sure to click the "Apply changes" button to save the new sample rates.
+To adjust the sample rates of all your projects at once, edit the overall sample rate for your organization by going to the [Dynamic Sampling settings page](https://sentry.io/orgredirect/organizations/:orgslug/settings/dynamic-sampling/). This will proportionally update each project's sample rate to meet your chosen target. The maximum rate is 100%, and adjustments will be made to balance the rates across projects. You'll be able to review and finalize the updated sample rates before saving. Make sure to click the "Apply changes" button to save the new sample rates. **Note:** Only certain Team, Business, and Enterprise plans have access to Dynamic Sampling see [overview details](#overview) for more information. 
 
 ![Change all projects at once in Advanced Mode](./img/advanced-org-level.png)
 

--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -36,6 +36,13 @@ There are two available flavors of dynamic sampling, depending on the plan type 
 - **Dynamic Sampling with Sampling Priorities & Custom Sample Rates** - available on selected Enterprise plans\
   Configure and adjust sample rates for stored spans right from the UI without needing to modify your SDK. This makes it possible for you to make instant updates without waiting for code freezes, app store approvals, or redeployments. In addition, by analyzing incoming traffic patterns, Dynamic Sampling is able to prioritize data based on the content of accepted spans. For more details, check out the [Configuration of Custom Sample Rates](#configuration-of-custom-sample-rates) section.
 
+<Alert level="warning">
+  "Selected plans" means that Dynamic Sampling isn't included in every plan of
+  these types. If the Dynamic Sampling settings page in Sentry shows "Dynamic
+  Sampling is not available on your current plan", your organization's plan
+  doesn't include it. To get access, please contact your account manager.
+</Alert>
+
 
 ## Prerequisites
 
@@ -57,7 +64,7 @@ There are two available flavors of dynamic sampling, depending on the plan type 
 
 ## Configuration of Custom Sample Rates
 <Alert>
-Configuration of custom sample rates has been available on selected Enterprise plans since June 2024.
+Configuration of custom sample rates has been available on selected Enterprise plans since June 2024. If the Dynamic Sampling settings page isn't available in your organization, this feature isn't included in your current plan. To get access, please contact your account manager.
 </Alert>
 In this section, you'll learn how to use Dynamic Sampling in your organization. Dynamic Sampling offers two modes based on the desired sampling control:
 


### PR DESCRIPTION
- Add a callout that custom sample rates can only be set on certain plans and if the settings page is not available, to contact their account manager