### PR TITLE
docs(go): Update logs option from EnableLogs to DisableLogs

### DIFF
--- a/docs/platforms/go/common/configuration/options.mdx
+++ b/docs/platforms/go/common/configuration/options.mdx
@@ -126,9 +126,9 @@ In practice, reporting very long chains usually provides little value when debug
 
 ## Logging Options
 
-<SdkOption name="EnableLogs" type="bool" defaultValue="false">
+<SdkOption name="DisableLogs" type="bool" defaultValue="false">
 
-Set this option to `true` to enable log capturing in Sentry. The SDK will only capture and send log messages to Sentry if this option is enabled.
+When set to `true`, the SDK does not capture or send log messages to Sentry. By default, logs are enabled.
 
 </SdkOption>
 

--- a/docs/platforms/go/common/logs/logrus.mdx
+++ b/docs/platforms/go/common/logs/logrus.mdx
@@ -39,7 +39,6 @@ To integrate Sentry with Logrus, you can set up both log hooks and event hooks t
 // Initialize Sentry SDK
 if err := sentry.Init(sentry.ClientOptions{
     Dsn: "___PUBLIC_DSN___",
-    EnableLogs:       true,
 }); err != nil {
     log.Fatalf("Sentry initialization failed: %v", err)
 }
@@ -108,7 +107,6 @@ logHook, err := sentrylogrus.NewLogHook(
     []logrus.Level{logrus.InfoLevel, logrus.WarnLevel},
     sentry.ClientOptions{
         Dsn: "___PUBLIC_DSN___",
-        EnableLogs: true, // Required for log entries
     },
 )
 ```
@@ -118,8 +116,7 @@ logHook, err := sentrylogrus.NewLogHook(
 Use `NewLogHookFromClient` if you've already initialized the Sentry SDK.
 ```go
 if err := sentry.Init(sentry.ClientOptions{
-    Dsn:        "___PUBLIC_DSN___",
-    EnableLogs: true,
+    Dsn: "___PUBLIC_DSN___",
 }); err != nil {
     log.Fatalf("Sentry initialization failed: %v", err)
 }
@@ -157,8 +154,7 @@ eventHook, err := sentrylogrus.NewEventHook(
 Use `NewEventHookFromClient` if you've already initialized the Sentry SDK.
 ```go
 if err := sentry.Init(sentry.ClientOptions{
-    Dsn:        "https://examplePublicKey@o0.ingest.sentry.io/0",
-    EnableLogs: true,
+    Dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
 }); err != nil {
     log.Fatalf("Sentry initialization failed: %v", err)
 }

--- a/docs/platforms/go/common/logs/zap.mdx
+++ b/docs/platforms/go/common/logs/zap.mdx
@@ -50,10 +50,9 @@ import (
 )
 
 func main() {
-    // Initialize Sentry with logs enabled
+    // Initialize Sentry (logs are enabled by default)
     err := sentry.Init(sentry.ClientOptions{
-        Dsn:        "___PUBLIC_DSN___",
-        EnableLogs: true,
+        Dsn: "___PUBLIC_DSN___",
     })
     if err != nil {
         panic(err)

--- a/docs/platforms/go/common/logs/zerolog.mdx
+++ b/docs/platforms/go/common/logs/zerolog.mdx
@@ -74,7 +74,7 @@ func main() {
 	// Initialize Sentry
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
-		// Note: EnableLogs is for Structured Logs, not zerolog error events
+		// Note: Structured Logs are enabled by default. To disable them, set DisableLogs: true.
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("sentry initialization failed")

--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -22,7 +22,7 @@ err := sentry.Init(sentry.ClientOptions{
     TracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
     // ___PRODUCT_OPTION_START___ logs
-    EnableLogs: true,
+    // Logs are enabled by default. To disable them, set DisableLogs: true.
     // ___PRODUCT_OPTION_END___ logs
 })
 if err != nil {

--- a/platform-includes/getting-started-include-logs-config/go.mdx
+++ b/platform-includes/getting-started-include-logs-config/go.mdx
@@ -14,7 +14,7 @@ err := sentry.Init(sentry.ClientOptions{
     // Adds request headers and IP for users,
     // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
     SendDefaultPII: true,
-    EnableLogs: true,
+    // Logs are enabled by default. To disable them, set DisableLogs: true.
     // ___PRODUCT_OPTION_START___ performance
     EnableTracing: true,
     // Set TracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/logs/options/go.mdx
+++ b/platform-includes/logs/options/go.mdx
@@ -4,8 +4,7 @@ To filter logs, or update them before they are sent to Sentry, you can use the `
 
 ```go
 sentry.Init(sentry.ClientOptions{
-    Dsn:        "___PUBLIC_DSN___",
-    EnableLogs: true,
+    Dsn: "___PUBLIC_DSN___",
     BeforeSendLog: func(log *sentry.Log) *sentry.Log {
         // filter out all trace logs
         if log.Level == sentry.LogLevelTrace {

--- a/platform-includes/logs/setup/go.mdx
+++ b/platform-includes/logs/setup/go.mdx
@@ -1,4 +1,4 @@
-To enable logging, you need to initialize the SDK with the `EnableLogs` option set to `true`.
+Logs are enabled by default. No additional configuration is needed beyond initializing the SDK.
 
 ```go
 package main
@@ -12,13 +12,20 @@ import (
 
 func main() {
 	if err := sentry.Init(sentry.ClientOptions{
-		Dsn:        "___PUBLIC_DSN___",
-		// Enable logs to be sent to Sentry
-		EnableLogs: true,
+		Dsn: "___PUBLIC_DSN___",
 	}); err != nil {
 		fmt.Printf("Sentry initialization failed: %v\n", err)
 	}
 	// Flush buffered events before the program terminates.
 	defer sentry.Flush(2 * time.Second)
 }
+```
+
+To disable logs, set `DisableLogs` to `true`:
+
+```go
+sentry.Init(sentry.ClientOptions{
+	Dsn:         "___PUBLIC_DSN___",
+	DisableLogs: true,
+})
 ```

--- a/platform-includes/logs/usage/go.mdx
+++ b/platform-includes/logs/usage/go.mdx
@@ -15,8 +15,7 @@ sent to Sentry, and can be searched from within the Logs UI, and even added to t
 ```go
 func main() {
 	if err := sentry.Init(sentry.ClientOptions{
-		Dsn:        "___PUBLIC_DSN___",
-		EnableLogs: true,
+		Dsn: "___PUBLIC_DSN___",
 	}); err != nil {
 		log.Fatalf("Sentry initialization failed: %v", err)
 	}


### PR DESCRIPTION
## DESCRIBE YOUR PR

Logs are now enabled by default in sentry-go ([getsentry/sentry-go#1306](https://github.com/getsentry/sentry-go/pull/1306)). The `EnableLogs` option has been replaced with `DisableLogs` for opt-out.

### Changes

- Replaced all `EnableLogs: true` references with updated guidance that logs are enabled by default
- Updated `SdkOption` in configuration docs from `EnableLogs` to `DisableLogs`  
- Updated setup docs, usage examples, and integration docs (logrus, zap, zerolog, slog)
- Updated getting-started config snippets

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+