### PR TITLE
fix(seer): correct pr_created provider value in webhook docs

### DIFF
--- a/docs/integrations/integration-platform/webhooks/seer.mdx
+++ b/docs/integrations/integration-platform/webhooks/seer.mdx
@@ -258,7 +258,7 @@ Includes pull request details, there may be more than one pull request if there 
           "pr_id": 456789
         },
         "repo_name": "my-app",
-        "provider": "github"
+        "provider": "unknown"
       }
     ]
   },


### PR DESCRIPTION
The `pr_created` (and the new `iteration_completed`) Seer webhook payloads emit `"provider": "unknown"`, not `"github"`.

The PR-state object that backs the payload (`RepoPRState`) carries no provider field, so the broadcaster hardcodes `"unknown"`. The docs example claimed `"github"`, which never matches what is actually delivered.

This updates the `pr_created` example to reflect the real value.

## PRE-MERGE CHECKLIST
- [x] None: Not urgent