### PR TITLE
docs(apple): Remove CocoaPods as supported install method

### DIFF
--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -6,6 +6,6 @@ sidebar_order: 2000
 
 <Alert level="warning" title="No Longer Supported">
 
-We no longer publish to CocoaPods. Please migrate to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually install the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases). All versions published before July 2026 remain available on CocoaPods.
+We no longer publish to CocoaPods after [v9.19.1](https://github.com/getsentry/sentry-cocoa/releases/tag/9.19.1). Please migrate to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually install the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases). All older versions remain available on CocoaPods.
 
 </Alert>

--- a/docs/platforms/apple/common/install/cocoapods.mdx
+++ b/docs/platforms/apple/common/install/cocoapods.mdx
@@ -1,24 +1,11 @@
 ---
-title: CocoaPods (Deprecated)
-description: "Learn about installing the Sentry SDK with CocoaPods."
+title: CocoaPods (No Longer Supported)
+description: "CocoaPods is no longer a supported installation method for the Sentry Apple SDK."
 sidebar_order: 2000
 ---
 
-<Alert level="warning" title="Deprecated">
-We will stop publishing to CocoaPods at the end of June 2026. We recommend migrating to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually installing the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases). All versions published before that date will remain available on CocoaPods.
+<Alert level="warning" title="No Longer Supported">
+
+We no longer publish to CocoaPods. Please migrate to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually install the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases). All versions published before July 2026 remain available on CocoaPods.
+
 </Alert>
-
-To integrate Sentry into your Xcode project using CocoaPods, specify it in your _Podfile_:
-
-```ruby
-platform :ios, '11.0'
-use_frameworks! # This is required
-
-target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '{{@inject packages.version('sentry.cocoa') }}'
-end
-```
-
-Afterwards run `pod install`.
-
-If you're using Xcode 14 or later, your project might fail to build due to `error: Sandbox: rsync.samba(42924)`. To resolve this you have to disable the "Enable User Script Sandbox" option in the target settings by setting it to `NO`. See <PlatformLink to="/troubleshooting#sandbox-error-using-cocoapods">Troubleshooting</PlatformLink> for more information.

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -155,33 +155,6 @@ If the release health page shows fewer events in the unhandled tab, your events 
 
 We introduced a bug with a refactoring [#4101](https://github.com/getsentry/sentry-cocoa/pull/4101) released in 8.30.1, that caused unhandled/crash events to have the unhandled property and mach info missing, which is required for release health to show events in the unhandled tab. It's essential to mention that this bug doesn't impact release health statistics, such as crash-free session or user rates.
 
-## Sandbox Error Using Cocoapods
-
-<Alert level="warning" title="Deprecated">
-We will stop publishing to CocoaPods at the end of June 2026. We recommend migrating to <PlatformLink to="/install/swift-package-manager/">Swift Package Manager (SPM)</PlatformLink> or manually installing the [pre-built XCFramework from GitHub releases](https://github.com/getsentry/sentry-cocoa/releases).
-</Alert>
-
-After setting up Cocoapods using a `Podfile` and running `pod install` to set up the project, you might see the following error when building the target:
-
-```
-error: Sandbox: rsync.samba(42924) deny(1) file-read-data <path/to/your/app>/Frameworks/Sentry.framework/Sentry.bundle (in target 'test' from project 'test')
-error: Sandbox: rsync.samba(42925) deny(1) file-read-data <path/to/your/app>/Frameworks/Sentry.framework/_CodeSignature/CodeResources (in target 'test' from project 'test')
-error: Sandbox: rsync.samba(42925) deny(1) file-write-create <path/to/your/app>/Frameworks/Sentry.framework/_CodeSignature/.CodeResources.a2sA9v (in target 'test' from project 'test')
-mkdir -p <path/to/your/app>/Frameworks
-rsync --delete -av --filter P .*.?????? --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "<path/to/derived/data>/Sentry/Sentry.framework" "<path/to/your/app>/Frameworks"
-building file list ... done
-rsync: opendir "<path/to/your/app>/Frameworks/Sentry.framework/Sentry.bundle" failed: Operation not permitted (1)
-IO error encountered -- skipping file deletion
-Sentry.framework/_CodeSignature/CodeResources
-rsync: mkstemp "<path/to/your/app>/Frameworks/Sentry.framework/_CodeSignature/.CodeResources.a2sA9v" failed: Operation not permitted (1)
-
-sent 15034 bytes  received 42 bytes  30152.00 bytes/sec
-total size is 4950281  speedup is 328.36
-rsync error: some files could not be transferred (code 23) at /AppleInternal/Library/BuildRoots/5bb93434-bef0-11ef-bef2-d285688f7a47/Library/Caches/com.apple.xbs/Sources/rsync/rsync/main.c(996) [sender=2.6.9]
-```
-
-While it seems to be related to Sentry, it is actually caused by the user script sandbox feature introduced in [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes), which is enabled by default. In order to fix this, you need to head to the target settings of your project and set the "Enable User Script Sandbox" option to `NO`.
-
 ## 'required' initializer 'init(from:)' must be provided by subclass
 
 Since Cocoa SDK version [8.45.0](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8450) and above,


### PR DESCRIPTION
## DESCRIBE YOUR PR

Remove CocoaPods as an officially supported installation method for the Sentry Apple SDK, as part of the CocoaPods EOL migration (trunk goes read-only Dec 2, 2026).

- Replace the CocoaPods install page with a minimal "no longer supported" stub directing users to SPM or XCFramework
- Remove the CocoaPods-specific sandbox error troubleshooting section

Closes https://github.com/getsentry/sentry-cocoa/issues/7381
Closes https://github.com/getsentry/sentry-cocoa/issues/7384

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [x] Other deadline: Before July 7th, 2026 (We stopped support July 1st)
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)