### PR TITLE
fix(middleware): add Link rel=canonical on .md responses; drop text/plain from Accept detection

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -99,3 +99,67 @@ describe('middleware redirect set selection', () => {
     });
   });
 });
+
+describe('canonical Link header on .md responses', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('adds Link rel=canonical pointing to the HTML page for a deep path', async () => {
+    const {middleware} = await importMiddleware({});
+    const res = middleware(makeRequest('/platforms/apple/cocoa.md'));
+    expect(res.headers.get('Link')).toBe(
+      '<https://docs.sentry.io/platforms/apple/cocoa/>; rel="canonical"'
+    );
+  });
+
+  it('maps /index.md to the root canonical URL', async () => {
+    const {middleware} = await importMiddleware({});
+    const res = middleware(makeRequest('/index.md'));
+    expect(res.headers.get('Link')).toBe('<https://docs.sentry.io/>; rel="canonical"');
+  });
+
+  it('handles top-level .md paths', async () => {
+    const {middleware} = await importMiddleware({});
+    const res = middleware(makeRequest('/platforms.md'));
+    expect(res.headers.get('Link')).toBe(
+      '<https://docs.sentry.io/platforms/>; rel="canonical"'
+    );
+  });
+
+  it('uses develop.sentry.dev origin in developer docs mode', async () => {
+    const {middleware} = await importMiddleware({NEXT_PUBLIC_DEVELOPER_DOCS: '1'});
+    const res = middleware(makeRequest('/platforms/apple/cocoa.md'));
+    expect(res.headers.get('Link')).toBe(
+      '<https://develop.sentry.dev/platforms/apple/cocoa/>; rel="canonical"'
+    );
+  });
+
+  it('does not add Link header for non-.md paths', async () => {
+    const {middleware} = await importMiddleware({});
+    const res = middleware(makeRequest('/platforms/apple/cocoa/'));
+    expect(res.headers.get('Link')).toBeNull();
+  });
+});
+
+describe('wantsMarkdownViaAccept: text/plain no longer triggers markdown', () => {
+  it('does not serve markdown for Accept: application/json, text/plain, */*', async () => {
+    const {middleware} = await importMiddleware({});
+    const req = new NextRequest(new URL('/platforms/apple/cocoa/', 'http://localhost:3000'), {
+      headers: {'Accept': 'application/json, text/plain, */*'},
+    });
+    const res = middleware(req);
+    // Should not rewrite to .md — Next rewrite changes the URL; a plain next() keeps it
+    expect(res.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  it('still serves markdown for explicit text/markdown Accept header', async () => {
+    const {middleware} = await importMiddleware({});
+    const req = new NextRequest(new URL('/platforms/apple/cocoa/', 'http://localhost:3000'), {
+      headers: {'Accept': 'text/markdown'},
+    });
+    const res = middleware(req);
+    // A rewrite to .md will set x-middleware-rewrite
+    expect(res.headers.get('x-middleware-rewrite')).toContain('.md');
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,8 @@ import {AI_AGENT_PATTERN, type TrafficType} from 'sentry-docs/lib/trafficClassif
 const isDeveloperDocs =
   process.env.DEVELOPER_DOCS || process.env.NEXT_PUBLIC_DEVELOPER_DOCS;
 
+const BASE_URL = isDeveloperDocs ? 'https://develop.sentry.dev' : 'https://docs.sentry.io';
+
 export const config = {
   // learn more: https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher
   matcher: [
@@ -90,13 +92,13 @@ function classifyTraffic(request: NextRequest): {
 }
 
 /**
- * Detects if client wants markdown via Accept header (standards-compliant)
+ * Detects if client wants markdown via Accept header (standards-compliant).
+ * Only matches explicit markdown MIME types — not text/plain, which is too broad
+ * and matches clients like Axios (`Accept: application/json, text/plain, *\/\/`).
  */
 function wantsMarkdownViaAccept(acceptHeader: string): boolean {
   return (
-    acceptHeader.includes('text/markdown') ||
-    acceptHeader.includes('text/x-markdown') ||
-    acceptHeader.includes('text/plain')
+    acceptHeader.includes('text/markdown') || acceptHeader.includes('text/x-markdown')
   );
 }
 
@@ -152,6 +154,19 @@ function rewriteWithClassification(request: NextRequest, destination: URL): Next
 }
 
 /**
+ * Derives the canonical HTML URL path from a .md pathname.
+ * Examples:
+ *   /platforms/apple/cocoa.md  →  /platforms/apple/cocoa/
+ *   /index.md                  →  /
+ *   /platforms.md              →  /platforms/
+ */
+function mdToCanonicalPath(mdPathname: string): string {
+  const withoutExt = mdPathname.replace(/\.md$/, '');
+  if (withoutExt === '/index') return '/';
+  return withoutExt.endsWith('/') ? withoutExt : `${withoutExt}/`;
+}
+
+/**
  * Handles redirection to markdown versions for AI/LLM clients
  */
 const handleAIClientRedirect = (request: NextRequest) => {
@@ -188,8 +203,13 @@ const handleAIClientRedirect = (request: NextRequest) => {
   }
 
   // Skip if already requesting a markdown file - pass through with classification headers
+  // and set a Link rel=canonical header pointing to the rendered HTML page so that search
+  // engine crawlers consolidate ranking to the human-readable URL instead of indexing the
+  // raw markdown. AI agents don't act on this header, so LLM ingestion is unaffected.
   if (url.pathname.endsWith('.md')) {
-    return nextWithClassification(request);
+    const response = nextWithClassification(request);
+    response.headers.set('Link', `<${BASE_URL}${mdToCanonicalPath(url.pathname)}>; rel="canonical"`);
+    return response;
   }
 
   // Skip API routes and static assets (should already be filtered by matcher)


### PR DESCRIPTION
## What

Search engines (Bing, DuckDuckGo) are indexing `.md` URLs (e.g. `/platforms/apple/cocoa.md`) as raw markdown instead of the rendered HTML docs pages. These URLs are discovered via `llms.txt`, which lists every page with its `.md` link. `robots.txt` allows all bots, so nothing was blocking crawlers from following and indexing them.

### Changes

**1. Canonical `Link` HTTP header on `.md` responses (middleware.ts)**

When the middleware passes through a `.md` request, it now adds:
```
Link: <https://docs.sentry.io/platforms/apple/cocoa/>; rel="canonical"
```
This tells Google and Bing that the authoritative version of the content lives at the rendered HTML page — they consolidate ranking there instead of indexing the raw markdown URL. AI agents don't act on `rel=canonical` headers, so LLM ingestion is completely unaffected.

The `mdToCanonicalPath` helper handles the path mapping:
- `/platforms/apple/cocoa.md` → `/platforms/apple/cocoa/`
- `/index.md` → `/`
- `/platforms.md` → `/platforms/`

Both `docs.sentry.io` and `develop.sentry.dev` origins are handled via `BASE_URL`.

**2. Narrow `wantsMarkdownViaAccept` — drop `text/plain` (middleware.ts)**

`text/plain` appeared in the Accept-header detection list, but it's too broad: Axios and similar HTTP libraries send `Accept: application/json, text/plain, */*` by default. Any non-LLM HTTP client using Axios would inadvertently receive raw markdown. Removing it leaves only explicit markdown MIME types (`text/markdown`, `text/x-markdown`). AI tools that don't set an Accept header are already caught by the user-agent check.

## Why not robots.txt Disallow?

Disallowing `*.md` in robots.txt would stop new crawling but doesn't clean up already-indexed URLs. The canonical header does both: prevents future indexing and signals to crawlers to deindex the `.md` URL in favour of the HTML one.

## Verification

14 tests pass (7 new):
- Canonical header is set correctly for deep paths, top-level paths, and `/index.md`
- Correct origin used for user docs vs. developer docs
- No `Link` header on non-`.md` requests
- `text/plain` Accept no longer triggers markdown rewrite
- Explicit `text/markdown` Accept still works

## Context

Raised in [#docs Slack thread](https://sentry.slack.com/archives/C57G8RSHE/p1781637614949629). Anton's suggestion (HTTP canonical header per [Google's guidance](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-header-method)) confirmed as the right fix.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0BB8KQT6MU%3A1781719605.692549%22)