### PR TITLE
docs(js): Document `streamGenAiSpans` being enabled by default

### DIFF
--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -69,7 +69,6 @@ import { openAIIntegration } from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     openAIIntegration(),
   ],
@@ -102,7 +101,6 @@ import { openAIIntegration } from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     openAIIntegration({
       recordInputs: false, // Don't capture prompts
@@ -122,9 +120,9 @@ Sentry.init({
 
 ### Streaming Gen AI Spans
 
-Set `streamGenAiSpans` to `true` to send `gen_ai` spans as standalone envelope items instead of bundling them in the transaction. This is recommended for all AI monitoring setups and is required for <Link to="/ai/monitoring/conversations/">Conversations</Link> to work.
+`gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction by default (since SDK version `10.61.0`). This prevents AI spans with large inputs and outputs from hitting transaction payload size limits and being dropped, and is required for <Link to="/ai/monitoring/conversations/">Conversations</Link> to work.
 
-Without this option, AI spans with large inputs and outputs can hit transaction payload size limits and be dropped.
+To send `gen_ai` spans as part of the transaction instead, set `streamGenAiSpans` to `false`. Self-hosted Sentry users should set this to `false`, as standalone `gen_ai` spans may not be ingested by their Sentry instance.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -135,7 +133,7 @@ import * as Sentry from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
+  streamGenAiSpans: false, // opt out of streaming gen_ai spans
 });
 ```
 

--- a/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/anthropic.mdx
@@ -127,7 +127,6 @@ Defaults to `true` if `dataCollection.genAI.outputs` is `true` (which is the def
   dsn: "____PUBLIC_DSN____",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
   Sentry.anthropicAIIntegration({
   // your options here

--- a/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/google-genai.mdx
@@ -123,7 +123,6 @@ Sentry.init({
   dsn: "____PUBLIC_DSN____",
    // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     Sentry.googleGenAIIntegration({
       // your options here

--- a/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langchain.mdx
@@ -127,7 +127,6 @@ Sentry.init({
   dsn: "____PUBLIC_DSN____",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     Sentry.langChainIntegration({
       // your options here

--- a/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/langgraph.mdx
@@ -149,7 +149,6 @@ Sentry.init({
   dsn: "____PUBLIC_DSN____",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     Sentry.langGraphIntegration({
       // your options here

--- a/docs/platforms/javascript/common/configuration/integrations/openai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/openai.mdx
@@ -127,7 +127,6 @@ Sentry.init({
   dsn: "____PUBLIC_DSN____",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     Sentry.openAIIntegration({
       // your options here

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -46,7 +46,6 @@ The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.
 Sentry.init({
   dsn: "____PUBLIC_DSN____"
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [
     Sentry.vercelAIIntegration({
       recordInputs: true,
@@ -65,7 +64,6 @@ This integration is not enabled by default. You need to manually enable it by pa
 Sentry.init({
   dsn: "____PUBLIC_DSN____"
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [Sentry.vercelAIIntegration()],
 });
 ```
@@ -79,7 +77,6 @@ This integration is enabled by default in the Node runtime, but not in the Edge 
 Sentry.init({
   dsn: "____PUBLIC_DSN____"
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   integrations: [Sentry.vercelAIIntegration()],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -661,11 +661,13 @@ See <PlatformLink to="/tracing/distributed-tracing/dealing-with-cors-issues/">De
 
 </SdkOption>
 
-<SdkOption name="streamGenAiSpans" type='boolean' defaultValue='false' availableSince='10.53.0'>
+<SdkOption name="streamGenAiSpans" type='boolean' defaultValue='true' defaultNote='since version 10.61.0' availableSince='10.53.0'>
 
-When set to `true`, `gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction payload. This prevents AI spans with large inputs and outputs from being dropped due to transaction payload size limits.
+When enabled, `gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction payload. This prevents AI spans with large inputs and outputs from being dropped due to transaction payload size limits.
 
-Enable this option if you are using <PlatformLink to="/ai-agent-monitoring/">AI Agent Monitoring</PlatformLink> or the <Link to="/ai/monitoring/conversations/">Conversations</Link> feature.
+This is enabled by default starting with SDK version `10.61.0` (before that, it defaulted to `false`). Set it to `false` to send `gen_ai` spans as part of the transaction instead.
+
+Self-hosted Sentry users should set this option to `false`, as standalone `gen_ai` spans may not be ingested by their Sentry instance.
 
 </SdkOption>
 
@@ -697,14 +699,14 @@ This function is called with a log object, and can return a modified log object,
 
 <SdkOption name="enableMetrics" type='boolean' defaultValue='true'>
 
-Set this option to `false` to disable metric capturing in Sentry (enabled by default). 
+Set this option to `false` to disable metric capturing in Sentry (enabled by default).
 Only when this option is enabled will the `metrics` APIs actually send metrics to Sentry.
 
 </SdkOption>
 
 <SdkOption name="beforeSendMetric" type='(metric: Metric) => Metric | null'>
 
-This function is called with a metric object, and can return a modified metric object, or `null` to skip sending this metric to Sentry. 
+This function is called with a metric object, and can return a modified metric object, or `null` to skip sending this metric to Sentry.
 This can be used, for instance, for manual PII scrubbing before sending, or to add custom attributes to all metrics.
 
 </SdkOption>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Flip the documented default for `streamGenAiSpans` to `true` to match SDK 10.61.0. Update the option reference and the AI Agent Monitoring guide to describe the opt-out behavior and the self-hosted caveat, and drop the now-redundant `streamGenAiSpans: true` from the integration setup examples.

Should not be merged before sentry-javascript releases 10.61.0

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
