### PR TITLE
docs(logs): Promote spec sections from candidate to stable

### DIFF
--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -2,7 +2,7 @@
 title: Logs
 description: Structured logging protocol with severity levels, trace context, and batched envelope delivery.
 spec_id: sdk/telemetry/logs
-spec_version: 2.1.0
+spec_version: 2.2.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
@@ -10,6 +10,9 @@ spec_depends_on:
   - id: sdk/foundations/state-management/scopes/attributes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 2.2.0
+    date: 2026-06-22
+    summary: Promoted most spec sections from candidate to stable
   - version: 2.1.0
     date: 2026-05-06
     summary: Clarified sendDefaultPii gating for user attributes — allowed when user manually sets data
@@ -129,7 +132,7 @@ Logs are buffered before sending. SDKs collect logs into a buffer and flush them
 
 ## Behavior
 
-<SpecSection id="log-processing-pipeline" status="candidate" since="1.3.0">
+<SpecSection id="log-processing-pipeline" status="stable" since="1.3.0">
 
 ### Log Processing Pipeline
 
@@ -152,7 +155,7 @@ An SDK **SHOULD** implement [Tracing without Performance](/sdk/foundations/trace
 
 </SpecSection>
 
-<SpecSection id="default-attributes" status="candidate" since="1.0.0">
+<SpecSection id="default-attributes" status="stable" since="1.0.0">
 
 ### Default Attributes
 
@@ -183,7 +186,7 @@ SDKs **SHOULD** minimize default attributes. Logs are charged per byte size. New
 
 </SpecSection>
 
-<SpecSection id="sdk-integration-origin" status="candidate" since="1.0.0">
+<SpecSection id="sdk-integration-origin" status="stable" since="1.0.0">
 
 ### SDK Integration Origin
 
@@ -197,7 +200,7 @@ Since 1.9.0, logs follow these rules:
 
 </SpecSection>
 
-<SpecSection id="user-attributes" status="candidate" since="1.5.0">
+<SpecSection id="user-attributes" status="stable" since="1.5.0">
 
 ### User Attributes
 
@@ -211,7 +214,7 @@ SDKs **MAY** attach user information as attributes, guarded by `sendDefaultPii` 
 
 </SpecSection>
 
-<SpecSection id="user-agent-parsing" status="candidate" since="1.5.0">
+<SpecSection id="user-agent-parsing" status="stable" since="1.5.0">
 
 ### User Agent Parsing
 
@@ -224,7 +227,7 @@ By default, Relay parses the user agent attached to an incoming log envelope to 
 
 </SpecSection>
 
-<SpecSection id="backend-attributes" status="candidate" since="1.0.0">
+<SpecSection id="backend-attributes" status="stable" since="1.0.0">
 
 ### Backend SDK Attributes
 
@@ -236,7 +239,7 @@ Backend SDKs (Node.js, Python, PHP, etc.) **SHOULD** attach:
 
 </SpecSection>
 
-<SpecSection id="mobile-native-attributes" status="candidate" since="1.5.0">
+<SpecSection id="mobile-native-attributes" status="stable" since="1.5.0">
 
 ### Mobile, Desktop, and Native SDK Attributes
 
@@ -252,7 +255,7 @@ Mobile, desktop, and native SDKs (Android, Apple, Electron, etc.) **SHOULD** att
 
 </SpecSection>
 
-<SpecSection id="buffering" status="candidate" since="1.0.0">
+<SpecSection id="buffering" status="stable" since="1.0.0">
 
 ### Buffering
 
@@ -266,7 +269,7 @@ SDKs **MUST NOT** release logging capabilities to users without a buffering impl
 
 </SpecSection>
 
-<SpecSection id="data-category-rate-limiting" status="candidate" since="1.0.0">
+<SpecSection id="data-category-rate-limiting" status="stable" since="1.0.0">
 
 ### Data Category and Rate Limiting
 
@@ -276,7 +279,7 @@ SDKs **MUST** track client outcomes for this data category to report how often l
 
 </SpecSection>
 
-<SpecSection id="sdk-integrations" status="candidate" since="1.0.0">
+<SpecSection id="sdk-integrations" status="stable" since="1.0.0">
 
 ### SDK Integrations
 
@@ -302,7 +305,7 @@ These rules exist because auto-emitted logs can cause a high volume of telemetry
 
 </SpecSection>
 
-<SpecSection id="tracing-association" status="candidate" since="1.0.0">
+<SpecSection id="tracing-association" status="stable" since="1.0.0">
 
 ### Tracing Association
 
@@ -310,7 +313,7 @@ Logs **SHOULD** be associated with traces. If a log is recorded during an active
 
 </SpecSection>
 
-<SpecSection id="replay-association" status="candidate" since="1.8.0">
+<SpecSection id="replay-association" status="stable" since="1.8.0">
 
 ### Replay Association
 
@@ -337,7 +340,7 @@ The sequence provides deterministic ordering within a single SDK instance. It do
 
 ### Debug Mode
 
-<SpecSection id="debug-mode" status="candidate" since="1.0.0">
+<SpecSection id="debug-mode" status="stable" since="1.0.0">
 
 ### Debug Mode
 
@@ -345,7 +348,7 @@ If `debug` is set to `true` in SDK init, calls to the Sentry logger API **SHOULD
 
 </SpecSection>
 
-<SpecSection id="client-reports" status="candidate" since="1.13.0">
+<SpecSection id="client-reports" status="stable" since="1.13.0">
 
 ### Client Reports
 
@@ -357,7 +360,7 @@ SDKs **MUST** report count (`log_item`) and size in bytes (`log_byte`) of discar
 
 ## Wire Format
 
-<SpecSection id="log-envelope-item" status="candidate" since="1.1.0">
+<SpecSection id="log-envelope-item" status="stable" since="1.1.0">
 
 ### `log` Envelope Item
 
@@ -399,7 +402,7 @@ The `log` envelope item **SHOULD** include `version` and `ingest_settings` prope
 
 </SpecSection>
 
-<SpecSection id="log-payload" status="candidate" since="1.0.0">
+<SpecSection id="log-payload" status="stable" since="1.0.0">
 
 ### `log` Envelope Item Payload
 
@@ -438,7 +441,7 @@ Each log in the `items` array is a JSON object:
 
 </SpecSection>
 
-<SpecSection id="otel-log-format" status="candidate" since="1.0.0">
+<SpecSection id="otel-log-format" status="stable" since="1.0.0">
 
 ### `otel_log` Envelope Item Payload
 
@@ -485,7 +488,7 @@ The `otel_log` envelope item payload is a JSON object implementing the [OpenTele
 
 ## Public API
 
-<SpecSection id="initialization-options" status="candidate" since="1.0.0">
+<SpecSection id="initialization-options" status="stable" since="1.0.0">
 
 ### Initialization Options
 
@@ -512,7 +515,7 @@ Sentry.init({
 
 </SpecSection>
 
-<SpecSection id="logger-api" status="candidate" since="1.0.0">
+<SpecSection id="logger-api" status="stable" since="1.0.0">
 
 ### Logger Module
 
@@ -531,7 +534,7 @@ The Hub/Scope and Client **MUST** exclusively provide a generic logging method (
 
 </SpecSection>
 
-<SpecSection id="threading-concurrency" status="candidate" since="1.0.0">
+<SpecSection id="threading-concurrency" status="stable" since="1.0.0">
 
 ### Threading and Concurrency
 

--- a/develop-docs/sdk/telemetry/logs.mdx
+++ b/develop-docs/sdk/telemetry/logs.mdx
@@ -501,18 +501,6 @@ SDKs **MUST** expose the following configuration options:
 
 The default for `enableLogs`/`enable_logs` was changed from `false` to `true` in version 2.0.0. The previous default required users to explicitly opt in before they could use the logging primitives. By defaulting to `true`, adding a `Sentry.logger.*` statement is itself the opt-in. Users can start logging without additional configuration. This aligns the behavior with [`enableMetrics`/`enable_metrics`](/sdk/telemetry/metrics/#initialization-options), which also defaults to `true`.
 
-While logs functionality is in an experimental state, SDKs **SHOULD** put these options in an experimental namespace to avoid breaking changes:
-
-```js
-Sentry.init({
-  // stable
-  enableLogs: true,
-
-  // experimental
-  _experiments: { enableLogs: true },
-});
-```
-
 </SpecSection>
 
 <SpecSection id="logger-api" status="stable" since="1.0.0">


### PR DESCRIPTION
Promote 20 of 23 `SpecSection` entries in the logs spec from `candidate` to `stable`, reflecting broad SDK implementation across JavaScript, Python, PHP, Java, and Swift.

Three newer sections remain on `candidate` pending wider SDK adoption:
- **`auto-emitted-logs`** (since 2.0.0) — opt-in requirements for integration-emitted logs
- **`log-ordering`** (since 1.16.0) — `sentry.timestamp.sequence` for frozen-timer runtimes
- **`log-envelope-item-ingest-settings`** (since 1.17.0) — `version`/`ingest_settings` envelope fields

Bumps spec version from 2.1.0 to 2.2.0.