### PR TITLE
docs(dynamic-sampling): Clarify custom sample rates availability for AM3

### DIFF
--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -34,7 +34,7 @@ Dynamic sampling only applies to spans and transactions, not errors.
 The configuration of custom sample rates described below is only available on plans that enrolled before June 2025. If your organization enrolled after this date, Dynamic Sampling with Sampling Priorities is applied automatically and no manual configuration is required.
 </Alert>
 
-Dynamic Sampling with Sampling Priorities is applied automatically on all paid plans. By analyzing incoming traffic patterns, Dynamic Sampling is able to automatically tailor its sample rate to both the actual traffic volume and the content of accepted transactions. For more details, check out the [Dynamic Sampling Priorities](#dynamic-sampling-priorities) section.
+Dynamic Sampling with Sampling Priorities is available on selected Team, Business, and Enterprise plans. By analyzing incoming traffic patterns, Dynamic Sampling is able to automatically tailor its sample rate to both the actual traffic volume and the content of accepted transactions. For more details, check out the [Dynamic Sampling Priorities](#dynamic-sampling-priorities) section.
 
 
 ## Prerequisites
@@ -146,7 +146,7 @@ You can use both Dynamic and SDK Sampling together to further optimize your even
 
 ## Dynamic Sampling Priorities
 <Alert>
-  Dynamic Sampling with Sampling Priorities is available on all paid plans.
+  Dynamic Sampling with Sampling Priorities is available on selected Team, Business, and Enterprise plans.
 </Alert>
 Below is a list of the strategies Dynamic Sampling employs to prioritize and deprioritize data. They are enabled by default, but can be updated on a per-project basis to better fit your organization's needs. To customize this behavior, go to Project Settings > Performance.
 

--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -30,11 +30,11 @@ Dynamic Sampling employs advanced sampling techniques to retain a representative
 Dynamic sampling only applies to spans and transactions, not errors.
 </Alert>
 
-There are two available flavors of dynamic sampling, depending on the plan type of your organization:
-- **Dynamic Sampling with Sampling Priorities** - available on selected Team, Business & Enterprise plans\
-  By analyzing incoming traffic patterns, Dynamic Sampling is able to automatically tailor its sample rate to both the actual traffic volume and the content of accepted transactions. For more details, check out the [Dynamic Sampling Priorities](#dynamic-sampling-priorities) section.
-- **Dynamic Sampling with Sampling Priorities & Custom Sample Rates** - available on selected Enterprise plans\
-  Configure and adjust sample rates for stored spans right from the UI without needing to modify your SDK. This makes it possible for you to make instant updates without waiting for code freezes, app store approvals, or redeployments. In addition, by analyzing incoming traffic patterns, Dynamic Sampling is able to prioritize data based on the content of accepted spans. For more details, check out the [Configuration of Custom Sample Rates](#configuration-of-custom-sample-rates) section.
+<Alert level="warning">
+The configuration of custom sample rates described below is only available on plans that enrolled before June 2025. If your organization enrolled after this date, Dynamic Sampling with Sampling Priorities is applied automatically and no manual configuration is required.
+</Alert>
+
+Dynamic Sampling with Sampling Priorities is applied automatically on all paid plans. By analyzing incoming traffic patterns, Dynamic Sampling is able to automatically tailor its sample rate to both the actual traffic volume and the content of accepted transactions. For more details, check out the [Dynamic Sampling Priorities](#dynamic-sampling-priorities) section.
 
 
 ## Prerequisites
@@ -56,8 +56,8 @@ There are two available flavors of dynamic sampling, depending on the plan type 
   - Go: 0.16.0 or later
 
 ## Configuration of Custom Sample Rates
-<Alert>
-Configuration of custom sample rates has been available on selected Enterprise plans since June 2024.
+<Alert level="warning">
+Configuration of custom sample rates is only available on plans that enrolled before June 2025. If you don't see these settings in your organization, your plan does not include this feature.
 </Alert>
 In this section, you'll learn how to use Dynamic Sampling in your organization. Dynamic Sampling offers two modes based on the desired sampling control:
 
@@ -146,7 +146,7 @@ You can use both Dynamic and SDK Sampling together to further optimize your even
 
 ## Dynamic Sampling Priorities
 <Alert>
-  Dynamic Sampling including Sampling Priorities has been available on selected paid plans since November 2022.
+  Dynamic Sampling with Sampling Priorities is available on all paid plans.
 </Alert>
 Below is a list of the strategies Dynamic Sampling employs to prioritize and deprioritize data. They are enabled by default, but can be updated on a per-project basis to better fit your organization's needs. To customize this behavior, go to Project Settings > Performance.
 

--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -31,7 +31,7 @@ Dynamic sampling only applies to spans and transactions, not errors.
 </Alert>
 
 <Alert level="warning">
-The configuration of custom sample rates described below is only available on plans that enrolled before June 2025. If your organization enrolled after this date, Dynamic Sampling with Sampling Priorities is applied automatically and no manual configuration is required.
+The [Configuration of Custom Sample Rates](#configuration-of-custom-sample-rates) section on this page is only available on plans that enrolled before June 2025. If your organization enrolled after this date, Dynamic Sampling with Sampling Priorities is applied automatically and no manual configuration is required.
 </Alert>
 
 Dynamic Sampling with Sampling Priorities is available on selected Team, Business, and Enterprise plans. By analyzing incoming traffic patterns, Dynamic Sampling is able to automatically tailor its sample rate to both the actual traffic volume and the content of accepted transactions. For more details, check out the [Dynamic Sampling Priorities](#dynamic-sampling-priorities) section.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Customers on AM3 (spans-based billing) don't have access to the dynamic sampling custom sample rates settings, but the docs describe them without any plan restrictions. This causes confusion and support tickets — customers read about the feature, can't find the settings screen, and contact support.

**Changes:**
- Add a warning alert at the top of the dynamic sampling page clarifying that custom sample rate configuration is only available on plans enrolled before June 2025
- Replace the two-flavor plan list with a single description of automatic Sampling Priorities (available on all paid plans)
- Update the Custom Sample Rates section alert to explain when settings are not visible
- Simplify the Sampling Priorities availability note

Closes https://linear.app/getsentry/issue/TET-2499/remove-ds-for-am3-docs

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


