### PR TITLE
docs: Adjust copy of flapgole to remove allowed_features and configure flags for ST

### DIFF
--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -221,7 +221,7 @@ Once the option change is deployed, the feature checks will immediately be activ
 
 ## Using Flagpole in single-tenants
 
-By default, every Flagpole feature is evaluated in single-tenant environments. To roll a feature everywhere except single-tenant environments, you can use the `sentry_singletenant` and `sentry_cell` context values in your feature conditions. For example:
+By default, every Flagpole feature is evaluated in single-tenant environments. To roll a feature everywhere except single-tenant environments, you can use the `*_customer_single_tenants` anchor and `sentry_cell` context values in your feature conditions. For example:
 
 ```yaml
 feature.organizations:cool-new-feature:
@@ -232,9 +232,9 @@ feature.organizations:cool-new-feature:
     - name: GA
       rollout: 100
       conditions:
-        - operator: equals
-          property: sentry_singletenant
-          value: false
+        - operator: not_in
+          property: sentry_cell
+          value: *_customer_single_tenants
 ```
 
 Conversely, to roll a feature out to specific cells only, match on `sentry_cell`:

--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -230,6 +230,7 @@ options:
 
 Features that aren't listed fall through to their normal flagpole.yml configuration. To roll a feature everywhere except single-tenant environments, add the following to flagpole.yml:
 
+```yaml
 feature.organizations:cool-new-feature:
   created_at: "2026-06-25"
   enabled: true
@@ -241,6 +242,7 @@ feature.organizations:cool-new-feature:
         - operator: equals
           property: sentry_singletenant
           value: false
+```
 
 You can also use the `sentry_singletenant` and `sentry_cell` context values in
 your feature conditions as required. For example, to roll out a feature to

--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -43,7 +43,7 @@ options:
 
 ### Owner
 
-`team` 
+`team`
 
 : The name of the team that owns this feature flag
 
@@ -221,15 +221,14 @@ Once the option change is deployed, the feature checks will immediately be activ
 
 ## Using Flagpole in single-tenants
 
-To allow your flagpole feature configuration to be used in single-tenant
-environments, you'll need to add your feature name to the
-`flagpole.allowed_features` list for each tenant. For example, in
-`options/regions/acme.yml` add the following:
+By default, every Flagpole feature is evaluated in single-tenant environments. You only need to configure a tenant if a feature should never be available there by adding its name to the `flagpole.disallowed_features` denylist. For example, in `options/regions/acme`.yml add the following:
 
 ```yaml
 options:
-    flagpole.allowed_features: ["organizations:is_sentry"]
+    flagpole.disallowed_features: ["organizations:is_sentry"]
 ```
+
+Features that aren't listed fall through to their normal flagpole.yml configuration.
 
 You can also use the `sentry_singletenant` and `sentry_cell` context values in
 your feature conditions as required. For example, to roll out a feature to

--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -221,14 +221,7 @@ Once the option change is deployed, the feature checks will immediately be activ
 
 ## Using Flagpole in single-tenants
 
-By default, every Flagpole feature is evaluated in single-tenant environments. You only need to configure a tenant if a feature should never be available there by adding its name to the `flagpole.disallowed_features` denylist. For example, in `options/regions/acme.yml` add the following:
-
-```yaml
-options:
-    flagpole.disallowed_features: ["organizations:is_sentry"]
-```
-
-Features that aren't listed fall through to their normal flagpole.yml configuration. To roll a feature everywhere except single-tenant environments, add the following to flagpole.yml:
+By default, every Flagpole feature is evaluated in single-tenant environments. To roll a feature everywhere except single-tenant environments, you can use the `sentry_singletenant` and `sentry_cell` context values in your feature conditions. For example:
 
 ```yaml
 feature.organizations:cool-new-feature:
@@ -244,19 +237,17 @@ feature.organizations:cool-new-feature:
           value: false
 ```
 
-You can also use the `sentry_singletenant` and `sentry_cell` context values in
-your feature conditions as required. For example, to roll out a feature to
-specific cells:
+Conversely, to roll a feature out to specific cells only, match on `sentry_cell`:
 
 ```yaml
-- conditions:
-  - operator: in
-    value:
-      - us
-      - de
-    property: sentry_cell
-  name: multi-region rollout
+- name: multi-region rollout
   rollout: 100
+  conditions:
+    - operator: in
+      property: sentry_cell
+      value:
+        - us
+        - de
 ```
 
 ## Testing a Flagpole feature locally

--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -228,7 +228,19 @@ options:
     flagpole.disallowed_features: ["organizations:is_sentry"]
 ```
 
-Features that aren't listed fall through to their normal flagpole.yml configuration.
+Features that aren't listed fall through to their normal flagpole.yml configuration. To roll a feature everywhere except single-tenant environments, add the following to flagpole.yml:
+
+feature.organizations:cool-new-feature:
+  created_at: "2026-06-25"
+  enabled: true
+  owner: my-team
+  segments:
+    - name: GA
+      rollout: 100
+      conditions:
+        - operator: equals
+          property: sentry_singletenant
+          value: false
 
 You can also use the `sentry_singletenant` and `sentry_cell` context values in
 your feature conditions as required. For example, to roll out a feature to

--- a/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
+++ b/develop-docs/backend/application-domains/feature-flags/flagpole.mdx
@@ -221,7 +221,7 @@ Once the option change is deployed, the feature checks will immediately be activ
 
 ## Using Flagpole in single-tenants
 
-By default, every Flagpole feature is evaluated in single-tenant environments. You only need to configure a tenant if a feature should never be available there by adding its name to the `flagpole.disallowed_features` denylist. For example, in `options/regions/acme`.yml add the following:
+By default, every Flagpole feature is evaluated in single-tenant environments. You only need to configure a tenant if a feature should never be available there by adding its name to the `flagpole.disallowed_features` denylist. For example, in `options/regions/acme.yml` add the following:
 
 ```yaml
 options:


### PR DESCRIPTION
## DESCRIBE YOUR PR
This PR adjusts the copy of the `allowed_features` behavior in `flagpole.mdx` to remove and to configure flags to handle ST envs from the start as proposed in [this project](https://linear.app/getsentry/project/migrate-from-allowed-features-to-disallowed-features-47c05e84c468/overview). 

Closes EXP-1038

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [X] Other deadline: July 1st
- [ ] None: Not urgent, can wait up to 1 week+