### PR TITLE
docs(android): add Perfetto callout and fix heading article on profiling troubleshooting page

### DIFF
--- a/docs/platforms/android/configuration/app-not-respond.mdx
+++ b/docs/platforms/android/configuration/app-not-respond.mdx
@@ -117,7 +117,7 @@ ANR Profiling is available starting in SDK version `8.35.0`. This feature is exp
 
 ANR profiles are powered by the Profiling platform and require a plan with profiling enabled. See the [pricing page](https://sentry.io/pricing/) for more details. 
 
-ANR profiles _don't_ use ART profiler, but are being captured differently. Therefore, they are not prone to the known [issues](https://docs.sentry.io/platforms/android/profiling/troubleshooting/#i-see-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated) with ART's profiler, and are safe to use in production.
+ANR profiles _don't_ use ART profiler, but are being captured differently. Therefore, they are not prone to the known [issues](https://docs.sentry.io/platforms/android/profiling/troubleshooting/#i-see-an-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated) with ART's profiler, and are safe to use in production.
 
 </Alert>
 

--- a/docs/platforms/android/index.mdx
+++ b/docs/platforms/android/index.mdx
@@ -41,7 +41,7 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 <OnboardingOption optionId="profiling">
 
 <Alert level="warning">
-  Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
+  Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-an-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
 </Alert>
 
 </OnboardingOption>

--- a/docs/platforms/android/profiling/index.mdx
+++ b/docs/platforms/android/profiling/index.mdx
@@ -13,6 +13,10 @@ sidebar_section: features
   Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-an-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
 </Alert>
 
+<Alert level="info" title="Improved Profiling Coming Soon">
+  We're working on a more stable profiling solution based on the Android <Link to="https://developer.android.com/reference/android/os/ProfilingManager">ProfilingManager APIs (Perfetto)</Link>. Follow the <Link to="https://github.com/getsentry/sentry-java/discussions/5560">discussion on GitHub</Link> for updates.
+</Alert>
+
 ## Installation
 
 Android UI Profiling is available starting in SDK version `8.7.0`.

--- a/docs/platforms/android/profiling/index.mdx
+++ b/docs/platforms/android/profiling/index.mdx
@@ -10,7 +10,7 @@ sidebar_section: features
 <PlatformContent includePath="profiling/index/why-profiling" />
 
 <Alert level="warning" title="Important">
-  Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
+  Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. See this <PlatformLink to="/profiling/troubleshooting#i-see-an-elevated-number-of-crashes-in-the-android-runtime-when-profiling-is-activated">troubleshooting</PlatformLink> entry for more information.
 </Alert>
 
 ## Installation

--- a/docs/platforms/android/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/android/profiling/troubleshooting/index.mdx
@@ -4,7 +4,11 @@ description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---
 
-## I see elevated number of crashes in the Android Runtime when profiling is activated
+<Alert level="info" title="Improved Profiling Coming Soon">
+  We're working on a more stable profiling solution based on the Android <Link to="https://developer.android.com/reference/android/os/ProfilingManager">ProfilingManager APIs (Perfetto)</Link>. Follow the <Link to="https://github.com/getsentry/sentry-java/discussions/5560">discussion on GitHub</Link> for updates.
+</Alert>
+
+## I see an elevated number of crashes in the Android Runtime when profiling is activated
 
 Profiling uses the Android runtime's `tracer` under the hood to sample threads. There are known issues that this `tracer` can cause crashes in certain circumstances. Read on for more information, and subscribe to this <Link to="https://github.com/getsentry/sentry-java/issues/3679">GitHub issue</Link> for updates.
 


### PR DESCRIPTION
## What changed

- Adds an info callout at the top of the Android profiling troubleshooting page noting that a more stable profiling solution based on Android ProfilingManager APIs (Perfetto) is in progress, linking to the [discussion](https://github.com/getsentry/sentry-java/discussions/5560).
- Fixes the heading article: "I see elevated number" → "I see **an** elevated number".
- Updates two internal anchor links in `profiling/index.mdx` and the top-level `android/index.mdx` to match the updated heading slug.

## Verified

Content consistency review — no automated build check run. Anchor links manually updated to reflect slug change from the heading edit.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0ANA6YA22F%3A1774348423.468149%22)