### PR TITLE
docs(sdk): add database query params to data-collection spec

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -2,7 +2,7 @@
 title: Data Collection
 description: Configuration for what data SDKs collect by default, including technical context, PII, and sensitive data.
 spec_id: sdk/foundations/client/data-collection
-spec_version: 0.4.0
+spec_version: 0.5.0
 spec_status: candidate
 spec_depends_on:
   - id: sdk/foundations/client
@@ -116,7 +116,7 @@ SDK documentation **MUST** document the default value and behavior of each `data
 
 </SpecSection>
 
-<SpecSection id="setup-snippet-opt-out" status="candidate" since="0.5.0">
+<SpecSection id="setup-snippet-opt-out" status="candidate" since="0.4.0">
 
 ### Setup Snippet Opt-Out Comment
 

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -8,6 +8,9 @@ spec_depends_on:
   - id: sdk/foundations/client
     version: ">=1.0.0"
 spec_changelog:
+  - version: 0.5.0
+    date: 2026-06-26
+    summary: Include configuration for database queries.
   - version: 0.4.0
     date: 2026-06-12
     summary: Added documentation requirements for default behavior and setup snippet opt-out comment with link to full dataCollection docs.
@@ -70,7 +73,7 @@ Personally Identifiable Information (PII) or user-linked data. Examples include,
 - Contact (email, phone number, address)
 - IP address
 - Cookies and headers that identify the user or session
-- HTTP request data (TBD)
+- HTTP request data or database query parameters (TBD)
 
 For context types that may carry PII fields (e.g. `device_unique_identifier` in [Device Context](/sdk/foundations/transport/event-payloads/contexts/#device-context), or fields in the [User Interface](/sdk/foundations/transport/event-payloads/user/)), see the linked specs.
 
@@ -530,6 +533,9 @@ init({
       inputs?: boolean                              // default: true
       outputs?: boolean                             // default: true
     },
+    database?: {
+      queryParams?: boolean                        // default: true
+    },
     stackFrameVariables?: boolean,                 // default: true
     frameContextLines?: integer,                   // default: 5 (see boolean fallback below)
   },
@@ -544,6 +550,7 @@ init({
 | `httpBodies` | `string[]` (body types) | all valid body types | 0.1.0 | List of body types to collect. Omitted = all body types valid for the platform; empty array (`[]`) = off. Valid values: `"incomingRequest"`, `"outgoingRequest"`, `"incomingResponse"`, `"outgoingResponse"`. Default changed from `[]` (off) to all valid body types in 0.2.0. |
 | `queryParams` | Key-value collection | `{ mode: "denyList" }` | 0.1.0 | Collect URL query parameters. All key names are always included; the SDK scrubs values for keys matching the sensitive denylist or custom allow/deny terms. |
 | `genAI` | `{ inputs?, outputs? }` | Both `true` | 0.1.0 | For `inputs`: Include the content of generative AI inputs (e.g. prompt text, tool call arguments). <br /><br /> For `outputs`: Include the content of generative AI outputs (e.g. completion text, tool call results). Metadata such as model name and token counts is always collected regardless of these settings. |
+| `database` | `{ queryParams? }` | `true` | 0.5.0 | Include parameters/arguments passed to database queries. Setting this to false will either omit the value altogether, or replace the value with '[Filtered]' |
 | `stackFrameVariables` | Boolean | `true` | 0.1.0 | Include local variable values captured within stack frames. |
 | `frameContextLines` | Integer (`Boolean` fallback) | `5` (`true`) | 0.1.0 | Number of source code lines to include above and below each stack frame. <br/> **`Boolean` fallback:** Not all platforms support integer configuration values. SDKs **MAY** accept a boolean, where `true` is equivalent to the platform default (typically `5`) and `false` is equivalent to `0` (no context lines). SDKs **SHOULD** prefer accepting an integer when their platform supports it. |
 

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -650,6 +650,9 @@ init({
       inputs: false,
       outputs: false,
     },
+    database: {
+      queryParams: false,
+    },
     httpHeaders: { deny: ["forwarded", "-ip", "remote-", "via", "-user"] },
     cookies: { deny: ["forwarded", "-ip", "remote-", "via", "-user"] },
     queryParams: { deny: ["forwarded", "-ip", "remote-", "via", "-user"] },

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -9,7 +9,7 @@ spec_depends_on:
     version: ">=1.0.0"
 spec_changelog:
   - version: 0.6.0
-    date: 2026-06-26
+    date: 2026-06-29
     summary: Include configuration for database queries.
   - version: 0.5.0
     date: 2026-06-26

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -116,7 +116,7 @@ SDK documentation **MUST** document the default value and behavior of each `data
 
 </SpecSection>
 
-<SpecSection id="setup-snippet-opt-out" status="candidate" since="0.4.0">
+<SpecSection id="setup-snippet-opt-out" status="candidate" since="0.5.0">
 
 ### Setup Snippet Opt-Out Comment
 
@@ -550,7 +550,7 @@ init({
 | `httpBodies` | `string[]` (body types) | all valid body types | 0.1.0 | List of body types to collect. Omitted = all body types valid for the platform; empty array (`[]`) = off. Valid values: `"incomingRequest"`, `"outgoingRequest"`, `"incomingResponse"`, `"outgoingResponse"`. Default changed from `[]` (off) to all valid body types in 0.2.0. |
 | `queryParams` | Key-value collection | `{ mode: "denyList" }` | 0.1.0 | Collect URL query parameters. All key names are always included; the SDK scrubs values for keys matching the sensitive denylist or custom allow/deny terms. |
 | `genAI` | `{ inputs?, outputs? }` | Both `true` | 0.1.0 | For `inputs`: Include the content of generative AI inputs (e.g. prompt text, tool call arguments). <br /><br /> For `outputs`: Include the content of generative AI outputs (e.g. completion text, tool call results). Metadata such as model name and token counts is always collected regardless of these settings. |
-| `database` | `{ queryParams? }` | `true` | 0.5.0 | Include parameters/arguments passed to database queries. Setting this to false will either omit the value altogether, or replace the value with '[Filtered]' |
+| `database` | `{ queryParams? }` | `true` | 0.5.0 | Include parameters/arguments passed to database queries. Setting this to false will either omit the value altogether, or replace the value with '[Filtered]'. |
 | `stackFrameVariables` | Boolean | `true` | 0.1.0 | Include local variable values captured within stack frames. |
 | `frameContextLines` | Integer (`Boolean` fallback) | `5` (`true`) | 0.1.0 | Number of source code lines to include above and below each stack frame. <br/> **`Boolean` fallback:** Not all platforms support integer configuration values. SDKs **MAY** accept a boolean, where `true` is equivalent to the platform default (typically `5`) and `false` is equivalent to `0` (no context lines). SDKs **SHOULD** prefer accepting an integer when their platform supports it. |
 


### PR DESCRIPTION
Adds `database.queryParams` as a new configuration option to the SDK data-collection spec. This covers the ability for SDKs to include or omit parameters passed to database queries, consistent with how `queryParams` works for HTTP and how `genAI` inputs/outputs are handled.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)


Fixes PY-2562