### PR TITLE
docs(sdk): add graphql settings to data-collection spec

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -2,12 +2,15 @@
 title: Data Collection
 description: Configuration for what data SDKs collect by default, including technical context, PII, and sensitive data.
 spec_id: sdk/foundations/client/data-collection
-spec_version: 0.4.0
+spec_version: 0.5.0
 spec_status: candidate
 spec_depends_on:
   - id: sdk/foundations/client
     version: ">=1.0.0"
 spec_changelog:
+  - version: 0.5.0
+    date: 2026-06-26
+    summary: Include configuration options for controlling the inclusion of graphql documents and variables.
   - version: 0.4.0
     date: 2026-06-12
     summary: Added documentation requirements for default behavior and setup snippet opt-out comment with link to full dataCollection docs.
@@ -526,9 +529,13 @@ init({
     },
     httpBodies?: string[],                         // default: all valid body types
     queryParams?: KeyValueCollectionBehavior,      // default: { mode: "denyList" }
+    graphql?: {
+      document?: boolean,                          // default: true
+      variables?: boolean,                         // default: true
+    },
     genAI?: {
-      inputs?: boolean                              // default: true
-      outputs?: boolean                             // default: true
+      inputs?: boolean,                              // default: true
+      outputs?: boolean,                             // default: true
     },
     stackFrameVariables?: boolean,                 // default: true
     frameContextLines?: integer,                   // default: 5 (see boolean fallback below)
@@ -543,6 +550,7 @@ init({
 | `httpHeaders` | `{ request?, response? }` | Both `{ mode: "denyList" }` | 0.1.0 | Collect HTTP headers. Configure request and response independently using key-value collection modes. All key names are always included. |
 | `httpBodies` | `string[]` (body types) | all valid body types | 0.1.0 | List of body types to collect. Omitted = all body types valid for the platform; empty array (`[]`) = off. Valid values: `"incomingRequest"`, `"outgoingRequest"`, `"incomingResponse"`, `"outgoingResponse"`. Default changed from `[]` (off) to all valid body types in 0.2.0. |
 | `queryParams` | Key-value collection | `{ mode: "denyList" }` | 0.1.0 | Collect URL query parameters. All key names are always included; the SDK scrubs values for keys matching the sensitive denylist or custom allow/deny terms. |
+| `graphql` | `{ document?, variables? }` | Both `true` | 0.5.0 | For `document`: Collect the GraphQL document. <br /><br /> For `variables`: Collect the variables that are passed to GraphQL operations. |
 | `genAI` | `{ inputs?, outputs? }` | Both `true` | 0.1.0 | For `inputs`: Include the content of generative AI inputs (e.g. prompt text, tool call arguments). <br /><br /> For `outputs`: Include the content of generative AI outputs (e.g. completion text, tool call results). Metadata such as model name and token counts is always collected regardless of these settings. |
 | `stackFrameVariables` | Boolean | `true` | 0.1.0 | Include local variable values captured within stack frames. |
 | `frameContextLines` | Integer (`Boolean` fallback) | `5` (`true`) | 0.1.0 | Number of source code lines to include above and below each stack frame. <br/> **`Boolean` fallback:** Not all platforms support integer configuration values. SDKs **MAY** accept a boolean, where `true` is equivalent to the platform default (typically `5`) and `false` is equivalent to `0` (no context lines). SDKs **SHOULD** prefer accepting an integer when their platform supports it. |
@@ -639,6 +647,10 @@ init({
   dataCollection: {
     userInfo: false,
     httpBodies: [],
+    graphql: {
+      document: false,
+      variables: false,
+    },
     genAI: {
       inputs: false,
       outputs: false,


### PR DESCRIPTION
Adds `graphql.document` and `graphql.variables` configuration options to the SDK data-collection spec (bumped to v0.5.0).

The new `graphql` sub-object under `networkData` lets SDKs control whether GraphQL documents and their variables are included in captured data. Both default to `true`. This mirrors the existing `genAI` pattern and updates the reference type signature, the option table, and the max-privacy example snippet accordingly.