### PR TITLE
docs(unreal): Session Replay platform-specific notes update

### DIFF
--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -20,11 +20,13 @@ Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/
 
 | Platform    | What gets captured                                                              | Requirements                                                                                        |
 | ----------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **Windows** | A rolling video clip of the game's backbuffer, attached to crash reports.       | The `AVCodecsCore` and `NVCodecs` plugins enabled, an NVIDIA GPU (NVENC), and a plugin rebuild after enabling (see [below](#windows-and-linux)). |
-| **Linux**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | The `AVCodecsCore` and `NVCodecs` plugins enabled, an NVIDIA GPU (NVENC), and a plugin rebuild after enabling (see [below](#windows-and-linux)). |
-| **macOS**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | The `AVCodecsCore` and `VTCodecs` plugins enabled, and a plugin rebuild after enabling (see [below](#macos)). |
+| **Windows** | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins matching the GPU vendor (NVIDIA or AMD) and a plugin rebuild.\*                |
+| **Linux**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins, an NVIDIA GPU, and a plugin rebuild.\*                                        |
+| **macOS**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins and a plugin rebuild.\*                                                        |
 | **Xbox**    | An OS-captured gameplay clip, attached to crash reports.                        | Development kits only.                                                                               |
 | **Android** | A full-session replay via the Android SDK, with default text and image masking. | None beyond the standard Android setup.                                                             |
+
+\* See the [Desktop platform notes](#desktop-windows-macos-and-linux) below for the exact plugin, GPU, and driver requirements.
 
 All other platforms (iOS, PlayStation, and Nintendo Switch) are not currently supported. On those platforms the setting is a no-op.
 
@@ -64,30 +66,24 @@ SessionReplayOptions=(FragmentSeconds=0.500000,RotationIntervalSeconds=1.000000,
 
 ## Platform Notes
 
-### Windows and Linux
+### Desktop (Windows, macOS, and Linux)
 
-On Windows and Linux, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports captured by the native crash handler. It relies on hardware-accelerated H.264 encoding and has the following requirements:
+On desktop platforms, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports captured by the native crash handler. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
 
-- **The `AVCodecsCore` and `NVCodecs` engine plugins must be enabled** in your project. The Sentry plugin only compiles the recorder when these are present.
-- **An NVIDIA GPU with a recent driver is required.** Encoding goes through NVIDIA NVENC; machines without a compatible NVIDIA GPU fall back to no recording (the feature self-disables and logs a warning). The engine's NVENC integration requires a minimum NVIDIA driver version of **531.61 on Windows** and **530.41 on Linux**. On Linux, the proprietary NVIDIA driver is required — NVENC isn't available with the open-source Nouveau driver.
+| Platform    | Encoder            | Engine plugins              | GPU and driver requirements                                                                     |
+| ----------- | ------------------ | --------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Windows** | NVIDIA NVENC       | `AVCodecsCore`, `NVCodecs`  | NVIDIA GPU with driver **531.61** or newer.                                                      |
+| **Windows** | AMD AMF            | `AVCodecsCore`, `AMFCodecs` | AMD GPU with a recent Adrenalin driver. D3D11/D3D12 RHI only — not available when running with `-vulkan`. |
+| **Linux**   | NVIDIA NVENC       | `AVCodecsCore`, `NVCodecs`  | NVIDIA GPU with proprietary driver **530.41** or newer — NVENC isn't available with the open-source Nouveau driver. |
+| **macOS**   | Apple VideoToolbox | `AVCodecsCore`, `VTCodecs`  | None — uses the dedicated hardware media engine on Apple Silicon and a software fallback on Intel Macs. |
+
+- **Enable the codec plugins for every GPU vendor you want to cover.** The Sentry plugin only compiles the recorder when `AVCodecsCore` is present. On Windows, `NVCodecs` and `AMFCodecs` can be enabled side by side — the encoder matching the player's GPU is selected at runtime.
 - **A plugin rebuild is required after toggling the setting.** Whether Session Replay is compiled in is decided at build time from `AttachSessionReplay`, so after enabling or disabling it, delete your project's `Binaries` and `Intermediate` directories and rebuild.
+- **Machines without a compatible encoder fall back to no recording.** The feature self-disables for the session and logs a warning; crash reporting itself is unaffected.
 
 <Alert>
 
 The most recent fraction of a second of footage (up to one fragment duration) may be missing from the attached clip, since the fragment being encoded at the moment of the crash isn't yet finalized.
-
-</Alert>
-
-### macOS
-
-On macOS, Session Replay encodes the game's backbuffer via Apple's VideoToolbox framework. Both Apple Silicon and Intel Macs are supported — VideoToolbox uses a dedicated hardware media engine on Apple Silicon and a software fallback elsewhere.
-
-- **The `AVCodecsCore` and `VTCodecs` engine plugins must be enabled** in your project. The Sentry plugin only compiles the recorder when these are present.
-- **A plugin rebuild is required after toggling the setting.** Whether Session Replay is compiled in is decided at build time from `AttachSessionReplay`, so after enabling or disabling it, delete your project's `Binaries` and `Intermediate` directories and rebuild.
-
-<Alert>
-
-As with Windows, the most recent fraction of a second of footage (up to one fragment duration) may be missing from the attached clip.
 
 </Alert>
 


### PR DESCRIPTION
This PR updates the Unreal Engine Session Replay docs for AMD GPU support.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1436