### PR TITLE
docs(integration-platform): Document error-surfacing convention for all UI components

### DIFF
--- a/docs/integrations/integration-platform/ui-components/alert-rule-action.mdx
+++ b/docs/integrations/integration-platform/ui-components/alert-rule-action.mdx
@@ -137,6 +137,4 @@ When a metric alert fires, your service will need to read the settings from the 
 }
 ```
 
-## Surfacing Errors
-
 <Include name="integration-platform-surfacing-errors.mdx" />

--- a/docs/integrations/integration-platform/ui-components/alert-rule-action.mdx
+++ b/docs/integrations/integration-platform/ui-components/alert-rule-action.mdx
@@ -139,10 +139,8 @@ When a metric alert fires, your service will need to read the settings from the 
 
 ## Surfacing Errors
 
-If a user setting up an alert rule action with your app tries to save an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io) by responding to the POST request with a JSON response in this shape:
+If a user setting up an alert rule action with your app tries to save an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io).
 
-```json
-{ "message": "Channel no longer exists!" }
-```
+<Include name="integration-platform-surfacing-errors.mdx" />
 
-Alternately, if an error code (40x, 50x) is returned, we will show a generic error message. If an error occurs, the user will not be able to save the alert rule.
+When an error occurs, the user won't be able to save the alert rule.

--- a/docs/integrations/integration-platform/ui-components/alert-rule-action.mdx
+++ b/docs/integrations/integration-platform/ui-components/alert-rule-action.mdx
@@ -139,8 +139,4 @@ When a metric alert fires, your service will need to read the settings from the 
 
 ## Surfacing Errors
 
-If a user setting up an alert rule action with your app tries to save an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io).
-
 <Include name="integration-platform-surfacing-errors.mdx" />
-
-When an error occurs, the user won't be able to save the alert rule.

--- a/docs/integrations/integration-platform/ui-components/formfield.mdx
+++ b/docs/integrations/integration-platform/ui-components/formfield.mdx
@@ -109,3 +109,9 @@ Response from `uri`, when specified, must be JSON and match the following format
   ...
 ]
 ```
+
+### Surfacing Errors
+
+If the request to load options fails, you can surface the error to the user directly in [sentry.io](https://sentry.io).
+
+<Include name="integration-platform-surfacing-errors.mdx" />

--- a/docs/integrations/integration-platform/ui-components/formfield.mdx
+++ b/docs/integrations/integration-platform/ui-components/formfield.mdx
@@ -112,6 +112,4 @@ Response from `uri`, when specified, must be JSON and match the following format
 
 ### Surfacing Errors
 
-If the request to load options fails, you can surface the error to the user directly in [sentry.io](https://sentry.io).
-
 <Include name="integration-platform-surfacing-errors.mdx" />

--- a/docs/integrations/integration-platform/ui-components/formfield.mdx
+++ b/docs/integrations/integration-platform/ui-components/formfield.mdx
@@ -110,6 +110,4 @@ Response from `uri`, when specified, must be JSON and match the following format
 ]
 ```
 
-### Surfacing Errors
-
 <Include name="integration-platform-surfacing-errors.mdx" />

--- a/docs/integrations/integration-platform/ui-components/issue-link.mdx
+++ b/docs/integrations/integration-platform/ui-components/issue-link.mdx
@@ -133,6 +133,4 @@ When creating or linking an issue, the response format _must_ have the following
 - `project`- The first part of the displayed issue that should probably be associated with a project in your system
 - `identifier`- The second part of the displayed issue that should be unique to the project
 
-## Surfacing Errors
-
 <Include name="integration-platform-surfacing-errors.mdx" />

--- a/docs/integrations/integration-platform/ui-components/issue-link.mdx
+++ b/docs/integrations/integration-platform/ui-components/issue-link.mdx
@@ -135,8 +135,4 @@ When creating or linking an issue, the response format _must_ have the following
 
 ## Surfacing Errors
 
-If a user trying to link or create an issue with your app submits an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io).
-
 <Include name="integration-platform-surfacing-errors.mdx" />
-
-When an error occurs, the issue won't be linked or created.

--- a/docs/integrations/integration-platform/ui-components/issue-link.mdx
+++ b/docs/integrations/integration-platform/ui-components/issue-link.mdx
@@ -132,3 +132,11 @@ When creating or linking an issue, the response format _must_ have the following
 - `webUrl`- The URL of the linked issue in your project management system
 - `project`- The first part of the displayed issue that should probably be associated with a project in your system
 - `identifier`- The second part of the displayed issue that should be unique to the project
+
+## Surfacing Errors
+
+If a user trying to link or create an issue with your app submits an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io).
+
+<Include name="integration-platform-surfacing-errors.mdx" />
+
+When an error occurs, the issue won't be linked or created.

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -1,0 +1,13 @@
+When a request to your service fails, Sentry surfaces the error to the user directly in [sentry.io](https://sentry.io). To show a specific, actionable message instead of a generic one, respond with an error status code (40x, 50x) and a JSON body in this shape:
+
+```json
+{ "message": "Channel no longer exists!" }
+```
+
+Sentry forwards your service's HTTP status code and displays the `message` from the response body to the user. If your service doesn't respond at all (for example, the request times out), Sentry shows a `502` instead. When no `message` is provided, the user sees a generic error message.
+
+<Alert>
+
+The `message` is shown to the user, so don't include any sensitive information in it.
+
+</Alert>

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -4,7 +4,7 @@ When a request to your service fails, Sentry surfaces the error to the user dire
 { "message": "Channel no longer exists!" }
 ```
 
-Sentry forwards your service's HTTP status code and displays the `message` from the response body to the user. If your service doesn't respond at all (for example, the request times out), Sentry shows a `502` instead. When no `message` is provided, the user sees a generic error message.
+Sentry forwards your service's HTTP status code and displays the `message` from the response body to the user. If your service doesn't respond at all (for example, the request times out), Sentry shows a `502` instead. When no `message` is provided, the user sees a generic error message. In all cases, the user's action won't complete until the request succeeds.
 
 <Alert>
 

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -1,3 +1,5 @@
+## Surfacing Errors
+
 When a request to your service fails, Sentry surfaces the error to the user directly in [sentry.io](https://sentry.io). To show a specific, actionable message instead of a generic one, respond with an error status code (40x, 50x) and a JSON body in this shape:
 
 ```json

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -1,15 +1,9 @@
 ## Surfacing Errors
 
-When a request to your service fails, Sentry surfaces the error to the user directly in [sentry.io](https://sentry.io). To show a specific, actionable message instead of a generic one, respond with an error status code (40x, 50x) and a JSON body in this shape:
+If a user interacting with your app submits an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io) by responding to the request with a JSON response in this shape:
 
 ```json
 { "message": "Channel no longer exists!" }
 ```
 
-Sentry forwards your service's HTTP status code and displays the `message` from the response body to the user. If your service doesn't respond at all (for example, the request times out), Sentry shows a `502` instead. When no `message` is provided, the user sees a generic error message. In all cases, the user's action won't complete until the request succeeds.
-
-<Alert>
-
-The `message` is shown to the user, so don't include any sensitive information in it.
-
-</Alert>
+Alternately, if an error code (40x, 50x) is returned, we will show a generic error message. If an error occurs, the user's action will not complete.

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -6,4 +6,4 @@ If a user interacting with your app submits an incorrect or malformed configurat
 { "message": "Channel no longer exists!" }
 ```
 
-Alternately, if an error code (40x, 50x) is returned, we will show a generic error message. If an error occurs, the user's action will not complete.
+Sentry forwards your service's status code and shows the `message` from the response body. If you return an error status without a `message`, the user sees a generic error message. If your service doesn't respond at all (for example, the request times out), Sentry returns a `502`. In all cases, the user's action won't complete until the request succeeds.

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -1,6 +1,6 @@
 ## Surfacing Errors
 
-If a user interacting with your app submits an incorrect or malformed configuration, you can surface the errors to them directly in [sentry.io](https://sentry.io) by responding to the request with a JSON response in this shape:
+When a request from this component to your service fails, you can surface the reason to the user directly in [sentry.io](https://sentry.io) by responding with a JSON body in this shape:
 
 ```json
 { "message": "Channel no longer exists!" }

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -1,6 +1,6 @@
 ## Surfacing Errors
 
-When a request to your service fails, you can surface the reason to the user directly in [sentry.io](https://sentry.io) by responding with a JSON body in this shape:
+When a request to your service fails, you can show the user a specific error message in [sentry.io](https://sentry.io) by responding with a JSON body in this shape:
 
 ```json
 { "message": "Channel no longer exists!" }

--- a/includes/integration-platform-surfacing-errors.mdx
+++ b/includes/integration-platform-surfacing-errors.mdx
@@ -1,6 +1,6 @@
 ## Surfacing Errors
 
-When a request from this component to your service fails, you can surface the reason to the user directly in [sentry.io](https://sentry.io) by responding with a JSON body in this shape:
+When a request to your service fails, you can surface the reason to the user directly in [sentry.io](https://sentry.io) by responding with a JSON body in this shape:
 
 ```json
 { "message": "Channel no longer exists!" }


### PR DESCRIPTION
Document the error-surfacing response convention across all Sentry App UI components that make external requests (issue link, alert rule action, and Select FormField options), via a shared include. Follow-up to docs feedback on https://github.com/getsentry/sentry/pull/116956#discussion_r3363443587.

<img width="1093" height="357" alt="image" src="https://github.com/user-attachments/assets/00a0848d-66c8-498e-ab0b-ee91287baa14" />
