### PR TITLE
docs(size-analysis): add GitHub Enterprise Checks permission requirement

### DIFF
--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -20,6 +20,8 @@ Size Analysis works by comparing a head vs a base build, similar to how code rev
 
    a. If you have previously installed the Sentry App, ensure you have accepted the latest permissions in order to receive Status Checks.
 
+   b. **GitHub Enterprise users:** The Sentry GitHub App must have **Checks: Read & Write** permission to post Size Analysis status checks. This permission is not included in the [default GitHub Enterprise setup instructions](/integrations/source-code-mgmt/github/#installing-github-enterprise). To enable it, navigate to your GitHub Enterprise instance and go to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit**, then under **Permissions & events > Repository permissions**, set **Checks** to **Read & write** and save. Existing installations will be prompted to approve the updated permission.
+
 2. Set up Size Analysis by following the guide for [iOS](/platforms/apple/guides/ios/size-analysis/) or [Android](/platforms/android/size-analysis/).
 
 3. Modify an existing workflow or create a new workflow to upload base builds from your main or default branch to Sentry:
@@ -182,6 +184,21 @@ The first time you set up Size Analysis, your main branch may not have any build
 
 1. Merge a PR or push to your main branch to trigger a build
 2. Future PRs will be able to compare against this base build
+
+### Status Check Failed to Post (GitHub Enterprise)
+
+If you see a "Status check failed to post" message on a build and you're using GitHub Enterprise, the most likely cause is a missing **Checks: Read & Write** permission on your Sentry GitHub App.
+
+To fix this:
+
+1. In your GitHub Enterprise instance, navigate to **Settings > Developer Settings > GitHub Apps**.
+2. Find your Sentry app and click **Edit**.
+3. Under **Permissions & events > Repository permissions**, set **Checks** to **Read & write**.
+4. Save the changes. GitHub will prompt users who installed the app to approve the updated permission.
+
+<Alert>
+The **Features** tab visible in GitHub.com App settings is not present in GitHub Enterprise. The **Checks** permission is the equivalent mechanism for enabling status checks in a GHE environment.
+</Alert>
 
 ### Unexpected Size Changes Show in the Comparison
 

--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -20,10 +20,11 @@ Size Analysis works by comparing a head vs a base build, similar to how code rev
 
    a. If you have previously installed the Sentry App, ensure you have accepted the latest permissions in order to receive Status Checks.
 
-   b. **GitHub Enterprise users:** The Sentry GitHub App requires two additional settings beyond the [default GitHub Enterprise setup instructions](/integrations/source-code-mgmt/github/#installing-github-enterprise) in order to post Size Analysis status checks. In your GitHub Enterprise instance, navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit** and make the following changes, then save. Existing installations will be prompted to approve updated permissions.
+   b. **GitHub Enterprise users:** Navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit > Permissions & events** and confirm the following are set:
 
-      - Under **Permissions & events > Repository permissions**, set **Checks** to **Read & write**.
-      - Under **Permissions & events > Subscribe to events**, enable **Check run**.
+      - Repository permissions: **Checks** — Read & write
+      - Repository permissions: **Pull requests** — Read & write
+      - Subscribe to events: **Check run**
 
 2. Set up Size Analysis by following the guide for [iOS](/platforms/apple/guides/ios/size-analysis/) or [Android](/platforms/android/size-analysis/).
 
@@ -190,18 +191,14 @@ The first time you set up Size Analysis, your main branch may not have any build
 
 ### Status Check Failed to Post (GitHub Enterprise)
 
-If you see a "Status check failed to post" message on a build and you're using GitHub Enterprise, the most likely cause is a missing **Checks: Read & Write** permission on your Sentry GitHub App.
+Navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit > Permissions & events** and confirm:
 
-To fix this:
-
-1. In your GitHub Enterprise instance, navigate to **Settings > Developer Settings > GitHub Apps**.
-2. Find your Sentry app and click **Edit**.
-3. Under **Permissions & events > Repository permissions**, set **Checks** to **Read & write**.
-4. Under **Permissions & events > Subscribe to events**, enable **Check run**.
-5. Save the changes. GitHub will prompt users who installed the app to approve the updated permissions.
+- Repository permissions: **Checks** — Read & write
+- Repository permissions: **Pull requests** — Read & write
+- Subscribe to events: **Check run**
 
 <Alert>
-The **Features** tab visible in GitHub.com App settings is not present in GitHub Enterprise. The **Checks** permission is the equivalent mechanism for enabling status checks in a GHE environment.
+GHE doesn't have the **Features** tab found in github.com App settings — the Checks permission is the equivalent.
 </Alert>
 
 ### Unexpected Size Changes Show in the Comparison

--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -20,7 +20,7 @@ Size Analysis works by comparing a head vs a base build, similar to how code rev
 
    a. If you have previously installed the Sentry App, ensure you have accepted the latest permissions in order to receive Status Checks.
 
-   b. **GitHub Enterprise users:** Navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit > Permissions & events** and confirm the following are set:
+   b. **GitHub Enterprise users:** After [installing the GitHub Enterprise app](/integrations/source-code-mgmt/github/#installing-github-enterprise), navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit > Permissions & events** and confirm the following are set:
 
       - Repository permissions: **Checks** — Read & write
       - Repository permissions: **Pull requests** — Read & write
@@ -188,18 +188,6 @@ The first time you set up Size Analysis, your main branch may not have any build
 
 1. Merge a PR or push to your main branch to trigger a build
 2. Future PRs will be able to compare against this base build
-
-### Status Check Failed to Post (GitHub Enterprise)
-
-Navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit > Permissions & events** and confirm:
-
-- Repository permissions: **Checks** — Read & write
-- Repository permissions: **Pull requests** — Read & write
-- Subscribe to events: **Check run**
-
-<Alert>
-GHE doesn't have the **Features** tab found in github.com App settings — the Checks permission is the equivalent.
-</Alert>
 
 ### Unexpected Size Changes Show in the Comparison
 

--- a/docs/product/size-analysis/integrating-into-ci.mdx
+++ b/docs/product/size-analysis/integrating-into-ci.mdx
@@ -20,7 +20,10 @@ Size Analysis works by comparing a head vs a base build, similar to how code rev
 
    a. If you have previously installed the Sentry App, ensure you have accepted the latest permissions in order to receive Status Checks.
 
-   b. **GitHub Enterprise users:** The Sentry GitHub App must have **Checks: Read & Write** permission to post Size Analysis status checks. This permission is not included in the [default GitHub Enterprise setup instructions](/integrations/source-code-mgmt/github/#installing-github-enterprise). To enable it, navigate to your GitHub Enterprise instance and go to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit**, then under **Permissions & events > Repository permissions**, set **Checks** to **Read & write** and save. Existing installations will be prompted to approve the updated permission.
+   b. **GitHub Enterprise users:** The Sentry GitHub App requires two additional settings beyond the [default GitHub Enterprise setup instructions](/integrations/source-code-mgmt/github/#installing-github-enterprise) in order to post Size Analysis status checks. In your GitHub Enterprise instance, navigate to **Settings > Developer Settings > GitHub Apps > [your Sentry app] > Edit** and make the following changes, then save. Existing installations will be prompted to approve updated permissions.
+
+      - Under **Permissions & events > Repository permissions**, set **Checks** to **Read & write**.
+      - Under **Permissions & events > Subscribe to events**, enable **Check run**.
 
 2. Set up Size Analysis by following the guide for [iOS](/platforms/apple/guides/ios/size-analysis/) or [Android](/platforms/android/size-analysis/).
 
@@ -194,7 +197,8 @@ To fix this:
 1. In your GitHub Enterprise instance, navigate to **Settings > Developer Settings > GitHub Apps**.
 2. Find your Sentry app and click **Edit**.
 3. Under **Permissions & events > Repository permissions**, set **Checks** to **Read & write**.
-4. Save the changes. GitHub will prompt users who installed the app to approve the updated permission.
+4. Under **Permissions & events > Subscribe to events**, enable **Check run**.
+5. Save the changes. GitHub will prompt users who installed the app to approve the updated permissions.
 
 <Alert>
 The **Features** tab visible in GitHub.com App settings is not present in GitHub Enterprise. The **Checks** permission is the equivalent mechanism for enabling status checks in a GHE environment.


### PR DESCRIPTION
## What

Adds GHE-specific guidance to the Size Analysis CI integration docs covering the `Checks: Read & Write` permission that's required for status checks to post.

## Why

GHE users who follow the [existing GitHub Enterprise setup instructions](https://docs.sentry.io/integrations/source-code-mgmt/github/#installing-github-enterprise) end up with a Sentry app that doesn't include the `Checks` permission (it's absent from that table). When Size Analysis tries to post a status check, GitHub returns a 403, and the build shows "Status check failed to post".

Also: GHE doesn't have the **Features** tab that exists in github.com App settings, so users can't find the toggle they're looking for there — the `Checks` permission is the equivalent mechanism.

## Changes

- **Installation step 1** — added sub-item (b) flagging the missing Checks permission for GHE users with a direct link to the GHE setup docs and the fix path.
- **Troubleshooting** — new section "Status Check Failed to Post (GitHub Enterprise)" with step-by-step fix and a note explaining the missing Features tab.

## Verified

Content consistency reviewed against the existing GHE setup instructions in `docs/integrations/source-code-mgmt/github/index.mdx` — navigation path `Settings > Developer Settings > GitHub Apps` matches what's already documented.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC090XRV76PP%3A1782399508.859529%22)