### PR TITLE
fix(typos): add stem-level entries INSER and SELEC

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -69,7 +69,9 @@ APIs = "APIs" # Plural
 MCP = "MCP"   # Model Context Protocol
 NPM = "NPM"   # Node Package Manager
 INSERTs = "INSERTs" # Pluralized SQL keyword (e.g., "ClickHouse INSERTs")
+INSER = "INSER"     # Stem of INSERTs - needed because typos splits at case boundaries
 SELECTs = "SELECTs" # Pluralized SQL keyword (e.g., "ClickHouse SELECTs")
+SELEC = "SELEC"     # Stem of SELECTs - needed because typos splits at case boundaries
 
 # Code identifiers that are intentionally "misspelled" or match external systems
 # Note: These should ONLY include cases where the spelling is intentional


### PR DESCRIPTION
## Summary

Follow-up to #18520. The full-word entries `INSERTs`/`SELECTs` added in that PR are not sufficient because `crate-ci/typos` splits mixed-case plurals at the case boundary (`INSER` + `Ts`) and checks each subword independently. The stems `INSER` and `SELEC` must also be allowlisted.

This follows the same pattern already used in the config:
- `STARTD` — stem of `MIGRATED_GETTING_STARTD_DOCS`
- `ERRO` — stem of `ERRORs`

## Motivation

Unblocks #17782, which is still blocked by the `Check Typos` CI check after #18520 was merged.