### PR TITLE
docs(godot): Document the C# native before-send hook

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -384,7 +384,7 @@ options.SetBeforeSendLog(log =>
 
 </SdkOption>
 
-### Native Hooks in C#
+## Native Hooks in C#
 
 In C#, hook methods set directly on `options` apply to managed SDK data, such as events and logs from your game's C# code and third-party .NET libraries. However, much of the Godot SDK's processing happens in the native C++ layer, including events and logs captured from the engine, GDScript, and GDExtension code. Native hook methods live under `options.Native`; use these callbacks to inspect, modify, or drop native data before it's sent to Sentry.
 

--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -327,6 +327,8 @@ options.SetBeforeSend((sentryEvent, hint) =>
 });
 ```
 
+In C#, `options.SetBeforeSend` covers managed events only. To filter native events from C# (such as engine, GDScript, and GDExtension errors), use [`Native.SetBeforeSend`](#Native.SetBeforeSend).
+
 </SdkOption>
 
 <SdkOption name="before_capture_screenshot" type="Callable">
@@ -377,6 +379,28 @@ options.SetBeforeSendLog(log =>
     // Add custom attributes.
     log.SetAttribute("current_scene", currentScene.Name);
     return log;
+});
+```
+
+</SdkOption>
+
+### Native Hooks in C#
+
+In C#, hook methods set directly on `options` apply to managed SDK data, such as events and logs from your game's C# code and third-party .NET libraries. However, much of the Godot SDK's processing happens in the native C++ layer, including events and logs captured from the engine, GDScript, and GDExtension code. Native hook methods live under `options.Native`; use these callbacks to inspect, modify, or drop native data before it's sent to Sentry.
+
+<SdkOption name="Native.SetBeforeSend" type="Func<SentryNativeEvent, SentryNativeEvent?>">
+
+Runs before a native event is sent. Return the event, with or without modifications, to send it, or `null` to drop it. This is most useful for engine, GDScript, and GDExtension errors. Native crash events aren't passed to this callback.
+
+```csharp
+options.Native.SetBeforeSend(nativeEvent =>
+{
+    // Drop a noisy error that you can't fix.
+    if (nativeEvent.GetExceptionValue(0)?.Contains("Noisy error") == true)
+    {
+        return null;
+    }
+    return nativeEvent;
 });
 ```
 

--- a/platform-includes/configuration/before-send/godot.mdx
+++ b/platform-includes/configuration/before-send/godot.mdx
@@ -47,16 +47,19 @@ SentrySdk.Init(options =>
 });
 ```
 
-In C#, `options.SetBeforeSend` filters managed events, such as exceptions from your game's C# code and third-party .NET libraries. Native events are captured in the native layer; to filter them from C#, set `options.Native.SetBeforeSend` inside the same `SentrySdk.Init`. This is most useful for engine, GDScript, and GDExtension errors. The callback receives a `SentryNativeEvent` that you can inspect, modify, or drop by returning `null`. Native crash events aren't passed to this callback.
+In C#, `options.SetBeforeSend` filters managed events, such as exceptions from your game's C# code and third-party .NET libraries. Native events are captured in the native layer; to filter them from C#, set `options.Native.SetBeforeSend` inside your `SentrySdk.Init`. This is most useful for engine, GDScript, and GDExtension errors. The callback receives a `SentryNativeEvent` that you can inspect, modify, or drop by returning `null`. Native crash events aren't passed to this callback.
 
 ```csharp
-options.Native.SetBeforeSend(nativeEvent =>
+SentrySdk.Init(options =>
 {
-    // Drop a noisy error that you can't fix.
-    if (nativeEvent.GetExceptionValue(0)?.Contains("Noisy error") == true)
+    options.Native.SetBeforeSend(nativeEvent =>
     {
-        return null;
-    }
-    return nativeEvent;
+        // Drop a noisy error that you can't fix.
+        if (nativeEvent.GetExceptionValue(0)?.Contains("Noisy error") == true)
+        {
+            return null;
+        }
+        return nativeEvent;
+    });
 });
 ```

--- a/platform-includes/configuration/before-send/godot.mdx
+++ b/platform-includes/configuration/before-send/godot.mdx
@@ -46,3 +46,17 @@ SentrySdk.Init(options =>
     });
 });
 ```
+
+In C#, `options.SetBeforeSend` filters managed events, such as exceptions from your game's C# code and third-party .NET libraries. Native events are captured in the native layer; to filter them from C#, set `options.Native.SetBeforeSend` inside the same `SentrySdk.Init`. This is most useful for engine, GDScript, and GDExtension errors. The callback receives a `SentryNativeEvent` that you can inspect, modify, or drop by returning `null`. Native crash events aren't passed to this callback.
+
+```csharp
+options.Native.SetBeforeSend(nativeEvent =>
+{
+    // Drop a noisy error that you can't fix.
+    if (nativeEvent.GetExceptionValue(0)?.Contains("Noisy error") == true)
+    {
+        return null;
+    }
+    return nativeEvent;
+});
+```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document `options.Native.SetBeforeSend`, the new C# hook in the Godot SDK that lets the .NET layer inspect, modify, or drop native events (engine, GDScript, and GDExtension errors) before they're sent to Sentry.

- Godot SDK PR: https://github.com/getsentry/sentry-godot/pull/737
- Tracking issue: getsentry/sentry-godot#752

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)