### PR TITLE
docs: fix typo in kafka troubleshooting guide

### DIFF
--- a/develop-docs/self-hosted/troubleshooting/kafka.mdx
+++ b/develop-docs/self-hosted/troubleshooting/kafka.mdx
@@ -150,7 +150,7 @@ Unlike the proper solution, this involves resetting the offsets of all consumer 
    ```shell
    docker compose down --volumes
    ```
-2. Remove the the Kafka volume:
+2. Remove the Kafka volume:
    ```shell
    docker volume rm sentry-kafka
    ```


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `the the` → `the` in `develop-docs/self-hosted/troubleshooting/kafka.mdx`.
