### PR TITLE
Add GitHub Copilot to Autofix coding agent handoff docs

### DIFF
--- a/docs/product/ai-in-sentry/seer/autofix/index.mdx
+++ b/docs/product/ai-in-sentry/seer/autofix/index.mdx
@@ -106,7 +106,7 @@ snippets and examples, and does not affect workflows involving your own coding a
 
 ![Screenshot of Seer showing code it generated =800x](../img/coding-step.png)
 
-### Handoff to Claude Code or Cursor Cloud Agents
+### Handoff to Claude Code, Cursor, or GitHub Copilot
 
 Seer always performs root cause analysis and solution planning using its own internal tools and Sentry context. At the final code generation step, instead of having Seer generate the code fix directly, you can hand off to an external coding agent for implementation. Seer passes along the root cause and solution plan so the coding agent can act on them. This lets you leverage the strengths of specialized code generation tools while still benefiting from Seer's debugging and analysis.
 
@@ -116,8 +116,9 @@ Supported coding agents for handoff:
 
 - **Claude Code** — Seer passes the root cause and solution as a structured prompt that Claude Code can act on directly in your terminal or CI environment.
 - **Cursor Cloud Agents** — Seer triggers a Cursor Cloud Agent to implement the fix asynchronously, without requiring your local IDE to be open.
+- **GitHub Copilot** — Seer hands off the root cause and solution to a GitHub Copilot coding agent, which implements the fix and opens a pull request in your linked GitHub repository. See [GitHub Copilot Agent](/integrations/coding-agents/copilot/) for setup and first-time authorization.
 
-To enable coding agent handoff, connect a coding agent integration in [Integrations settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/integrations/?category=coding%20agent). Once connected, the handoff option will appear at the Code Generation step of the Autofix flow, alongside the standard "Create PR" and "Checkout locally" options.
+To enable coding agent handoff, connect a coding agent integration in [Integrations settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/integrations/?category=coding%20agent). Once connected, the handoff option will appear at the Code Generation step of the Autofix flow, alongside the standard "Create PR" and "Checkout locally" options. For provider-specific setup, see [Claude Code](/integrations/coding-agents/claude/), [Cursor](/integrations/coding-agents/cursor/), and [GitHub Copilot](/integrations/coding-agents/copilot/).
 
 <Alert>
 Coding agent integrations handle their own authentication and repository access. Make sure the agent can access the same repositories connected to your Sentry project.

--- a/docs/product/ai-in-sentry/seer/autofix/index.mdx
+++ b/docs/product/ai-in-sentry/seer/autofix/index.mdx
@@ -106,7 +106,7 @@ snippets and examples, and does not affect workflows involving your own coding a
 
 ![Screenshot of Seer showing code it generated =800x](../img/coding-step.png)
 
-### Handoff to Claude Code, Cursor, or GitHub Copilot
+### Handoff to Claude Code, Cursor, or GitHub Copilot Cloud Agent
 
 Seer always performs root cause analysis and solution planning using its own internal tools and Sentry context. At the final code generation step, instead of having Seer generate the code fix directly, you can hand off to an external coding agent for implementation. Seer passes along the root cause and solution plan so the coding agent can act on them. This lets you leverage the strengths of specialized code generation tools while still benefiting from Seer's debugging and analysis.
 
@@ -116,7 +116,7 @@ Supported coding agents for handoff:
 
 - **Claude Code** — Seer passes the root cause and solution as a structured prompt that Claude Code can act on directly in your terminal or CI environment.
 - **Cursor Cloud Agents** — Seer triggers a Cursor Cloud Agent to implement the fix asynchronously, without requiring your local IDE to be open.
-- **GitHub Copilot** — Seer hands off the root cause and solution to a GitHub Copilot coding agent, which implements the fix and opens a pull request in your linked GitHub repository. See [GitHub Copilot Agent](/integrations/coding-agents/copilot/) for setup and first-time authorization.
+- **GitHub Copilot Cloud Agent** — Seer hands off the root cause and solution to a GitHub Copilot cloud agent, which implements the fix and opens a pull request in your linked GitHub repository. See [GitHub Copilot Agent](/integrations/coding-agents/copilot/) for setup and first-time authorization.
 
 To enable coding agent handoff, connect a coding agent integration in [Integrations settings](https://sentry.io/orgredirect/organizations/:orgslug/settings/integrations/?category=coding%20agent). Once connected, the handoff option will appear at the Code Generation step of the Autofix flow, alongside the standard "Create PR" and "Checkout locally" options. For provider-specific setup, see [Claude Code](/integrations/coding-agents/claude/), [Cursor](/integrations/coding-agents/cursor/), and [GitHub Copilot](/integrations/coding-agents/copilot/).
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Autofix page lists Claude Code and Cursor as supported coding agents for handoff but omits GitHub Copilot, which is supported and documented at [GitHub Copilot Agent](https://docs.sentry.io/integrations/coding-agents/copilot/).

This PR adds GitHub Copilot to that page:
- Updates the section heading to include GitHub Copilot
- Adds a GitHub Copilot bullet to the supported coding agents list, linking to the existing setup page
- Adds provider-specific setup links for Claude Code, Cursor, and GitHub Copilot

No behavioral or product changes; documentation only.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
