### PR TITLE
fix(consoles): Add clear note about pricing and enterprise plans

### DIFF
--- a/docs/platforms/nintendo-switch/index.mdx
+++ b/docs/platforms/nintendo-switch/index.mdx
@@ -9,6 +9,12 @@ categories:
   - gaming
 ---
 
+<Alert level="info" title="Availability of Nintendo Switch support">
+Access to Sentry's error and crash reporting for consoles is a paid feature available on our Enterprise plan. We will review the pricing and details with you during the verification process.
+
+Nintendo Switch support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
+</Alert>
+
 <Include name="console-intro/nintendo-switch" />
 
 <Include name="console-intro/game-engine-integration" />

--- a/docs/platforms/nintendo-switch/index.mdx
+++ b/docs/platforms/nintendo-switch/index.mdx
@@ -9,12 +9,6 @@ categories:
   - gaming
 ---
 
-<Alert level="info" title="Availability of Nintendo Switch support">
-Access to Sentry's error and crash reporting for consoles is a paid feature available on our Enterprise plan. We will review the pricing and details with you during the verification process.
-
-Nintendo Switch support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
-</Alert>
-
 <Include name="console-intro/nintendo-switch" />
 
 <Include name="console-intro/game-engine-integration" />

--- a/docs/platforms/playstation/index.mdx
+++ b/docs/platforms/playstation/index.mdx
@@ -9,14 +9,16 @@ categories:
   - gaming
 ---
 
+<Alert>
+Access to Sentry's error and crash reporting for consoles is a paid feature available on our Enterprise plan. We will review the pricing and details with you during the verification process.
+</Alert>
+
 <Include name="console-intro/playstation" />
 
 <Include name="console-intro/game-engine-integration" />
 
 <Alert level="info" title="Availability of PlayStation support">
 PlayStation support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
-
-Access to Sentry's error and crash reporting for consoles is a paid feature. We will review the pricing and details with you during the verification process.
 </Alert>
 ----
 

--- a/docs/platforms/playstation/index.mdx
+++ b/docs/platforms/playstation/index.mdx
@@ -9,17 +9,15 @@ categories:
   - gaming
 ---
 
-<Alert>
+<Alert level="info" title="Availability of PlayStation support">
 Access to Sentry's error and crash reporting for consoles is a paid feature available on our Enterprise plan. We will review the pricing and details with you during the verification process.
+
+PlayStation support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
 </Alert>
 
 <Include name="console-intro/playstation" />
 
 <Include name="console-intro/game-engine-integration" />
-
-<Alert level="info" title="Availability of PlayStation support">
-PlayStation support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
-</Alert>
 ----
 
 "PlayStation", "PS5" are registered trademarks or trademarks of Sony Interactive Entertainment Inc.

--- a/docs/platforms/unity/game-consoles/index.mdx
+++ b/docs/platforms/unity/game-consoles/index.mdx
@@ -5,6 +5,12 @@ sidebar_order: 7
 sidebar_section: features
 ---
 
+<Alert>
+  Access to Sentry's error and crash reporting for consoles is a paid feature
+  available on our Enterprise plan. We will review the pricing and details with
+  you during the verification process.
+</Alert>
+
 ## How It Works
 
 The Unity SDK is a hybrid integration built on top of the [.NET SDK](/platforms/dotnet/). The C# layer captures managed exceptions and enriches events with context, while platform-specific native SDKs capture native crashes. Both layers synchronize scope data bidirectionally.
@@ -27,12 +33,6 @@ Each console has a different crash capture model:
 
 Sentry supports [PlayStation](/platforms/playstation/), [Xbox](/platforms/xbox/) and [Nintendo Switch](/platforms/nintendo-switch/) via the Unity SDK. Once you submit the middleware verification process, we'll reach out and send you an invite to our private GitHub repositories with console-specific code.
 This allows your configuration and custom data set via C# to show up in C# exceptions as well as crash dumps on these console platforms.
-
-<Alert>
-  Access to Sentry's error and crash reporting for consoles is a paid feature.
-  We will review the pricing and details with you during the verification
-  process.
-</Alert>
 
 ## Nintendo Switch
 

--- a/docs/platforms/unity/game-consoles/index.mdx
+++ b/docs/platforms/unity/game-consoles/index.mdx
@@ -5,7 +5,7 @@ sidebar_order: 7
 sidebar_section: features
 ---
 
-<Alert>
+<Alert level="info" title="Availability of console support">
   Access to Sentry's error and crash reporting for consoles is a paid feature
   available on our Enterprise plan. We will review the pricing and details with
   you during the verification process.

--- a/docs/platforms/unreal/game-consoles/index.mdx
+++ b/docs/platforms/unreal/game-consoles/index.mdx
@@ -5,7 +5,7 @@ sidebar_order: 7
 sidebar_section: features
 ---
 
-<Alert>
+<Alert level="info" title="Availability of console support">
   Access to Sentry's error and crash reporting for consoles is a paid feature
   available on our Enterprise plan. We will review the pricing and details with
   you during the verification process.

--- a/docs/platforms/unreal/game-consoles/index.mdx
+++ b/docs/platforms/unreal/game-consoles/index.mdx
@@ -5,6 +5,12 @@ sidebar_order: 7
 sidebar_section: features
 ---
 
+<Alert>
+  Access to Sentry's error and crash reporting for consoles is a paid feature
+  available on our Enterprise plan. We will review the pricing and details with
+  you during the verification process.
+</Alert>
+
 ## How It Works
 
 The Unreal SDK is a thin C++ wrapper that provides a consistent Unreal-friendly API (C++ and Blueprints) while delegating to platform-specific SDKs underneath: [sentry-native](/platforms/native/) on Windows/Linux, [sentry-cocoa](/platforms/apple/) on macOS/iOS, and [sentry-java](/platforms/java/) on Android.
@@ -26,12 +32,6 @@ Each console has a different crash capture model:
 
 Sentry supports [PlayStation](/platforms/playstation/), [Xbox](/platforms/xbox/) and [Nintendo Switch](/platforms/nintendo-switch/) via the Unreal Engine SDK extensions. Once you submit the middleware verification process, we'll reach out and send you an invite to our private GitHub repositories with console-specific code.
 This allows your configuration and custom data set via C++ or Blueprints to show up in non-fatal events as well as crash dumps on these console platforms.
-
-<Alert>
-  Access to Sentry's error and crash reporting for consoles is a paid feature.
-  We will review the pricing and details with you during the verification
-  process.
-</Alert>
 
 ## PlayStation
 

--- a/docs/platforms/xbox/index.mdx
+++ b/docs/platforms/xbox/index.mdx
@@ -9,13 +9,13 @@ categories:
   - gaming
 ---
 
+<Alert>
+Access to Sentry's error and crash reporting for consoles is a paid feature available on our Enterprise plan. We will review the pricing and details with you during the verification process.
+</Alert>
+
 <Include name="console-intro/xbox" />
 
 <Include name="console-intro/game-engine-integration" />
-
-<Alert>
-Access to Sentry's error and crash reporting for consoles is a paid feature. We will review the pricing and details with you during the verification process.
-</Alert>
 ----
 
 "Microsoft", "Xbox" are trademarks of the Microsoft group of companies.

--- a/docs/platforms/xbox/index.mdx
+++ b/docs/platforms/xbox/index.mdx
@@ -9,8 +9,10 @@ categories:
   - gaming
 ---
 
-<Alert>
+<Alert level="info" title="Availability of Xbox support">
 Access to Sentry's error and crash reporting for consoles is a paid feature available on our Enterprise plan. We will review the pricing and details with you during the verification process.
+
+Xbox support is exclusive to our SaaS offering, as it depends on confidential components that cannot be distributed for self-hosted use.
 </Alert>
 
 <Include name="console-intro/xbox" />


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Adds note on pricing and enterprise plans for Gaming Console Platforms (PlayStation/Xbox  + Unreal/Unity).

Nintendo is omitted on purpose (different plan structure).

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
