### PR TITLE
feat(dotnet): document PropagateTraceparent option

### DIFF
--- a/docs/concepts/otlp/sentry-with-otel.mdx
+++ b/docs/concepts/otlp/sentry-with-otel.mdx
@@ -69,6 +69,13 @@ The following SDKs support the `propagateTraceparent` option:
   - <LinkWithPlatformIcon platform="react-native" label="React Native" url="/platforms/react-native/configuration/options/#propagateTraceparent" />
 
   </div>
+  <div>
+
+  ### .NET
+
+  - <LinkWithPlatformIcon platform="dotnet" label=".NET" url="/platforms/dotnet/configuration/options/#PropagateTraceparent" />
+
+  </div>
 </div>
 
 ## OTLP Integration

--- a/docs/concepts/otlp/sentry-with-otel.mdx
+++ b/docs/concepts/otlp/sentry-with-otel.mdx
@@ -68,9 +68,6 @@ The following SDKs support the `propagateTraceparent` option:
   - <LinkWithPlatformIcon platform="native" label="Native" url="/platforms/native/configuration/options/#propagate_traceparent" />
   - <LinkWithPlatformIcon platform="react-native" label="React Native" url="/platforms/react-native/configuration/options/#propagateTraceparent" />
 
-  </div>
-  <div>
-
   ### .NET
 
   - <LinkWithPlatformIcon platform="dotnet" label=".NET" url="/platforms/dotnet/configuration/options/#PropagateTraceparent" />

--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -345,3 +345,13 @@ Disables the `SentryHttpMessageHandler`, which normally instruments outgoing HTT
 This option was added in SDK version 5.1.0.
 
 </SdkOption>
+
+<SdkOption name="PropagateTraceparent" type="bool" defaultValue="false" availableSince="6.0.0">
+
+If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/) to outgoing HTTP requests, in addition to the `sentry-trace` and `baggage` headers. Enable this when your backend services are instrumented with a W3C Trace Context compatible library, such as OpenTelemetry, and you want to continue the trace from the client.
+
+The `traceparent` header is only attached to requests whose URLs match `TracePropagationTargets`.
+
+This option was added in SDK version 6.0.0.
+
+</SdkOption>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the `PropagateTraceparent` option for the .NET SDK, which was added in sentry-dotnet 6.0.0 but never surfaced in the docs.

- Add **.NET** to the list of SDKs that support `propagateTraceparent` on the OTLP concepts page (`/concepts/otlp/sentry-with-otel/`).
- Document the `PropagateTraceparent` option on the .NET `SentryOptions` reference page (`/platforms/dotnet/configuration/options/`).

Closes getsentry/sentry-dotnet#5300

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
