### PR TITLE
docs(react-native): Note root component wrapping on tracing page

### DIFF
--- a/docs/platforms/react-native/tracing/index.mdx
+++ b/docs/platforms/react-native/tracing/index.mdx
@@ -21,6 +21,16 @@ The two options are meant to be mutually exclusive. If you set both, <PlatformId
 
 Learn more about tracing <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">tracesSampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
+## Wrap Your Root Component
+
+To get the most out of tracing, including accurate [App Start](/platforms/react-native/tracing/instrumentation/automatic-instrumentation/#app-start-instrumentation) measurements and [automatic instrumentation](/platforms/react-native/tracing/instrumentation/automatic-instrumentation/), wrap your root component with `Sentry.wrap`:
+
+```javascript {filename:App.js}
+export default Sentry.wrap(App);
+```
+
+Without wrapping the root component, the App Start measurement will finish when the JavaScript code is initialized instead of when the first component mounts, and some performance features won't be available.
+
 ## Verify
 
 Verify that tracing is working correctly by using our <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/">automatic instrumentation</PlatformLink> or by starting and finishing a transaction using <PlatformLink to="/tracing/instrumentation/custom-instrumentation/">custom instrumentation</PlatformLink>.

--- a/docs/platforms/react-native/tracing/index.mdx
+++ b/docs/platforms/react-native/tracing/index.mdx
@@ -23,7 +23,7 @@ Learn more about tracing <PlatformLink to="/configuration/options/#tracing-optio
 
 ## Wrap Your Root Component
 
-To get the most out of tracing, including accurate [App Start](/platforms/react-native/tracing/instrumentation/automatic-instrumentation/#app-start-instrumentation) measurements and [automatic instrumentation](/platforms/react-native/tracing/instrumentation/automatic-instrumentation/), wrap your root component with `Sentry.wrap`:
+To get the most out of tracing, including accurate <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#app-start-instrumentation">App Start</PlatformLink> measurements and <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/">automatic instrumentation</PlatformLink>, wrap your root component with `Sentry.wrap`:
 
 ```javascript {filename:App.js}
 export default Sentry.wrap(App);


### PR DESCRIPTION
Surfaces `Sentry.wrap` on the tracing setup page so users don't have to navigate to the automatic instrumentation page to find it.

Fixes getsentry/sentry-react-native#6271