### PR TITLE
fix(toc): Track hash in state to fix browser back navigation scrolling

### DIFF
--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -86,6 +86,10 @@ export function TableOfContents({ignoreIds = []}: Props) {
   // The TOC starts empty and populates client-side, which pushes content down
   // and causes the browser's initial anchor scroll to land on the wrong section.
   // This effect re-runs whenever the hash or treeItems change.
+  //
+  // Note: This causes a redundant scroll when clicking TOC links (browser scrolls,
+  // then our effect scrolls again), but the performance impact is negligible and
+  // ensures correct behavior for initial page loads and browser back/forward navigation.
   useEffect(() => {
     if (treeItems.length === 0 || !currentHash) {
       return undefined;

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -90,10 +90,11 @@ export function TableOfContents({ignoreIds = []}: Props) {
     if (treeItems.length === 0 || !currentHash) {
       return;
     }
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       const id = decodeURIComponent(currentHash.slice(1));
       document.getElementById(id)?.scrollIntoView();
     });
+    return () => cancelAnimationFrame(rafId);
   }, [currentHash, treeItems]);
 
   return (

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -88,13 +88,15 @@ export function TableOfContents({ignoreIds = []}: Props) {
   // This effect re-runs whenever the hash or treeItems change.
   useEffect(() => {
     if (treeItems.length === 0 || !currentHash) {
-      return;
+      return undefined;
     }
     const rafId = requestAnimationFrame(() => {
       const id = decodeURIComponent(currentHash.slice(1));
       document.getElementById(id)?.scrollIntoView();
     });
-    return () => cancelAnimationFrame(rafId);
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
   }, [currentHash, treeItems]);
 
   return (

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -108,8 +108,9 @@ export function TableOfContents({ignoreIds = []}: Props) {
     if (scrolledHashRef.current === currentHash) {
       return undefined;
     }
-    scrolledHashRef.current = currentHash;
     const rafId = requestAnimationFrame(() => {
+      // Set the ref inside RAF to ensure we only mark as scrolled when it actually happens
+      scrolledHashRef.current = currentHash;
       const id = decodeURIComponent(currentHash.slice(1));
       document.getElementById(id)?.scrollIntoView();
     });

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 type TreeItem = {
   children: TreeItem[];
@@ -71,42 +71,30 @@ export function TableOfContents({ignoreIds = []}: Props) {
     setTreeItems(_tocItems);
   }, [ignoreIds]);
 
-  // Re-scroll to hash anchor after TOC renders to compensate for layout shift.
-  // The TOC starts empty and populates client-side, which pushes content down
-  // and causes the browser's initial anchor scroll to land on the wrong section.
-  const hasScrolledToHash = useRef(false);
-  const lastHash = useRef<string>('');
+  // Track current hash to trigger scroll when it changes (e.g., browser back/forward)
+  const [currentHash, setCurrentHash] = useState('');
 
-  // Reset scroll flag when hash changes (e.g., via browser back/forward)
   useEffect(() => {
-    const handleHashChange = () => {
-      const currentHash = window.location.hash;
-      if (currentHash !== lastHash.current) {
-        hasScrolledToHash.current = false;
-        lastHash.current = currentHash;
-      }
-    };
-
-    // Listen for hash changes
+    // Initialize hash and listen for changes
+    setCurrentHash(window.location.hash);
+    const handleHashChange = () => setCurrentHash(window.location.hash);
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, []);
 
+  // Re-scroll to hash anchor after TOC renders to compensate for layout shift.
+  // The TOC starts empty and populates client-side, which pushes content down
+  // and causes the browser's initial anchor scroll to land on the wrong section.
+  // This effect re-runs whenever the hash or treeItems change.
   useEffect(() => {
-    if (hasScrolledToHash.current || treeItems.length === 0) {
+    if (treeItems.length === 0 || !currentHash) {
       return;
     }
-    const hash = window.location.hash;
-    if (!hash) {
-      return;
-    }
-    hasScrolledToHash.current = true;
-    lastHash.current = hash;
     requestAnimationFrame(() => {
-      const id = decodeURIComponent(hash.slice(1));
+      const id = decodeURIComponent(currentHash.slice(1));
       document.getElementById(id)?.scrollIntoView();
     });
-  }, [treeItems]);
+  }, [currentHash, treeItems]);
 
   return (
     <ul>

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -75,6 +75,23 @@ export function TableOfContents({ignoreIds = []}: Props) {
   // The TOC starts empty and populates client-side, which pushes content down
   // and causes the browser's initial anchor scroll to land on the wrong section.
   const hasScrolledToHash = useRef(false);
+  const lastHash = useRef<string>('');
+
+  // Reset scroll flag when hash changes (e.g., via browser back/forward)
+  useEffect(() => {
+    const handleHashChange = () => {
+      const currentHash = window.location.hash;
+      if (currentHash !== lastHash.current) {
+        hasScrolledToHash.current = false;
+        lastHash.current = currentHash;
+      }
+    };
+
+    // Listen for hash changes
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
   useEffect(() => {
     if (hasScrolledToHash.current || treeItems.length === 0) {
       return;
@@ -84,6 +101,7 @@ export function TableOfContents({ignoreIds = []}: Props) {
       return;
     }
     hasScrolledToHash.current = true;
+    lastHash.current = hash;
     requestAnimationFrame(() => {
       const id = decodeURIComponent(hash.slice(1));
       document.getElementById(id)?.scrollIntoView();

--- a/src/components/tableOfContents.tsx
+++ b/src/components/tableOfContents.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 type TreeItem = {
   children: TreeItem[];
@@ -73,11 +73,18 @@ export function TableOfContents({ignoreIds = []}: Props) {
 
   // Track current hash to trigger scroll when it changes (e.g., browser back/forward)
   const [currentHash, setCurrentHash] = useState('');
+  // Track which hash we've scrolled to for this navigation, to avoid re-scrolling
+  // when treeItems rebuild due to parent re-renders
+  const scrolledHashRef = useRef<string>('');
 
   useEffect(() => {
     // Initialize hash and listen for changes
     setCurrentHash(window.location.hash);
-    const handleHashChange = () => setCurrentHash(window.location.hash);
+    const handleHashChange = () => {
+      setCurrentHash(window.location.hash);
+      // Reset scroll tracking on navigation
+      scrolledHashRef.current = '';
+    };
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, []);
@@ -85,7 +92,10 @@ export function TableOfContents({ignoreIds = []}: Props) {
   // Re-scroll to hash anchor after TOC renders to compensate for layout shift.
   // The TOC starts empty and populates client-side, which pushes content down
   // and causes the browser's initial anchor scroll to land on the wrong section.
-  // This effect re-runs whenever the hash or treeItems change.
+  // This effect runs when:
+  // - treeItems populate initially (layout shift correction)
+  // - Hash changes (navigation, back/forward)
+  // BUT NOT when treeItems rebuild due to parent re-renders (tracked via ref).
   //
   // Note: This causes a redundant scroll when clicking TOC links (browser scrolls,
   // then our effect scrolls again), but the performance impact is negligible and
@@ -94,6 +104,11 @@ export function TableOfContents({ignoreIds = []}: Props) {
     if (treeItems.length === 0 || !currentHash) {
       return undefined;
     }
+    // Skip if we've already scrolled to this hash during this navigation
+    if (scrolledHashRef.current === currentHash) {
+      return undefined;
+    }
+    scrolledHashRef.current = currentHash;
     const rafId = requestAnimationFrame(() => {
       const id = decodeURIComponent(currentHash.slice(1));
       document.getElementById(id)?.scrollIntoView();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## DESCRIBE YOUR PR

This PR fixes a browser navigation bug where clicking the back button would restore the URL hash but not scroll to the correct anchor position on the page.

**Root Cause:**
Commit `8a810dae3` (May 18, 2026) by Shannon Anahata added a `hasScrolledToHash` ref to fix anchor links opened in new tabs landing on the wrong section. While that fix worked for its intended purpose, the ref was never reset during the page lifecycle, causing issues with browser back/forward navigation. When users clicked back to return to a URL with a hash anchor, the browser correctly updated the URL but the page didn't scroll because the component thought it had already handled that scroll.

**The Solution:**
Instead of using refs and manually managing scroll flags, the fix uses React state to track the current hash. This leverages React's dependency system - when the hash changes (via browser back/forward or any other navigation), the effect automatically re-runs and scrolls to the correct section.

**Additional Fixes from BugBot Analysis:**

1. **Redundant scroll on TOC clicks**: BugBot correctly identified that clicking TOC links causes the browser to scroll, then our effect scrolls again. We accept this tradeoff because:
   - Performance impact is negligible (one RAF'd `scrollIntoView()` call)
   - Alternative (only scrolling on popstate) broke browser back/forward navigation
   - Effect is essential for initial page load and back/forward correction

2. **Unwanted scrolls during re-renders**: BugBot identified that parent re-renders creating new `ignoreIds` array references would trigger TOC rebuilds, causing users to be yanked back to hash anchors while reading. Fixed by:
   - Tracking which hash we've scrolled to via a ref
   - Skipping scroll when treeItems rebuild but hash hasn't changed
   - Resetting ref on hash changes to allow navigation/back/forward scrolls

**Testing:**
Manually tested:
1. Navigate to `/product/ai-in-sentry/seer/autofix/#handoff-to-coding-agents` ✅ Scrolls correctly
2. Click "Cursor Cloud Agent" link ✅ Navigates to new page  
3. Click browser back button ✅ **Correctly scrolls back to the anchor section**
4. Click TOC links ✅ Smooth scrolling with no jank
5. Scroll away from hash anchor ✅ **Page stays put, doesn't jump back**
6. Trigger re-renders ✅ **Still doesn't jump back to hash**

[After clicking back button - correctly scrolled to anchor](https://cursor.com/agents/bc-25ab8bbe-477b-53bd-9921-ed0a634ade6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frefactored_back_button_test.webp)

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/D090PH7SF7C/p1783010548795199?thread_ts=1783010548.795199&cid=D090PH7SF7C)

<div><a href="https://cursor.com/agents/bc-25ab8bbe-477b-53bd-9921-ed0a634ade6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25ab8bbe-477b-53bd-9921-ed0a634ade6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

