### PR TITLE
feat(develop/spans): Add `sentry.trace_lifecycle` attribute as common span attribute

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-protocol.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-protocol.mdx
@@ -230,6 +230,7 @@ All attributes mentioned below MUST be attached to every span being emitted from
 |---------------|------|----------|-------------|
 | `sentry.segment.name` | string | **Strictly Required** | The segment name (e.g., `"GET /users"`) |
 | `sentry.segment.id` | string | **Strictly Required** | The segment span id |
+| `sentry.trace_lifecycle` | string | Required | The trace lifecycle mode. MUST be set to `"stream"`. |
 | `sentry.op` | string | Required, see note | The [span op](../../traces/span-operations/) (e.g., `"http.client"`, `"db.query"`) of the span. MUST be set on spans from auto instrumentation, MAY be set by manually started spans. |
 | `sentry.release` | string | Required | The release version of the application |
 | `sentry.environment` | string | Required | The environment name (e.g., `"production"`, `"staging"`, `"development"`) |


### PR DESCRIPTION
[This attribute ](https://getsentry.github.io/sentry-conventions/attributes/sentry/#sentry-trace_lifecycle)can be used as an explicit signal in the product that the span was sent as a streamed v2 span from the SDK. 