### PR TITLE
docs(specs): Add trace_metric_byte client reports requirement

### DIFF
--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -2,12 +2,15 @@
 title: Client Reports
 description: SDK self-reporting protocol for tracking discarded events and their discard reasons.
 spec_id: sdk/telemetry/client-reports
-spec_version: 1.22.0
+spec_version: 1.23.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.23.0
+    date: 2026-06-22
+    summary: Added metric byte outcomes for tracking discarded metric data size
   - version: 1.22.0
     date: 2026-04-09
     summary: Added `no_parent_span` discard reason
@@ -219,6 +222,18 @@ When a log is dropped, SDKs **MUST** record an additional `log_byte` category en
 Since client reports use a `(reason, category) → quantity` map for aggregation, byte sizes are tracked as a separate category rather than an extra field. Each dropped log produces two entries in the map: one incrementing the `log_item` count by 1, and one incrementing the `log_byte` count by the log's byte size.
 
 The byte size does not need to be exact. SDKs **MAY** use an approximation, such as the in-memory size of the log object or the size of its serialized representation. The goal is to provide a useful signal, not a precise measurement.
+
+</SpecSection>
+
+<SpecSection id="metric-byte-outcomes" status="candidate" since="1.23.0">
+
+### Metric Byte Outcomes
+
+When a metric is dropped, SDKs **MUST** record an additional `trace_metric_byte` category entry containing the byte size of the metric. This provides visibility into the volume of metric data being discarded, complementing the item count reported under the `trace_metric` category.
+
+Since client reports use a `(reason, category) → quantity` map for aggregation, byte sizes are tracked as a separate category rather than an extra field. Each dropped metric produces two entries in the map: one incrementing the `trace_metric` count by 1, and one incrementing the `trace_metric_byte` count by the metric's byte size.
+
+The byte size does not need to be exact. SDKs **MAY** use an approximation, such as the in-memory size of the metric object or the size of its serialized representation. The goal is to provide a useful signal, not a precise measurement.
 
 </SpecSection>
 
@@ -457,6 +472,29 @@ When 5 logs totaling approximately 12,400 bytes are dropped due to buffer overfl
 ```
 
 The `log_item` entry counts the number of dropped logs, while the `log_byte` entry tracks the total byte size of those logs.
+
+### Metric Byte Outcome Example
+
+When 3 metrics totaling approximately 4,800 bytes are dropped due to rate limiting:
+
+```json
+{
+  "discarded_events": [
+    {
+      "reason": "ratelimit_backoff",
+      "category": "trace_metric",
+      "quantity": 3
+    },
+    {
+      "reason": "ratelimit_backoff",
+      "category": "trace_metric_byte",
+      "quantity": 4800
+    }
+  ]
+}
+```
+
+The `trace_metric` entry counts the number of dropped metrics, while the `trace_metric_byte` entry tracks the total byte size of those metrics.
 
 ---
 

--- a/develop-docs/sdk/telemetry/metrics.mdx
+++ b/develop-docs/sdk/telemetry/metrics.mdx
@@ -2,7 +2,7 @@
 title: Metrics
 description: Counter, gauge, and distribution metrics sent as batched trace_metric envelope items.
 spec_id: sdk/telemetry/metrics
-spec_version: 2.9.0
+spec_version: 2.10.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
@@ -10,6 +10,9 @@ spec_depends_on:
   - id: sdk/foundations/state-management/scopes/attributes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 2.10.0
+    date: 2026-06-22
+    summary: Added client reports requirement (trace_metric count, trace_metric_byte size)
   - version: 2.9.0
     date: 2026-05-18
     summary: Added optional `timestamp` parameter to metrics public API. Changed `sentry.timestamp.sequence` to a continuously incrementing Int64 that never resets on timestamp change.
@@ -249,6 +252,14 @@ However, metrics that are **automatically emitted by integrations or libraries**
 **Third-party metrics bindings** — An SDK feature that binds to an external library's metrics API and mirrors those metrics as Sentry metrics in the background (e.g., syncing from a framework's built-in metrics or an OpenTelemetry metrics pipeline) **MUST** also be opt-in. Users **MUST** explicitly enable the binding before any metrics are forwarded to Sentry.
 
 These rules exist because auto-emitted metrics can cause a high volume of telemetry that directly impacts a user's quota. Unlike spans or errors — where users have prior intuition about volume — silently emitting metrics on their behalf could lead to unexpected costs. Requiring opt-in ensures users remain in control of their metrics volume.
+
+</SpecSection>
+
+<SpecSection id="client-reports" status="candidate" since="2.10.0">
+
+### Client Reports
+
+SDKs **MUST** report count (`trace_metric`) and size in bytes (`trace_metric_byte`) of discarded metrics. An approximation of metric size is sufficient (e.g., by counting as if serialized).
 
 </SpecSection>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Add `trace_metric_byte` client reports support to the Metrics and Client Reports develop specs, mirroring the existing `log_byte` pattern from the Logs spec.

- **Metrics spec** (2.9.0 → 2.10.0): Add candidate `Client Reports` section requiring SDKs to report count (`trace_metric`) and size in bytes (`trace_metric_byte`) of discarded metrics
- **Client Reports spec** (1.22.0 → 1.23.0): Add candidate `Metric Byte Outcomes` section describing the `trace_metric_byte` category, plus a wire format example

No existing content was modified.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)