### PR TITLE
fix(redirects): add redirect for /integrations/linear-sentry-agent/ to correct URL

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -788,6 +788,10 @@ const userDocsRedirects = [
     destination: '/integrations/issue-tracking/makeplane/',
   },
   {
+    source: '/integrations/linear-sentry-agent/',
+    destination: '/integrations/issue-tracking/sentry-linear-agent/',
+  },
+  {
     source: '/integrations/sentry-linear-agent/',
     destination: '/integrations/issue-tracking/sentry-linear-agent/',
   },


### PR DESCRIPTION
Adds a missing redirect for the broken URL reported by a user.

The Documentation button on the Linear Agent integration page points to `/integrations/linear-sentry-agent/`, which 404s. This adds a redirect to the correct location at `/integrations/issue-tracking/sentry-linear-agent/`.

A redirect for `/integrations/sentry-linear-agent/` already existed — this just adds coverage for the transposed slug variant.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3ACQDHVRS2W%3A1782473506.263449%22)