### PR TITLE
docs(develop): update profile data categories from Relay

### DIFF
--- a/develop-docs/sdk/foundations/transport/rate-limiting.mdx
+++ b/develop-docs/sdk/foundations/transport/rate-limiting.mdx
@@ -94,8 +94,11 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
   - `security`: Events with event_type `csp`
   - `attachment`: Attachment bytes stored (unused for rate limiting)
   - `session`: Session update events
-  - `profile`: Profiling events
-  - `profile_chunk`: Continuous Profiling chunks
+  - `profile`: Profiling events (rate limiting: apply to all profiles).
+  - `profile_chunk`: Continuous Profiling chunks (rate limiting: apply to profile chunks).
+  - `profile_chunk_ui`: UI Profiling chunks; counterpart to `profile_chunk` for UI platforms cocoa, android, and javascript (rate limiting: apply to profile chunks).
+  - `profile_backend`: Transaction profiles for backend platforms (rate limiting: optional, apply to backend transaction profiles).
+  - `profile_ui`: Transaction profiles for UI platforms (rate limiting: optional, apply to UI transaction profiles).
   - `replay`: Session Replays
   - `feedback`: User Feedbacks
   - `trace_metric`: Metric type events.

--- a/develop-docs/sdk/foundations/transport/rate-limiting.mdx
+++ b/develop-docs/sdk/foundations/transport/rate-limiting.mdx
@@ -102,7 +102,7 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
 
   Relay utilizes various data categories for profiles, allowing separate rate limiting for each. SDKs must implement the same logic applied to other data categories and discard the associated profiling data when a rate limit is active:
 
-  - `profile`: Profiling events for backend platforms.
+  - `profile`: Transaction profiles for all platforms.
   - `profile_chunk`: Continuous Profiling chunks for backend platforms.
   - `profile_chunk_ui`: Continuous Profiling chunks for UI platforms.
   - `profile_backend`: Transaction profiles for backend platforms.

--- a/develop-docs/sdk/foundations/transport/rate-limiting.mdx
+++ b/develop-docs/sdk/foundations/transport/rate-limiting.mdx
@@ -94,16 +94,19 @@ While these [data categories](https://github.com/getsentry/relay/blob/master/rel
   - `security`: Events with event_type `csp`
   - `attachment`: Attachment bytes stored (unused for rate limiting)
   - `session`: Session update events
-  - `profile`: Profiling events (rate limiting: apply to all profiles).
-  - `profile_chunk`: Continuous Profiling chunks (rate limiting: apply to profile chunks).
-  - `profile_chunk_ui`: UI Profiling chunks; counterpart to `profile_chunk` for UI platforms cocoa, android, and javascript (rate limiting: apply to profile chunks).
-  - `profile_backend`: Transaction profiles for backend platforms (rate limiting: optional, apply to backend transaction profiles).
-  - `profile_ui`: Transaction profiles for UI platforms (rate limiting: optional, apply to UI transaction profiles).
   - `replay`: Session Replays
   - `feedback`: User Feedbacks
   - `trace_metric`: Metric type events.
   - `trace_metric_byte`: Metric bytes stored.
   - `internal`: a sentry/system internal event[^internal]
+
+  Relay utilizes various data categories for profiles, allowing separate rate limiting for each. SDKs must implement the same logic applied to other data categories and discard the associated profiling data when a rate limit is active:
+
+  - `profile`: Profiling events for backend platforms.
+  - `profile_chunk`: Continuous Profiling chunks for backend platforms.
+  - `profile_chunk_ui`: Continuous Profiling chunks for UI platforms.
+  - `profile_backend`: Transaction profiles for backend platforms.
+  - `profile_ui`: Transaction profiles for UI platforms.
 
 - **Scope**: The unit / model in Sentry that quotas are enforced for.
   - `organization`


### PR DESCRIPTION
## DESCRIBE YOUR PR

While investigating getsentry/sentry-cocoa#8174, I noticed the develop-docs rate-limiting Definitions list was missing some profile data categories. This updates it to match Relay.

I only added the categories relevant for rate limiting (those that can appear in the `X-Sentry-Rate-Limits` header), not every profile category Relay defines. I'm not 100% sure I got the distinction right — someone from the Relay team should take a close look.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
