### PR TITLE
docs(drains): simplify Cloudflare auth using sentry_key query param

### DIFF
--- a/docs/product/drains/cloudflare.mdx
+++ b/docs/product/drains/cloudflare.mdx
@@ -35,13 +35,13 @@ ___OTLP_LOGS_URL___?sentry_key=___PUBLIC_KEY___
 
 You can find your Sentry OTLP logs endpoint and public key in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **OpenTelemetry (OTLP)** under the **OTLP Logs Endpoint** section.
 
-<Note>
+<Alert level="info">
 
 Alternatively, you can omit the query parameter from the URL and instead add a custom header:
 - Header name: `x-sentry-auth`
 - Header value: `sentry sentry_key={SENTRY_PUBLIC_KEY}`
 
-</Note>
+</Alert>
 
 ### Traces Destination
 
@@ -57,13 +57,13 @@ ___OTLP_TRACES_URL___?sentry_key=___PUBLIC_KEY___
 
 You can find your Sentry OTLP traces endpoint and public key in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **OpenTelemetry (OTLP)** under the **OTLP Traces Endpoint** section.
 
-<Note>
+<Alert level="info">
 
 Alternatively, you can omit the query parameter from the URL and instead add a custom header:
 - Header name: `x-sentry-auth`
 - Header value: `sentry sentry_key={SENTRY_PUBLIC_KEY}`
 
-</Note>
+</Alert>
 
 ## Step 2: Configure your Worker
 

--- a/docs/product/drains/cloudflare.mdx
+++ b/docs/product/drains/cloudflare.mdx
@@ -27,21 +27,21 @@ To configure your logs destination, click **Add destination** and configure the 
 
 1. Destination Name: `sentry-logs` (or any descriptive name)
 2. Destination Type: Select Logs
-3. OTLP Endpoint: Your Sentry OTLP logs endpoint (e.g., `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/logs`)
+3. OTLP Endpoint: Your Sentry OTLP logs endpoint with your public key as a query parameter (e.g., `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/logs?sentry_key={SENTRY_PUBLIC_KEY}`)
 
 ```bash
-___OTLP_LOGS_URL___
+___OTLP_LOGS_URL___?sentry_key=___PUBLIC_KEY___
 ```
 
-4. Custom Headers: Add the Sentry authentication header:
-   - Header name: `x-sentry-auth`
-   - Header value: `sentry sentry_key={SENTRY_PUBLIC_KEY}` where `{SENTRY_PUBLIC_KEY}` is your Sentry project's public key
+You can find your Sentry OTLP logs endpoint and public key in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **OpenTelemetry (OTLP)** under the **OTLP Logs Endpoint** section.
 
-```
-sentry sentry_key=___PUBLIC_KEY___
-```
+<Note>
 
-You can find your Sentry OTLP logs endpoint and authentication header value in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **OpenTelemetry (OTLP)** under the **OTLP Logs Endpoint** section.
+Alternatively, you can omit the query parameter from the URL and instead add a custom header:
+- Header name: `x-sentry-auth`
+- Header value: `sentry sentry_key={SENTRY_PUBLIC_KEY}`
+
+</Note>
 
 ### Traces Destination
 
@@ -49,21 +49,21 @@ To configure your traces destination, click **Add destination** and configure th
 
 1. Destination Name: `sentry-traces` (or any descriptive name)
 2. Destination Type: Select Traces
-3. OTLP Endpoint: Your Sentry OTLP traces endpoint (e.g., `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/traces`)
+3. OTLP Endpoint: Your Sentry OTLP traces endpoint with your public key as a query parameter (e.g., `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/traces?sentry_key={SENTRY_PUBLIC_KEY}`)
 
 ```bash
-___OTLP_TRACES_URL___
+___OTLP_TRACES_URL___?sentry_key=___PUBLIC_KEY___
 ```
 
-4. Custom Headers: Add the Sentry authentication header:
-   - Header name: `x-sentry-auth`
-   - Header value: `sentry sentry_key={SENTRY_PUBLIC_KEY}` where `{SENTRY_PUBLIC_KEY}` is your Sentry project's public key
+You can find your Sentry OTLP traces endpoint and public key in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **OpenTelemetry (OTLP)** under the **OTLP Traces Endpoint** section.
 
-```
-sentry sentry_key=___PUBLIC_KEY___
-```
+<Note>
 
-You can find your Sentry OTLP traces endpoint and authentication header value in your [Sentry Project Settings](https://sentry.io/settings/projects/) under **Client Keys (DSN)** > **OpenTelemetry (OTLP)** under the **OTLP Traces Endpoint** section.
+Alternatively, you can omit the query parameter from the URL and instead add a custom header:
+- Header name: `x-sentry-auth`
+- Header value: `sentry sentry_key={SENTRY_PUBLIC_KEY}`
+
+</Note>
 
 ## Step 2: Configure your Worker
 


### PR DESCRIPTION
## What changed

The Cloudflare log drains page previously only documented the `x-sentry-auth` custom header for authentication. This adds friction because Cloudflare's destination UI requires a separate header configuration step.

`?sentry_key=` is already supported as a query parameter on OTLP endpoints (used in integration tests too). This PR makes it the primary approach — just append the key to the endpoint URL and skip the header entirely. The header method is preserved as a `<Note>` for users who prefer it.

**Changes:**
- Logs destination: endpoint example now includes `?sentry_key=___PUBLIC_KEY___`
- Traces destination: same
- Custom header instructions moved to an optional `<Note>` in both sections

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AG6MCDB51U%3A1781723189.543099%22)