### PR TITLE
docs(apple): Update User Feedback Docs

### DIFF
--- a/docs/platforms/apple/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/configuration/index.mdx
@@ -1,200 +1,251 @@
 ---
 title: Configure User Feedback
 sidebar_order: 6900
-description: "Learn about general User Feedback configuration fields."
+description: "Learn about User Feedback configuration fields."
 fullWidth: true
 ---
 
 <PlatformSection notSupported={["apple.macos", "apple.tvos", "apple.watchos", "apple.visionos"]}>
 
-## User Feedback Widget
+User Feedback configuration controls how the managed feedback form opens, what fields it shows, and how it looks. Set global configuration in `SentryOptions.configureUserFeedback` to install the User Feedback integration required by `SentrySDK.feedback.show()` and global shake and screenshot triggers, then override individual form presentations when needed.
 
-The User Feedback Widget offers many customization options, and if the available options are insufficient, you can [use your own UI](#bring-your-own-widget).
+## Global Configuration
 
-### General
+Use global configuration for behavior that should apply across your app, such as screenshot triggers, shake gestures, default form text, hooks, and theming. This is also where the SDK installs the User Feedback integration for automatic presentation. With global configuration, the SDK tracks the active managed form and won't present another form from SDK-managed presentation paths while one is already open.
 
-The following options can be configured for the integration in `SentryUserFeedbackConfiguration`:
+```swift {tabTitle:Swift} {mdExpandTabs}
+import Sentry
 
-| Option                   | Type            | Default                | Description                                                                                                                                                                                                       |
-| ------------------------ | --------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `animations`             | `Bool`          | `true`                 | Whether or not to show animations, like for presenting and dismissing the form.                                                                                                                                   |
-| `useShakeGesture`        | `Bool`          | `false`                | Use a shake gesture to display the form. Only supported on iOS and iPadOS; this is a no-op on macOS, tvOS, watchOS, and visionOS.                                                                                 |
-| `showFormForScreenshots` | `Bool`          | `false`                | Any time a user takes a screenshot, bring up the form with the screenshot attached.                                                                                                                               |
-| `customButton`           | `UIButton?`     | `nil`                  | Install a hook for the specified button to show the form when it is pressed. If this is set, `configureWidget` is ignored.                                                                                        |
-| `tags`                   | `[String: Any]` | `nil`                  | Tags to set on the feedback event. This is a dictionary where keys are strings and values can be different data types such as `NSNumber`, `NSString`, etc.                                                        |
-
-Some hooks are available so you can react to the user opening and closing the form, when the user successfully submits the form or when there is an error:
-
-| Hook              | Type                      | Description                                                              |
-| ----------------- | ------------------------- | ------------------------------------------------------------------------ |
-| `onFormOpen`      | `() -> Void`              | Called when the feedback form is opened.                                 |
-| `onFormClose`     | `() -> Void`              | Called when the feedback form is closed.                                 |
-| `onSubmitSuccess` | `([String: Any]) -> Void` | Called when feedback is successfully submitted via the prepared form.    |
-| `onSubmitError`   | `(Error) -> Void`         | Called when there is an error submitting feedback via the prepared form. |
-
-`onSubmitSuccess` provides a dictionary with the following keys:
-
-- `message`: The message the user entered in the feedback form.
-- `name`: The name the user entered in the feedback form.
-- `email`: The email the user entered in the feedback form.
-- `attachments`: An array of attachments to be included with the feedback; currently only one screenshot is supported.
-
-Example:
-
-```swift
 SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
     options.configureUserFeedback = { config in
         config.showFormForScreenshots = true
-        config.onSubmitSuccess = { data in
-            print("Feedback submitted successfully from \(data["name"]) at \(data["email"]): \(data["message"])")
+        config.configureForm = { form in
+            form.formTitle = "Report Feedback"
+            form.submitButtonLabel = "Send Feedback"
         }
     }
 }
 ```
 
-### Widget
+```objc {tabTitle:Objective-C}
+@import SentryObjC;
 
-The following options can be configured for the integration in `SentryUserFeedbackWidgetConfiguration`:
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.configureUserFeedback = ^(SentryObjCUserFeedbackConfiguration *config) {
+        config.showFormForScreenshots = YES;
+        config.configureForm = ^(SentryObjCUserFeedbackFormConfiguration *form) {
+            form.formTitle = @"Report Feedback";
+            form.submitButtonLabel = @"Send Feedback";
+        };
+    };
+}];
+```
 
-| Option           | Type                      | Default                     | Description                                                                                                                                                                                                       |
-| ---------------- | ------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `location`       | `[NSDirectionalRectEdge]` | `[.bottom, .trailing]`      | The location of the widget on the screen.                                                                                                                                                                         |
-| `autoInject`     | `Bool`                    | `true`                      | Injects the Feedback widget into the application when the integration is added. Set `autoInject: false` if you want to call `SentrySDK.feedback.showWidget()` directly, e.g. to show the widget on certain views. |
-| `windowLevel`    | `UIWindow.Level`          | `UIWindow.Level.normal + 1` | The window level of the widget.                                                                                                                                                                                   |
-| `showIcon`       | `Bool`                    | `true`                      | Whether to show the widget icon.                                                                                                                                                                                  |
-| `labelText`      | `String?`                 | `"Report a Bug"`            | The text of the widget label. If `nil`, then only the icon is shown. It is an error to set both `labelText` to `nil` and `showIcon` to `false`.                                                                   |
-| `layoutUIOffset` | `UIOffset`                | `UIOffset.zero`             | The offset of the widget from edge(s) of the screen specified in `location`.                                                                                                                                      |
+The following options can be configured in `SentryUserFeedbackConfiguration`:
 
-### Form Configuration
+| Option                   | Type            | Default | Description                                                                                     |
+| ------------------------ | --------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `animations`             | `Bool`          | `true`  | Shows animations when presenting and dismissing the form.                                       |
+| `useShakeGesture`        | `Bool`          | `false` | Opens the form when the user shakes the device.                                                 |
+| `showFormForScreenshots` | `Bool`          | `false` | Opens the form when the user takes a screenshot and attaches that screenshot.                   |
+| `configureForm`          | Callback        | `nil`   | Configures the managed form fields and labels.                                                  |
+| `configureTheme`         | Callback        | `nil`   | Configures colors, fonts, and form element outlines.                                            |
+| `tags`                   | `[String: Any]` | `nil`   | Sets tags on the feedback event. Values can be strings, numbers, or other serializable objects. |
 
-You can customize which form elements are shown, whether they are required, and even prefill some info, in `SentryUserFeedbackFormConfiguration`:
+The following hooks let you react to the form lifecycle and submission result:
 
-| Option                        | Type     | Default                                  | Description                                                                                                               |
-| ----------------------------- | -------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `showBranding`                | `Bool`   | `true`                                   | Displays the Sentry logo inside of the form                                                                               |
-| `formTitle`                   | `String` | `"Report a Bug"`                         | The title of the feedback form.                                                                                           |
-| `messageLabel`                | `String` | `"Description"`                          | The label of the feedback description input field.                                                                        |
-| `messagePlaceholder`          | `String` | `"What's the bug? What did you expect?"` | The placeholder in the feedback description input field.                                                                  |
-| `isRequiredLabel`             | `String` | `"(Required)"`                           | The text to attach to the title label for a required field.                                                               |
-| `removeScreenshotButtonLabel` | `String` | `"Remove screenshot"`                    | The label of the remove screenshot button.                                                                                |
-| `isNameRequired`              | `Bool`   | `false`                                  | Requires the name field on the feedback form to be filled in.                                                             |
-| `showName`                    | `Bool`   | `true`                                   | Displays the name field on the feedback form. Ignored if `isNameRequired` is `true`.                                      |
-| `nameLabel`                   | `String` | `"Name"`                                 | The label next to the name input field.                                                                                   |
-| `namePlaceholder`             | `String` | `"Your Name"`                            | The placeholder in the name input field.                                                                                  |
-| `isEmailRequired`             | `Bool`   | `false`                                  | Requires the email field on the feedback form to be filled in.                                                            |
-| `showEmail`                   | `Bool`   | `true`                                   | Displays the email field on the feedback form. Ignored if `isEmailRequired` is `true`.                                    |
-| `emailLabel`                  | `String` | `"Email"`                                | The label next to the email input field.                                                                                  |
-| `emailPlaceholder`            | `String` | `"your.email@example.org"`               | The placeholder in the email input field.                                                                                 |
-| `submitButtonLabel`           | `String` | `"Send Bug Report"`                      | The label of the submit button.                                                                                           |
-| `cancelButtonLabel`           | `String` | `"Cancel"`                               | The label of the cancel button.                                                                                           |
-| `useSentryUser`               | `Bool`   | `true`                                   | Sets the `email` and `name` fields to the corresponding Sentry SDK user fields that were called with `SentrySDK.setUser`. |
+| Hook              | Type                      | Description                                                                       |
+| ----------------- | ------------------------- | --------------------------------------------------------------------------------- |
+| `onFormOpen`      | `() -> Void`              | Called when the managed feedback form opens.                                      |
+| `onFormClose`     | `() -> Void`              | Called when the managed feedback form closes.                                     |
+| `onSubmitSuccess` | `([String: Any]) -> Void` | Called when feedback is successfully submitted through the managed form.          |
+| `onSubmitError`   | `(Error) -> Void`         | Called when the form fails validation or another client-side submit error occurs. |
 
-Example:
+`onSubmitSuccess` receives a dictionary with these keys:
 
-```swift
+- `message`: The feedback message.
+- `name`: The submitted name, when available.
+- `email`: The submitted email, when available.
+- `attachments`: The submitted attachments, when available. The managed form currently supports screenshot attachments.
+
+## Per-Presentation Configuration
+
+Use per-presentation configuration when one screen needs different labels, hooks, or theme values. The SDK copies the global configuration, applies your overrides, and uses the result only for that form presentation.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+SentrySDK.feedback.show { config in
+    config.configureForm = { form in
+        form.formTitle = "Feedback for checkout"
+        form.submitButtonLabel = "Send Feedback"
+    }
+}
+```
+
+```objc {tabTitle:Objective-C}
+[[SentryObjCSDK feedback] showWithConfigure:^(SentryObjCUserFeedbackConfiguration *config) {
+    config.configureForm = ^(SentryObjCUserFeedbackFormConfiguration *form) {
+        form.formTitle = @"Feedback for checkout";
+        form.submitButtonLabel = @"Send Feedback";
+    };
+}];
+```
+
+Per-presentation configuration doesn't apply to global-only settings. `useShakeGesture`, `showFormForScreenshots`, and deprecated widget or custom button settings must be set in `options.configureUserFeedback`.
+
+## Form Configuration
+
+Use `SentryUserFeedbackFormConfiguration` to customize the managed form. The message field is always required. Name and email are optional unless you mark them as required.
+
+| Option                                     | Type     | Default                                  | Description                                                             |
+| ------------------------------------------ | -------- | ---------------------------------------- | ----------------------------------------------------------------------- |
+| `useSentryUser`                            | `Bool`   | `true`                                   | Prefills name and email from the current Sentry user when available.    |
+| `showBranding`                             | `Bool`   | `true`                                   | Shows Sentry branding inside the form.                                  |
+| `formTitle`                                | `String` | `"Report a Bug"`                         | Title at the top of the form.                                           |
+| `messageLabel`                             | `String` | `"Description"`                          | Label for the feedback message field.                                   |
+| `messagePlaceholder`                       | `String` | `"What's the bug? What did you expect?"` | Placeholder for the feedback message field.                             |
+| `messageTextViewAccessibilityLabel`        | `String` | `messagePlaceholder`                     | Accessibility label for the feedback message field.                     |
+| `isRequiredLabel`                          | `String` | `"(Required)"`                           | Text shown next to required fields.                                     |
+| `removeScreenshotButtonLabel`              | `String` | `"Remove screenshot"`                    | Label for the remove screenshot button.                                 |
+| `removeScreenshotButtonAccessibilityLabel` | `String` | `removeScreenshotButtonLabel`            | Accessibility label for the remove screenshot button.                   |
+| `isNameRequired`                           | `Bool`   | `false`                                  | Requires the name field.                                                |
+| `showName`                                 | `Bool`   | `true`                                   | Shows the name field. Ignored when `isNameRequired` is `true`.          |
+| `nameLabel`                                | `String` | `"Name"`                                 | Label for the name field.                                               |
+| `namePlaceholder`                          | `String` | `"Your Name"`                            | Placeholder for the name field.                                         |
+| `nameTextFieldAccessibilityLabel`          | `String` | `namePlaceholder`                        | Accessibility label for the name field.                                 |
+| `isEmailRequired`                          | `Bool`   | `false`                                  | Requires the email field.                                               |
+| `showEmail`                                | `Bool`   | `true`                                   | Shows the email field. Ignored when `isEmailRequired` is `true`.        |
+| `emailLabel`                               | `String` | `"Email"`                                | Label for the email field.                                              |
+| `emailPlaceholder`                         | `String` | `"your.email@example.org"`               | Placeholder for the email field.                                        |
+| `emailTextFieldAccessibilityLabel`         | `String` | `"Your email address"`                   | Accessibility label for the email field.                                |
+| `submitButtonLabel`                        | `String` | `"Send Bug Report"`                      | Label for the submit button.                                            |
+| `submitButtonAccessibilityLabel`           | `String` | `submitButtonLabel`                      | Accessibility label for the submit button.                              |
+| `cancelButtonLabel`                        | `String` | `"Cancel"`                               | Label for cancel buttons.                                               |
+| `cancelButtonAccessibilityLabel`           | `String` | `cancelButtonLabel`                      | Accessibility label for cancel buttons.                                 |
+| `unexpectedErrorText`                      | `String` | `"Unexpected client error."`             | Message shown when an unexpected client error happens while submitting. |
+| `validationErrorMessage`                   | Callback | Default validation message               | Returns the message shown when required fields are missing.             |
+
+```swift {tabTitle:Swift} {mdExpandTabs}
 SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
     options.configureUserFeedback = { config in
         config.configureForm = { form in
-            form.isRequiredLabel = "*"
-            form.formTitle = "We want to hear from you!"
+            form.formTitle = "Tell us what happened"
+            form.messageLabel = "What happened?"
+            form.isEmailRequired = true
             form.useSentryUser = false
         }
     }
 }
 ```
 
-### Theme Customization
+```objc {tabTitle:Objective-C}
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.configureUserFeedback = ^(SentryObjCUserFeedbackConfiguration *config) {
+        config.configureForm = ^(SentryObjCUserFeedbackFormConfiguration *form) {
+            form.formTitle = @"Tell us what happened";
+            form.messageLabel = @"What happened?";
+            form.isEmailRequired = YES;
+            form.useSentryUser = NO;
+        };
+    };
+}];
+```
 
-Colors can be customized via the top-level config object, configuring for both light and dark themes.
+## Theme Customization
 
-| Option             | Light                                       | Dark                                        | Description                                                  |
-| ------------------ | ------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------ |
-| `background`       | `rgb(255, 255, 255)`                        | `rgb(41, 35, 47)`                           | Background color of the widget and form.                     |
-| `foreground`       | `rgb(43, 34, 51)`                           | `rgb(235, 230, 239)`                        | Foreground text color of the widget and form.                |
-| `submitForeground` | `rgb(255, 255, 255)`                        | `rgb(255, 255, 255)`                        | Foreground color for the form submit button.                 |
-| `submitBackground` | `rgb(88, 74, 192)`                          | `rgb(88, 74, 192)`                          | Background color for the form submit button.                 |
-| `buttonForeground` | Same as `foreground`                        | Same as `foreground`                        | Foreground color for the cancel and screenshot buttons.      |
-| `buttonBackground` | `UIColor.clear`                             | `UIColor.clear`                             | Background color for the form cancel and screenshot buttons. |
-| `errorColor`       | `rgb(223, 51, 56)`                          | `rgb(245, 84, 89)`                          | Color used for error-related components.                     |
-| `inputBackground`  | `UIColor.`<br />`secondarySystemBackground` | `UIColor.`<br />`secondarySystemBackground` | Background color for form inputs.                            |
-| `inputForeground`  | `UIColor.darkText`                          | `UIColor.lightText`                         | Foreground color for form inputs.                            |
+Use `SentryUserFeedbackThemeConfiguration` to customize colors, fonts, and form element outlines. Use dynamic `UIColor` values when you need different light and dark mode colors.
 
-Form element outlines can be configured via the `outlineStyle` property. By default, the color is `rgb(204, 204, 204)`, the width is `0.5`, and the corner radius is `5.0`.
+| Option             | Default                                                                 | Description                                         |
+| ------------------ | ----------------------------------------------------------------------- | --------------------------------------------------- |
+| `fontFamily`       | System font                                                             | Font family for form text.                          |
+| `foreground`       | Light: `rgb(43, 34, 51)`<br />Dark: `rgb(235, 230, 239)`                | Foreground text color.                              |
+| `background`       | Light: `rgb(255, 255, 255)`<br />Dark: `rgb(41, 35, 47)`                | Form background color.                              |
+| `submitForeground` | `rgb(255, 255, 255)`                                                    | Foreground color for the submit button.             |
+| `submitBackground` | `rgb(88, 74, 192)`                                                      | Background color for the submit button.             |
+| `buttonForeground` | Same as `foreground`                                                    | Foreground color for cancel and screenshot buttons. |
+| `buttonBackground` | `UIColor.clear`                                                         | Background color for cancel and screenshot buttons. |
+| `errorColor`       | Light: `rgb(223, 51, 56)`<br />Dark: `rgb(245, 84, 89)`                 | Color for validation and error UI.                  |
+| `outlineStyle`     | Color: `rgb(204, 204, 204)`<br />Width: `0.5`<br />Corner radius: `5.0` | Outline style for inputs and buttons.               |
+| `inputBackground`  | `UIColor.secondarySystemBackground`                                     | Background color for text inputs.                   |
+| `inputForeground`  | Light: `UIColor.darkText`<br />Dark: `UIColor.lightText`                | Foreground color for text inputs.                   |
 
-Fonts can be directly customized, but by default they will scale with the user's preferred text size using predefined font styles:
-
-| Option       | Default Text Style          | Description                                                                 |
-| ------------ | --------------------------- | --------------------------------------------------------------------------- |
-| `font`       | `"UIFontTextStyleCallout"`  | The font family to use for form input elements and the widget button label. |
-| `headerFont` | `"UIFontTextStyleTitle1"`   | The font family to use for the main header title of the feedback form.      |
-| `titleFont`  | `"UIFontTextStyleHeadline"` | The font family to use for titles of text fields and buttons in the form.   |
-
-You can still configure the `fontFamily` setting and we will request an appropriately scaled font from the system.
-
-Here is an example of customizing only the background color for the light theme using the Feedback constructor configuration:
-
-```swift
+```swift {tabTitle:Swift} {mdExpandTabs}
 SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
     options.configureUserFeedback = { config in
-        // configureTheme is used for light themes on iOS versions that support dark mode, and as the sole theme configuration for earlier iOS versions that don't support dark mode
         config.configureTheme = { theme in
-            theme.background = .yellow
-        }
-        config.configureDarkTheme = { theme in
-            theme.background = .darkGray
-        }
-    }
-}
-```
-
-### Accessibility
-
-The Feedback widget is designed to be accessible, with a set of default accessibility labels that can be overridden. The following attributes are set to ensure the widget is accessible:
-
-#### `SentryUserFeedbackWidgetConfiguration`
-
-| Configuration Key          | Default Value                                      |
-| -------------------------- | -------------------------------------------------- |
-| `widgetAccessibilityLabel` | `labelText` or, if that is `nil`, `"Report a Bug"` |
-
-#### `SentryUserFeedbackFormConfiguration`
-
-| Configuration Key                          | Default Value                 |
-| ------------------------------------------ | ----------------------------- |
-| `messageTextViewAccessibilityLabel`        | `messagePlaceholder`          |
-| `removeScreenshotButtonAccessibilityLabel` | `removeScreenshotButtonLabel` |
-| `nameTextFieldAccessibilityLabel`          | `namePlaceholder`             |
-| `emailTextFieldAccessibilityLabel`         | `"Your email address"`        |
-| `submitButtonAccessibilityLabel`           | `submitButtonLabel`           |
-| `cancelButtonAccessibilityLabel`           | `cancelButtonLabel`           |
-
-Example:
-
-```swift
-SentrySDK.start { options in
-    options.configureUserFeedback = { config in
-        config.configureWidget = { widget in
-            widget.widgetAccessibilityLabel = "Report an Issue" // default: "Report a Bug"
-        }
-        config.configureForm = { form in
-            form.messageTextViewAccessibilityLabel = "What happened?" // default: "What's the bug? What did you expect?"
+            theme.background = UIColor { traits in
+                traits.userInterfaceStyle == .dark ? .darkGray : .yellow
+            }
+            theme.submitBackground = .systemPurple
         }
     }
 }
 ```
 
-### Bring Your Own Widget
-
-You can also use your own UI components to gather feedback and pass the feedback data object to the `SentrySDK.capture(feedback: SentryFeedback)` function.
-
-```swift
-SentrySDK.capture(feedback: .init(
-    message: "This is an example feedback", // required
-    name: "Jane Doe", // optional
-    email: "email@example.org", // optional
-    source: .custom,
-    attachments: [Attachment(data: somePngImageData, filename: "screenshot.png")] // optional
-));
+```objc {tabTitle:Objective-C}
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.configureUserFeedback = ^(SentryObjCUserFeedbackConfiguration *config) {
+        config.configureTheme = ^(SentryObjCUserFeedbackThemeConfiguration *theme) {
+            theme.background = [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traits) {
+                return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? UIColor.darkGrayColor : UIColor.yellowColor;
+            }];
+            theme.submitBackground = UIColor.systemPurpleColor;
+        };
+    };
+}];
 ```
+
+`configureDarkTheme` is deprecated. Use dynamic `UIColor` values in `configureTheme` instead.
+
+## Deprecated Widget and Custom Button Configuration
+
+The Sentry-managed User Feedback widget and the SDK-installed custom button path are deprecated and will be removed in v10.
+
+Deprecated APIs and configuration include:
+
+- `SentrySDK.feedback.showWidget()` and `hideWidget()`
+- `SentryUserFeedbackConfiguration.configureWidget`
+- `SentryUserFeedbackWidgetConfiguration`
+- `SentryUserFeedbackConfiguration.customButton`
+- `SentryUserFeedbackConfiguration.configureDarkTheme`
+
+Instead of configuring Sentry to inject or hook up a button, add a button to your own UI and call a presentation API from its action.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+@IBAction private func feedbackButtonTapped(_ sender: UIButton) {
+    SentrySDK.feedback.show()
+}
+```
+
+```objc {tabTitle:Objective-C}
+- (IBAction)feedbackButtonTapped:(UIButton *)sender {
+    [[SentryObjCSDK feedback] show];
+}
+```
+
+If you need exact presenter control, create and present the form yourself:
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+@IBAction private func feedbackButtonTapped(_ sender: UIButton) {
+    let form = SentrySDK.FeedbackForm()
+    present(form, animated: true)
+}
+```
+
+```objc {tabTitle:Objective-C}
+- (IBAction)feedbackButtonTapped:(UIButton *)sender {
+    UIViewController *form = [SentryObjCFeedbackForm viewController];
+    [self presentViewController:form animated:YES completion:nil];
+}
+```
+
+## Manual Feedback Capture
+
+If you build the entire feedback UI yourself, create a `SentryFeedback` object and send it with `SentrySDK.capture(feedback:)`. For an example, see [User Feedback API](../#user-feedback-api).
 
 </PlatformSection>

--- a/docs/platforms/apple/common/user-feedback/configuration/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/configuration/index.mdx
@@ -156,21 +156,21 @@ SentrySDK.start { options in
 
 ## Theme Customization
 
-Use `SentryUserFeedbackThemeConfiguration` to customize colors, fonts, and form element outlines. Use dynamic `UIColor` values when you need different light and dark mode colors.
+Use `SentryUserFeedbackThemeConfiguration` to customize colors, fonts, and form element outlines. Use dynamic `UIColor` values when you need different light and dark mode colors. The SDK applies default theme values when you don't override them.
 
-| Option             | Default                                                                 | Description                                         |
-| ------------------ | ----------------------------------------------------------------------- | --------------------------------------------------- |
-| `fontFamily`       | System font                                                             | Font family for form text.                          |
-| `foreground`       | Light: `rgb(43, 34, 51)`<br />Dark: `rgb(235, 230, 239)`                | Foreground text color.                              |
-| `background`       | Light: `rgb(255, 255, 255)`<br />Dark: `rgb(41, 35, 47)`                | Form background color.                              |
-| `submitForeground` | `rgb(255, 255, 255)`                                                    | Foreground color for the submit button.             |
-| `submitBackground` | `rgb(88, 74, 192)`                                                      | Background color for the submit button.             |
-| `buttonForeground` | Same as `foreground`                                                    | Foreground color for cancel and screenshot buttons. |
-| `buttonBackground` | `UIColor.clear`                                                         | Background color for cancel and screenshot buttons. |
-| `errorColor`       | Light: `rgb(223, 51, 56)`<br />Dark: `rgb(245, 84, 89)`                 | Color for validation and error UI.                  |
-| `outlineStyle`     | Color: `rgb(204, 204, 204)`<br />Width: `0.5`<br />Corner radius: `5.0` | Outline style for inputs and buttons.               |
-| `inputBackground`  | `UIColor.secondarySystemBackground`                                     | Background color for text inputs.                   |
-| `inputForeground`  | Light: `UIColor.darkText`<br />Dark: `UIColor.lightText`                | Foreground color for text inputs.                   |
+| Option             | Description                                         |
+| ------------------ | --------------------------------------------------- |
+| `fontFamily`       | Font family for form text.                          |
+| `foreground`       | Foreground text color.                              |
+| `background`       | Form background color.                              |
+| `submitForeground` | Foreground color for the submit button.             |
+| `submitBackground` | Background color for the submit button.             |
+| `buttonForeground` | Foreground color for cancel and screenshot buttons. |
+| `buttonBackground` | Background color for cancel and screenshot buttons. |
+| `errorColor`       | Color for validation and error UI.                  |
+| `outlineStyle`     | Outline style for inputs and buttons.               |
+| `inputBackground`  | Background color for text inputs.                   |
+| `inputForeground`  | Foreground color for text inputs.                   |
 
 ```swift {tabTitle:Swift} {mdExpandTabs}
 SentrySDK.start { options in

--- a/docs/platforms/apple/common/user-feedback/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/index.mdx
@@ -9,13 +9,12 @@ og_image: /og-images/platforms-apple-common-user-feedback.png
 
 User Feedback lets you collect feedback from anywhere in your app without waiting for an error event. On supported platforms, you can use Sentry's managed feedback form, or you can collect feedback in your own UI and send it with the User Feedback API.
 
-<Alert>
-  If you're using a self-hosted Sentry instance, you'll need to be on version
-  24.4.2 or higher in order to use the full functionality of the User Feedback
-  feature. Lower versions may have limited functionality.
-</Alert>
-
 <PlatformSection notSupported={["apple.macos", "apple.tvos", "apple.watchos", "apple.visionos"]}>
+
+<Alert>
+  If you use a self-hosted Sentry instance, use version 24.4.2 or higher for the
+  managed feedback form. Lower versions may have limited functionality.
+</Alert>
 
 ## Managed Feedback Form
 

--- a/docs/platforms/apple/common/user-feedback/index.mdx
+++ b/docs/platforms/apple/common/user-feedback/index.mdx
@@ -7,9 +7,7 @@ sidebar_section: features
 og_image: /og-images/platforms-apple-common-user-feedback.png
 ---
 
-<PlatformSection notSupported={["apple.macos", "apple.tvos", "apple.watchos", "apple.visionos"]}>
-
-The User Feedback feature allows you to collect user feedback from anywhere inside your application at any time, without needing an error event to occur first.
+User Feedback lets you collect feedback from anywhere in your app without waiting for an error event. On supported platforms, you can use Sentry's managed feedback form, or you can collect feedback in your own UI and send it with the User Feedback API.
 
 <Alert>
   If you're using a self-hosted Sentry instance, you'll need to be on version
@@ -17,178 +15,269 @@ The User Feedback feature allows you to collect user feedback from anywhere insi
   feature. Lower versions may have limited functionality.
 </Alert>
 
-## User Feedback Widget
+<PlatformSection notSupported={["apple.macos", "apple.tvos", "apple.watchos", "apple.visionos"]}>
 
-The User Feedback widget allows users to submit feedback from anywhere inside your application.
+## Managed Feedback Form
 
-![An example of the User Feedback Widget on iOS =350x](./img/user-feedback-apple-widget.png)
+The managed feedback form is available for iOS and iPadOS apps that can use UIKit. SwiftUI apps can present the same form through Sentry's SwiftUI helpers.
 
-### Pre-requisites
+<Alert level="warning">
+  The managed form presentation APIs are experimental and aren't available in
+  app extensions.
+</Alert>
 
-Ensure that your project is set up with Sentry and that you have added the Sentry Cocoa SDK to your project.
+### Prerequisites
 
-### Installation
+1. Set up Sentry in your app.
+2. Use the latest Sentry Cocoa SDK. The Swift presentation APIs require version 9.17.0 or newer.
+3. Configure User Feedback when starting the SDK.
 
-1. Install the Sentry Cocoa SDK using Swift Package Manager or by manually adding the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases).
-2. Ensure you are using version 8.46.0 or above of the SDK to access the latest features.
+The Objective-C snippets on this page use the <PlatformLink to="/install/swift-package-manager/#sentryobjc">SentryObjC</PlatformLink> API.
 
-### Set Up
+### Configure User Feedback
 
-To start using the User Feedback widget in your Cocoa application, provide a feedback configuration in your `SentryOptions` when starting the SDK:
+Set `configureUserFeedback` during SDK initialization. This closure installs the User Feedback integration, which is required for the automatic `SentrySDK.feedback.show()` API and for global shake and screenshot triggers. It also provides the global configuration used by `SentrySDK.feedback.show()`, `SentrySDK.FeedbackForm`, and `.sentryFeedback(isPresented:)`.
 
-```swift
- SentrySDK.start { options in
-     options.configureUserFeedback = { config in
-          config.onSubmitSuccess = { data in
-               print("Feedback submitted successfully: \(data)")
-          }
-          config.onSubmitError = { error in
-               print("Failed to submit feedback: \(error)")
-          }
-     }
- }
-```
-
-This setup will insert the widget into your app's view hierarchy. By default, it appears in the bottom trailing corner of the screen, but you can fully customize its appearance and behavior.
-
-#### SwiftUI
-
-SwiftUI apps don’t currently support automatic widget injection when the SDK starts. Several options exist to display the feedback form:
-
-##### Use your own button
-
-Add a `UIButton` to your app, then provide the reference to the feedback configuration in the SDK start options:
-
-```swift
+```swift {tabTitle:Swift} {mdExpandTabs}
 import Sentry
-import SwiftUI
-import UIKit
 
-@main
-struct SwiftUIApp: App {
-    // a button displayed somewhere in your app
-    public let feedbackButton = {
-        let button = UIButton(type: .custom)
-        button.setTitle("BYOB Feedback", for: .normal)
-        return button
-    }()
-
-    init() {
-        // start the SentrySDK as usual, as early as possible in your app's launch sequence
-        SentrySDK.start { options in
-            options.configureUserFeedback = { config in
-                config.customButton = feedbackButton
-            }
-
-            // your other SDK options
-        }
-    }
-}
-```
-
-##### Manually display the widget from a connected `UIWindowSceneDelegate`
-
-You must set up a `UIApplicationDelegateAdaptor`, connect a `UIScene` to your app, and manually call `SentrySDK.feedback.showWidget()`:
-
-```swift
-import Sentry
-import SwiftUI
-
-@main
-struct SwiftUIApp: App {
-    @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
-
-    init() {
-        // start the SentrySDK as usual, as early as possible in your app's launch sequence
-        SentrySDK.start { options in
-            options.configureUserFeedback = { config in
-                // configure user feedback and any other SDK options
-            }
-        }
-    }
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-    }
-}
-
-class MyAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        let configuration = UISceneConfiguration(
-            name: nil,
-            sessionRole: connectingSceneSession.role)
-        if connectingSceneSession.role == .windowApplication {
-            configuration.delegateClass = MySceneDelegate.self
-        }
-        return configuration
-    }
-}
-
-class MySceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
-    var initializedSentry = false
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        guard !initializedSentry else { return }
-
-        // display the feedback widget
-        SentrySDK.feedback.showWidget()
-
-        initializedSentry = true
-    }
-}
-```
-
-##### Manually display the widget from an `onAppear` view modifier
-
-You can manually call `SentrySDK.feedback.showWidget()` from an `onAppear` view modifier. Ideally, you should call this from the root view of your app, so that the widget is displayed as soon as the app is launched and only called once.
-
-```swift
-import Sentry
-import SwiftUI
-
-@main
-struct SwiftUIApp: App {
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-                .onAppear {
-                    SentrySDK.feedback.showWidget()
-                }
-        }
-    }
-}
-```
-
-### Shake to Report
-
-You can enable shake-to-report so that shaking the device opens the User Feedback form. This is only supported on iOS.
-
-```swift
 SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
+    options.configureUserFeedback = { config in
+        config.configureForm = { form in
+            form.formTitle = "Report Feedback"
+            form.submitButtonLabel = "Send Feedback"
+        }
+        config.onSubmitSuccess = { data in
+            print("Feedback submitted: \(data)")
+        }
+        config.onSubmitError = { error in
+            print("Feedback failed: \(error)")
+        }
+    }
+}
+```
+
+```objc {tabTitle:Objective-C}
+@import SentryObjC;
+
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.configureUserFeedback = ^(SentryObjCUserFeedbackConfiguration *config) {
+        config.configureForm = ^(SentryObjCUserFeedbackFormConfiguration *form) {
+            form.formTitle = @"Report Feedback";
+            form.submitButtonLabel = @"Send Feedback";
+        };
+        config.onSubmitSuccess = ^(NSDictionary<NSString *, id> *data) {
+            NSLog(@"Feedback submitted: %@", data);
+        };
+        config.onSubmitError = ^(NSError *error) {
+            NSLog(@"Feedback failed: %@", error);
+        };
+    };
+}];
+```
+
+For all configuration fields, see [Configure User Feedback](./configuration/).
+
+With global configuration, the SDK tracks the active managed form and won't present another form from SDK-managed presentation paths while one is already open.
+
+If you create `SentrySDK.FeedbackForm` or `SentrySDK.FeedbackFormView` directly without global configuration, the form uses default settings plus any per-presentation configuration you provide.
+
+### Present the Form
+
+Choose between programmatic presentation APIs and automatic triggers based on how much control your app needs:
+
+- Use `SentrySDK.feedback.show()` when the SDK can choose the presenter from the active scene.
+- Use the UIKit or SwiftUI APIs when your app needs exact control over the presenting view controller, scene, window, or sheet.
+- Use shake and screenshot triggers when the form should open from a global user action.
+
+#### Show From the Active Screen
+
+Use `SentrySDK.feedback.show()` when you want the SDK to find a suitable view controller in the active scene and present the form for you.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+SentrySDK.feedback.show { config in
+    config.configureForm = { form in
+        form.formTitle = "Feedback for this screen"
+    }
+}
+```
+
+```objc {tabTitle:Objective-C}
+[[SentryObjCSDK feedback] showWithConfigure:^(SentryObjCUserFeedbackConfiguration *config) {
+    config.configureForm = ^(SentryObjCUserFeedbackFormConfiguration *form) {
+        form.formTitle = @"Feedback for this screen";
+    };
+}];
+```
+
+You can also pass a `UIImage` screenshot:
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+SentrySDK.feedback.show(screenshot: screenshot)
+```
+
+```objc {tabTitle:Objective-C}
+[[SentryObjCSDK feedback] showWithScreenshot:screenshot];
+```
+
+The SDK chooses a presenting view controller from the foreground-active scene when possible, with a window fallback for apps that don't use scenes. It only presents when that view controller isn't already presenting or transitioning.
+
+If your app needs exact scene, window, or presenting view controller control, use the UIKit or SwiftUI APIs below to present the form yourself.
+
+#### Present From UIKit
+
+Use `SentrySDK.FeedbackForm` when your app should decide which view controller presents the form.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+let form = SentrySDK.FeedbackForm(screenshot: screenshot) { config in
+    config.configureForm = { form in
+        form.formTitle = "Report Feedback"
+        form.submitButtonLabel = "Send Feedback"
+    }
+}
+
+present(form, animated: true)
+```
+
+```objc {tabTitle:Objective-C}
+UIViewController *form = [SentryObjCFeedbackForm
+    viewControllerWithScreenshot:screenshot
+                       configure:^(SentryObjCUserFeedbackConfiguration *config) {
+    config.configureForm = ^(SentryObjCUserFeedbackFormConfiguration *formConfig) {
+        formConfig.formTitle = @"Report Feedback";
+        formConfig.submitButtonLabel = @"Send Feedback";
+    };
+}];
+
+[self presentViewController:form animated:YES completion:nil];
+```
+
+#### Present From SwiftUI
+
+Use `.sentryFeedback(isPresented:)` when a SwiftUI state binding should control the form presentation.
+
+```swift
+import Sentry
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var isFeedbackPresented = false
+
+    var body: some View {
+        Button("Send Feedback") {
+            isFeedbackPresented = true
+        }
+        .sentryFeedback(isPresented: $isFeedbackPresented) { config in
+            config.configureForm = { form in
+                form.submitButtonLabel = "Send Feedback"
+            }
+        }
+    }
+}
+```
+
+If you already manage your own presentation container, embed `SentrySDK.FeedbackFormView` in a SwiftUI sheet:
+
+```swift
+import Sentry
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var isFeedbackPresented = false
+
+    var body: some View {
+        Button("Send Feedback") {
+            isFeedbackPresented = true
+        }
+        .sheet(isPresented: $isFeedbackPresented) {
+            SentrySDK.FeedbackFormView { config in
+                config.configureForm = { form in
+                    form.submitButtonLabel = "Send Feedback"
+                }
+            }
+        }
+    }
+}
+```
+
+#### Open Automatically From a Shake Gesture or Screenshot
+
+You can also open the managed form from a device shake or immediately after the user takes a screenshot. These options are global and only apply when set in `options.configureUserFeedback`.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+SentrySDK.start { options in
+    options.dsn = "___PUBLIC_DSN___"
     options.configureUserFeedback = { config in
         config.useShakeGesture = true
+        config.showFormForScreenshots = true
     }
 }
+```
+
+```objc {tabTitle:Objective-C}
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+    options.dsn = @"___PUBLIC_DSN___";
+    options.configureUserFeedback = ^(SentryObjCUserFeedbackConfiguration *config) {
+        config.useShakeGesture = YES;
+        config.showFormForScreenshots = YES;
+    };
+}];
 ```
 
 ### Session Replay
 
-The User Feedback widget integrates seamlessly with Session Replay. When the widget is opened, the Replay SDK buffers up to 30 seconds of the user's session. If feedback is submitted, this replay is sent along with the feedback, allowing you to view both the feedback and the user's actions leading up to the feedback submission.
+The managed feedback form works with <PlatformLink to="/session-replay/">Session Replay</PlatformLink>. When the form opens, the Replay SDK buffers up to 30 seconds of the user's session. If the user submits feedback, the replay is sent with the feedback so you can see what led up to it.
+
+### Deprecated Widget and Custom Button Setup
+
+The Sentry-managed User Feedback widget, `showWidget()`, `hideWidget()`, `configureWidget`, and `customButton` configuration are deprecated and will be removed in v10.
+
+If you're migrating from `customButton`, keep your existing button and replace the SDK configuration with a regular button action. If you're migrating from the widget, add your own button, menu item, or other entry point and call the same presentation API. Your global `configureUserFeedback` form, theme, and hook configuration still applies.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+@IBAction private func feedbackButtonTapped(_ sender: UIButton) {
+    SentrySDK.feedback.show()
+}
+```
+
+```objc {tabTitle:Objective-C}
+- (IBAction)feedbackButtonTapped:(UIButton *)sender {
+    [[SentryObjCSDK feedback] show];
+}
+```
 
 </PlatformSection>
 
-### User Feedback API
+## User Feedback API
 
-The User Feedback API allows you to collect user feedback while using your own UI components. You can submit feedback directly using the `SentrySDK.capture(feedback:)` method:
+Use the User Feedback API when you collect feedback with your own UI. The SDK sends the feedback to Sentry, so you don't need to build the HTTP request yourself.
 
-```swift
-SentrySDK.capture(feedback: .init(
-    message: "I encountered a bug while using the app.",
-    name: "John Doe",
-    email: "john.doe@example.com",
+You can optionally pass an `associatedEventId` to connect feedback to an error event.
+
+```swift {tabTitle:Swift} {mdExpandTabs}
+import Sentry
+
+let feedback = SentryFeedback(
+    message: "The settings screen is confusing.",
+    name: "Ada",
+    email: "ada@example.com",
     source: .custom,
-    attachments: [Attachment(data: somePngImageData, filename: "screenshot.png")] // optional
-))
+    associatedEventId: nil,
+    attachments: nil
+)
+
+SentrySDK.capture(feedback: feedback)
+```
+
+```objc {tabTitle:Objective-C}
+@import SentryObjC;
+
+[SentryObjCSDK captureFeedbackWithMessage:@"The settings screen is confusing."
+                                     name:@"Ada"
+                                    email:@"ada@example.com"
+                                   source:SentryObjCFeedbackSourceCustom
+                        associatedEventId:nil
+                              attachments:nil];
 ```


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Updates the Apple User Feedback docs to cover the current managed feedback form APIs and manual feedback capture flow.

- Documents `configureUserFeedback` as the setup path for managed form presentation
- Adds Swift and Objective-C examples for presenting feedback from UIKit, SwiftUI, and automatic triggers
- Marks the managed widget and SDK-installed custom button setup as deprecated
- Expands configuration docs for form fields, hooks, theming, and per-presentation overrides

Closes https://github.com/getsentry/sentry-cocoa/issues/8066

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)