### PR TITLE
docs(vercel-ai): add v7 support

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -34,6 +34,12 @@ Requires SDK version `10.12.0` or higher for Deno.
 
 </Alert>
 
+<Alert level="warning">
+
+Don't use the AI SDK's `registerTelemetry` API (AI SDK v7 and above) together with this integration. Sentry's `vercelAIIntegration` already instruments the AI SDK, so registering telemetry separately will result in duplicate spans.
+
+</Alert>
+
 _Import name: `Sentry.vercelAIIntegration`_
 
 The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
@@ -241,7 +247,7 @@ const result = await generateText({
 
 ## Supported Versions
 
-- `ai`: `>=3.0.0 <=6`
+- `ai`: `>=3.0.0 <=7`
 
 ## Troubleshooting
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Using `registerTelemetry` together with our integration leads to double spans. Also expand the version range for the vercel AI integration since we are releasing v7 support today.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [x] Other deadline: we will release v7 support today so should be merged today
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
