### PR TITLE
docs(transport): Add missing byte data categories to rate limiting

### DIFF
--- a/develop-docs/sdk/foundations/transport/rate-limiting.mdx
+++ b/develop-docs/sdk/foundations/transport/rate-limiting.mdx
@@ -90,6 +90,7 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
   - `monitor`: Monitor check-ins.
   - `span`: Span type events.
   - `log_item`: Log events.
+  - `log_byte`: Log bytes stored.
   - `security`: Events with event_type `csp`
   - `attachment`: Attachment bytes stored (unused for rate limiting)
   - `session`: Session update events
@@ -97,7 +98,8 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
   - `profile_chunk`: Continuous Profiling chunks
   - `replay`: Session Replays
   - `feedback`: User Feedbacks
-  - `trace_metric`: Metric type events
+  - `trace_metric`: Metric type events.
+  - `trace_metric_byte`: Metric bytes stored.
   - `internal`: a sentry/system internal event[^internal]
 
 - **Scope**: The unit / model in Sentry that quotas are enforced for.


### PR DESCRIPTION
Add `log_byte` and `trace_metric_byte` to the rate limiting data categories
list. Both exist in Relay's `DataCategory` enum but were missing from the SDK
develop docs, so SDK authors had no reference for these categories when
implementing rate limit handling.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)