### PR TITLE
Add troubleshooting section for duplicate native crash events (.NET)

### DIFF
--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -39,6 +39,10 @@ This issue affects:
 - Applications built in release mode with trimming enabled
 - Specifically impacts the `net9.0-ios*` target frameworks
 
+</PlatformSection>
+
+<PlatformSection supported={["dotnet.maui", "dotnet.apple", "dotnet.android"]}>
+
 ## Duplicate events from native crashes
 
 On Android and iOS, a single managed exception that surfaces as a native signal — for example a `NullReferenceException` that the runtime raises as a `SIGSEGV` — can be reported to Sentry **twice**: once as the managed .NET exception, and once as a native crash. This happens because both the .NET runtime and Sentry's native layer handle the same fault.

--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -39,6 +39,36 @@ This issue affects:
 - Applications built in release mode with trimming enabled
 - Specifically impacts the `net9.0-ios*` target frameworks
 
+## Duplicate events from native crashes
+
+On Android and iOS, a single managed exception that surfaces as a native signal — for example a `NullReferenceException` that the runtime raises as a `SIGSEGV` — can be reported to Sentry **twice**: once as the managed .NET exception, and once as a native crash. This happens because both the .NET runtime and Sentry's native layer handle the same fault.
+
+### iOS
+
+This is handled automatically as of **version 6.4.0** — no configuration is required. The SDK intercepts the managed exception first and tells the native layer to ignore the resulting signal, so you get a single event. If you're seeing duplicates on iOS, upgrade to 6.4.0 or later.
+
+### Android
+
+The preferred fix is to change the order in which the native and managed signal handlers run, so the .NET runtime handles the managed exception first. This is currently **experimental** and opt-in:
+
+```csharp
+options.Native.ExperimentalOptions.SignalHandlerStrategy =
+    Sentry.Android.SignalHandlerStrategy.ChainAtStart;
+```
+
+**Important Note:**
+- Requires Android 8.0 (API level 26) or later. On older versions, the SDK falls back to the default strategy automatically.
+- Only needed on the **Mono** runtime. On CoreCLR, the SDK already avoids the duplicate and keeps the default strategy.
+- Not compatible with .NET runtimes 10.0.0–10.0.3 (.NET SDKs 10.0.100–10.0.103). On those versions, the SDK falls back to the default strategy automatically. This was fixed in .NET runtime 10.0.4 (.NET SDK 10.0.200).
+
+As an alternative — or if you can't opt into the experimental strategy — you can suppress native segfault capture entirely:
+
+```csharp
+options.Android.SuppressSegfaults = true;
+```
+
+**Important Note**: This stops the native SDK from capturing `SIGSEGV` errors altogether, so it can also hide *genuine* native segfaults originating in native (non-managed) code. Prefer `SignalHandlerStrategy.ChainAtStart` where possible.
+
 </PlatformSection>
 
 ## Sentry CLI not configured

--- a/docs/platforms/dotnet/common/troubleshooting.mdx
+++ b/docs/platforms/dotnet/common/troubleshooting.mdx
@@ -47,10 +47,14 @@ This issue affects:
 
 On Android and iOS, a single managed exception that surfaces as a native signal — for example a `NullReferenceException` that the runtime raises as a `SIGSEGV` — can be reported to Sentry **twice**: once as the managed .NET exception, and once as a native crash. This happens because both the .NET runtime and Sentry's native layer handle the same fault.
 
+</PlatformSection>
+<PlatformSection supported={["dotnet.maui", "dotnet.apple"]}>
 ### iOS
 
 This is handled automatically as of **version 6.4.0** — no configuration is required. The SDK intercepts the managed exception first and tells the native layer to ignore the resulting signal, so you get a single event. If you're seeing duplicates on iOS, upgrade to 6.4.0 or later.
 
+</PlatformSection>
+<PlatformSection supported={["dotnet.maui", "dotnet.android"]}>
 ### Android
 
 The preferred fix is to change the order in which the native and managed signal handlers run, so the .NET runtime handles the managed exception first. This is currently **experimental** and opt-in:


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a **Duplicate events from native crashes** section to the .NET Troubleshooting page, covering the case where a single managed exception that surfaces as a native signal (e.g. a `NullReferenceException` raised as a `SIGSEGV`) is reported to Sentry twice — once as the managed .NET exception and once as a native crash.

The section documents the platform-specific fixes:

- **iOS** — handled automatically as of SDK 6.4.0; no configuration needed.
- **Android** — preferred (experimental) fix via `options.Native.ExperimentalOptions.SignalHandlerStrategy = SignalHandlerStrategy.ChainAtStart`, with runtime/version caveats, plus the `options.Android.SuppressSegfaults` fallback.

This resolves getsentry/sentry-dotnet#3943 (which asked to document `AndroidOptions.SuppressSegfaults`), reframing it around the newer preferred fix landed by @jpnurmi and demoting `SuppressSegfaults` to a documented fallback.

Related sentry-dotnet PRs: #4676 (Android/Mono), #5126 (iOS), #5127 (Android/CoreCLR); tracking issue #3954.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)