### PR TITLE
docs(snapshots): Add latest base snapshot URL

### DIFF
--- a/docs/product/snapshots/reviewing-snapshots/index.mdx
+++ b/docs/product/snapshots/reviewing-snapshots/index.mdx
@@ -80,6 +80,16 @@ You can get to a specific snapshot from the links on the status check or through
 
 ![Snapshots on the Sentry Releases page](../img/snapshots_releases.png)
 
+### Linking to the Latest Base Snapshot
+
+You can go to the latest base snapshot using this URL:
+
+```
+https://sentry.io/preprod/snapshots/<project-slug>/<app-id>/
+```
+
+Replace `<project-slug>` with your project slug and `<app-id>` with the snapshot `app_id`.
+
 ## Approving Changes
 
 There are two ways to approve snapshot changes:


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the stable, shareable URL that resolves to the latest base snapshot for an app, added in [getsentry/sentry#118658](https://github.com/getsentry/sentry/pull/118658). Users can bookmark or share the link without needing a snapshot ID.

- Add a "Linking to the Latest Base Snapshot" subsection to Reviewing Snapshots

Refs EME-1220

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)