### PR TITLE
docs(native): update to 'new' user_feedback API

### DIFF
--- a/platform-includes/user-feedback/sdk-api-example/native.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/native.mdx
@@ -5,7 +5,7 @@ sentry_value_t event = sentry_value_new_message_event(
     SENTRY_LEVEL_INFO, "my-logger", "Hello user feedback!");
 sentry_uuid_t event_id = sentry_capture_event(event);
 
-sentry_value_t user_feedback = sentry_value_new_user_feedback(
-    &event_id, "Jane", "jane.doe@example.com", "Feedback message");
-sentry_capture_user_feedback(user_feedback);
+sentry_value_t user_feedback = sentry_value_new_feedback(
+    "Feedback message", "jane.doe@example.com", "Jane", &event_id);
+sentry_capture_feedback(feedback);
 ```

--- a/platform-includes/user-feedback/sdk-api-example/native.mdx
+++ b/platform-includes/user-feedback/sdk-api-example/native.mdx
@@ -7,5 +7,5 @@ sentry_uuid_t event_id = sentry_capture_event(event);
 
 sentry_value_t user_feedback = sentry_value_new_feedback(
     "Feedback message", "jane.doe@example.com", "Jane", &event_id);
-sentry_capture_feedback(feedback);
+sentry_capture_feedback(user_feedback);
 ```


### PR DESCRIPTION
Current: https://docs.sentry.io/platforms/native/user-feedback/
Vercel preview: https://sentry-docs-git-joshua-fixnativeuserfeedbackdocs.sentry.dev/platforms/native/user-feedback/

## DESCRIBE YOUR PR
Raised in a comment on the PR that introduced the new API https://github.com/getsentry/sentry-native/pull/1304#issuecomment-4776203268 ; the example was still using the old (marked deprecated) user feedback functions.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)