### PR TITLE
fix(docs): Use platform-specific agent skills URL on JS common pages

### DIFF
--- a/docs/platforms/javascript/common/metrics/index.mdx
+++ b/docs/platforms/javascript/common/metrics/index.mdx
@@ -10,7 +10,7 @@ notSupported:
   - javascript.capacitor
 ---
 
-<AgentSkillsCallout />
+<PlatformContent includePath="llm-rules-platform" />
 
 With [Sentry's Application Metrics](/product/explore/metrics/), you can send counters, gauges, and distributions from your applications to Sentry. Once in Sentry, these metrics can be viewed alongside relevant errors, and searched using their individual attributes.
 

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -6,7 +6,7 @@ sidebar_order: 6
 sidebar_section: features
 ---
 
-<AgentSkillsCallout />
+<PlatformContent includePath="llm-rules-platform" />
 
 With [tracing](/product/dashboards/sentry-dashboards/), Sentry automatically tracks your software performance across your application services, measuring metrics like throughput and latency, and displaying the impact of errors across multiple systems.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The shared JavaScript "common" pages for tracing and metrics used a bare `<AgentSkillsCallout />` without a `skill` prop, causing the Agent-Assisted Setup section to show the generic `https://skills.sentry.dev/` URL on all JS guides (React, Next.js, Svelte, etc.).

Replaced with `<PlatformContent includePath="llm-rules-platform" />` so each guide renders its own SDK-specific skills URL (e.g. `sentry-react-sdk`, `sentry-nextjs-sdk`), matching the pattern already used on guide index pages.

- `docs/platforms/javascript/common/tracing/index.mdx`
- `docs/platforms/javascript/common/metrics/index.mdx`

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)