### PR TITLE
docs(dashboards): note .NET SDK support for outbound HTTP requests

### DIFF
--- a/docs/product/dashboards/sentry-dashboards/outbound-api-requests.mdx
+++ b/docs/product/dashboards/sentry-dashboards/outbound-api-requests.mdx
@@ -16,7 +16,7 @@ On the [Requests page](#requests-page), you get an overview of the domains that 
 Network requests using non-HTTP protocols (FTP, WebSocket, etc.) are not supported at this time.
 </Alert>
 
-Availability of HTTP request monitoring depends on the SDK your application uses. In most cases, Sentry's SDKs automatically enable HTTP request tracking. You can check your SDK's <PlatformLink to="/tracing/instrumentation/automatic-instrumentation">automatic instrumentation documentation</PlatformLink> to see if it includes tracking HTTP requests.
+Availability of HTTP request monitoring depends on the SDK your application uses. In most cases, Sentry's SDKs automatically enable HTTP request tracking. You can check your SDK's <PlatformLink to="/tracing/instrumentation/automatic-instrumentation">automatic instrumentation documentation</PlatformLink> to see if it includes tracking HTTP requests. For example, the [.NET SDK](/platforms/dotnet/tracing/instrumentation/automatic-instrumentation/) automatically instruments outgoing HTTP requests through its `SentryHttpMessageHandler`.
 
 If the SDK you're using doesn't automatically instrument HTTP requests, you can set up custom instrumentation. Dedicated platform documentation is available for these platforms:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The [Outbound API Requests](https://docs.sentry.io/product/dashboards/sentry-dashboards/outbound-api-requests/#prerequisites-and-limitations) prerequisites section only named the Python and JavaScript SDKs, even though the .NET SDK has supported this feature for some time — it automatically instruments outgoing HTTP requests via `SentryHttpMessageHandler`.

This adds an explicit mention of the .NET SDK next to the automatic-instrumentation guidance and links to its automatic instrumentation docs.

- Mention the .NET SDK in `docs/product/dashboards/sentry-dashboards/outbound-api-requests.mdx`

(The old `/product/insights/requests/` URL referenced in the linked issue now redirects to this Dashboards page.)

Fixes getsentry/sentry-dotnet#3679

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)