### PR TITLE
docs(js): share sentry init setup includes

### DIFF
--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -14,57 +14,13 @@ categories:
 
 ## Install
 
-<Alert level="warning">
+<PlatformContent includePath="sentry-init/experimental-warning" />
 
-The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
+<PlatformContent includePath="sentry-init/install-command" />
 
-</Alert>
+<PlatformContent includePath="sentry-init/how-it-works" />
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
-Run the Sentry init command in your project directory to automatically configure Sentry in your Nuxt application.
-
-The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
-
-</SplitSectionText>
-<SplitSectionCode>
-
-```bash
-npx sentry@latest init
-```
-
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
-
-<Expandable title="How does sentry init work?">
-
-The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
-
-- **Analyzes your project** — reads project files and manifests to understand your Nuxt app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
-- **Detects your framework** — identifies Nuxt and selects the `@sentry/nuxt` SDK.
-- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
-- **Installs dependencies** — adds `@sentry/nuxt` using your project's package manager.
-- **Creates and modifies files** — sets up client-side and server-side initialization, Nuxt module configuration, and other selected features based on your project structure.
-- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
-
-For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
-
-</Expandable>
-
-<Expandable title="Prefer the existing Nuxt wizard?">
-
-If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
-
-```bash
-npx @sentry/wizard@latest -i nuxt
-```
-
-To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/guides/nuxt/manual-setup/) guide.
-
-</Expandable>
+<PlatformContent includePath="sentry-init/framework-wizard" />
 
 ## Avoid Ad Blockers With Tunneling (Optional)
 

--- a/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/nuxt/manual-setup.mdx
@@ -4,10 +4,6 @@ sidebar_order: 1
 description: "Learn how to manually set up Sentry in your Nuxt app and capture your first errors."
 ---
 
-<Alert level="info">
-  Looking for automatic setup with `sentry init` or the Nuxt wizard? Follow the
-  [Nuxt quickstart](/platforms/javascript/guides/nuxt/) instead.
-  Continue with this guide to set up Sentry manually.
-</Alert>
+<PlatformContent includePath="sentry-init/manual-setup-callout" />
 
 <PlatformContent includePath="getting-started-complete" />

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -33,58 +33,13 @@ If you're using React Router in data or declarative mode, follow the instruction
 
 ## Install
 
-<Alert level="warning">
+<PlatformContent includePath="sentry-init/experimental-warning" />
 
-The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
+<PlatformContent includePath="sentry-init/install-command" />
 
-</Alert>
+<PlatformContent includePath="sentry-init/how-it-works" />
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
-Run the Sentry init command in your project directory to automatically configure Sentry in your React Router v7 Framework Mode application.
-
-The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
-
-</SplitSectionText>
-<SplitSectionCode>
-
-```bash
-npx sentry@latest init
-```
-
-</SplitSectionCode>
-
-</SplitSection>
-</SplitLayout>
-
-<Expandable title="How does sentry init work?">
-
-The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
-
-- **Analyzes your project** — reads project files and manifests to understand your React Router Framework app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
-- **Detects your framework** — identifies React Router v7 Framework Mode and selects the `@sentry/react-router` SDK.
-- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
-- **Installs dependencies** — adds `@sentry/react-router` using your project's package manager.
-- **Creates and modifies files** — sets up client-side and server-side initialization, error capture, tracing, and other selected features based on your existing project structure.
-- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
-
-For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
-
-</Expandable>
-
-<Expandable title="Prefer the existing React Router wizard?">
-
-If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
-
-```bash
-npx @sentry/wizard@latest -i reactRouter
-```
-
-To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/guides/react-router/manual-setup/) guide.
-
-</Expandable>
+<PlatformContent includePath="sentry-init/framework-wizard" />
 
 ## Configure
 

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -11,12 +11,7 @@ description: "Learn how to manually set up Sentry in your React Router v7 app an
   you have any feedback or concerns.
 </Alert>
 
-<Alert level="info">
-  Looking for automatic setup with `sentry init` or the React Router Framework
-  Mode wizard? Follow the [React Router
-  quickstart](/platforms/javascript/guides/react-router/) instead. Continue with
-  this guide to set up Sentry manually.
-</Alert>
+<PlatformContent includePath="sentry-init/manual-setup-callout" />
 
 <PlatformContent includePath="getting-started-prerequisites" />
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -16,58 +16,13 @@ categories:
 <StepComponent>
 ## Install
 
-<Alert level="warning">
+<PlatformContent includePath="sentry-init/experimental-warning" />
 
-The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
+<PlatformContent includePath="sentry-init/install-command" />
 
-</Alert>
+<PlatformContent includePath="sentry-init/how-it-works" />
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
-Run the Sentry init command in your project directory to automatically configure Sentry in your SvelteKit application.
-
-The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
-
-</SplitSectionText>
-
-<SplitSectionCode>
-
-```bash
-npx sentry@latest init
-```
-
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
-
-<Expandable title="How does sentry init work?">
-
-The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
-
-- **Analyzes your project** — reads project files and manifests to understand your SvelteKit app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
-- **Detects your framework** — identifies SvelteKit and selects the `@sentry/sveltekit` SDK.
-- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
-- **Installs dependencies** — adds `@sentry/sveltekit` using your project's package manager.
-- **Creates and modifies files** — sets up client-side and server-side initialization, SvelteKit hooks or instrumentation, and other selected features based on your SvelteKit version and project structure.
-- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
-
-For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
-
-</Expandable>
-
-<Expandable title="Prefer the existing SvelteKit wizard?">
-
-If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
-
-```bash
-npx @sentry/wizard@latest -i sveltekit
-```
-
-To configure Sentry manually, follow the [Manual Setup](/platforms/javascript/guides/sveltekit/manual-setup/) guide.
-
-</Expandable>
+<PlatformContent includePath="sentry-init/framework-wizard" />
 
 ## Avoid Ad Blockers With Tunneling (Optional)
 

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup.mdx
@@ -4,10 +4,6 @@ sidebar_order: 1
 description: "Learn how to manually set up Sentry in your SvelteKit app and capture your first errors."
 ---
 
-<Alert level="info">
-  Looking for automatic setup with `sentry init` or the SvelteKit wizard? Follow
-  the [SvelteKit quickstart](/platforms/javascript/guides/sveltekit/) instead.
-  Continue with this guide to set up Sentry manually.
-</Alert>
+<PlatformContent includePath="sentry-init/manual-setup-callout" />
 
 <PlatformContent includePath="getting-started-complete" />

--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -24,32 +24,13 @@ Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issu
 
 ## Install
 
-<Alert level="warning">
+<PlatformContent includePath="sentry-init/experimental-warning" />
 
-The wizard is currently experimental. If you run into any issues, check out the [Manual Setup](/platforms/javascript/guides/tanstackstart-react/manual-setup/) guide.
+<PlatformContent includePath="sentry-init/install-command" />
 
-</Alert>
+<PlatformContent includePath="sentry-init/how-it-works" />
 
-Run the Sentry init command to automatically configure Sentry in your TanStack Start React application:
-
-```bash
-npx sentry@latest init
-```
-
-<Expandable title="How does the wizard work?">
-
-The Sentry init wizard is AI-powered — it analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
-
-- **Analyzes your project** — reads your project's files and manifests to understand its structure, including monorepos. It also respects any AI instruction files you have (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, etc.).
-- **Detects your framework** — identifies TanStack Start and selects the right SDK (`@sentry/tanstackstart-react`)
-- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating your integration code, so you always get up-to-date setup
-- **Installs dependencies** — adds `@sentry/tanstackstart-react` using your project's package manager
-- **Creates and modifies files** — sets up client-side and server-side initialization, the Vite plugin for source maps, the server entry point, and middleware — all adapted to your project's structure
-- **Verifies the integration** — re-reads the modified files after writing to confirm Sentry was correctly integrated
-
-For full details on what each file does, see the [Manual Setup](/platforms/javascript/guides/tanstackstart-react/manual-setup/) guide.
-
-</Expandable>
+<PlatformContent includePath="sentry-init/framework-wizard" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
@@ -10,11 +10,7 @@ categories:
   - browser
 ---
 
-<Alert>
-
-For the fastest setup, we recommend using the [installation wizard](/platforms/javascript/guides/tanstackstart-react/).
-
-</Alert>
+<PlatformContent includePath="sentry-init/manual-setup-callout" />
 
 <Alert level="warning" title="Beta">
 

--- a/platform-includes/sentry-init/experimental-warning/_default.mdx
+++ b/platform-includes/sentry-init/experimental-warning/_default.mdx
@@ -1,0 +1,5 @@
+<Alert level="warning">
+
+The AI-powered `sentry init` flow is currently experimental. To use the existing framework-specific setup instead, see the option below, or check out the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Alert>

--- a/platform-includes/sentry-init/experimental-warning/javascript.tanstackstart-react.mdx
+++ b/platform-includes/sentry-init/experimental-warning/javascript.tanstackstart-react.mdx
@@ -1,0 +1,5 @@
+<Alert level="warning">
+
+The AI-powered `sentry init` flow is currently experimental. If you run into any issues, check out the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Alert>

--- a/platform-includes/sentry-init/framework-wizard/javascript.nuxt.mdx
+++ b/platform-includes/sentry-init/framework-wizard/javascript.nuxt.mdx
@@ -1,0 +1,11 @@
+<Expandable title="Prefer the existing Nuxt wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i nuxt
+```
+
+To configure Sentry manually, follow the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/framework-wizard/javascript.react-router.mdx
+++ b/platform-includes/sentry-init/framework-wizard/javascript.react-router.mdx
@@ -1,0 +1,11 @@
+<Expandable title="Prefer the existing React Router wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i reactRouter
+```
+
+To configure Sentry manually, follow the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/framework-wizard/javascript.sveltekit.mdx
+++ b/platform-includes/sentry-init/framework-wizard/javascript.sveltekit.mdx
@@ -1,0 +1,11 @@
+<Expandable title="Prefer the existing SvelteKit wizard?">
+
+If you don't want to use the experimental AI-powered flow, run the framework-specific installation wizard instead:
+
+```bash
+npx @sentry/wizard@latest -i sveltekit
+```
+
+To configure Sentry manually, follow the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/how-it-works/javascript.nuxt.mdx
+++ b/platform-includes/sentry-init/how-it-works/javascript.nuxt.mdx
@@ -1,0 +1,14 @@
+<Expandable title="How does sentry init work?">
+
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+
+- **Analyzes your project** — reads project files and manifests to understand your Nuxt app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies Nuxt and selects the `@sentry/nuxt` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/nuxt` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, Nuxt module configuration, and other selected features based on your project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
+
+For full details on what each file does, see the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/how-it-works/javascript.react-router.mdx
+++ b/platform-includes/sentry-init/how-it-works/javascript.react-router.mdx
@@ -1,0 +1,14 @@
+<Expandable title="How does sentry init work?">
+
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+
+- **Analyzes your project** — reads project files and manifests to understand your React Router Framework app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies React Router v7 Framework Mode and selects the `@sentry/react-router` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/react-router` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, error capture, tracing, and other selected features based on your existing project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
+
+For full details on what each file does, see the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/how-it-works/javascript.sveltekit.mdx
+++ b/platform-includes/sentry-init/how-it-works/javascript.sveltekit.mdx
@@ -1,0 +1,14 @@
+<Expandable title="How does sentry init work?">
+
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+
+- **Analyzes your project** — reads project files and manifests to understand your SvelteKit app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies SvelteKit and selects the `@sentry/sveltekit` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/sveltekit` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, SvelteKit hooks or instrumentation, and other selected features based on your SvelteKit version and project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
+
+For full details on what each file does, see the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/how-it-works/javascript.tanstackstart-react.mdx
+++ b/platform-includes/sentry-init/how-it-works/javascript.tanstackstart-react.mdx
@@ -1,0 +1,14 @@
+<Expandable title="How does sentry init work?">
+
+The `sentry init` command is AI-powered. It analyzes your project and generates a tailored integration, rather than applying a fixed template. Here's what it does:
+
+- **Analyzes your project** — reads project files and manifests to understand your TanStack Start React app structure, including monorepos. It also respects AI instruction files such as `CLAUDE.md`, `AGENTS.md`, and `.cursorrules`.
+- **Detects your framework** — identifies TanStack Start and selects the `@sentry/tanstackstart-react` SDK.
+- **Fetches official Sentry docs** — uses the current Sentry documentation as the source of truth when generating integration code.
+- **Installs dependencies** — adds `@sentry/tanstackstart-react` using your project's package manager.
+- **Creates and modifies files** — sets up client-side and server-side initialization, the Vite plugin for source maps, the server entry point, and middleware based on your project structure.
+- **Verifies the integration** — re-reads modified files after writing to confirm Sentry was integrated.
+
+For full details on what each file does, see the <PlatformLink to="/manual-setup/">Manual Setup</PlatformLink> guide.
+
+</Expandable>

--- a/platform-includes/sentry-init/install-command/_default.mdx
+++ b/platform-includes/sentry-init/install-command/_default.mdx
@@ -1,0 +1,19 @@
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Run the Sentry init command in your project directory to automatically configure Sentry in your <PlatformOrGuideName/>application.
+
+The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
+
+</SplitSectionText>
+
+<SplitSectionCode>
+
+```bash
+npx sentry@latest init
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>

--- a/platform-includes/sentry-init/install-command/javascript.react-router.mdx
+++ b/platform-includes/sentry-init/install-command/javascript.react-router.mdx
@@ -1,0 +1,19 @@
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Run the Sentry init command in your project directory to automatically configure Sentry in your React Router v7 Framework Mode application.
+
+The command guides you through setup and asks which optional Sentry features you want to enable beyond error monitoring.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```bash
+npx sentry@latest init
+```
+
+</SplitSectionCode>
+
+</SplitSection>
+</SplitLayout>

--- a/platform-includes/sentry-init/manual-setup-callout/javascript.nuxt.mdx
+++ b/platform-includes/sentry-init/manual-setup-callout/javascript.nuxt.mdx
@@ -1,0 +1,5 @@
+<Alert level="info">
+  Looking for automatic setup with `sentry init` or the Nuxt wizard? Follow the
+  <PlatformLink to="/">Nuxt quickstart</PlatformLink> instead.
+  Continue with this guide to set up Sentry manually.
+</Alert>

--- a/platform-includes/sentry-init/manual-setup-callout/javascript.react-router.mdx
+++ b/platform-includes/sentry-init/manual-setup-callout/javascript.react-router.mdx
@@ -1,0 +1,6 @@
+<Alert level="info">
+  Looking for automatic setup with `sentry init` or the React Router Framework
+  Mode wizard? Follow the <PlatformLink to="/">React Router quickstart</PlatformLink>
+  instead.
+  Continue with this guide to set up Sentry manually.
+</Alert>

--- a/platform-includes/sentry-init/manual-setup-callout/javascript.sveltekit.mdx
+++ b/platform-includes/sentry-init/manual-setup-callout/javascript.sveltekit.mdx
@@ -1,0 +1,5 @@
+<Alert level="info">
+  Looking for automatic setup with `sentry init` or the SvelteKit wizard? Follow
+  the <PlatformLink to="/">SvelteKit quickstart</PlatformLink> instead.
+  Continue with this guide to set up Sentry manually.
+</Alert>

--- a/platform-includes/sentry-init/manual-setup-callout/javascript.tanstackstart-react.mdx
+++ b/platform-includes/sentry-init/manual-setup-callout/javascript.tanstackstart-react.mdx
@@ -1,0 +1,5 @@
+<Alert level="info">
+  Looking for automatic setup with `sentry init`? Follow the
+  <PlatformLink to="/">TanStack Start React quickstart</PlatformLink> instead.
+  Continue with this guide to set up Sentry manually.
+</Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Extracts the repeated `sentry init` quickstart and manual-setup copy into shared `PlatformContent` includes. This keeps the approved SvelteKit, React Router, Nuxt, and TanStack Start setup pattern in one place while preserving framework-specific SDK names, legacy wizard commands, and verification nuances.

This is stacked on #18367 so the approved Nuxt PR can stay unchanged. After #18367 merges, this PR should be retargeted or rebased onto `master`.

Follow-up to Serge's review note on #18367 about sharing the `sentry init` copy across SDK docs.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## TEST PLAN

- `git diff --check`
- `pnpm generate-doctree`
- Targeted `rg` checks confirmed repeated `sentry init` warning/command/wizard copy moved from framework pages into `platform-includes/sentry-init`
- Not run: `pnpm lint:typos` (`typos` binary unavailable in this checkout)
- Not run: rendered-page/Vercel preview spot-check; draft PR preview pending

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
