### PR TITLE
Correct contact email

### DIFF
--- a/docs/integrations/source-code-mgmt/gitlab/index.mdx
+++ b/docs/integrations/source-code-mgmt/gitlab/index.mdx
@@ -198,7 +198,7 @@ For more details, see the full documentation for [Code Owners](/product/issues/o
 ## Seer
 
 <Alert>
-The Gitlab Seer integration is currently in early beta, slowly opening up to more organizations. Please reach out to support@sentry.io if you are interested in trying it out.
+The Gitlab Seer integration is currently in early beta, slowly opening up to more organizations. Please reach out to seer@sentry.io if you are interested in trying it out.
 </Alert>
 
 With the GitLab integration connected, you can use Seer's AI features, including [Autofix](/product/ai-in-sentry/seer/autofix/) and [Code Review](/product/ai-in-sentry/seer/code-review) with your GitLab repositories.


### PR DESCRIPTION
Correcting contact email to get access to GitLab Seer close beta, from support@sentry.io to seer@sentry.io as mentioned in this comment: https://github.com/getsentry/sentry/issues/93724#issuecomment-4675495077

> We've started rolling out GitLab Seer beta access to the few orgs who wrote to so they can try this out and give us feedback. If you want access as well please write to us at [seer@sentry.io](mailto:seer@sentry.io) and share your Sentry organization slug