### PR TITLE
docs(snapshots): Document all-image-file-names flags for selective uploads

### DIFF
--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -66,13 +66,13 @@ When an upload is marked as selective, Sentry only diffs the snapshots you uploa
 
 ## Diff Threshold
 
-Use `--diff-threshold` to ignore sub-pixel or anti-aliasing noise. The value is a float between `0.0` and `1.0` representing the fraction of pixels that must change before Sentry reports an image as changed:
+Use `--diff-threshold` to ignore sub-pixel or anti-aliasing noise. The value is a float between `0.0` and `1.0` representing the share of pixels that must change before Sentry reports an image as changed:
 
 ```bash
 sentry-cli snapshots upload ./snapshots --app-id web-frontend --diff-threshold 0.01
 ```
 
-With a value of `0.01`, images with less than 1% of pixels changed are reported as unchanged.
+With a value of `0.01`, images with 1% or less of pixels changed are reported as unchanged.
 
 ## Flag Reference
 
@@ -90,7 +90,7 @@ sentry-cli snapshots upload [OPTIONS] --app-id <APP_ID> <PATH>
 | `--selective`                        | Mark the upload as a subset. Use when uploading only a portion of your snapshots (for example, affected tests only).                                                                                    |
 | `--all-image-file-names <NAMES>`     | Comma-separated list of all image file names in the full test suite. Enables removal and rename detection, and implicitly enables `--selective`. Mutually exclusive with `--all-image-file-names-file`. |
 | `--all-image-file-names-file <PATH>` | Same as `--all-image-file-names`, but reads the names from a file (`.txt`, `.csv`, etc.), one per line.                                                                                                 |
-| `--diff-threshold <THRESHOLD>`       | Float between `0.0` and `1.0`. Sentry only reports images as changed if the percentage of changed pixels exceeds this value.                                                                            |
+| `--diff-threshold <THRESHOLD>`       | Float between `0.0` and `1.0`. Sentry only reports images as changed if the share of changed pixels exceeds this value.                                                                                 |
 | `--head-sha <SHA>`                   | Commit SHA for the upload. Auto-detected in CI.                                                                                                                                                         |
 | `--base-sha <SHA>`                   | Base commit SHA for comparison (PR only). Auto-detected from merge-base.                                                                                                                                |
 | `--vcs-provider <PROVIDER>`          | VCS provider (for example, `github`). Auto-detected from the git remote.                                                                                                                                |

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -60,26 +60,9 @@ sentry-cli snapshots upload ./snapshots --app-id web-frontend --selective
 
 When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as unchanged (skipped) rather than removed.
 
-### Detecting Removals and Renames in Selective Mode
+### Detecting Removals and Renames
 
-By default, selective mode cannot detect removals or renames. If you want Sentry to distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite:
-
-- `--all-image-file-names <NAMES>` — a comma-separated list of all image file names.
-- `--all-image-file-names-file <PATH>` — a path to a file (`.txt`, `.csv`, etc.) containing all image file names, one per line.
-
-Both flags implicitly enable `--selective`.
-
-```bash
-sentry-cli snapshots upload ./snapshots \
-  --app-id web-frontend \
-  --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
-```
-
-With the full list provided, Sentry can tell apart three categories of missing images:
-
-- **Skipped** — in the list but not uploaded (part of the test suite, just not run in this CI job).
-- **Removed** — not in the list and not uploaded (deliberately deleted from the test suite).
-- **Renamed** — a new image has the same content hash as a missing one.
+<Include name="snapshots/detecting-removals-renames" />
 
 ## Diff Threshold
 

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -58,7 +58,28 @@ If you only upload a subset of your snapshots per CI run — for example, becaus
 sentry-cli snapshots upload ./snapshots --app-id web-frontend --selective
 ```
 
-When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as unchanged rather than removed. Removals and renames cannot be detected when using `--selective`, because Sentry cannot distinguish a deliberately deleted snapshot from one that was not part of the subset.
+When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as unchanged (skipped) rather than removed.
+
+### Detecting Removals and Renames in Selective Mode
+
+By default, selective mode cannot detect removals or renames. If you want Sentry to distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite:
+
+- `--all-image-file-names <NAMES>` — a comma-separated list of all image file names.
+- `--all-image-file-names-file <PATH>` — a path to a file (`.txt`, `.csv`, etc.) containing all image file names, one per line.
+
+Both flags implicitly enable `--selective`.
+
+```bash
+sentry-cli snapshots upload ./snapshots \
+  --app-id web-frontend \
+  --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
+```
+
+With the full list provided, Sentry can tell apart three categories of missing images:
+
+- **Skipped** — in the list but not uploaded (part of the test suite, just not run in this CI job).
+- **Removed** — not in the list and not uploaded (deliberately deleted from the test suite).
+- **Renamed** — a new image has the same content hash as a missing one.
 
 ## Diff Threshold
 
@@ -76,27 +97,29 @@ With a value of `0.01`, images with less than 1% of pixels changed are reported 
 sentry-cli snapshots upload [OPTIONS] --app-id <APP_ID> <PATH>
 ```
 
-| Flag                            | Description                                                                                                                                                                    |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `<PATH>`                        | Directory containing `.png` or `.jpeg` images (and optional `.json` sidecars).                                                                                                 |
-| `--app-id <APP_ID>`             | Identifier for the app or bundle (for example, `web-frontend`, `ios-app`). Must be consistent across uploads — Sentry uses it to match head and base snapshots. Max 255 chars. |
-| `--auth-token <TOKEN>`          | Sentry auth token. Can also be set via `SENTRY_AUTH_TOKEN`.                                                                                                                    |
-| `-o`, `--org <ORG>`             | Sentry organization slug. Can also be set via `SENTRY_ORG`.                                                                                                                    |
-| `-p`, `--project <PROJECT>`     | Sentry project slug. Can also be set via `SENTRY_PROJECT`.                                                                                                                     |
-| `--selective`                   | Mark the upload as a subset. Use when uploading only a portion of your snapshots (for example, affected tests only).                                                           |
-| `--diff-threshold <THRESHOLD>`  | Float between `0.0` and `1.0`. Sentry only reports images as changed if the percentage of changed pixels exceeds this value.                                                   |
-| `--head-sha <SHA>`              | Commit SHA for the upload. Auto-detected in CI.                                                                                                                                |
-| `--base-sha <SHA>`              | Base commit SHA for comparison (PR only). Auto-detected from merge-base.                                                                                                       |
-| `--vcs-provider <PROVIDER>`     | VCS provider (for example, `github`). Auto-detected from the git remote.                                                                                                       |
-| `--head-repo-name <OWNER/REPO>` | Repository in `owner/repo` format. Auto-detected from the git remote.                                                                                                          |
-| `--base-repo-name <OWNER/REPO>` | Base repository in `owner/repo` format (required for PRs from forks).                                                                                                          |
-| `--head-ref <BRANCH>`           | Head branch name. Auto-detected in CI.                                                                                                                                         |
-| `--base-ref <BRANCH>`           | Base branch name (PR only). Auto-detected from the remote tracking branch.                                                                                                     |
-| `--pr-number <NUMBER>`          | Pull request number. Auto-detected in GitHub Actions `pull_request` workflows.                                                                                                 |
-| `--no-git-metadata`             | Skip automatic git metadata detection.                                                                                                                                         |
-| `--force-git-metadata`          | Force git metadata collection outside CI.                                                                                                                                      |
-| `--log-level <LEVEL>`           | Logging verbosity: `trace`, `debug`, `info`, `warn`, or `error`.                                                                                                               |
-| `--quiet`                       | Suppress output while preserving exit codes. Alias: `--silent`.                                                                                                                |
+| Flag                                 | Description                                                                                                                                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<PATH>`                             | Directory containing `.png` or `.jpeg` images (and optional `.json` sidecars).                                                                                                                          |
+| `--app-id <APP_ID>`                  | Identifier for the app or bundle (for example, `web-frontend`, `ios-app`). Must be consistent across uploads — Sentry uses it to match head and base snapshots. Max 255 chars.                          |
+| `--auth-token <TOKEN>`               | Sentry auth token. Can also be set via `SENTRY_AUTH_TOKEN`.                                                                                                                                             |
+| `-o`, `--org <ORG>`                  | Sentry organization slug. Can also be set via `SENTRY_ORG`.                                                                                                                                             |
+| `-p`, `--project <PROJECT>`          | Sentry project slug. Can also be set via `SENTRY_PROJECT`.                                                                                                                                              |
+| `--selective`                        | Mark the upload as a subset. Use when uploading only a portion of your snapshots (for example, affected tests only).                                                                                    |
+| `--all-image-file-names <NAMES>`     | Comma-separated list of all image file names in the full test suite. Enables removal and rename detection, and implicitly enables `--selective`. Mutually exclusive with `--all-image-file-names-file`. |
+| `--all-image-file-names-file <PATH>` | Same as `--all-image-file-names`, but reads the names from a file (`.txt`, `.csv`, etc.), one per line.                                                                                                 |
+| `--diff-threshold <THRESHOLD>`       | Float between `0.0` and `1.0`. Sentry only reports images as changed if the percentage of changed pixels exceeds this value.                                                                            |
+| `--head-sha <SHA>`                   | Commit SHA for the upload. Auto-detected in CI.                                                                                                                                                         |
+| `--base-sha <SHA>`                   | Base commit SHA for comparison (PR only). Auto-detected from merge-base.                                                                                                                                |
+| `--vcs-provider <PROVIDER>`          | VCS provider (for example, `github`). Auto-detected from the git remote.                                                                                                                                |
+| `--head-repo-name <OWNER/REPO>`      | Repository in `owner/repo` format. Auto-detected from the git remote.                                                                                                                                   |
+| `--base-repo-name <OWNER/REPO>`      | Base repository in `owner/repo` format (required for PRs from forks).                                                                                                                                   |
+| `--head-ref <BRANCH>`                | Head branch name. Auto-detected in CI.                                                                                                                                                                  |
+| `--base-ref <BRANCH>`                | Base branch name (PR only). Auto-detected from the remote tracking branch.                                                                                                                              |
+| `--pr-number <NUMBER>`               | Pull request number. Auto-detected in GitHub Actions `pull_request` workflows.                                                                                                                          |
+| `--no-git-metadata`                  | Skip automatic git metadata detection.                                                                                                                                                                  |
+| `--force-git-metadata`               | Force git metadata collection outside CI.                                                                                                                                                               |
+| `--log-level <LEVEL>`                | Logging verbosity: `trace`, `debug`, `info`, `warn`, or `error`.                                                                                                                                        |
+| `--quiet`                            | Suppress output while preserving exit codes. Alias: `--silent`.                                                                                                                                         |
 
 ## Download Baselines
 

--- a/docs/platforms/apple/common/snapshots/selective-testing.mdx
+++ b/docs/platforms/apple/common/snapshots/selective-testing.mdx
@@ -47,7 +47,7 @@ xcodebuild test \
   -scheme MyApp \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'
 
-sentry-cli build snapshots "/tmp/base_snapshots" \
+sentry-cli snapshots upload "/tmp/base_snapshots" \
   --app-id com.example.MyApp
 ```
 
@@ -96,7 +96,7 @@ This produces a set of only Module A's rendered images:
 Upload the subset with the `--selective` flag:
 
 ```bash
-sentry-cli build snapshots "/tmp/head_snapshots" \
+sentry-cli snapshots upload "/tmp/head_snapshots" \
   --app-id com.example.MyApp \
   --selective
 ```
@@ -205,7 +205,7 @@ ModuleB_SettingsView.swift_Settings.png
 Add the flag `--all-image-file-names-file <path>` with your image-name file when uploading.
 
 ```bash
-sentry-cli build snapshots "/tmp/head_snapshots" \
+sentry-cli snapshots upload "/tmp/head_snapshots" \
   --app-id com.example.MyApp \
   --all-image-file-names-file /tmp/names_all.txt
 ```
@@ -213,7 +213,7 @@ sentry-cli build snapshots "/tmp/head_snapshots" \
 Alternatively you can pass the image filenames as a comma-separated list by using `--all-image-file-names <names>` instead of `--all-image-file-names-file <path>`.
 
 ```bash
-sentry-cli build snapshots "/tmp/head_snapshots" \
+sentry-cli snapshots upload "/tmp/head_snapshots" \
   --app-id com.example.MyApp \
   --all-image-file-names "ModuleA_HomeView.swift_Light.png, ModuleA_HomeView.swift_Dark.png, ModuleA_ProfileView.swift_Profile.png, ModuleB_CartView.swift_Cart.png, ModuleB_CheckoutView.swift_Checkout.png, ModuleB_SettingsView.swift_Settings.png"
 ```

--- a/docs/platforms/apple/common/snapshots/selective-testing.mdx
+++ b/docs/platforms/apple/common/snapshots/selective-testing.mdx
@@ -215,7 +215,7 @@ Alternatively you can pass the image filenames as a comma-separated list by usin
 ```bash
 sentry-cli snapshots upload "/tmp/head_snapshots" \
   --app-id com.example.MyApp \
-  --all-image-file-names "ModuleA_HomeView.swift_Light.png, ModuleA_HomeView.swift_Dark.png, ModuleA_ProfileView.swift_Profile.png, ModuleB_CartView.swift_Cart.png, ModuleB_CheckoutView.swift_Checkout.png, ModuleB_SettingsView.swift_Settings.png"
+  --all-image-file-names "ModuleA_HomeView.swift_Light.png,ModuleA_HomeView.swift_Dark.png,ModuleA_ProfileView.swift_Profile.png,ModuleB_CartView.swift_Cart.png,ModuleB_CheckoutView.swift_Checkout.png,ModuleB_SettingsView.swift_Settings.png"
 ```
 
 And that's it! Sentry will now diff the uploaded subset against the baseline and report any changes.

--- a/docs/product/snapshots/local-testing/index.mdx
+++ b/docs/product/snapshots/local-testing/index.mdx
@@ -32,6 +32,14 @@ sentry-cli snapshots download --snapshot-id 259299
 
 Use `--output` to change the destination directory. See the [full download reference](/cli/snapshots/#download-baselines) for all available flags.
 
+<Alert level="info">
+  For very large test suites (tens of thousands of images), you may hit download
+  size limits. In that case, an alternative would be to generate your baseline
+  snapshots locally instead of downloading them (via your base branch). If
+  you're running into this limit with a smaller number of images than expected,
+  [reach out to support](https://sentry.io/contact/support/).
+</Alert>
+
 ## Diffing Locally
 
 Use `sentry-cli snapshots diff` to compare two directories of images. See the [full diff reference](/cli/snapshots/#local-diff) for all available flags.

--- a/docs/product/snapshots/local-testing/index.mdx
+++ b/docs/product/snapshots/local-testing/index.mdx
@@ -48,7 +48,7 @@ Use `sentry-cli snapshots diff` to compare two directories of images. See the [f
 sentry-cli snapshots diff ./snapshots-base ./snapshots-head
 ```
 
-This outputs JSON with per-image results (`changed`, `unchanged`, `added`, `removed`) and writes diff mask images to `./diff-output/`. Use `--fail-on-diff` to exit with code 1 when any differences are found — useful in CI or pre-push hooks:
+This outputs JSON with per-image results (`changed`, `unchanged`, `added`, `removed`, and `skipped` when using `--selective`) and writes diff mask images to `./diff-output/`. Use `--fail-on-diff` to exit with code 1 when any differences are found — useful in CI or pre-push hooks:
 
 ```bash
 sentry-cli snapshots diff ./snapshots-base ./snapshots-head --fail-on-diff

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -90,10 +90,30 @@ sentry-cli snapshots upload ./snapshots --app-id web-frontend --selective
 
 When an upload is marked as selective, Sentry only diffs the snapshots you uploaded. Any snapshot that exists in the base build but was not included in the upload is treated as **unchanged** (skipped) rather than removed.
 
-<Alert level="warning">
-  Because Sentry cannot distinguish a deliberately deleted snapshot from one
-  that was not part of the subset, removals and renames cannot be detected when
-  using `--selective`.
-</Alert>
+### Detecting Removals and Renames
+
+By default, selective mode cannot detect removals or renames. If you want Sentry to distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite.
+
+You can provide literal file names:
+
+```bash
+sentry-cli build snapshots ./snapshots \
+  --app-id web-frontend \
+  --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
+```
+
+Or, for large test suites, use a file (`.txt`, `.csv`, etc.) with one name per line:
+
+```bash
+sentry-cli build snapshots ./snapshots \
+  --app-id web-frontend \
+  --all-image-file-names-file ./all-snapshot-names.txt
+```
+
+Both flags implicitly enable `--selective`. With the full list provided, Sentry categorizes missing images as:
+
+- **Skipped** — in the list but not uploaded (part of the suite, just not run in this job).
+- **Removed** — not in the list and not uploaded (deleted from the suite).
+- **Renamed** — a new image has the same content hash as a missing one.
 
 For the full `sentry-cli snapshots upload` flag reference, see [Snapshots (CLI)](/cli/snapshots/).

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -92,28 +92,6 @@ When an upload is marked as selective, Sentry only diffs the snapshots you uploa
 
 ### Detecting Removals and Renames
 
-By default, selective mode cannot detect removals or renames. If you want Sentry to distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite.
-
-You can provide literal file names:
-
-```bash
-sentry-cli snapshots upload ./snapshots \
-  --app-id web-frontend \
-  --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
-```
-
-Or, for large test suites, use a file (`.txt`, `.csv`, etc.) with one name per line:
-
-```bash
-sentry-cli snapshots upload ./snapshots \
-  --app-id web-frontend \
-  --all-image-file-names-file ./all-snapshot-names.txt
-```
-
-Both flags implicitly enable `--selective`. With the full list provided, Sentry categorizes missing images as:
-
-- **Skipped** — in the list but not uploaded (part of the suite, just not run in this job).
-- **Removed** — not in the list and not uploaded (deleted from the suite).
-- **Renamed** — a new image has the same content hash as a missing one.
+<Include name="snapshots/detecting-removals-renames" />
 
 For the full `sentry-cli snapshots upload` flag reference, see [Snapshots (CLI)](/cli/snapshots/).

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -97,7 +97,7 @@ By default, selective mode cannot detect removals or renames. If you want Sentry
 You can provide literal file names:
 
 ```bash
-sentry-cli build snapshots ./snapshots \
+sentry-cli snapshots upload ./snapshots \
   --app-id web-frontend \
   --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
 ```
@@ -105,7 +105,7 @@ sentry-cli build snapshots ./snapshots \
 Or, for large test suites, use a file (`.txt`, `.csv`, etc.) with one name per line:
 
 ```bash
-sentry-cli build snapshots ./snapshots \
+sentry-cli snapshots upload ./snapshots \
   --app-id web-frontend \
   --all-image-file-names-file ./all-snapshot-names.txt
 ```

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -8,7 +8,7 @@ description: Structure your snapshot directory and upload from CI with sentry-cl
 
 <Include name="snapshots/ci-alert" />
 
-Snapshots works for any platform with a frontend. You can view specific platform examples [here](/product/snapshots#supported-platforms). This page covers the general upload structure and metadata schema.
+Snapshots works for any platform with a frontend. You can view specific platform examples [here](/product/snapshots#recommended-platform-workflows). This page covers the general upload structure and metadata schema.
 
 ## Upload command
 
@@ -18,14 +18,14 @@ You upload snapshots with the `sentry-cli snapshots upload` command, which takes
 sentry-cli snapshots upload <output-dir> \
   --auth-token "$SENTRY_AUTH_TOKEN" \
   --app-id <app-id> \
-  --project <project-slug> \
+  --project <project-slug>
 ```
 
 For the full command reference, including auto-detected git metadata, see [Snapshots (CLI)](/cli/snapshots/). For an end-to-end CI setup, see [Integrating Into CI](/product/snapshots/integrating-into-ci/).
 
 ### Upload Structure
 
-Each snapshot consists of two files: a `.png` image and an optional `.json` metadata file with the same base name and path. You can optionally organize snapshots into subdirectories. If using subdirectories, the filename property in the Sentry UX will include the subdirectory path.
+Each snapshot is a `.png` image with an optional `.json` metadata file of the same base name and path. You can optionally organize snapshots into subdirectories. If using subdirectories, the filename property in the Sentry UX will include the subdirectory path.
 
 ```
 snapshots/

--- a/includes/snapshots/detecting-removals-renames.mdx
+++ b/includes/snapshots/detecting-removals-renames.mdx
@@ -1,0 +1,16 @@
+By default, selective mode cannot detect removals or renames. To distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite with one of these flags (both implicitly enable `--selective`):
+
+- `--all-image-file-names <NAMES>` — a comma-separated list of all image file names.
+- `--all-image-file-names-file <PATH>` — a path to a file (`.txt`, `.csv`, etc.) with all image file names, one per line.
+
+```bash
+sentry-cli snapshots upload ./snapshots \
+  --app-id web-frontend \
+  --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
+```
+
+With the full list provided, Sentry sorts missing images into three categories:
+
+- **Skipped** — in the list but not uploaded (part of the test suite, just not run in this job).
+- **Removed** — not in the list and not uploaded (deliberately deleted from the test suite).
+- **Renamed** — a new image has the same content hash as a missing one.

--- a/includes/snapshots/detecting-removals-renames.mdx
+++ b/includes/snapshots/detecting-removals-renames.mdx
@@ -9,8 +9,8 @@ sentry-cli snapshots upload ./snapshots \
   --all-image-file-names "homepage.png,settings/profile.png,settings/billing.png"
 ```
 
-With the full list provided, Sentry sorts missing images into three categories:
+With the full list provided, Sentry sorts each baseline image that wasn't uploaded into three categories:
 
-- **Skipped** — in the list but not uploaded (part of the test suite, just not run in this job).
-- **Removed** — not in the list and not uploaded (deliberately deleted from the test suite).
-- **Renamed** — a new image has the same content hash as a missing one.
+- **Skipped** — still in the list (part of the test suite, just not run in this job).
+- **Removed** — no longer in the list (deleted from the test suite).
+- **Renamed** — matches a newly uploaded image by content hash, under a different name.

--- a/includes/snapshots/detecting-removals-renames.mdx
+++ b/includes/snapshots/detecting-removals-renames.mdx
@@ -1,4 +1,4 @@
-By default, selective mode cannot detect removals or renames. To distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite with one of these flags (both implicitly enable `--selective`):
+By default, selective mode cannot detect removals or renames. To distinguish deliberately deleted snapshots from ones that simply weren't run, pass the full list of image file names from your test suite with one of these flags (use one, not both — each implicitly enables `--selective`):
 
 - `--all-image-file-names <NAMES>` — a comma-separated list of all image file names.
 - `--all-image-file-names-file <PATH>` — a path to a file (`.txt`, `.csv`, etc.) with all image file names, one per line.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new `--all-image-file-names` / `--all-image-file-names-file` flags that let Sentry detect removals and renames in selective mode, and tightens the surrounding snapshot docs.

- Add a "Detecting Removals and Renames in Selective Mode" section to the CLI reference and the Uploading Snapshots product page, including the Skipped/Removed/Renamed categorization.
- Add the two new flags to the CLI flag reference table.
- Add a Local Testing note about download size limits for very large test suites.
- Trim redundant wording: removed a recap Alert, dropped references to undocumented "patterns", de-duplicated the flag-table rows, and fixed a command that didn't match the rest of the file.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)