### PR TITLE
docs(ssl): add Google Trust Services (pki.goog) root CAs to certificate pinning list

### DIFF
--- a/docs/security-legal-pii/security/ssl.mdx
+++ b/docs/security-legal-pii/security/ssl.mdx
@@ -44,7 +44,7 @@ This suite of protocols and cipher suites represents Sentry's official support; 
 
 ## Certificate Pinning
 
-At the moment, all Sentry TLS certificates use either Digicert or Let's Encrypt as certificate authorities. If this list of roots needs to be changed, we will publish an announcement on [status.sentry.io](https://status.sentry.io/).
+At the moment, all Sentry TLS certificates use Digicert, Let's Encrypt, or Google Trust Services (pki.goog) as certificate authorities. If this list of roots needs to be changed, we will publish an announcement on [status.sentry.io](https://status.sentry.io/).
 
 
 Here are corresponding root CA certificates if you would like to pin them in your applications:
@@ -79,4 +79,31 @@ Valid until: 17/Sep/2040
 Serial Number: 41:d2:9d:d1:72:ea:ee:a7:80:c1:2c:6c:e9:2f:87:52
 SHA1 Fingerprint: BD:B1:B9:3C:D5:97:8D:45:C6:26:14:55:F8:DB:95:C7:5A:D1:53:AF
 SHA256 Fingerprint: 69:72:9B:8E:15:A8:6E:FC:17:7A:57:AF:B7:17:1D:FC:64:AD:D2:8C:2F:CA:8C:F1:50:7E:34:45:3C:CB:14:70
+```
+- [Google Trust Services](https://pki.goog/repository/)
+
+```
+GTS Root R1
+Valid until: 22/Jun/2036
+Serial Number: 02:03:E5:93:6F:31:B0:13:49:88:6B:A2:17
+SHA1 Fingerprint: E5:8C:1C:C4:91:3B:38:63:4B:E9:10:6E:E3:AD:8E:6B:9D:D9:81:4A
+SHA256 Fingerprint: D9:47:43:2A:BD:E7:B7:FA:90:FC:2E:6B:59:10:1B:12:80:E0:E1:C7:E4:E4:0F:A3:C6:88:7F:FF:57:A7:F4:CF
+
+GTS Root R2
+Valid until: 22/Jun/2036
+Serial Number: 02:03:E5:AE:C5:8D:04:25:1A:AB:11:25:AA
+SHA1 Fingerprint: 9A:44:49:76:32:DB:DE:FA:D0:BC:FB:5A:7B:17:BD:9E:56:09:24:94
+SHA256 Fingerprint: 8D:25:CD:97:22:9D:BF:70:35:6B:DA:4E:B3:CC:73:40:31:E2:4C:F0:0F:AF:CF:D3:2D:C7:6E:B5:84:1C:7E:A8
+
+GTS Root R3
+Valid until: 22/Jun/2036
+Serial Number: 02:03:E5:B8:82:EB:20:F8:25:27:6D:3D:66
+SHA1 Fingerprint: ED:E5:71:80:2B:C8:92:B9:5B:83:3C:D2:32:68:3F:09:CD:A0:1E:46
+SHA256 Fingerprint: 34:D8:A7:3E:E2:08:D9:BC:DB:0D:95:65:20:93:4B:4E:40:E6:94:82:59:6E:8B:6F:73:C8:42:6B:01:0A:6F:48
+
+GTS Root R4
+Valid until: 22/Jun/2036
+Serial Number: 02:03:E5:C0:68:EF:63:1A:9C:72:90:50:52
+SHA1 Fingerprint: 77:D3:03:67:B5:E0:0C:15:F6:0C:38:61:DF:7C:E1:3B:92:46:4D:47
+SHA256 Fingerprint: 34:9D:FA:40:58:C5:E2:63:12:3B:39:8A:E7:95:57:3C:4E:13:13:C8:3F:E6:8F:93:55:6C:D5:E8:03:1B:3C:7D
 ```


### PR DESCRIPTION
Adds Google Trust Services (pki.goog) root CAs to the certificate pinning documentation.

## Why

Sentry is deploying the US2 region using GCP-managed TLS certificates. GCP can issue certs from either `letsencrypt.org` or `pki.goog`. The GTS roots were missing from our pinning docs, which could break customers who pin certificates and end up being served a pki.goog cert.

All four GTS root CAs (R1–R4, covering both RSA and EC) are included. Fingerprints verified directly from the live `https://pki.goog/roots.pem` bundle via openssl.

Also updates the introductory sentence in the Certificate Pinning section to mention Google Trust Services alongside Digicert and Let's Encrypt.

**GlobalSign ECC Root CA - R4 is not included.**
GlobalSign ECC Root CA - R4 shows up in pki.goog/roots.pem because that bundle contains every root GTS has a trust relationship with — 20 certs total, including GlobalSign, DigiCert, GoDaddy, COMODO, USERTrust, etc. It's not a root GTS issues from.

GCP-managed certificates chain to GTS Root R1–R4 only (R1/R2 for RSA, R3/R4 for EC). GlobalSign R4 was historically used for cross-signing GTS intermediates for broader device compatibility, but modern GTS-issued certs go straight to their own roots.

## Context

https://sentry.slack.com/archives/C1G612XHC/p1779718624966249

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC1G612XHC%3A1779718624.966249%22)
