### PR TITLE
chore(opsgenie): Update Opsgenie docs

### DIFF
--- a/docs/integrations/notification-incidents/opsgenie/index.mdx
+++ b/docs/integrations/notification-incidents/opsgenie/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Opsgenie Integration
+title: Opsgenie
 sidebar_order: 1
 description: >-
   Learn more about Sentry's Opsgenie integration, which allows you to send issue
@@ -8,6 +8,10 @@ og_image: /og-images/organization-integrations-notification-incidents-opsgenie.p
 ---
 
 The Opsgenie integration allows you to connect your Sentry organization with one or more Opsgenie accounts. Once your accounts have been connected, you'll be able to configure issue and metric alerts in Sentry to be sent to the Opsgenie teams of your choice.
+
+<Alert level="warning">
+  Atlassian has [deprecated](https://www.atlassian.com/software/opsgenie/migration) the Opsgenie product in favor of Jira Service Management. The JSM integration is community supported and maintained.
+</Alert>
 
 <Include name="feature-available-for-plan-business.mdx" />
 
@@ -19,7 +23,7 @@ You'll need Sentry owner, manager, or admin-level permissions to be able to inst
 
 </Alert>
 
-1. To get started, go to **Settings > Integrations > Opsgenie (Integration)** and click "Add Installation".
+1. To get started, go to **Settings > Integrations > Opsgenie** and click "Add Installation".
 
    ![Install Opsgenie integration](./img/opsgenie-install.png)
 


### PR DESCRIPTION
Update the Opsgenie integration docs to call out that the product has been replaced by JSM and the integration is community supported and maintained. 