### PR TITLE
fix ssl docs language

### DIFF
--- a/docs/security-legal-pii/security/ssl.mdx
+++ b/docs/security-legal-pii/security/ssl.mdx
@@ -1,7 +1,7 @@
 ---
-title: "SSL Protocols and Ciphers"
+title: "SSL Protocols and Cipher Suites"
 sidebar_order: 6
-description: "Learn how Sentry's SaaS product uses SSL Protocols and Ciphers for security and compatibility."
+description: "Learn how Sentry's SaaS product uses SSL protocols and cipher suites for security and compatibility."
 ---
 
 <Alert title="Note" level="warning">
@@ -13,13 +13,13 @@ apply to self-hosted or single tenant.
 
 Sentry's API, dashboard, and event submission require a minimum TLS version of 1.2 to communicate securely.
 
-Sentry provides a suite of protocols and ciphers that focus on giving our users a balance of security and compatibility. Our servers will negotiate a cipher to the most secure combination the client can support in the preferential order specified below. The set of ciphers depends on the endpoint and negotiated TLS version.
+Sentry provides a suite of protocols and cipher suites that focus on giving our users a balance of security and compatibility. Our servers will negotiate the most secure cipher suite the client can support in the preferential order specified below. The set of cipher suites depends on the endpoint and negotiated TLS version.
 
 ### sentry.io and \*.ingest.sentry.io
 
 TLS versions 1.2 and 1.3 are supported for both Sentry's API, dashboard, and legacy event submission (via `sentry.io`), and for event ingestion domains (via `*.ingest.sentry.io`).
 
-Supported ciphers:
+Supported cipher suites:
 
 #### TLS 1.3
 
@@ -40,7 +40,7 @@ Supported ciphers:
 - TLS_RSA_WITH_AES_256_CBC_SHA
 - TLS_RSA_WITH_3DES_EDE_CBC_SHA
 
-This suite of protocols and ciphers represents Sentry's official support; however, clients may experience an agreement on individual ciphers that exceed the strength ratings of those listed above.
+This suite of protocols and cipher suites represents Sentry's official support; however, clients may negotiate individual cipher suites that exceed the strength ratings of those listed above.
 
 ## Certificate Pinning
 


### PR DESCRIPTION
Our SSL docs aren't accurate as we're referring to specific ciphers rather than cipher suites, the full negotiated bundle that makes up key exchange, auth, cipher, and MAC. Small fix for accuracy.

## IS YOUR CHANGE URGENT?  

- [ X ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [X] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
