### PR TITLE
docs(react-native): Clarify native vs JS initialization for autoInitializeNativeSdk

### DIFF
--- a/docs/platforms/react-native/configuration/options.mdx
+++ b/docs/platforms/react-native/configuration/options.mdx
@@ -358,7 +358,7 @@ Set this boolean to `false` to disable the auto initialization of the native lay
 
 To disable the native layer, use [enableNative](#enableNative).
 
-You should follow the [guide to native initialization](/platforms/react-native/manual-setup/native-init/) if you chose to use this option.
+You should follow the [guide to native initialization](/platforms/react-native/manual-setup/native-init/) if you chose to use this option. Note that when this is `false`, the JavaScript and native layers are configured independently: `Sentry.init()` is still required in JS, the `dsn` must be set on both sides, and options are not merged between them.
 
 </SdkOption>
 

--- a/docs/platforms/react-native/manual-setup/native-init.mdx
+++ b/docs/platforms/react-native/manual-setup/native-init.mdx
@@ -31,6 +31,21 @@ Do not use `autoInitializeNativeSdk` to disable the native layer, instead use [e
 
 Next, initialize the native SDKs for Android, which is documented below, or for iOS by following the [configuration guide to initialize the Sentry Cocoa SDK](/platforms/apple/guides/ios/#configure). Note that you do not need to install the native SDKs as they are already packaged with the React Native SDK.
 
+## Native and JavaScript Initialization
+
+When you initialize the native SDKs yourself with `autoInitializeNativeSdk: false`, the JavaScript and native layers are configured independently. Keep the following in mind:
+
+- **`Sentry.init()` is still required in JavaScript.** The native SDK only captures native errors and crashes (with native stack traces). To capture JavaScript errors and use APIs like `Sentry.captureException()`, you must still call `Sentry.init()` on the JS layer.
+- **The `dsn` is required on both sides.** Set it in both the native initialization and `Sentry.init()`. You can point each layer at a different project (for example, separate projects for JavaScript, iOS, and Android), but we recommend using a single project unless you specifically need them separated.
+- **Options are not merged.** With `autoInitializeNativeSdk: false`, the options you pass to `Sentry.init()` are not forwarded to the native SDKs. Each layer uses only the options it was initialized with, so any option you want applied natively must be set in the native initialization.
+- **Avoid enabling tracing on both layers.** If you enable performance tracing (for example, `tracesSampleRate` together with `enableAutoPerformanceTracing`) in both the native and JS layers, screen navigation and other instrumentation are captured independently by each layer, resulting in **duplicate transactions** in Sentry. When the native SDK is initialized automatically from JS (`autoInitializeNativeSdk: true`), the React Native SDK avoids this by not forwarding `tracesSampleRate` to the native layer.
+
+<Alert level="info" title="Capturing App Start Errors">
+
+If your goal is to capture crashes that happen before JavaScript loads, prefer the [Capture App Start Errors](/platforms/react-native/manual-setup/app-start-error-capture/) approach (SDK 8.0.0+). It uses a `sentry.options.json` file and, unlike the manual flow described here, merges your JavaScript options on top of the file options.
+
+</Alert>
+
 ## iOS Configuration
 
 To enable App Start Instrumentation and Slow and Frozen Frames on iOS when initializing the Sentry Cocoa SDK manually,


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarifies how the native and JavaScript layers interact when initializing the native SDKs manually with `autoInitializeNativeSdk: false`.

Resolves getsentry/sentry-react-native#6302

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES
