### PR TITLE
docs(ai-monitoring): Add setUser / user attribution to Conversations docs

### DIFF
--- a/docs/ai/monitoring/conversations/index.mdx
+++ b/docs/ai/monitoring/conversations/index.mdx
@@ -12,6 +12,8 @@ keywords:
   - gen_ai.conversation.id
   - conversation tracking
   - LLM conversations
+  - setUser
+  - user attribution
 ---
 
 <Alert>
@@ -47,6 +49,26 @@ Conversations and traces are independent concepts. A single conversation can spa
 
 The reverse is also true: a single trace can contain spans from different conversations. For example, if a user starts a new chat session without refreshing the page, the new conversation's spans appear in the same trace as the previous one.
 
+## User Attribution
+
+The Conversations view includes a **User** column that shows which user initiated each conversation. To populate it, call `setUser` (JavaScript) or `set_user` (Python) once per request or session, before any AI calls:
+
+```javascript
+// JavaScript / Node.js
+import * as Sentry from "@sentry/node";
+
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
+```python
+# Python
+import sentry_sdk
+
+sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": "jane"})
+```
+
+Any of `id`, `email`, or `username` is sufficient. If no user is set, the column displays "Unknown".
+
 ## Conversations List
 
 The [Conversations](https://sentry.io/orgredirect/organizations/:orgslug/explore/conversations/) page shows the most recent conversations that match your filters.
@@ -55,6 +77,7 @@ The [Conversations](https://sentry.io/orgredirect/organizations/:orgslug/explore
 
 Each row in the list displays:
 
+- **User** — the user who initiated the conversation, populated by `setUser` / `set_user`
 - **First input** — the first user message in the conversation
 - **Last output** — the most recent assistant response
 - **Cost** — estimated dollar cost and token usage

--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -200,7 +200,7 @@ import * as Sentry from "___SDK_PACKAGE___";
 Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
 ```
 
-Any of `id`, `email`, or `username` is sufficient — Conversations displays whichever fields are present. See the [User Feedback](/platforms/javascript/user-feedback/#identifying-users) documentation for the full list of supported fields.
+Any of `id`, `email`, or `username` is sufficient — Conversations displays whichever fields are present. See the [setUser API reference](/platforms/javascript/apis/#setUser) for the full list of supported fields.
 
 ## Manual Instrumentation
 

--- a/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/ai-agent-monitoring/index.mdx
@@ -192,6 +192,18 @@ Sentry.setConversationId(null);
 </SplitSection>
 </SplitLayout>
 
+## Identifying Users in Conversations
+
+The [Conversations](/ai/monitoring/conversations/) view includes a **User** column. To populate it, call `setUser` once per request or session, before any AI calls:
+
+```javascript
+import * as Sentry from "___SDK_PACKAGE___";
+
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
+Any of `id`, `email`, or `username` is sufficient — Conversations displays whichever fields are present. See the [User Feedback](/platforms/javascript/user-feedback/#identifying-users) documentation for the full list of supported fields.
+
 ## Manual Instrumentation
 
 If you're using a library that Sentry does not automatically instrument, you can manually instrument your code to capture spans. For your AI agents data to show up in the [AI Agents Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/?filter=onlyPrebuilt&query=agents&sort=mostPopular), spans must have well-defined names and data attributes.

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module.mdx
@@ -227,6 +227,18 @@ response = openai.responses.create(
 )
 ```
 
+## Identifying Users in Conversations
+
+The [Conversations](/ai/monitoring/conversations/) view includes a **User** column. To populate it, call `sentry_sdk.set_user` once per request or session, before any AI calls:
+
+```python
+import sentry_sdk
+
+sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": "jane"})
+```
+
+Any of `id`, `email`, or `username` is sufficient — Conversations displays whichever fields are present.
+
 ## Common Span Attributes
 
 <Include name="tracing/ai-agents-module/common-span-attributes" />


### PR DESCRIPTION
Adds 'Identifying Users in Conversations' sections to the JS and Python AI agent monitoring guides, and a 'User Attribution' section to the Conversations product page.

The Conversations view shows a User column that is empty unless setUser / set_user is called. These additions make that requirement explicit at the point users are reading about Conversations, with JS and Python code snippets. The Conversations List description is updated to mention the User column.

Also fixes a broken anchor — the initial draft linked to /platforms/javascript/user-feedback/#identifying-users which does not exist; the link now points to the setUser API reference instead.

**Companion PRs:**
- sentry: https://github.com/getsentry/sentry/pull/118441
- sentry-for-ai: https://github.com/getsentry/sentry-for-ai/pull/217

Refs TET-2513