### PR TITLE
feat(js): Add Metrics options to Options page

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -698,14 +698,14 @@ This function is called with a log object, and can return a modified log object,
 <SdkOption name="enableMetrics" type='boolean' defaultValue='true'>
 
 Set this option to `true` to enable metric capturing in Sentry. 
-Only when this option is enabled will the `metrics` APIs actually send logs to Sentry.
+Only when this option is enabled will the `metrics` APIs actually send metrics to Sentry.
 
 </SdkOption>
 
 <SdkOption name="beforeSendMetric" type='(metric: Metric) => Metric | null'>
 
-This function is called with a metric object, and can return a modified metric object, or `null` to skip sending this log to Sentry. 
-This can be used, for instance, for manual PII stripping before sending, or to add custom attributes to all logs.
+This function is called with a metric object, and can return a modified metric object, or `null` to skip sending this metric to Sentry. 
+This can be used, for instance, for manual PII scrubbing before sending, or to add custom attributes to all metrics.
 
 </SdkOption>
 

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -688,6 +688,27 @@ This function is called with a log object, and can return a modified log object,
 
 </SdkOption>
 
+## Metrics Options
+
+<PlatformSection supported={["javascript.electron"]}>
+  **Note:** For Electron, metric options apply to the process where these options
+  are set.
+</PlatformSection>
+
+<SdkOption name="enableMetrics" type='boolean' defaultValue='true'>
+
+Set this option to `true` to enable metric capturing in Sentry. 
+Only when this option is enabled will the `metrics` APIs actually send logs to Sentry.
+
+</SdkOption>
+
+<SdkOption name="beforeSendMetric" type='(metric: Metric) => Metric | null'>
+
+This function is called with a metric object, and can return a modified metric object, or `null` to skip sending this log to Sentry. 
+This can be used, for instance, for manual PII stripping before sending, or to add custom attributes to all logs.
+
+</SdkOption>
+
 <PlatformCategorySection supported={['browser']}>
 
 ## Session Replay Options

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -697,7 +697,7 @@ This function is called with a log object, and can return a modified log object,
 
 <SdkOption name="enableMetrics" type='boolean' defaultValue='true'>
 
-Set this option to `true` to enable metric capturing in Sentry. 
+Set this option to `false` to disable metric capturing in Sentry (enabled by default). 
 Only when this option is enabled will the `metrics` APIs actually send metrics to Sentry.
 
 </SdkOption>


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

While working on https://github.com/getsentry/sentry-docs/pull/18013, I noticed we don't document `enableMetrics` and `beforeSendMetric` yet in the Options page. This PR adds both options, analogously to and directly below the logs options.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/) 