### PR TITLE
docs(js): Pass empty `dataCollection` object instead of commenting it out

### DIFF
--- a/docs/platforms/javascript/guides/angular/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/angular/manual-setup.mdx
@@ -117,9 +117,12 @@ import * as Sentry from "@sentry/angular";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -182,9 +185,12 @@ import * as Sentry from "@sentry/angular";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance

--- a/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
@@ -73,9 +73,12 @@ const Sentry = require("@sentry/aws-serverless");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Tracing by setting tracesSampleRate and adding integration
@@ -94,9 +97,12 @@ import * as Sentry from "@sentry/aws-serverless";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Tracing by setting tracesSampleRate and adding integration

--- a/docs/platforms/javascript/guides/aws-lambda/install/npm.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/npm.mdx
@@ -99,9 +99,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
   integrations: [nodeProfilingIntegration()],
 
@@ -134,9 +137,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
   integrations: [nodeProfilingIntegration()],
 

--- a/docs/platforms/javascript/guides/azure-functions/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/index.mdx
@@ -60,9 +60,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/azure-functions/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/azure-functions/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],

--- a/docs/platforms/javascript/guides/bun/index.mdx
+++ b/docs/platforms/javascript/guides/bun/index.mdx
@@ -63,9 +63,12 @@ import * as Sentry from "@sentry/bun";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/bun/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/bun/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Performance Monitoring by setting tracesSampleRate

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
@@ -100,9 +100,12 @@ export const onRequest = [
   // Make sure Sentry is the first middleware
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     tracesSampleRate: 1.0,
   })),
   // Add more middlewares here

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
@@ -85,9 +85,12 @@ import { hydrateRoot } from "react-dom/client";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -164,9 +167,12 @@ import * as Sentry from "@sentry/react-router";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ logs
 
   // Enable logs to be sent to Sentry
@@ -218,9 +224,12 @@ export default {
           // ___PRODUCT_OPTION_START___ logs
           enableLogs: true,
           // ___PRODUCT_OPTION_END___ logs
-          // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-          // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-          // dataCollection: { userInfo: false, httpBodies: [] },
+          dataCollection: {
+            // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+            // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+            // userInfo: false,
+            // httpBodies: [],
+          },
         },
         request: request as any,
         context: executionContext,

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/tanstack-start.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/tanstack-start.mdx
@@ -85,9 +85,12 @@ export default Sentry.withSentry(
   () => ({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry
@@ -153,9 +156,12 @@ export const getRouter = () => {
 +   Sentry.init({
 +     dsn: "___PUBLIC_DSN___",
 +
-+     // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-+     // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-+     // dataCollection: { userInfo: false, httpBodies: [] },
++     dataCollection: {
++       // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
++       // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
++       // userInfo: false,
++       // httpBodies: [],
++     },
 +
 +     integrations: [
 +       // ___PRODUCT_OPTION_START___ performance

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -97,9 +97,12 @@ export const onRequest = [
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry

--- a/docs/platforms/javascript/guides/cordova/index.mdx
+++ b/docs/platforms/javascript/guides/cordova/index.mdx
@@ -88,9 +88,12 @@ onDeviceReady: function() {
   Sentry.init({
     dsn: '___PUBLIC_DSN___',
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
   });
 }
 ```

--- a/docs/platforms/javascript/guides/deno/index.mdx
+++ b/docs/platforms/javascript/guides/deno/index.mdx
@@ -69,9 +69,12 @@ import * as Sentry from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/deno/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/deno/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/elysia/index.mdx
+++ b/docs/platforms/javascript/guides/elysia/index.mdx
@@ -85,9 +85,12 @@ import { Elysia } from "elysia";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -117,9 +120,12 @@ import { node } from "@elysiajs/node";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/ember/index.mdx
+++ b/docs/platforms/javascript/guides/ember/index.mdx
@@ -68,9 +68,12 @@ import * as Sentry from "@sentry/ember";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/ember/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/ember/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   // ___PRODUCT_OPTION_START___ session-replay
   integrations: [

--- a/docs/platforms/javascript/guides/firebase/index.mdx
+++ b/docs/platforms/javascript/guides/firebase/index.mdx
@@ -101,9 +101,12 @@ const Sentry = require("@sentry/node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/firebase/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/firebase/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Tracing by setting tracesSampleRate

--- a/docs/platforms/javascript/guides/gatsby/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/index.mdx
@@ -119,9 +119,12 @@ import * as Sentry from "@sentry/gatsby";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/gatsby/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/gatsby/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance

--- a/docs/platforms/javascript/guides/hono/index.mdx
+++ b/docs/platforms/javascript/guides/hono/index.mdx
@@ -174,9 +174,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],
@@ -255,9 +258,12 @@ app.use(
   sentry(app, {
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -301,9 +307,12 @@ app.use(
   sentry(app, {
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -333,9 +342,12 @@ app.use(
   sentry(app, {
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/nextjs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/index.mdx
@@ -62,9 +62,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
@@ -89,9 +92,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
@@ -107,9 +113,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
@@ -132,9 +132,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -177,9 +180,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -200,9 +206,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/pages-router.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/pages-router.mdx
@@ -156,9 +156,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -191,9 +194,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -214,9 +220,12 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production

--- a/docs/platforms/javascript/guides/nitro/index.mdx
+++ b/docs/platforms/javascript/guides/nitro/index.mdx
@@ -141,9 +141,12 @@ import * as Sentry from "@sentry/nitro";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nitro/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nitro/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -132,9 +132,12 @@ import { HydratedRouter } from "react-router/dom";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -217,9 +220,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ logs
 
   // Enable logs to be sent to Sentry

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -131,9 +131,12 @@ The `sentryOnError` handler integrates with React Router's [`onError` hook](http
 +Sentry.init({
 +  dsn: "___PUBLIC_DSN___",
 +
-+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-+  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-+  // dataCollection: { userInfo: false, httpBodies: [] },
++  dataCollection: {
++    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
++    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
++    // userInfo: false,
++    // httpBodies: [],
++  },
 +
 +  integrations: [
 +    // ___PRODUCT_OPTION_START___ performance
@@ -229,9 +232,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ logs
 
   // Enable logs to be sent to Sentry

--- a/docs/platforms/javascript/guides/react/index.mdx
+++ b/docs/platforms/javascript/guides/react/index.mdx
@@ -77,9 +77,12 @@ import * as Sentry from "@sentry/react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance

--- a/docs/platforms/javascript/guides/solid/index.mdx
+++ b/docs/platforms/javascript/guides/solid/index.mdx
@@ -85,9 +85,12 @@ if (!DEV) {
   Sentry.init({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     integrations: [
       // ___PRODUCT_OPTION_START___ performance

--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -101,9 +101,12 @@ import { mount, StartClient } from "@solidjs/start/client";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     // add solidRouterBrowserTracingIntegration if you're using Solid Router
@@ -168,9 +171,12 @@ import * as Sentry from "@sentry/solidstart";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/svelte/index.mdx
+++ b/docs/platforms/javascript/guides/svelte/index.mdx
@@ -78,9 +78,12 @@ import * as Sentry from "@sentry/svelte";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/svelte/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/svelte/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance

--- a/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
@@ -92,9 +92,12 @@ import * as Sentry from "@sentry/tanstackstart-react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ session-replay
@@ -216,9 +219,12 @@ import * as Sentry from "@sentry/tanstackstart-react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ logs
 
   // Enable logs to be sent to Sentry

--- a/docs/platforms/javascript/guides/vue/index.mdx
+++ b/docs/platforms/javascript/guides/vue/index.mdx
@@ -85,9 +85,12 @@ Sentry.init({
   app,
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance

--- a/platform-includes/getting-started-complete/javascript.astro.mdx
+++ b/platform-includes/getting-started-complete/javascript.astro.mdx
@@ -131,9 +131,12 @@ import handler from "@astrojs/cloudflare/entrypoints/server";
 export default Sentry.withSentry(
   (env) => ({
     dsn: env.SENTRY_DSN,
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ performance
     // Define how likely traces are sampled. Adjust this value in production,
     // or use tracesSampler for greater control.
@@ -224,9 +227,12 @@ import * as Sentry from "@sentry/astro";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -330,9 +336,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -101,9 +101,12 @@ Sentry.init({
   // modify depending on your custom runtime config
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ session-replay
 
   // Replay may only be enabled for the client-side

--- a/platform-includes/getting-started-complete/javascript.remix.mdx
+++ b/platform-includes/getting-started-complete/javascript.remix.mdx
@@ -19,9 +19,12 @@ import { useEffect } from "react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -173,9 +176,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   // Add our Profiling integration
@@ -283,9 +289,12 @@ export const onRequest = [
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/getting-started-complete/javascript.sveltekit.mdx
+++ b/platform-includes/getting-started-complete/javascript.sveltekit.mdx
@@ -130,9 +130,12 @@ import * as Sentry from "@sentry/sveltekit";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -246,9 +249,12 @@ import * as Sentry from "@sentry/sveltekit";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -329,9 +335,12 @@ export const handle = sequence(
   initCloudflareSentryHandle({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/getting-started-config/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-config/javascript.aws-lambda.mdx
@@ -7,9 +7,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],
@@ -46,9 +49,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -6,9 +6,12 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
@@ -95,9 +98,12 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
@@ -180,9 +186,12 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
@@ -258,9 +267,12 @@ Sentry.init(
       },
     },
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
@@ -324,9 +336,12 @@ import * as SentryNuxt from "@sentry/nuxt";
 Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
@@ -392,9 +407,12 @@ import { feedbackIntegration } from "@sentry/browser";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   // Set your release version, such as "getsentry@1.0.0"
   release: "my-project-name@<release-name>",

--- a/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
@@ -20,9 +20,12 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry

--- a/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
@@ -14,9 +14,12 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry

--- a/platform-includes/getting-started-config/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-config/javascript.gcp-functions.mdx
@@ -7,9 +7,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/gcp-functions/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/gcp-functions/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/getting-started-config/javascript.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.hono.mdx
@@ -8,9 +8,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [
@@ -52,9 +55,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/getting-started-config/javascript.mdx
+++ b/platform-includes/getting-started-config/javascript.mdx
@@ -16,9 +16,12 @@ import * as Sentry from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   // Alternatively, use `process.env.npm_package_version` for a dynamic release version
   // if your build tool supports it.
@@ -77,9 +80,12 @@ Sentry.init({
     Sentry.init({
       dsn: "___PUBLIC_DSN___",
 
-      // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false, httpBodies: [] },
+      dataCollection: {
+        // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+        // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
+        // userInfo: false,
+        // httpBodies: [],
+      },
 
       // Alternatively, use `process.env.npm_package_version` for a dynamic release version
       // if your build tool supports it.
@@ -140,9 +146,12 @@ Sentry.init({
   Sentry.init({
     dsn: "___PUBLIC_DSN___",
 
-    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false, httpBodies: [] },
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
 
     // Alternatively, use `process.env.npm_package_version` for a dynamic release version
     // if your build tool supports it.

--- a/platform-includes/getting-started-config/javascript.node.mdx
+++ b/platform-includes/getting-started-config/javascript.node.mdx
@@ -8,9 +8,12 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [
@@ -52,9 +55,12 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/performance/configure-sample-rate/javascript.solid.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.solid.mdx
@@ -6,9 +6,12 @@ import { render } from "solid-js/web";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false, httpBodies: [] },
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   integrations: [
     solidRouterBrowserTracingIntegration(),


### PR DESCRIPTION
Before:

```javascript
// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
// https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
// dataCollection: { userInfo: false, httpBodies: [] },
```

After:
```javascript
dataCollection: {
  // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
  // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
  // userInfo: false,
  // httpBodies: [],
},
```