### PR TITLE
docs(godot): Add Source Context page for script frames

### DIFF
--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -11,7 +11,7 @@ For C#, embedding isn't an option: scripts are compiled, so the SDK can't read t
 
 ## Fetching Source From Your Repository
 
-Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), [GitLab](https://sentry-docs-git-limbonaut-docsgodot-source-context.sentry.dev/integrations/source-code-mgmt/gitlab/), [Perforce](https://sentry-docs-git-limbonaut-docsgodot-source-context.sentry.dev/integrations/source-code-mgmt/perforce/), etc., and display it next to each stack trace frame — no need to bundle your scripts as plain text.
+Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), [GitLab](/integrations/source-code-mgmt/gitlab/), or [Perforce](/integrations/source-code-mgmt/perforce/), and display it next to each stack trace frame — no need to bundle your scripts as plain text.
 
 This works for frames in any language — GDScript, <PlatformLink to="/dotnet/">C#</PlatformLink>, and native (C/C++) code — as long as they carry a file path and line number. Native frames require symbolication to get those — see [Readable Stack Traces](/platforms/godot/configuration/stack-traces/).
 

--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -33,7 +33,7 @@ Events then carry the source lines around each frame (up to 5 lines before and a
 
 ## Uploading Source Bundles
 
-Compiled code — C# and native — can get source context without an SCM connection: `sentry-cli` can scan your debug files for source references, bundle the referenced files, and upload them alongside the debug files. Add `--include-sources` to your `sentry-cli debug-files upload` commands — the native upload in [Readable Stack Traces](/platforms/godot/configuration/stack-traces/#uploading-debug-symbols) already includes it. See [Creating Source Bundles](/cli/dif/#creating-source-bundles) for details.
+Compiled code — C# and native — can get source context without an SCM connection: `sentry-cli` can scan your debug files for source references, bundle the referenced files, and upload them alongside the debug files. Source bundles are created during debug file upload — add `--include-sources` to your `sentry-cli debug-files upload` command. See the [debug symbol upload steps](/platforms/godot/configuration/stack-traces/#uploading-debug-symbols) for the full command and [Creating Source Bundles](/cli/dif/#creating-source-bundles) for details.
 
 This doesn't work for GDScript, which has no debug information files.
 

--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -5,13 +5,15 @@ description: "Learn how to see source code around each stack trace frame in Sent
 
 Source context shows the lines of code around each frame in a stack trace, so you can spot the failing code right in Sentry without opening your project.
 
-Source context works for frames in any language — GDScript, C#, and native (C/C++) code — as long as the frame carries a file path and line number. For native frames, that means symbolication first; see [Readable Stack Traces](/platforms/godot/configuration/stack-traces/).
+When you run your project from the editor, the SDK reads GDScript source straight from disk and includes it with each event automatically. Exported builds are a different story: by default, Godot exports GDScript as compressed binary tokens, stripping the source the SDK needs. You have three ways to get source context for exported games — fetching source from your repository (any language), embedding it in events (GDScript only), or uploading source bundles (C# and native only).
 
-When you run your project from the editor, the SDK reads GDScript source straight from disk and includes it with each event automatically. Exported builds are a different story: by default, Godot exports GDScript as compressed binary tokens, stripping the source the SDK needs. You have two ways to get source context for exported games — fetching source from your repository (any language) or embedding it in events (GDScript only).
+For C#, embedding isn't an option: scripts are compiled, so the SDK can't read their source at capture time. C# frames get their file paths and line numbers from debug symbols, as covered in [Readable Stack Traces](/platforms/godot/configuration/stack-traces/#c-managed-code), and source context comes from your repository or from uploaded source bundles.
 
 ## Fetching Source From Your Repository
 
 Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), and display it next to each stack trace frame. Your source stays out of the exported game — Sentry reads it straight from your repository.
+
+This works for frames in any language — GDScript, <PlatformLink to="/dotnet/">C#</PlatformLink>, and native (C/C++) code — as long as they carry a file path and line number. Native frames require symbolication to get those — see [Readable Stack Traces](/platforms/godot/configuration/stack-traces/).
 
 To set it up:
 
@@ -28,6 +30,12 @@ Sentry fetches each file at the commit associated with the event's release, fall
 If you'd rather not connect an SCM integration, the SDK can embed GDScript source context directly in the events it sends — but only if your scripts are exported as text. In the **Export** dialog, open the **Scripts** tab of your export preset and set **GDScript Export Mode** to **Text**.
 
 Events then carry the source lines around each frame (up to 5 lines before and after). The trade-off: your GDScript source is distributed in plain text inside the exported project PCK file.
+
+## Uploading Source Bundles
+
+Compiled code — C# and native — can get source context without an SCM connection: `sentry-cli` can scan your debug files for source references, bundle the referenced files, and upload them alongside the debug files. Add `--include-sources` to your `sentry-cli debug-files upload` commands — the native upload in [Readable Stack Traces](/platforms/godot/configuration/stack-traces/#uploading-debug-symbols) already includes it. See [Creating Source Bundles](/cli/dif/#creating-source-bundles) for details.
+
+This doesn't work for GDScript, which has no debug information files.
 
 ## Troubleshooting
 

--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -11,7 +11,7 @@ For C#, embedding isn't an option: scripts are compiled, so the SDK can't read t
 
 ## Fetching Source From Your Repository
 
-Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), and display it next to each stack trace frame — no need to bundle your scripts as plain text.
+Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), [GitLab](https://sentry-docs-git-limbonaut-docsgodot-source-context.sentry.dev/integrations/source-code-mgmt/gitlab/), [Perforce](https://sentry-docs-git-limbonaut-docsgodot-source-context.sentry.dev/integrations/source-code-mgmt/perforce/), etc., and display it next to each stack trace frame — no need to bundle your scripts as plain text.
 
 This works for frames in any language — GDScript, <PlatformLink to="/dotnet/">C#</PlatformLink>, and native (C/C++) code — as long as they carry a file path and line number. Native frames require symbolication to get those — see [Readable Stack Traces](/platforms/godot/configuration/stack-traces/).
 

--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -11,7 +11,7 @@ For C#, embedding isn't an option: scripts are compiled, so the SDK can't read t
 
 ## Fetching Source From Your Repository
 
-Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), and display it next to each stack trace frame. Your source stays out of the exported game — Sentry reads it straight from your repository.
+Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), and display it next to each stack trace frame — no need to bundle your scripts as plain text.
 
 This works for frames in any language — GDScript, <PlatformLink to="/dotnet/">C#</PlatformLink>, and native (C/C++) code — as long as they carry a file path and line number. Native frames require symbolication to get those — see [Readable Stack Traces](/platforms/godot/configuration/stack-traces/).
 
@@ -29,7 +29,7 @@ Sentry fetches each file at the commit associated with the event's release, fall
 
 If you'd rather not connect an SCM integration, the SDK can embed GDScript source context directly in the events it sends — but only if your scripts are exported as text. In the **Export** dialog, open the **Scripts** tab of your export preset and set **GDScript Export Mode** to **Text**.
 
-Events then carry the source lines around each frame (up to 5 lines before and after). The trade-off: your GDScript source is distributed in plain text inside the exported project PCK file.
+Events then carry the source lines around each frame (up to 5 lines before and after). The trade-off: your scripts are bundled in plain text inside the exported project PCK file.
 
 ## Uploading Source Bundles
 

--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -18,7 +18,7 @@ This works for frames in any language — GDScript, <PlatformLink to="/dotnet/">
 To set it up:
 
 1. Install a [supported SCM integration](/integrations/source-code-mgmt/source-context/#prerequisites) for your Sentry organization.
-2. Add a code mapping for your project — see [Stack Trace Linking](/integrations/source-code-mgmt/github/#stack-trace-linking) for the full walkthrough.
+2. Add a code mapping for your project — see the **Stack Trace Linking** section of your SCM provider's docs for the full walkthrough.
    - GDScript frames reference scripts by their `res://` path, so set the **Stack Trace Root** to `res://` and the **Source Code Root** to the repository directory containing your `project.godot` — for example, `project/` if your Godot project lives in the `project` folder, or leave it empty if it sits at the repository root.
    - C# and native frames use regular file paths, so map them with their own code mappings based on the paths you see in your stack traces.
 3. Turn on **Enable SCM Source Context** under your project's **Settings > General Settings > Client Security**.

--- a/docs/platforms/godot/configuration/source-context.mdx
+++ b/docs/platforms/godot/configuration/source-context.mdx
@@ -1,0 +1,39 @@
+---
+title: Source Context
+description: "Learn how to see source code around each stack trace frame in Sentry."
+---
+
+Source context shows the lines of code around each frame in a stack trace, so you can spot the failing code right in Sentry without opening your project.
+
+Source context works for frames in any language — GDScript, C#, and native (C/C++) code — as long as the frame carries a file path and line number. For native frames, that means symbolication first; see [Readable Stack Traces](/platforms/godot/configuration/stack-traces/).
+
+When you run your project from the editor, the SDK reads GDScript source straight from disk and includes it with each event automatically. Exported builds are a different story: by default, Godot exports GDScript as compressed binary tokens, stripping the source the SDK needs. You have two ways to get source context for exported games — fetching source from your repository (any language) or embedding it in events (GDScript only).
+
+## Fetching Source From Your Repository
+
+Sentry can fetch source on demand from a connected source code management (SCM) integration, such as [GitHub](/integrations/source-code-mgmt/github/), and display it next to each stack trace frame. Your source stays out of the exported game — Sentry reads it straight from your repository.
+
+To set it up:
+
+1. Install a [supported SCM integration](/integrations/source-code-mgmt/source-context/#prerequisites) for your Sentry organization.
+2. Add a code mapping for your project — see [Stack Trace Linking](/integrations/source-code-mgmt/github/#stack-trace-linking) for the full walkthrough.
+   - GDScript frames reference scripts by their `res://` path, so set the **Stack Trace Root** to `res://` and the **Source Code Root** to the repository directory containing your `project.godot` — for example, `project/` if your Godot project lives in the `project` folder, or leave it empty if it sits at the repository root.
+   - C# and native frames use regular file paths, so map them with their own code mappings based on the paths you see in your stack traces.
+3. Turn on **Enable SCM Source Context** under your project's **Settings > General Settings > Client Security**.
+
+Sentry fetches each file at the commit associated with the event's release, falling back to the code mapping's default branch. For details on how fetching works, who can view the fetched source, and its limitations, see [SCM Source Context Fetching](/integrations/source-code-mgmt/source-context/).
+
+## Embedding Source Context in Events
+
+If you'd rather not connect an SCM integration, the SDK can embed GDScript source context directly in the events it sends — but only if your scripts are exported as text. In the **Export** dialog, open the **Scripts** tab of your export preset and set **GDScript Export Mode** to **Text**.
+
+Events then carry the source lines around each frame (up to 5 lines before and after). The trade-off: your GDScript source is distributed in plain text inside the exported project PCK file.
+
+## Troubleshooting
+
+If frames show no source context with SCM fetching, check that:
+
+- For GDScript frames, the code mapping's stack trace root is `res://` and its source root points to the directory containing `project.godot` in your repository.
+- **Enable SCM Source Context** is turned on in your project settings.
+- The SCM integration is installed and has access to the repository.
+- The event is associated with a release whose commit Sentry can resolve — otherwise Sentry falls back to the default branch, which may not match the shipped code.

--- a/docs/platforms/godot/configuration/stack-traces.mdx
+++ b/docs/platforms/godot/configuration/stack-traces.mdx
@@ -10,6 +10,12 @@ og_image: /og-images/platforms-godot-configuration-stack-traces.png
 
 Debug information files allow Sentry to extract stack traces and provide additional information from crash reports. In order to get stack traces that contain function names, line numbers and file paths, Sentry needs to have these debug information files available when processing the crash dumps. For that, you need to export your Godot project using an export template that contains debug information.
 
+<Alert>
+
+This guide covers native engine and GDExtension (C/C++) code. To see GDScript source around stack trace frames, check out [Source Context](/platforms/godot/configuration/source-context/).
+
+</Alert>
+
 ## Prerequisites
 
 To get debug information, we need to compile export templates with debug symbols produced. You'll need Git, SCons build tool, Python, and a C++ compiler for your target platform installed.

--- a/docs/platforms/godot/configuration/stack-traces.mdx
+++ b/docs/platforms/godot/configuration/stack-traces.mdx
@@ -12,7 +12,7 @@ Debug information files allow Sentry to extract stack traces and provide additio
 
 <Alert>
 
-This guide covers native engine and GDExtension (C/C++) code. To see GDScript source around stack trace frames, check out [Source Context](/platforms/godot/configuration/source-context/).
+This guide covers compiled code — the native engine, GDExtension (C/C++), and C#. To see GDScript source around stack trace frames, check out [Source Context](/platforms/godot/configuration/source-context/).
 
 </Alert>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Sentry can now fetch source on demand from a connected SCM integration and show it around stack trace frames — for Godot users, this is the first way to get GDScript source context without exporting scripts as text. This PR adds a Source Context page to the Godot SDK docs covering both options for GDScript and C# (including the `res://` → project-directory code mapping), and cross-links it from Readable Stack Traces, which keeps covering native (C/C++) frames.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)