### PR TITLE
docs(godot): Document Metrics general availability in SDK 2.0.0

### DIFF
--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -182,6 +182,40 @@ This option is turned off by default.
 
 </SdkOption>
 
+<SdkOption name="before_send_log" type="Callable" availableSince="1.2.0">
+
+If assigned, this callback will be called before sending a log message to Sentry.
+It can be used to modify the log message or prevent it from being sent.
+
+```gdscript {tabTitle:GDScript} {mdExpandTabs}
+func _before_send_log(log_entry: SentryLog) -> SentryLog:
+	# Filter junk.
+	if log_entry.body == "Junk message":
+		return null
+	# Remove sensitive information from log messages.
+	log_entry.body = log_entry.body.replace("Bruno", "REDACTED")
+	# Add custom attributes.
+	log_entry.set_attribute("current_scene", current_scene.name)
+	return log_entry
+```
+
+```csharp {tabTitle:C#}
+// The .NET hook applies to logs emitted from your C# code.
+options.SetBeforeSendLog(log =>
+{
+    // Filter junk.
+    if (log.Message == "Junk message")
+    {
+        return null;
+    }
+    // Add custom attributes.
+    log.SetAttribute("current_scene", currentScene.Name);
+    return log;
+});
+```
+
+</SdkOption>
+
 ## Godot Logger Options
 
 <SdkOption name="logger_enabled" type="bool" defaultValue="true">
@@ -290,6 +324,38 @@ This option is turned on by default.
 
 </SdkOption>
 
+<SdkOption name="before_send_metric" type="Callable" availableSince="2.0.0">
+
+If assigned, this callback runs before a metric is sent to Sentry.
+It can be used to modify the metric or prevent it from being sent.
+It takes a `SentryMetric` as a parameter and returns either the same metric object, with or without modifications, or `null` to discard it.
+
+```gdscript {tabTitle:GDScript} {mdExpandTabs}
+func _before_send_metric(metric: SentryMetric) -> SentryMetric:
+	# Drop debug-only metrics in release builds.
+	if not OS.is_debug_build() and metric.name.begins_with("debug."):
+		return null
+	# Enrich with runtime context.
+	metric.set_attribute("current_scene", get_tree().current_scene.name)
+	return metric
+```
+
+```csharp {tabTitle:C#}
+options.SetBeforeSendMetric(metric =>
+{
+    // Drop debug-only metrics in release builds.
+    if (!OS.IsDebugBuild() && metric.Name.StartsWith("debug."))
+    {
+        return null;
+    }
+    // Enrich with runtime context.
+    metric.SetAttribute("current_scene", GetTree().CurrentScene.Name);
+    return metric;
+});
+```
+
+</SdkOption>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
@@ -357,72 +423,6 @@ func _before_capture_screenshot(event: SentryEvent) -> bool:
 This callback isn't available in the .NET layer yet, so it can only be set from GDScript.
 
 </Alert>
-
-</SdkOption>
-
-<SdkOption name="before_send_log" type="Callable" availableSince="1.2.0">
-
-If assigned, this callback will be called before sending a log message to Sentry.
-It can be used to modify the log message or prevent it from being sent.
-
-```gdscript {tabTitle:GDScript} {mdExpandTabs}
-func _before_send_log(log_entry: SentryLog) -> SentryLog:
-	# Filter junk.
-	if log_entry.body == "Junk message":
-		return null
-	# Remove sensitive information from log messages.
-	log_entry.body = log_entry.body.replace("Bruno", "REDACTED")
-	# Add custom attributes.
-	log_entry.set_attribute("current_scene", current_scene.name)
-	return log_entry
-```
-
-```csharp {tabTitle:C#}
-// The .NET hook applies to logs emitted from your C# code.
-options.SetBeforeSendLog(log =>
-{
-    // Filter junk.
-    if (log.Message == "Junk message")
-    {
-        return null;
-    }
-    // Add custom attributes.
-    log.SetAttribute("current_scene", currentScene.Name);
-    return log;
-});
-```
-
-</SdkOption>
-
-<SdkOption name="before_send_metric" type="Callable" availableSince="2.0.0">
-
-If assigned, this callback runs before a metric is sent to Sentry.
-It can be used to modify the metric or prevent it from being sent.
-It takes a `SentryMetric` as a parameter and returns either the same metric object, with or without modifications, or `null` to discard it.
-
-```gdscript {tabTitle:GDScript} {mdExpandTabs}
-func _before_send_metric(metric: SentryMetric) -> SentryMetric:
-	# Drop debug-only metrics in release builds.
-	if not OS.is_debug_build() and metric.name.begins_with("debug."):
-		return null
-	# Enrich with runtime context.
-	metric.set_attribute("current_scene", get_tree().current_scene.name)
-	return metric
-```
-
-```csharp {tabTitle:C#}
-options.SetBeforeSendMetric(metric =>
-{
-    // Drop debug-only metrics in release builds.
-    if (!OS.IsDebugBuild() && metric.Name.StartsWith("debug."))
-    {
-        return null;
-    }
-    // Enrich with runtime context.
-    metric.SetAttribute("current_scene", GetTree().CurrentScene.Name);
-    return metric;
-});
-```
 
 </SdkOption>
 

--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -216,6 +216,48 @@ options.SetBeforeSendLog(log =>
 
 </SdkOption>
 
+## Metrics Options
+
+<SdkOption name="enable_metrics" type="bool" defaultValue="true" availableSince="2.0.0">
+
+If `true`, enables Sentry metrics functionality, allowing you to emit custom counters, gauges, and distributions through `SentrySDK.metrics`. See <PlatformLink to="/metrics/">Set Up Metrics</PlatformLink> for usage details.
+
+This option is turned on by default.
+
+</SdkOption>
+
+<SdkOption name="before_send_metric" type="Callable" availableSince="2.0.0">
+
+If assigned, this callback runs before a metric is sent to Sentry.
+It can be used to modify the metric or prevent it from being sent.
+It takes a `SentryMetric` as a parameter and returns either the same metric object, with or without modifications, or `null` to discard it.
+
+```gdscript {tabTitle:GDScript} {mdExpandTabs}
+func _before_send_metric(metric: SentryMetric) -> SentryMetric:
+	# Drop debug-only metrics in release builds.
+	if not OS.is_debug_build() and metric.name.begins_with("debug."):
+		return null
+	# Enrich with runtime context.
+	metric.set_attribute("current_scene", get_tree().current_scene.name)
+	return metric
+```
+
+```csharp {tabTitle:C#}
+options.SetBeforeSendMetric(metric =>
+{
+    // Drop debug-only metrics in release builds.
+    if (!OS.IsDebugBuild() && metric.Name.StartsWith("debug."))
+    {
+        return null;
+    }
+    // Enrich with runtime context.
+    metric.SetAttribute("current_scene", GetTree().CurrentScene.Name);
+    return metric;
+});
+```
+
+</SdkOption>
+
 ## Godot Logger Options
 
 <SdkOption name="logger_enabled" type="bool" defaultValue="true">
@@ -311,48 +353,6 @@ This option contains multiple properties that govern the behavior of throttling.
 `throttle_events` specifies the maximum number of events allowed within a sliding time window of `throttle_window_ms` milliseconds. If exceeded, errors will be captured as breadcrumbs only until capacity is freed. Default: `20`.
 
 `throttle_window_ms` specifies the time window in milliseconds for `throttle_events`. Set it to `0` to disable this limit. Default: `10000`.
-
-</SdkOption>
-
-## Metrics Options
-
-<SdkOption name="enable_metrics" type="bool" defaultValue="true" availableSince="2.0.0">
-
-If `true`, enables Sentry metrics functionality, allowing you to emit custom counters, gauges, and distributions through `SentrySDK.metrics`. See <PlatformLink to="/metrics/">Set Up Metrics</PlatformLink> for usage details.
-
-This option is turned on by default.
-
-</SdkOption>
-
-<SdkOption name="before_send_metric" type="Callable" availableSince="2.0.0">
-
-If assigned, this callback runs before a metric is sent to Sentry.
-It can be used to modify the metric or prevent it from being sent.
-It takes a `SentryMetric` as a parameter and returns either the same metric object, with or without modifications, or `null` to discard it.
-
-```gdscript {tabTitle:GDScript} {mdExpandTabs}
-func _before_send_metric(metric: SentryMetric) -> SentryMetric:
-	# Drop debug-only metrics in release builds.
-	if not OS.is_debug_build() and metric.name.begins_with("debug."):
-		return null
-	# Enrich with runtime context.
-	metric.set_attribute("current_scene", get_tree().current_scene.name)
-	return metric
-```
-
-```csharp {tabTitle:C#}
-options.SetBeforeSendMetric(metric =>
-{
-    // Drop debug-only metrics in release builds.
-    if (!OS.IsDebugBuild() && metric.Name.StartsWith("debug."))
-    {
-        return null;
-    }
-    // Enrich with runtime context.
-    metric.SetAttribute("current_scene", GetTree().CurrentScene.Name);
-    return metric;
-});
-```
 
 </SdkOption>
 

--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -220,7 +220,7 @@ options.SetBeforeSendLog(log =>
 
 <SdkOption name="enable_metrics" type="bool" defaultValue="true" availableSince="2.0.0">
 
-If `true`, enables Sentry metrics functionality, allowing you to emit custom counters, gauges, and distributions through `SentrySDK.metrics`. See <PlatformLink to="/metrics/">Set Up Metrics</PlatformLink> for usage details.
+If `true`, enables [Sentry's Application Metrics](https://docs.sentry.io/product/explore/metrics/) functionality, allowing you to emit custom counters, gauges, and distributions through `SentrySDK.metrics`. See <PlatformLink to="/metrics/">Set Up Metrics</PlatformLink> for usage details.
 
 This option is turned on by default.
 

--- a/docs/platforms/godot/configuration/options.mdx
+++ b/docs/platforms/godot/configuration/options.mdx
@@ -280,6 +280,16 @@ This option contains multiple properties that govern the behavior of throttling.
 
 </SdkOption>
 
+## Metrics Options
+
+<SdkOption name="enable_metrics" type="bool" defaultValue="true" availableSince="2.0.0">
+
+If `true`, enables Sentry metrics functionality, allowing you to emit custom counters, gauges, and distributions through `SentrySDK.metrics`. See <PlatformLink to="/metrics/">Set Up Metrics</PlatformLink> for usage details.
+
+This option is turned on by default.
+
+</SdkOption>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.
@@ -379,6 +389,38 @@ options.SetBeforeSendLog(log =>
     // Add custom attributes.
     log.SetAttribute("current_scene", currentScene.Name);
     return log;
+});
+```
+
+</SdkOption>
+
+<SdkOption name="before_send_metric" type="Callable" availableSince="2.0.0">
+
+If assigned, this callback runs before a metric is sent to Sentry.
+It can be used to modify the metric or prevent it from being sent.
+It takes a `SentryMetric` as a parameter and returns either the same metric object, with or without modifications, or `null` to discard it.
+
+```gdscript {tabTitle:GDScript} {mdExpandTabs}
+func _before_send_metric(metric: SentryMetric) -> SentryMetric:
+	# Drop debug-only metrics in release builds.
+	if not OS.is_debug_build() and metric.name.begins_with("debug."):
+		return null
+	# Enrich with runtime context.
+	metric.set_attribute("current_scene", get_tree().current_scene.name)
+	return metric
+```
+
+```csharp {tabTitle:C#}
+options.SetBeforeSendMetric(metric =>
+{
+    // Drop debug-only metrics in release builds.
+    if (!OS.IsDebugBuild() && metric.Name.StartsWith("debug."))
+    {
+        return null;
+    }
+    // Enrich with runtime context.
+    metric.SetAttribute("current_scene", GetTree().CurrentScene.Name);
+    return metric;
 });
 ```
 

--- a/platform-includes/metrics/options/godot.mdx
+++ b/platform-includes/metrics/options/godot.mdx
@@ -1,9 +1,9 @@
 The following configuration options are available for Sentry's [Application Metrics](/product/explore/metrics/) in Godot Engine:
 
-| Option                 | Description                                                        | Default |
-| ---------------------- | ------------------------------------------------------------------ | ------- |
-| **enable_metrics**     | Toggle for the metrics feature (experimental)                      | `true`  |
-| **before_send_metric** | Callback to modify or filter metrics before sending (experimental) | None    |
+| Option                 | Description                                         | Default |
+| ---------------------- | --------------------------------------------------- | ------- |
+| **enable_metrics**     | Toggle for the metrics feature                      | `true`  |
+| **before_send_metric** | Callback to modify or filter metrics before sending | None    |
 
 ### before_send_metric
 
@@ -11,7 +11,7 @@ To filter metrics or modify them before they are sent to Sentry, you can use the
 
 ```gdscript {tabTitle:GDScript} {mdExpandTabs}
 SentrySDK.init(func(options: SentryOptions) -> void:
-	options.experimental.before_send_metric = _before_send_metric
+	options.before_send_metric = _before_send_metric
 )
 
 func _before_send_metric(metric: SentryMetric) -> SentryMetric:

--- a/platform-includes/metrics/requirements/godot.mdx
+++ b/platform-includes/metrics/requirements/godot.mdx
@@ -1,1 +1,1 @@
-Metrics for Godot Engine are supported in Sentry Godot SDK version `1.4.0` and above.
+Metrics for Godot Engine are supported in Sentry Godot SDK version `2.0.0` and above (previously experimental since `1.4.0`).

--- a/platform-includes/metrics/setup/godot.mdx
+++ b/platform-includes/metrics/setup/godot.mdx
@@ -1,13 +1,8 @@
 Metrics are enabled by default in the Sentry Godot SDK. No additional setup is required to start sending metrics.
 
-<Alert title="Note">
-  Adding metrics from GDScript isn't supported on Apple platforms yet (macOS and iOS).
-  The first attempt to use metrics on these platforms will result in a warning.
-</Alert>
-
 ### Project Settings Configuration
 
-To disable metrics, navigate to **Project Settings > Sentry > Experimental** and uncheck the **Enable Metrics** option.
+To disable metrics, navigate to **Project Settings > Sentry > Options** and uncheck the **Enable Metrics** option.
 
 ### Programmatic Configuration
 
@@ -15,7 +10,7 @@ Alternatively, you can disable metrics programmatically when initializing the SD
 
 ```gdscript {tabTitle:GDScript} {mdExpandTabs}
 SentrySDK.init(func(options: SentryOptions) -> void:
-	options.experimental.enable_metrics = false
+	options.enable_metrics = false
 )
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents Sentry Metrics for the Godot SDK becoming generally available in SDK `2.0.0`, where they are now supported on all platforms (including Apple) and the `enable_metrics` / `before_send_metric` options move out of the experimental namespace onto `SentryOptions`.

- Godot SDK PR: https://github.com/getsentry/sentry-godot/pull/755

> [!WARNING]
> This documents the **unreleased** Godot SDK `2.0.0`. Don't merge!

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
