### PR TITLE
fix(size-analysis): update hackernews workflow links after rename

### DIFF
--- a/docs/product/size-analysis/index.mdx
+++ b/docs/product/size-analysis/index.mdx
@@ -34,7 +34,7 @@ jobs:
     # ...
 ```
 
-See [Integrating Into CI](/product/size-analysis/integrating-into-ci/) for end-to-end setup, and our sample GitHub actions for [Android](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_emerge_upload.yml) and [iOS](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_emerge_upload_pr.yml). Platform-specific upload steps are covered in the [Upload Guides](#upload-guides) below.
+See [Integrating Into CI](/product/size-analysis/integrating-into-ci/) for end-to-end setup, and our sample GitHub actions for [Android](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_sentry_size_analysis.yml) and [iOS](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_sentry_upload_pr.yml). Platform-specific upload steps are covered in the [Upload Guides](#upload-guides) below.
 
 ## Features
 

--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -43,8 +43,8 @@ jobs:
 
 **Example workflows:**
 
-- [Android main branch workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_emerge_upload.yml) - Handles both push to main and pull requests in a single workflow
-- [iOS main branch workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_emerge_upload_main.yml) - Separate workflow for main branch
+- [Android main branch workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_sentry_size_analysis.yml) - Handles both push to main and pull requests in a single workflow
+- [iOS main branch workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_sentry_upload_main.yml) - Separate workflow for main branch
 
 Confirm that builds uploaded from this workflow have the correct `sha` metadata value, as well as no `base_sha` being set.
 
@@ -64,8 +64,8 @@ jobs:
 
 **Example workflows:**
 
-- [Android pull request workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_emerge_upload.yml) - Combined main and PR workflow
-- [iOS pull request workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_emerge_upload_pr.yml) - Separate PR workflow
+- [Android pull request workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/android_sentry_size_analysis.yml) - Combined main and PR workflow
+- [iOS pull request workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_sentry_upload_pr.yml) - Separate PR workflow
 
 Confirm that builds uploaded from this workflow have the correct `sha` and `base_sha` metadata values.
 


### PR DESCRIPTION
The EmergeTools/hackernews sample repo renamed several workflow files in [this commit](https://github.com/EmergeTools/hackernews/commit/cff820578affa35ea3d1e9bd649e47d6df3e44eb), breaking links in the size analysis docs.

**Renamed files:**
- `android_emerge_upload.yml` → `android_sentry_size_analysis.yml`
- `ios_emerge_upload_main.yml` → `ios_sentry_upload_main.yml`
- `ios_emerge_upload_pr.yml` → `ios_sentry_upload_pr.yml`

Updated 5 links across `index.mdx` and `integrating-into-ci.mdx`.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC08QY4YGR3Q%3A1782309068.467689%22)