### PR TITLE
docs(python): document stream_gen_ai_spans enabled by default

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -513,11 +513,13 @@ A number between `0` and `1`, controlling the percentage chance a given session 
 
 </SdkOption>
 
-<SdkOption name="stream_gen_ai_spans" type='bool' defaultValue='False' availableSince='2.60.0'>
+<SdkOption name="stream_gen_ai_spans" type='bool' defaultValue='True' defaultNote='since version 2.64.0' availableSince='2.60.0'>
 
-When set to `True`, `gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction payload. This prevents AI spans with large inputs and outputs from being dropped due to transaction payload size limits.
+When enabled, `gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction payload. This prevents AI spans with large inputs and outputs from being dropped due to transaction payload size limits.
 
-Enable this option if you are using AI Agent Monitoring or the Conversations feature.
+This is enabled by default starting with SDK version `2.64.0` (before that, it defaulted to `False`). Set it to `False` to send `gen_ai` spans as part of the transaction instead.
+
+Self-hosted Sentry users should set this option to `False`, as standalone `gen_ai` spans may not be ingested by their Sentry instance.
 
 </SdkOption>
 

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -78,7 +78,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         AnthropicIntegration(

--- a/docs/platforms/python/integrations/google-genai/index.mdx
+++ b/docs/platforms/python/integrations/google-genai/index.mdx
@@ -36,7 +36,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         GoogleGenAIIntegration(),
@@ -92,7 +91,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         GoogleGenAIIntegration(

--- a/docs/platforms/python/integrations/huggingface_hub/index.mdx
+++ b/docs/platforms/python/integrations/huggingface_hub/index.mdx
@@ -30,7 +30,6 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     environment="local",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )
 ```
@@ -112,7 +111,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         HuggingfaceHubIntegration(

--- a/docs/platforms/python/integrations/langchain/index.mdx
+++ b/docs/platforms/python/integrations/langchain/index.mdx
@@ -32,7 +32,6 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     environment="local",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     debug=True,
     integrations=[
@@ -50,7 +49,6 @@ sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     environment="local",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     debug=True,
     integrations=[
@@ -175,7 +173,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LangchainIntegration(

--- a/docs/platforms/python/integrations/langgraph/index.mdx
+++ b/docs/platforms/python/integrations/langgraph/index.mdx
@@ -104,7 +104,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LanggraphIntegration(

--- a/docs/platforms/python/integrations/litellm/index.mdx
+++ b/docs/platforms/python/integrations/litellm/index.mdx
@@ -36,7 +36,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(),
@@ -56,7 +55,6 @@ import litellm
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(),
@@ -97,7 +95,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(

--- a/docs/platforms/python/integrations/mcp/index.mdx
+++ b/docs/platforms/python/integrations/mcp/index.mdx
@@ -49,7 +49,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(),
@@ -77,7 +76,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(),
@@ -133,7 +131,6 @@ from mcp.types import Tool, TextContent, GetPromptResult, PromptMessage
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(),
@@ -237,7 +234,6 @@ sentry_sdk.init(
     # ...
     # Add data like tool inputs and outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         MCPIntegration(

--- a/docs/platforms/python/integrations/openai-agents/index.mdx
+++ b/docs/platforms/python/integrations/openai-agents/index.mdx
@@ -69,7 +69,6 @@ async def main() -> None:
         traces_sample_rate=1.0,
         # Add data like LLM and tool inputs/outputs;
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
         send_default_pii=True,
     )
 
@@ -107,7 +106,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         OpenAIAgentsIntegration(

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -89,7 +89,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         OpenAIIntegration(

--- a/docs/platforms/python/integrations/pydantic-ai/index.mdx
+++ b/docs/platforms/python/integrations/pydantic-ai/index.mdx
@@ -42,7 +42,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like LLM and tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         PydanticAIIntegration(),
@@ -59,7 +58,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like LLM and tool inputs/outputs;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         PydanticAIIntegration(),
@@ -121,7 +119,6 @@ async def main() -> None:
         traces_sample_rate=1.0,
         # Add data like LLM and tool inputs/outputs;
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
         send_default_pii=True,
         integrations=[
             PydanticAIIntegration(),
@@ -186,7 +183,6 @@ async def main() -> None:
         traces_sample_rate=1.0,
         # Add data like LLM and tool inputs/outputs;
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
         send_default_pii=True,
         integrations=[
             PydanticAIIntegration(),
@@ -228,7 +224,6 @@ sentry_sdk.init(
     # ...
     # Add data like inputs and responses;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         PydanticAIIntegration(


### PR DESCRIPTION
`stream_gen_ai_spans` defaults to `True` since Python SDK 2.64.0. The option reference now documents the new default with opt-out and self-hosted guidance, and the Python AI integration examples (OpenAI, Anthropic, LangChain, LangGraph, LiteLLM, MCP, OpenAI Agents, Pydantic AI, Google GenAI, Hugging Face) no longer set it explicitly since it is on by default.

Mirrors the equivalent JS docs change (getsentry/sentry-docs#18535). Companion PRs:

- Product onboarding: getsentry/sentry#118714
- sentry-for-ai skills: getsentry/sentry-for-ai#231

Refs TET-2553