### PR TITLE
docs(issues): Add Low-Value Span Issues product page

### DIFF
--- a/docs/product/issues/issue-details/low-value-span-issues/index.mdx
+++ b/docs/product/issues/issue-details/low-value-span-issues/index.mdx
@@ -6,7 +6,7 @@ description: "Learn more about Low-Value Span issues and how to reduce noise and
 
 <Alert title="Currently in Beta">
 
-Low-Value Span Issues are currently in beta.
+Low-Value Span Issues are currently in open beta.
 
 </Alert>
 

--- a/docs/product/issues/issue-details/low-value-span-issues/index.mdx
+++ b/docs/product/issues/issue-details/low-value-span-issues/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Low-Value Span Issues
+sidebar_order: 55
+description: "Learn more about Low-Value Span issues and how to reduce noise and span volume in your traces."
+---
+
+A _low-value span issue_ is raised when Sentry detects a span that is sent frequently but adds little value to your traces. These spans clutter the trace view, make it harder to spot the spans that actually help with debugging, and contribute to your stored span volume and cost.
+
+Sentry groups matching spans into a single low-value span issue. These issues are set to `LOW` priority and are excluded from the default issue search. To find them, open the **Sentry Configuration** view on the **Issues** page or filter with `issue.category:configuration`.
+
+## Issue Details
+
+The **Issue Details** page for a low-value span issue summarizes the offending span and its projected impact:
+
+- **Affected span** — A summary of the span Sentry detected. Click through to see matching spans in [Trace Explorer](/product/explore/trace-explorer/).
+- **Span count** — Projected 30-day volume of this span, extrapolated from a recent sample.
+- **Estimated cost** — Projected 30-day cost of ingesting and storing this span, when available.
+- **Average duration** — Average duration of this span in the analyzed sample.
+
+## Fixing a Low-Value Span Issue
+
+How you fix the issue depends on where the span comes from. The **Troubleshooting** section of the issue tells you whether the span originates from SDK automatic instrumentation or from your own custom instrumentation, and shows a ready-to-use snippet for filtering it.
+
+[Seer Autofix](/product/ai-in-sentry/seer/autofix/) can also generate and apply the fix for you directly from the issue.
+
+- **Automatic instrumentation** — Drop the span before it is sent using your SDK's filtering options. See <PlatformLink to="/configuration/filtering/">Filtering</PlatformLink>.
+- **Custom instrumentation** — Remove the span from your code, or add attributes that make it more useful. See <PlatformLink to="/tracing/instrumentation/custom-instrumentation/">Custom Instrumentation</PlatformLink>.
+
+## Limitations
+
+- Low-value span issues do not trigger workflow notifications.
+- They are excluded from the default issue search. Open the **Sentry Configuration** view on the **Issues** page or filter with `issue.category:configuration` to find them.

--- a/docs/product/issues/issue-details/low-value-span-issues/index.mdx
+++ b/docs/product/issues/issue-details/low-value-span-issues/index.mdx
@@ -12,7 +12,7 @@ Low-Value Span Issues are currently in open beta.
 
 A _low-value span issue_ is raised when Sentry detects a span that is sent frequently but adds little value to your traces. These spans clutter the trace view, make it harder to spot the spans that actually help with debugging, and contribute to your stored span volume and cost.
 
-Sentry groups matching spans into a single low-value span issue. These issues are set to `LOW` priority and are excluded from the default issue search. To find them, open the **Sentry Configuration** view on the **Issues** page or filter with `issue.category:configuration`.
+Sentry groups matching spans into a single low-value span issue. These issues are set to `LOW` priority and are excluded from the default issue search. To find them, open the **Configuration** view on the **Issues** page or filter with `issue.category:configuration`.
 
 ## Issue Details
 
@@ -35,4 +35,4 @@ How you fix the issue depends on where the span comes from. The **Troubleshootin
 ## Limitations
 
 - Low-value span issues do not trigger workflow notifications.
-- They are excluded from the default issue search. Open the **Sentry Configuration** view on the **Issues** page or filter with `issue.category:configuration` to find them.
+- They are excluded from the default issue search. Open the **Configuration** view on the **Issues** page or filter with `issue.category:configuration` to find them.

--- a/docs/product/issues/issue-details/low-value-span-issues/index.mdx
+++ b/docs/product/issues/issue-details/low-value-span-issues/index.mdx
@@ -4,6 +4,12 @@ sidebar_order: 55
 description: "Learn more about Low-Value Span issues and how to reduce noise and span volume in your traces."
 ---
 
+<Alert title="Currently in Beta">
+
+Low-Value Span Issues are currently in beta.
+
+</Alert>
+
 A _low-value span issue_ is raised when Sentry detects a span that is sent frequently but adds little value to your traces. These spans clutter the trace view, make it harder to spot the spans that actually help with debugging, and contribute to your stored span volume and cost.
 
 Sentry groups matching spans into a single low-value span issue. These issues are set to `LOW` priority and are excluded from the default issue search. To find them, open the **Sentry Configuration** view on the **Issues** page or filter with `issue.category:configuration`.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a product docs page for the new Low-Value Span Issues type that lives under the **Sentry Configuration** view.

- New page at `docs/product/issues/issue-details/low-value-span-issues/index.mdx`
- Marked as beta, matching the current rollout status
- Covers what the issue type is, what the Issue Details page shows (affected span, span count, estimated cost, average duration), and how to fix it
- Points users to SDK filtering, custom instrumentation, and Seer Autofix as remediation paths

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): Jul 1st
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

Closes TET-2459