### PR TITLE
fix(typos): allow pluralized SQL keywords INSERTs and SELECTs

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -68,6 +68,8 @@ API = "API"   # Application Programming Interface
 APIs = "APIs" # Plural
 MCP = "MCP"   # Model Context Protocol
 NPM = "NPM"   # Node Package Manager
+INSERTs = "INSERTs" # Pluralized SQL keyword (e.g., "ClickHouse INSERTs")
+SELECTs = "SELECTs" # Pluralized SQL keyword (e.g., "ClickHouse SELECTs")
 
 # Code identifiers that are intentionally "misspelled" or match external systems
 # Note: These should ONLY include cases where the spelling is intentional


### PR DESCRIPTION
## Summary

The `crate-ci/typos` checker splits `INSERTs` and `SELECTs` into stems `INSER` and `SELEC`, then flags them as misspellings of `INSERT` and `SELECT`. These are valid pluralized SQL keywords used in technical documentation (e.g., "ClickHouse INSERTs").

This adds both words to the `[default.extend-words]` allowlist in `_typos.toml`, following the same pattern already used for `DSNs`, `SDKs`, `APIs`, etc.

## Motivation

Unblocks #17782, which is blocked by the required `Check Typos` CI check due to these false positives on line 89 of `develop-docs/self-hosted/troubleshooting/snuba.mdx`.