### PR TITLE
feat: add CI linter to detect redirect chains and stale content links

### DIFF
--- a/.github/workflows/check-redirects-on-rename.yml
+++ b/.github/workflows/check-redirects-on-rename.yml
@@ -140,17 +140,17 @@ jobs:
             comment += '---\n';
             comment += '_Note: `middleware.ts` is recommended for simple exact-match redirects. Use `redirects.js` for redirects with path parameters (e.g., `:path*`)._\n';
 
-            // Check for existing comments from this action
-            const {data: comments} = await github.rest.issues.listComments({
+            // Check for existing comments from this action (paginate to handle PRs with 30+ comments)
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
 
-            const existingComment = comments.find(comment => 
-              comment.user.type === 'Bot' && 
-              (comment.user.login === 'github-actions[bot]' || comment.user.login.includes('bot')) &&
-              comment.body.includes('Missing Redirects Detected')
+            const existingComment = comments.find(c => 
+              c.user.type === 'Bot' && 
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Missing Redirects Detected')
             );
 
             if (existingComment) {

--- a/.github/workflows/lint-redirect-chains.yml
+++ b/.github/workflows/lint-redirect-chains.yml
@@ -125,8 +125,8 @@ jobs:
             comment += '---\n';
             comment += '*Each redirect hop loses ~15% of SEO link equity and adds latency for users.*\n';
 
-            // Check for existing comments from this action
-            const {data: comments} = await github.rest.issues.listComments({
+            // Check for existing comments from this action (paginate to handle PRs with 30+ comments)
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
@@ -134,7 +134,7 @@ jobs:
 
             const existingComment = comments.find(c =>
               c.user.type === 'Bot' &&
-              (c.user.login === 'github-actions[bot]' || c.user.login.includes('bot')) &&
+              c.user.login === 'github-actions[bot]' &&
               c.body.includes('Redirect Chain Issues Detected')
             );
 

--- a/.github/workflows/lint-redirect-chains.yml
+++ b/.github/workflows/lint-redirect-chains.yml
@@ -74,12 +74,9 @@ jobs:
               const jsonString = JSON.parse(lintResultJsonString);
               lintResult = JSON.parse(jsonString);
             } catch (e) {
-              try {
-                lintResult = JSON.parse(lintResultJsonString);
-              } catch (e2) {
-                console.error('Failed to parse lint result:', e2);
-                return;
-              }
+              console.error('Failed to parse lint result:', e);
+              core.setFailed('Failed to parse redirect chain lint output');
+              return;
             }
 
             const redirectChains = lintResult.redirectChains || [];

--- a/.github/workflows/lint-redirect-chains.yml
+++ b/.github/workflows/lint-redirect-chains.yml
@@ -1,0 +1,169 @@
+name: Lint Redirect Chains
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'middleware.ts'
+      - 'redirects.js'
+      - 'docs/**/*.mdx'
+      - 'docs/**/*.md'
+      - 'develop-docs/**/*.mdx'
+      - 'develop-docs/**/*.md'
+      - 'includes/**/*.mdx'
+      - 'includes/**/*.md'
+      - 'platform-includes/**/*.mdx'
+      - 'platform-includes/**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint-redirect-chains:
+    name: Check for redirect chains
+    runs-on: ubuntu-latest
+    continue-on-error: true # Fail the check but don't block merge
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: Run redirect chain lint
+        id: lint
+        continue-on-error: true
+        run: |
+          set +e
+          OUTPUT=$(npx tsx scripts/lint-redirect-chains.ts 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          echo "$OUTPUT"
+
+          # Extract JSON output if present
+          HAS_JSON=false
+          if echo "$OUTPUT" | grep -Fq -- "---JSON_OUTPUT---"; then
+            JSON_OUTPUT=$(echo "$OUTPUT" | sed -n '/---JSON_OUTPUT---/,/---JSON_OUTPUT---/p' | sed '1d;$d')
+            echo "lint_result<<EOF" >> $GITHUB_OUTPUT
+            echo "$JSON_OUTPUT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            HAS_JSON=true
+          fi
+
+          echo "has_results=$HAS_JSON" >> $GITHUB_OUTPUT
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+
+      - name: Post comment if redirect chains found
+        if: steps.lint.outputs.exit_code == '1' && steps.lint.outputs.has_results == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const lintResultJsonString = ${{ toJSON(steps.lint.outputs.lint_result) }};
+            let lintResult;
+            try {
+              const jsonString = JSON.parse(lintResultJsonString);
+              lintResult = JSON.parse(jsonString);
+            } catch (e) {
+              try {
+                lintResult = JSON.parse(lintResultJsonString);
+              } catch (e2) {
+                console.error('Failed to parse lint result:', e2);
+                return;
+              }
+            }
+
+            const redirectChains = lintResult.redirectChains || [];
+            const contentLinkIssues = lintResult.contentLinkIssues || [];
+
+            if (redirectChains.length === 0 && contentLinkIssues.length === 0) {
+              return;
+            }
+
+            let comment = '## \u26a0\ufe0f Redirect Chain Issues Detected\n\n';
+            comment += 'This PR introduces or contains redirect chains that degrade SEO and add latency.\n\n';
+
+            if (redirectChains.length > 0) {
+              comment += '### Redirect-to-Redirect Chains\n\n';
+              comment += 'These redirect destinations point to another redirect, creating multi-hop chains. ';
+              comment += 'Update the destination to point directly to the final URL:\n\n';
+              comment += '| Source | Current Destination | Should Be | File |\n';
+              comment += '|--------|-------------------|-----------|------|\n';
+              for (const chain of redirectChains) {
+                const docLabel = chain.isDeveloperDocs ? ' (dev)' : '';
+                comment += `| \`${chain.source}\` | \`${chain.currentDest}\` | \`${chain.finalDest}\` | ${chain.file}${docLabel} |\n`;
+              }
+              comment += '\n';
+            }
+
+            if (contentLinkIssues.length > 0) {
+              // Group by file
+              const byFile = {};
+              for (const issue of contentLinkIssues) {
+                if (!byFile[issue.filePath]) byFile[issue.filePath] = [];
+                byFile[issue.filePath].push(issue);
+              }
+
+              comment += `### Content Links Pointing to Redirects (${contentLinkIssues.length} found)\n\n`;
+              comment += 'These links point to URLs that redirect. Update them to point directly to the final destination:\n\n';
+              comment += '| File | Line | Current Link | Should Be |\n';
+              comment += '|------|------|--------------|-----------|\n';
+              for (const [file, issues] of Object.entries(byFile)) {
+                for (const issue of issues) {
+                  comment += `| \`${file}\` | ${issue.line} | \`${issue.linkPath}\` | \`${issue.finalDest}\` |\n`;
+                }
+              }
+              comment += '\n';
+            }
+
+            comment += '---\n';
+            comment += '*Each redirect hop loses ~15% of SEO link equity and adds latency for users.*\n';
+
+            // Check for existing comments from this action
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existingComment = comments.find(c =>
+              c.user.type === 'Bot' &&
+              (c.user.login === 'github-actions[bot]' || c.user.login.includes('bot')) &&
+              c.body.includes('Redirect Chain Issues Detected')
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }
+
+      - name: Report failure if redirect chains found
+        if: steps.lint.outputs.exit_code == '1' && steps.lint.outputs.has_results == 'true'
+        run: |
+          echo "::warning::Redirect chain issues detected. See PR comment for details."
+          exit 1
+
+      - name: Success
+        if: steps.lint.outputs.exit_code == '0'
+        run: |
+          echo "No redirect chains or content link issues found."

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:prettier": "prettier --check \"./{src,app,scripts}/**/*.{md,mdx,ts,tsx,js,jsx,mjs}\"",
     "lint:prettier:fix": "prettier --write \"./{src,app,scripts}/**/*.{md,mdx,ts,tsx,js,jsx,mjs}\"",
     "lint:typos": "typos",
+    "lint:redirect-chains": "tsx scripts/lint-redirect-chains.ts",
     "lint:fix": "pnpm run lint:prettier:fix && pnpm run lint:eslint:fix",
     "sidecar": "spotlight-sidecar",
     "test": "vitest",

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -265,22 +265,39 @@ Check out the [old page](/old/path/) for more info.
   });
 
   it('should skip PlatformLink to= attributes (platform-relative paths)', () => {
-    const mdxContent = `<PlatformLink to="/old/feature/">text</PlatformLink>`;
+    // PlatformLink to= should be skipped since PlatformLink prepends
+    // the platform base URL, making these platform-relative paths.
+    // The linter checks for <PlatformLink on the line level.
+    const line = `<PlatformLink to="/old/feature/">text</PlatformLink>`;
+    const isPlatformLinkLine = line.includes('<PlatformLink');
+    expect(isPlatformLinkLine).toBe(true);
 
-    // PlatformLink to= should NOT be matched since PlatformLink prepends
-    // the platform base URL, making these platform-relative paths
-    const jsxToRegex = /(?<!PlatformLink\s+)to="(\/[^"#]+?)(?:#[^"]+)?"/g;
-    const matches = [...mdxContent.matchAll(jsxToRegex)];
-    expect(matches).toHaveLength(0);
+    // The to= attribute IS matched by the regex...
+    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const matches = [...line.matchAll(jsxLinkRegex)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][1]).toBe('to'); // attribute name
+    // ...but the linter skips it because isPlatformLinkLine is true and attr is 'to'
+  });
+
+  it('should skip PlatformLink with props before to= attribute', () => {
+    // Handles case where PlatformLink has other props first
+    const line = `<PlatformLink platform="android" to="/old/feature/">text</PlatformLink>`;
+    const isPlatformLinkLine = line.includes('<PlatformLink');
+    expect(isPlatformLinkLine).toBe(true);
+    // Skipped because the line contains <PlatformLink and attr is 'to'
   });
 
   it('should detect non-PlatformLink to= attributes', () => {
-    const mdxContent = `<Link to="/old/feature/">text</Link>`;
+    const line = `<Link to="/old/feature/">text</Link>`;
+    const isPlatformLinkLine = line.includes('<PlatformLink');
+    expect(isPlatformLinkLine).toBe(false);
 
-    const jsxToRegex = /(?<!PlatformLink\s+)to="(\/[^"#]+?)(?:#[^"]+)?"/g;
-    const matches = [...mdxContent.matchAll(jsxToRegex)];
+    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const matches = [...line.matchAll(jsxLinkRegex)];
     expect(matches).toHaveLength(1);
-    expect(matches[0][1]).toBe('/old/feature/');
+    expect(matches[0][2]).toBe('/old/feature/');
+    // Not skipped because isPlatformLinkLine is false
   });
 });
 

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -4,7 +4,6 @@ import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 import {parseMiddlewareTs, parseRedirectsJs} from './check-redirects-on-rename';
 import {
-  detectContentLinkIssues,
   detectRedirectChains,
   resolveToFinal,
   walkChain,
@@ -224,19 +223,7 @@ Check out the [old page](/old/path/) for more info.
 `;
     fs.writeFileSync(path.join(tempDir, 'docs', 'test.mdx'), mdxContent);
 
-    // Monkey-patch findAllMdxFiles to use our temp dir
-    const jsRedirects = {
-      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
-      userDocsRedirects: [
-        {source: '/old/path/', destination: '/new/path/'},
-      ],
-    };
-    const mwRedirects = {
-      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
-      userDocsRedirects: [] as Array<{destination: string; source: string}>,
-    };
-
-    // We test the link detection logic by checking the regex patterns directly
+    // Test the link detection logic by checking the regex patterns directly
     const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
     const matches = [...mdxContent.matchAll(markdownLinkRegex)];
     expect(matches).toHaveLength(1);
@@ -287,11 +274,21 @@ Check out the [old page](/old/path/) for more info.
     // Normalization adds trailing slash: /old/path -> /old/path/
   });
 
-  it('should detect PlatformLink to= attributes', () => {
+  it('should skip PlatformLink to= attributes (platform-relative paths)', () => {
     const mdxContent = `<PlatformLink to="/old/feature/">text</PlatformLink>`;
 
-    const jsxLinkRegex = /(?:href|to|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
-    const matches = [...mdxContent.matchAll(jsxLinkRegex)];
+    // PlatformLink to= should NOT be matched since PlatformLink prepends
+    // the platform base URL, making these platform-relative paths
+    const jsxToRegex = /(?<!PlatformLink\s+)to="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const matches = [...mdxContent.matchAll(jsxToRegex)];
+    expect(matches).toHaveLength(0);
+  });
+
+  it('should detect non-PlatformLink to= attributes', () => {
+    const mdxContent = `<Link to="/old/feature/">text</Link>`;
+
+    const jsxToRegex = /(?<!PlatformLink\s+)to="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const matches = [...mdxContent.matchAll(jsxToRegex)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('/old/feature/');
   });

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -122,6 +122,28 @@ describe('detectRedirectChains', () => {
     expect(chains[0].file).toBe('middleware.ts');
   });
 
+  it('should report duplicate sources from both files separately', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [{source: '/dup/', destination: '/middle/'}],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/dup/', destination: '/other-middle/'},
+        {source: '/middle/', destination: '/final/'},
+        {source: '/other-middle/', destination: '/other-final/'},
+      ],
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    // Both entries for /dup/ should be reported with correct file attribution
+    const dupChains = chains.filter(c => c.source === '/dup/');
+    expect(dupChains).toHaveLength(2);
+    expect(dupChains.find(c => c.file === 'redirects.js')).toBeDefined();
+    expect(dupChains.find(c => c.file === 'middleware.ts')).toBeDefined();
+  });
+
   it('should return empty array when no chains exist', () => {
     const jsRedirects = {
       developerDocsRedirects: [] as Array<{destination: string; source: string}>,
@@ -214,7 +236,7 @@ Check out the [old page](/old/path/) for more info.
     fs.writeFileSync(path.join(tempDir, 'docs', 'test.mdx'), mdxContent);
 
     // Test the link detection logic by checking the regex patterns directly
-    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(#[^)]+)?\)/g;
     const matches = [...mdxContent.matchAll(markdownLinkRegex)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('/old/path/');
@@ -223,25 +245,26 @@ Check out the [old page](/old/path/) for more info.
   it('should detect JSX links pointing to redirect sources', () => {
     const mdxContent = `<LinkCard href="/old/path/" title="Test" />`;
 
-    const jsxLinkRegex = /(?:href|to|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(#[^"]+)?"/g;
     const matches = [...mdxContent.matchAll(jsxLinkRegex)];
     expect(matches).toHaveLength(1);
-    expect(matches[0][1]).toBe('/old/path/');
+    expect(matches[0][2]).toBe('/old/path/');
   });
 
-  it('should strip anchors from links', () => {
+  it('should extract path and fragment separately from anchored links', () => {
     const mdxContent = `[link](/old/path/#section)`;
 
-    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(#[^)]+)?\)/g;
     const matches = [...mdxContent.matchAll(markdownLinkRegex)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('/old/path/');
+    expect(matches[0][2]).toBe('#section');
   });
 
   it('should skip external links', () => {
     const mdxContent = `[link](https://example.com/path/)`;
 
-    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(#[^)]+)?\)/g;
     const matches = [...mdxContent.matchAll(markdownLinkRegex)];
     expect(matches).toHaveLength(0);
   });
@@ -249,7 +272,7 @@ Check out the [old page](/old/path/) for more info.
   it('should skip hash-only links', () => {
     const mdxContent = `[link](#section)`;
 
-    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(#[^)]+)?\)/g;
     const matches = [...mdxContent.matchAll(markdownLinkRegex)];
     expect(matches).toHaveLength(0);
   });
@@ -257,7 +280,7 @@ Check out the [old page](/old/path/) for more info.
   it('should handle links without trailing slashes', () => {
     const mdxContent = `[link](/old/path)`;
 
-    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(#[^)]+)?\)/g;
     const matches = [...mdxContent.matchAll(markdownLinkRegex)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('/old/path');
@@ -273,7 +296,7 @@ Check out the [old page](/old/path/) for more info.
     expect(isPlatformLinkLine).toBe(true);
 
     // The to= attribute IS matched by the regex...
-    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(#[^"]+)?"/g;
     const matches = [...line.matchAll(jsxLinkRegex)];
     expect(matches).toHaveLength(1);
     expect(matches[0][1]).toBe('to'); // attribute name
@@ -293,7 +316,7 @@ Check out the [old page](/old/path/) for more info.
     const isPlatformLinkLine = line.includes('<PlatformLink');
     expect(isPlatformLinkLine).toBe(false);
 
-    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(#[^"]+)?"/g;
     const matches = [...line.matchAll(jsxLinkRegex)];
     expect(matches).toHaveLength(1);
     expect(matches[0][2]).toBe('/old/feature/');

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -224,6 +224,25 @@ describe('detectRedirectChains', () => {
     expect(chains).toHaveLength(1);
     expect(chains[0].isDeveloperDocs).toBe(true);
   });
+
+  it('should detect chains with trailing slash mismatches', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/old/', destination: '/middle'}, // no trailing slash on dest
+        {source: '/middle/', destination: '/new/'}, // source has trailing slash
+      ],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].source).toBe('/old/');
+    expect(chains[0].finalDest).toBe('/new/');
+  });
 });
 
 describe('detectContentLinkIssues', () => {

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -140,8 +140,20 @@ describe('detectRedirectChains', () => {
     // Both entries for /dup/ should be reported with correct file attribution
     const dupChains = chains.filter(c => c.source === '/dup/');
     expect(dupChains).toHaveLength(2);
-    expect(dupChains.find(c => c.file === 'redirects.js')).toBeDefined();
-    expect(dupChains.find(c => c.file === 'middleware.ts')).toBeDefined();
+
+    const jsChain = dupChains.find(c => c.file === 'redirects.js');
+    const mwChain = dupChains.find(c => c.file === 'middleware.ts');
+    expect(jsChain).toBeDefined();
+    expect(mwChain).toBeDefined();
+
+    // Each entry's chain should be consistent with its own currentDest
+    expect(jsChain!.currentDest).toBe('/middle/');
+    expect(jsChain!.chain[1]).toBe('/middle/'); // chain starts source -> currentDest
+    expect(jsChain!.finalDest).toBe('/final/');
+
+    expect(mwChain!.currentDest).toBe('/other-middle/');
+    expect(mwChain!.chain[1]).toBe('/other-middle/');
+    expect(mwChain!.finalDest).toBe('/other-final/');
   });
 
   it('should return empty array when no chains exist', () => {

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -3,11 +3,7 @@ import path from 'path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 import {parseMiddlewareTs, parseRedirectsJs} from './check-redirects-on-rename';
-import {
-  detectRedirectChains,
-  resolveToFinal,
-  walkChain,
-} from './lint-redirect-chains';
+import {detectRedirectChains, resolveToFinal, walkChain} from './lint-redirect-chains';
 
 describe('walkChain', () => {
   it('should return just the source when no chain exists', () => {
@@ -112,15 +108,11 @@ describe('detectRedirectChains', () => {
   it('should detect cross-system chains (middleware -> redirects.js)', () => {
     const jsRedirects = {
       developerDocsRedirects: [] as Array<{destination: string; source: string}>,
-      userDocsRedirects: [
-        {source: '/middle/', destination: '/final/'},
-      ],
+      userDocsRedirects: [{source: '/middle/', destination: '/final/'}],
     };
     const mwRedirects = {
       developerDocsRedirects: [] as Array<{destination: string; source: string}>,
-      userDocsRedirects: [
-        {source: '/old/', destination: '/middle/'},
-      ],
+      userDocsRedirects: [{source: '/old/', destination: '/middle/'}],
     };
 
     const chains = detectRedirectChains(jsRedirects, mwRedirects);
@@ -149,9 +141,7 @@ describe('detectRedirectChains', () => {
 
   it('should handle self-redirect cycles', () => {
     const jsRedirects = {
-      developerDocsRedirects: [
-        {source: '/loop/', destination: '/loop/'},
-      ],
+      developerDocsRedirects: [{source: '/loop/', destination: '/loop/'}],
       userDocsRedirects: [] as Array<{destination: string; source: string}>,
     };
     const mwRedirects = {

--- a/scripts/lint-redirect-chains.spec.ts
+++ b/scripts/lint-redirect-chains.spec.ts
@@ -1,0 +1,312 @@
+import fs from 'fs';
+import path from 'path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {parseMiddlewareTs, parseRedirectsJs} from './check-redirects-on-rename';
+import {
+  detectContentLinkIssues,
+  detectRedirectChains,
+  resolveToFinal,
+  walkChain,
+} from './lint-redirect-chains';
+
+describe('walkChain', () => {
+  it('should return just the source when no chain exists', () => {
+    const map = new Map([
+      ['/a/', '/b/'],
+      ['/c/', '/d/'],
+    ]);
+    expect(walkChain('/a/', map)).toEqual(['/a/', '/b/']);
+  });
+
+  it('should walk a 2-hop chain', () => {
+    const map = new Map([
+      ['/a/', '/b/'],
+      ['/b/', '/c/'],
+    ]);
+    expect(walkChain('/a/', map)).toEqual(['/a/', '/b/', '/c/']);
+  });
+
+  it('should walk a 3-hop chain', () => {
+    const map = new Map([
+      ['/a/', '/b/'],
+      ['/b/', '/c/'],
+      ['/c/', '/d/'],
+    ]);
+    expect(walkChain('/a/', map)).toEqual(['/a/', '/b/', '/c/', '/d/']);
+  });
+
+  it('should detect cycles', () => {
+    const map = new Map([
+      ['/a/', '/b/'],
+      ['/b/', '/a/'],
+    ]);
+    const result = walkChain('/a/', map);
+    expect(result).toEqual(['/a/', '/b/', '/a/ (CYCLE)']);
+  });
+
+  it('should detect self-referencing cycles', () => {
+    const map = new Map([['/a/', '/a/']]);
+    const result = walkChain('/a/', map);
+    expect(result).toEqual(['/a/', '/a/ (CYCLE)']);
+  });
+
+  it('should cap at maxDepth', () => {
+    const map = new Map<string, string>();
+    for (let i = 0; i < 20; i++) {
+      map.set(`/${i}/`, `/${i + 1}/`);
+    }
+    const result = walkChain('/0/', map, 5);
+    expect(result).toHaveLength(6); // source + 5 hops
+  });
+});
+
+describe('resolveToFinal', () => {
+  it('should resolve a single redirect', () => {
+    const map = new Map([['/a/', '/b/']]);
+    expect(resolveToFinal('/a/', map)).toBe('/b/');
+  });
+
+  it('should resolve a chain to the final destination', () => {
+    const map = new Map([
+      ['/a/', '/b/'],
+      ['/b/', '/c/'],
+      ['/c/', '/d/'],
+    ]);
+    expect(resolveToFinal('/a/', map)).toBe('/d/');
+  });
+
+  it('should handle self-referencing cycles without infinite loop', () => {
+    const map = new Map([['/a/', '/a/']]);
+    expect(resolveToFinal('/a/', map)).toBe('/a/');
+  });
+
+  it('should return the source when not in the map', () => {
+    const map = new Map([['/a/', '/b/']]);
+    expect(resolveToFinal('/x/', map)).toBe('/x/');
+  });
+});
+
+describe('detectRedirectChains', () => {
+  it('should detect chains within a single redirect source', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/old/', destination: '/middle/'},
+        {source: '/middle/', destination: '/new/'},
+      ],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].source).toBe('/old/');
+    expect(chains[0].currentDest).toBe('/middle/');
+    expect(chains[0].finalDest).toBe('/new/');
+    expect(chains[0].file).toBe('redirects.js');
+    expect(chains[0].isDeveloperDocs).toBe(false);
+  });
+
+  it('should detect cross-system chains (middleware -> redirects.js)', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/middle/', destination: '/final/'},
+      ],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/old/', destination: '/middle/'},
+      ],
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].source).toBe('/old/');
+    expect(chains[0].finalDest).toBe('/final/');
+    expect(chains[0].file).toBe('middleware.ts');
+  });
+
+  it('should return empty array when no chains exist', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/a/', destination: '/b/'},
+        {source: '/c/', destination: '/d/'},
+      ],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(0);
+  });
+
+  it('should handle self-redirect cycles', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [
+        {source: '/loop/', destination: '/loop/'},
+      ],
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].finalDest).toBe('(CYCLE DETECTED)');
+  });
+
+  it('should handle parameterized redirect chains', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/old/:path*', destination: '/middle/:path*'},
+        {source: '/middle/:path*', destination: '/new/:path*'},
+      ],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].source).toBe('/old/:path*');
+    expect(chains[0].finalDest).toBe('/new/:path*');
+  });
+
+  it('should separate user docs and developer docs', () => {
+    const jsRedirects = {
+      developerDocsRedirects: [
+        {source: '/sdk/old/', destination: '/sdk/middle/'},
+        {source: '/sdk/middle/', destination: '/sdk/new/'},
+      ],
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    const chains = detectRedirectChains(jsRedirects, mwRedirects);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].isDeveloperDocs).toBe(true);
+  });
+});
+
+describe('detectContentLinkIssues', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = path.join(process.cwd(), '__test_mdx_temp__');
+    fs.mkdirSync(path.join(tempDir, 'docs'), {recursive: true});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  it('should detect markdown links pointing to redirect sources', () => {
+    const mdxContent = `---
+title: Test
+---
+
+Check out the [old page](/old/path/) for more info.
+`;
+    fs.writeFileSync(path.join(tempDir, 'docs', 'test.mdx'), mdxContent);
+
+    // Monkey-patch findAllMdxFiles to use our temp dir
+    const jsRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [
+        {source: '/old/path/', destination: '/new/path/'},
+      ],
+    };
+    const mwRedirects = {
+      developerDocsRedirects: [] as Array<{destination: string; source: string}>,
+      userDocsRedirects: [] as Array<{destination: string; source: string}>,
+    };
+
+    // We test the link detection logic by checking the regex patterns directly
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const matches = [...mdxContent.matchAll(markdownLinkRegex)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][1]).toBe('/old/path/');
+  });
+
+  it('should detect JSX links pointing to redirect sources', () => {
+    const mdxContent = `<LinkCard href="/old/path/" title="Test" />`;
+
+    const jsxLinkRegex = /(?:href|to|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const matches = [...mdxContent.matchAll(jsxLinkRegex)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][1]).toBe('/old/path/');
+  });
+
+  it('should strip anchors from links', () => {
+    const mdxContent = `[link](/old/path/#section)`;
+
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const matches = [...mdxContent.matchAll(markdownLinkRegex)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][1]).toBe('/old/path/');
+  });
+
+  it('should skip external links', () => {
+    const mdxContent = `[link](https://example.com/path/)`;
+
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const matches = [...mdxContent.matchAll(markdownLinkRegex)];
+    expect(matches).toHaveLength(0);
+  });
+
+  it('should skip hash-only links', () => {
+    const mdxContent = `[link](#section)`;
+
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const matches = [...mdxContent.matchAll(markdownLinkRegex)];
+    expect(matches).toHaveLength(0);
+  });
+
+  it('should handle links without trailing slashes', () => {
+    const mdxContent = `[link](/old/path)`;
+
+    const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+    const matches = [...mdxContent.matchAll(markdownLinkRegex)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][1]).toBe('/old/path');
+    // Normalization adds trailing slash: /old/path -> /old/path/
+  });
+
+  it('should detect PlatformLink to= attributes', () => {
+    const mdxContent = `<PlatformLink to="/old/feature/">text</PlatformLink>`;
+
+    const jsxLinkRegex = /(?:href|to|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
+    const matches = [...mdxContent.matchAll(jsxLinkRegex)];
+    expect(matches).toHaveLength(1);
+    expect(matches[0][1]).toBe('/old/feature/');
+  });
+});
+
+describe('integration: real redirect files', () => {
+  it('should parse real redirects.js without errors', () => {
+    const result = parseRedirectsJs('redirects.js');
+    expect(result.userDocsRedirects.length).toBeGreaterThan(0);
+    expect(result.developerDocsRedirects.length).toBeGreaterThan(0);
+  });
+
+  it('should parse real middleware.ts without errors', () => {
+    const result = parseMiddlewareTs('middleware.ts');
+    expect(result.userDocsRedirects.length).toBeGreaterThan(0);
+    expect(result.developerDocsRedirects.length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -124,11 +124,17 @@ function detectRedirectChains(
       ? mwRedirects.developerDocsRedirects
       : mwRedirects.userDocsRedirects;
 
-    // Build unified map for chain resolution (last entry wins, matching runtime)
+    // Build unified map for chain resolution (last entry wins, matching runtime).
+    // Store both with and without trailing slash so lookups catch mismatches.
     const allRedirects = [...jsArr, ...mwArr];
     const redirectMap = new Map<string, string>();
     for (const r of allRedirects) {
       redirectMap.set(r.source, r.destination);
+      // Also index the normalized form (with trailing slash) if different
+      const normalized = r.source.endsWith('/') ? r.source : r.source + '/';
+      if (normalized !== r.source) {
+        redirectMap.set(normalized, r.destination);
+      }
     }
 
     // Process each file's redirects separately to get correct file attribution.
@@ -140,16 +146,22 @@ function detectRedirectChains(
 
     for (const {file, redirects} of fileSources) {
       for (const r of redirects) {
-        // Check if this entry's own destination chains into another redirect
-        if (redirectMap.has(r.destination)) {
+        // Check if this entry's destination chains into another redirect,
+        // normalizing trailing slashes for the lookup
+        const dest = r.destination;
+        const destNormalized = dest.endsWith('/') ? dest : dest + '/';
+        const matchedDest = redirectMap.has(dest)
+          ? dest
+          : redirectMap.has(destNormalized)
+            ? destNormalized
+            : null;
+
+        if (matchedDest) {
           // Walk from the entry's own destination (not source) to build a
           // consistent chain: source -> currentDest -> ... -> finalDest.
-          // This avoids mismatches when the same source exists in both files
-          // with different destinations (the unified map would use the other
-          // file's destination for walkChain(r.source, ...) ).
-          const tailChain = walkChain(r.destination, redirectMap);
+          const tailChain = walkChain(matchedDest, redirectMap);
           const chain = [r.source, ...tailChain];
-          const finalDest = resolveToFinal(r.destination, redirectMap);
+          const finalDest = resolveToFinal(matchedDest, redirectMap);
 
           // Skip self-referencing cycles
           if (finalDest === r.source || chain.some(s => s.includes('(CYCLE)'))) {

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -203,8 +203,11 @@ function detectContentLinkIssues(
   // Regex patterns for extracting internal links
   // Markdown: [text](/path/) or [text](/path/#anchor)
   const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
-  // JSX: href="/path/" or to="/path/" or url="/path/"
-  const jsxLinkRegex = /(?:href|to|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
+  // JSX: href="/path/" or url="/path/" (but NOT PlatformLink to="/path/" since
+  // PlatformLink prepends the platform base URL, making them platform-relative)
+  const jsxHrefUrlRegex = /(?:href|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
+  // For 'to' attributes, only match if NOT preceded by PlatformLink
+  const jsxToRegex = /(?<!PlatformLink\s+)to="(\/[^"#]+?)(?:#[^"]+)?"/g;
 
   const issues: ContentLinkIssue[] = [];
 
@@ -217,22 +220,30 @@ function detectContentLinkIssues(
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
-      for (const regex of [markdownLinkRegex, jsxLinkRegex]) {
+      for (const regex of [markdownLinkRegex, jsxHrefUrlRegex, jsxToRegex]) {
         regex.lastIndex = 0;
         let match;
         while ((match = regex.exec(line)) !== null) {
           let linkPath = match[1];
-          // Normalize: ensure trailing slash
-          if (!linkPath.endsWith('/')) {
-            linkPath += '/';
-          }
+          // Normalize: ensure trailing slash for lookup
+          const normalizedPath = linkPath.endsWith('/')
+            ? linkPath
+            : linkPath + '/';
 
-          if (map.has(linkPath)) {
-            const finalDest = resolveToFinal(linkPath, map);
+          // Check both with and without trailing slash, since some redirect
+          // sources in redirects.js omit trailing slashes
+          const matchedPath = map.has(normalizedPath)
+            ? normalizedPath
+            : map.has(linkPath)
+              ? linkPath
+              : null;
+
+          if (matchedPath) {
+            const finalDest = resolveToFinal(matchedPath, map);
             issues.push({
               filePath,
               line: i + 1,
-              linkPath,
+              linkPath: matchedPath,
               finalDest,
               isDeveloperDocs: isDevDocsFile,
             });

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -179,10 +179,7 @@ function detectContentLinkIssues(
 ): ContentLinkIssue[] {
   // Build redirect maps
   const userRedirectMap = new Map<string, string>();
-  for (const r of [
-    ...jsRedirects.userDocsRedirects,
-    ...mwRedirects.userDocsRedirects,
-  ]) {
+  for (const r of [...jsRedirects.userDocsRedirects, ...mwRedirects.userDocsRedirects]) {
     userRedirectMap.set(r.source, r.destination);
   }
   const devRedirectMap = new Map<string, string>();
@@ -226,9 +223,7 @@ function detectContentLinkIssues(
         while ((match = regex.exec(line)) !== null) {
           let linkPath = match[1];
           // Normalize: ensure trailing slash for lookup
-          const normalizedPath = linkPath.endsWith('/')
-            ? linkPath
-            : linkPath + '/';
+          const normalizedPath = linkPath.endsWith('/') ? linkPath : linkPath + '/';
 
           // Check both with and without trailing slash, since some redirect
           // sources in redirects.js omit trailing slashes
@@ -274,9 +269,7 @@ if (require.main === module) {
     console.log(`\n❌ Found ${chains.length} redirect chain(s):\n`);
     for (const c of chains) {
       console.log(`  [${c.file}] ${c.chain.join(' -> ')}`);
-      console.log(
-        `    Fix: Change destination of "${c.source}" to "${c.finalDest}"`
-      );
+      console.log(`    Fix: Change destination of "${c.source}" to "${c.finalDest}"`);
     }
   } else {
     console.log('\n✅ No redirect chains found.');

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -200,11 +200,8 @@ function detectContentLinkIssues(
   // Regex patterns for extracting internal links
   // Markdown: [text](/path/) or [text](/path/#anchor)
   const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
-  // JSX: href="/path/" or url="/path/" (but NOT PlatformLink to="/path/" since
-  // PlatformLink prepends the platform base URL, making them platform-relative)
-  const jsxHrefUrlRegex = /(?:href|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
-  // For 'to' attributes, only match if NOT preceded by PlatformLink
-  const jsxToRegex = /(?<!PlatformLink\s+)to="(\/[^"#]+?)(?:#[^"]+)?"/g;
+  // JSX: href="/path/", to="/path/", or url="/path/"
+  const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(?:#[^"]+)?"/g;
 
   const issues: ContentLinkIssue[] = [];
 
@@ -217,11 +214,24 @@ function detectContentLinkIssues(
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
-      for (const regex of [markdownLinkRegex, jsxHrefUrlRegex, jsxToRegex]) {
+      // Check if this line contains a PlatformLink tag (platform-relative paths)
+      const isPlatformLinkLine = line.includes('<PlatformLink');
+
+      for (const regex of [markdownLinkRegex, jsxLinkRegex]) {
         regex.lastIndex = 0;
         let match;
         while ((match = regex.exec(line)) !== null) {
-          let linkPath = match[1];
+          // For jsxLinkRegex, capture group 1 is the attribute name, group 2 is the path
+          // For markdownLinkRegex, capture group 1 is the path
+          const isJsxMatch = regex === jsxLinkRegex;
+          const attrName = isJsxMatch ? match[1] : null;
+          let linkPath = isJsxMatch ? match[2] : match[1];
+
+          // Skip PlatformLink to= attributes since PlatformLink prepends
+          // the platform base URL, making them platform-relative paths
+          if (isPlatformLinkLine && attrName === 'to') {
+            continue;
+          }
           // Normalize: ensure trailing slash for lookup
           const normalizedPath = linkPath.endsWith('/') ? linkPath : linkPath + '/';
 

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -31,6 +31,7 @@ interface RedirectChain {
 interface ContentLinkIssue {
   filePath: string;
   finalDest: string;
+  fragment: string;
   isDeveloperDocs: boolean;
   line: number;
   linkPath: string;
@@ -104,6 +105,9 @@ function resolveToFinal(source: string, map: Map<string, string>): string {
 
 /**
  * Phase 1: Detect redirect-to-redirect chains
+ *
+ * Processes each file's redirects separately to correctly attribute chains
+ * and handle cases where the same source exists in both files.
  */
 function detectRedirectChains(
   jsRedirects: {developerDocsRedirects: Redirect[]; userDocsRedirects: Redirect[]},
@@ -120,49 +124,52 @@ function detectRedirectChains(
       ? mwRedirects.developerDocsRedirects
       : mwRedirects.userDocsRedirects;
 
-    // Build unified map for chain detection
+    // Build unified map for chain resolution (last entry wins, matching runtime)
     const allRedirects = [...jsArr, ...mwArr];
     const redirectMap = new Map<string, string>();
     for (const r of allRedirects) {
       redirectMap.set(r.source, r.destination);
     }
 
-    // Track which file each source comes from
-    const jsSourceSet = new Set(jsArr.map(r => r.source));
+    // Process each file's redirects separately to get correct file attribution.
+    // Use the unified map for chain walking so cross-file chains are detected.
+    const fileSources: Array<{file: string; redirects: Redirect[]}> = [
+      {file: 'redirects.js', redirects: jsArr},
+      {file: 'middleware.ts', redirects: mwArr},
+    ];
 
-    // Find chains
-    const seenSources = new Set<string>();
-    for (const r of allRedirects) {
-      if (seenSources.has(r.source)) {
-        continue;
-      }
-      seenSources.add(r.source);
+    for (const {file, redirects} of fileSources) {
+      for (const r of redirects) {
+        // Use the unified map to check if this redirect's destination
+        // chains into another redirect from either file
+        if (redirectMap.has(r.destination)) {
+          const chain = walkChain(r.source, redirectMap);
+          // Use resolveToFinal for the correct final destination,
+          // since walkChain caps at maxDepth for display purposes
+          const finalDest = resolveToFinal(r.source, redirectMap);
 
-      if (redirectMap.has(r.destination)) {
-        const chain = walkChain(r.source, redirectMap);
-        const finalDest = chain[chain.length - 1];
+          // Skip self-referencing cycles
+          if (finalDest === r.source || chain.some(s => s.includes('(CYCLE)'))) {
+            chains.push({
+              source: r.source,
+              currentDest: r.destination,
+              finalDest: '(CYCLE DETECTED)',
+              chain,
+              file,
+              isDeveloperDocs: isDevDocs,
+            });
+            continue;
+          }
 
-        // Skip self-referencing cycles
-        if (finalDest === r.source || finalDest.includes('(CYCLE)')) {
           chains.push({
             source: r.source,
             currentDest: r.destination,
-            finalDest: '(CYCLE DETECTED)',
+            finalDest,
             chain,
-            file: jsSourceSet.has(r.source) ? 'redirects.js' : 'middleware.ts',
+            file,
             isDeveloperDocs: isDevDocs,
           });
-          continue;
         }
-
-        chains.push({
-          source: r.source,
-          currentDest: r.destination,
-          finalDest,
-          chain,
-          file: jsSourceSet.has(r.source) ? 'redirects.js' : 'middleware.ts',
-          isDeveloperDocs: isDevDocs,
-        });
       }
     }
   }
@@ -197,11 +204,11 @@ function detectContentLinkIssues(
     'platform-includes',
   ]);
 
-  // Regex patterns for extracting internal links
+  // Regex patterns for extracting internal links (capturing fragment separately)
   // Markdown: [text](/path/) or [text](/path/#anchor)
-  const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+  const markdownLinkRegex = /\]\((\/[^)#\s]+?)(#[^)]+)?\)/g;
   // JSX: href="/path/", to="/path/", or url="/path/"
-  const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(?:#[^"]+)?"/g;
+  const jsxLinkRegex = /((?:href|to|url))="(\/[^"#]+?)(#[^"]+)?"/g;
 
   const issues: ContentLinkIssue[] = [];
 
@@ -221,11 +228,12 @@ function detectContentLinkIssues(
         regex.lastIndex = 0;
         let match;
         while ((match = regex.exec(line)) !== null) {
-          // For jsxLinkRegex, capture group 1 is the attribute name, group 2 is the path
-          // For markdownLinkRegex, capture group 1 is the path
+          // For jsxLinkRegex: group 1 = attr name, group 2 = path, group 3 = fragment
+          // For markdownLinkRegex: group 1 = path, group 2 = fragment
           const isJsxMatch = regex === jsxLinkRegex;
           const attrName = isJsxMatch ? match[1] : null;
           let linkPath = isJsxMatch ? match[2] : match[1];
+          const fragment = (isJsxMatch ? match[3] : match[2]) || '';
 
           // Skip PlatformLink to= attributes since PlatformLink prepends
           // the platform base URL, making them platform-relative paths
@@ -248,8 +256,9 @@ function detectContentLinkIssues(
             issues.push({
               filePath,
               line: i + 1,
-              linkPath: matchedPath,
-              finalDest,
+              linkPath: matchedPath + fragment,
+              finalDest: finalDest + fragment,
+              fragment,
               isDeveloperDocs: isDevDocsFile,
             });
           }

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -1,0 +1,333 @@
+/**
+ * Lint redirect chains: detects multi-hop redirects and content links
+ * pointing to redirect sources.
+ *
+ * Phase 1: Finds redirect-to-redirect chains in middleware.ts and redirects.js
+ *          (where redirect A's destination is another redirect B's source).
+ * Phase 2: Finds internal links in .mdx content files that point to URLs
+ *          which are redirect sources (and should point to the final destination).
+ *
+ * Outputs structured JSON for the GitHub Action workflow to post as a PR comment.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import {parseMiddlewareTs, parseRedirectsJs} from './check-redirects-on-rename';
+
+interface Redirect {
+  destination: string;
+  source: string;
+}
+
+interface RedirectChain {
+  chain: string[];
+  currentDest: string;
+  file: string;
+  finalDest: string;
+  isDeveloperDocs: boolean;
+  source: string;
+}
+
+interface ContentLinkIssue {
+  filePath: string;
+  finalDest: string;
+  isDeveloperDocs: boolean;
+  line: number;
+  linkPath: string;
+}
+
+/**
+ * Recursively finds all .mdx and .md files in the given directories
+ */
+function findAllMdxFiles(dirs: string[]): string[] {
+  const files: string[] = [];
+  for (const dir of dirs) {
+    if (!fs.existsSync(dir)) {
+      continue;
+    }
+    const walk = (d: string) => {
+      for (const entry of fs.readdirSync(d, {withFileTypes: true})) {
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.name.endsWith('.mdx') || entry.name.endsWith('.md')) {
+          files.push(full);
+        }
+      }
+    };
+    walk(dir);
+  }
+  return files;
+}
+
+/**
+ * Walks a redirect chain to its final destination.
+ * Returns the full chain path including the starting source.
+ * Detects cycles and caps at maxDepth to prevent infinite loops.
+ */
+function walkChain(
+  source: string,
+  redirectMap: Map<string, string>,
+  maxDepth = 10
+): string[] {
+  const chain = [source];
+  let current = source;
+  const seen = new Set<string>();
+  seen.add(current);
+  let depth = 0;
+  while (redirectMap.has(current) && depth < maxDepth) {
+    const next = redirectMap.get(current)!;
+    if (seen.has(next)) {
+      chain.push(next + ' (CYCLE)');
+      break;
+    }
+    seen.add(next);
+    chain.push(next);
+    current = next;
+    depth++;
+  }
+  return chain;
+}
+
+/**
+ * Resolves a path through the redirect map to its final destination.
+ */
+function resolveToFinal(source: string, map: Map<string, string>): string {
+  let current = source;
+  const seen = new Set<string>();
+  while (map.has(current) && !seen.has(current)) {
+    seen.add(current);
+    current = map.get(current)!;
+  }
+  return current;
+}
+
+/**
+ * Phase 1: Detect redirect-to-redirect chains
+ */
+function detectRedirectChains(
+  jsRedirects: {developerDocsRedirects: Redirect[]; userDocsRedirects: Redirect[]},
+  mwRedirects: {developerDocsRedirects: Redirect[]; userDocsRedirects: Redirect[]}
+): RedirectChain[] {
+  const chains: RedirectChain[] = [];
+
+  for (const docType of ['user', 'developer'] as const) {
+    const isDevDocs = docType === 'developer';
+    const jsArr = isDevDocs
+      ? jsRedirects.developerDocsRedirects
+      : jsRedirects.userDocsRedirects;
+    const mwArr = isDevDocs
+      ? mwRedirects.developerDocsRedirects
+      : mwRedirects.userDocsRedirects;
+
+    // Build unified map for chain detection
+    const allRedirects = [...jsArr, ...mwArr];
+    const redirectMap = new Map<string, string>();
+    for (const r of allRedirects) {
+      redirectMap.set(r.source, r.destination);
+    }
+
+    // Track which file each source comes from
+    const jsSourceSet = new Set(jsArr.map(r => r.source));
+
+    // Find chains
+    const seenSources = new Set<string>();
+    for (const r of allRedirects) {
+      if (seenSources.has(r.source)) {
+        continue;
+      }
+      seenSources.add(r.source);
+
+      if (redirectMap.has(r.destination)) {
+        const chain = walkChain(r.source, redirectMap);
+        const finalDest = chain[chain.length - 1];
+
+        // Skip self-referencing cycles
+        if (finalDest === r.source || finalDest.includes('(CYCLE)')) {
+          chains.push({
+            source: r.source,
+            currentDest: r.destination,
+            finalDest: '(CYCLE DETECTED)',
+            chain,
+            file: jsSourceSet.has(r.source) ? 'redirects.js' : 'middleware.ts',
+            isDeveloperDocs: isDevDocs,
+          });
+          continue;
+        }
+
+        chains.push({
+          source: r.source,
+          currentDest: r.destination,
+          finalDest,
+          chain,
+          file: jsSourceSet.has(r.source) ? 'redirects.js' : 'middleware.ts',
+          isDeveloperDocs: isDevDocs,
+        });
+      }
+    }
+  }
+
+  return chains;
+}
+
+/**
+ * Phase 2: Detect content links pointing to redirect sources
+ */
+function detectContentLinkIssues(
+  jsRedirects: {developerDocsRedirects: Redirect[]; userDocsRedirects: Redirect[]},
+  mwRedirects: {developerDocsRedirects: Redirect[]; userDocsRedirects: Redirect[]}
+): ContentLinkIssue[] {
+  // Build redirect maps
+  const userRedirectMap = new Map<string, string>();
+  for (const r of [
+    ...jsRedirects.userDocsRedirects,
+    ...mwRedirects.userDocsRedirects,
+  ]) {
+    userRedirectMap.set(r.source, r.destination);
+  }
+  const devRedirectMap = new Map<string, string>();
+  for (const r of [
+    ...jsRedirects.developerDocsRedirects,
+    ...mwRedirects.developerDocsRedirects,
+  ]) {
+    devRedirectMap.set(r.source, r.destination);
+  }
+
+  const mdxFiles = findAllMdxFiles([
+    'docs',
+    'develop-docs',
+    'includes',
+    'platform-includes',
+  ]);
+
+  // Regex patterns for extracting internal links
+  // Markdown: [text](/path/) or [text](/path/#anchor)
+  const markdownLinkRegex = /\]\((\/[^)#\s]+?)(?:#[^)]+)?\)/g;
+  // JSX: href="/path/" or to="/path/" or url="/path/"
+  const jsxLinkRegex = /(?:href|to|url)="(\/[^"#]+?)(?:#[^"]+)?"/g;
+
+  const issues: ContentLinkIssue[] = [];
+
+  for (const filePath of mdxFiles) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+    const isDevDocsFile = filePath.startsWith('develop-docs/');
+    const map = isDevDocsFile ? devRedirectMap : userRedirectMap;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      for (const regex of [markdownLinkRegex, jsxLinkRegex]) {
+        regex.lastIndex = 0;
+        let match;
+        while ((match = regex.exec(line)) !== null) {
+          let linkPath = match[1];
+          // Normalize: ensure trailing slash
+          if (!linkPath.endsWith('/')) {
+            linkPath += '/';
+          }
+
+          if (map.has(linkPath)) {
+            const finalDest = resolveToFinal(linkPath, map);
+            issues.push({
+              filePath,
+              line: i + 1,
+              linkPath,
+              finalDest,
+              isDeveloperDocs: isDevDocsFile,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// Main execution
+if (require.main === module) {
+  console.log('Linting redirect chains...\n');
+
+  const jsRedirects = parseRedirectsJs('redirects.js');
+  const mwRedirects = parseMiddlewareTs('middleware.ts');
+
+  console.log(
+    `Parsed: ${jsRedirects.userDocsRedirects.length + jsRedirects.developerDocsRedirects.length} from redirects.js, ` +
+      `${mwRedirects.userDocsRedirects.length + mwRedirects.developerDocsRedirects.length} from middleware.ts`
+  );
+
+  // Phase 1: Redirect chains
+  const chains = detectRedirectChains(jsRedirects, mwRedirects);
+  if (chains.length > 0) {
+    console.log(`\n❌ Found ${chains.length} redirect chain(s):\n`);
+    for (const c of chains) {
+      console.log(`  [${c.file}] ${c.chain.join(' -> ')}`);
+      console.log(
+        `    Fix: Change destination of "${c.source}" to "${c.finalDest}"`
+      );
+    }
+  } else {
+    console.log('\n✅ No redirect chains found.');
+  }
+
+  // Phase 2: Content links
+  const contentIssues = detectContentLinkIssues(jsRedirects, mwRedirects);
+  if (contentIssues.length > 0) {
+    console.log(
+      `\n❌ Found ${contentIssues.length} content link(s) pointing to redirect sources:\n`
+    );
+
+    // Group by file for readable output
+    const byFile = new Map<string, ContentLinkIssue[]>();
+    for (const issue of contentIssues) {
+      const arr = byFile.get(issue.filePath) || [];
+      arr.push(issue);
+      byFile.set(issue.filePath, arr);
+    }
+
+    for (const [file, fileIssues] of byFile) {
+      console.log(`  ${file}:`);
+      for (const issue of fileIssues) {
+        console.log(
+          `    L${issue.line}: ${issue.linkPath} -> should be ${issue.finalDest}`
+        );
+      }
+    }
+  } else {
+    console.log('\n✅ No content links pointing to redirect sources.');
+  }
+
+  // Summary and JSON output
+  const hasIssues = chains.length > 0 || contentIssues.length > 0;
+
+  if (hasIssues) {
+    console.log('\n---JSON_OUTPUT---');
+    console.log(
+      JSON.stringify(
+        {
+          redirectChains: chains,
+          contentLinkIssues: contentIssues,
+        },
+        null,
+        2
+      )
+    );
+    console.log('---JSON_OUTPUT---\n');
+
+    process.exit(1);
+  } else {
+    console.log(
+      '\n✅ All clear: no redirect chains or content links pointing to redirect sources.'
+    );
+    process.exit(0);
+  }
+}
+
+export {
+  detectContentLinkIssues,
+  detectRedirectChains,
+  findAllMdxFiles,
+  resolveToFinal,
+  walkChain,
+};

--- a/scripts/lint-redirect-chains.ts
+++ b/scripts/lint-redirect-chains.ts
@@ -140,13 +140,16 @@ function detectRedirectChains(
 
     for (const {file, redirects} of fileSources) {
       for (const r of redirects) {
-        // Use the unified map to check if this redirect's destination
-        // chains into another redirect from either file
+        // Check if this entry's own destination chains into another redirect
         if (redirectMap.has(r.destination)) {
-          const chain = walkChain(r.source, redirectMap);
-          // Use resolveToFinal for the correct final destination,
-          // since walkChain caps at maxDepth for display purposes
-          const finalDest = resolveToFinal(r.source, redirectMap);
+          // Walk from the entry's own destination (not source) to build a
+          // consistent chain: source -> currentDest -> ... -> finalDest.
+          // This avoids mismatches when the same source exists in both files
+          // with different destinations (the unified map would use the other
+          // file's destination for walkChain(r.source, ...) ).
+          const tailChain = walkChain(r.destination, redirectMap);
+          const chain = [r.source, ...tailChain];
+          const finalDest = resolveToFinal(r.destination, redirectMap);
 
           // Skip self-referencing cycles
           if (finalDest === r.source || chain.some(s => s.includes('(CYCLE)'))) {


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow and linting script that catches redirect chain issues on PRs before they get merged into production. This prevents the kind of multi-hop redirect buildup that required cleanup in #18606 and #18619.

### What it detects

**1. Redirect-to-redirect chains**
Where redirect A's destination is another redirect B's source, creating multi-hop chains. Example:
```
/old/path/ -> /middle/path/ -> /final/path/
                ^^^ this destination is also a redirect source
```

**2. Content links pointing to redirect sources**
Where `.mdx` files contain internal links that hit a redirect instead of pointing directly to the final destination.

### How it works

- Reuses the existing `parseRedirectsJs()` and `parseMiddlewareTs()` parsers from `check-redirects-on-rename.ts`
- Builds a unified redirect map from both `middleware.ts` and `redirects.js`
- **Phase 1:** Checks if any redirect's destination exists as another redirect's source (simple string equality -- works for both exact-match and parameterized redirects like `:path*`, `:platform`, etc.)
- **Phase 2:** Scans all `.mdx` files in `docs/`, `develop-docs/`, `includes/`, and `platform-includes/` for internal links matching redirect sources
- Posts/updates a PR comment with tables showing all issues found + suggested fixes

### New files

| File | Lines | Purpose |
|------|-------|---------|
| `scripts/lint-redirect-chains.ts` | 333 | Linter script |
| `scripts/lint-redirect-chains.spec.ts` | 312 | 25 test cases |
| `.github/workflows/lint-redirect-chains.yml` | 169 | GitHub Actions workflow |

### Design decisions

- **Advisory, not blocking:** `continue-on-error: true` -- marks the check as failed but does not block merge, matching the existing `check-redirects-on-rename` pattern
- **Path-filtered triggers:** Only runs when `middleware.ts`, `redirects.js`, or content files change
- **No new dependencies:** Uses only Node builtins (`fs`, `path`) and existing project deps (`tsx`, `vitest`)
- **Reuses existing parsers:** Imports `parseRedirectsJs` and `parseMiddlewareTs` from `check-redirects-on-rename.ts` -- no duplicate parsing logic

### PR comment format

When issues are found, the workflow posts a comment like:

> ## :warning: Redirect Chain Issues Detected
>
> ### Redirect-to-Redirect Chains
> | Source | Current Destination | Should Be | File |
> |--------|-------------------|-----------|------|
> | `/old/` | `/middle/` | `/final/` | redirects.js |
>
> ### Content Links Pointing to Redirects
> | File | Line | Current Link | Should Be |
> |------|------|-------------|-----------|
> | `docs/foo.mdx` | 42 | `/old/path/` | `/new/path/` |

### Note

This PR should be merged after #18619 (cleanup of existing chains), so the linter starts clean against master.