### PR TITLE
docs(apple): Surface optional diff_threshold in Fastlane snapshot upload

### DIFF
--- a/docs/platforms/apple/common/snapshots/index.mdx
+++ b/docs/platforms/apple/common/snapshots/index.mdx
@@ -133,6 +133,7 @@ lane :upload_snapshots do |options|
     auth_token: ENV['SENTRY_AUTH_TOKEN'],
     org_slug: 'your-org',
     project_slug: 'your-project'
+    # diff_threshold: 0.001 # optional: only flag images with >0.1% pixel change
   )
 end
 ```

--- a/docs/platforms/apple/common/snapshots/index.mdx
+++ b/docs/platforms/apple/common/snapshots/index.mdx
@@ -132,7 +132,7 @@ lane :upload_snapshots do |options|
     app_id: 'com.example.your-app',
     auth_token: ENV['SENTRY_AUTH_TOKEN'],
     org_slug: 'your-org',
-    project_slug: 'your-project'
+    project_slug: 'your-project',
     # diff_threshold: 0.001 # optional: only flag images with >0.1% pixel change
   )
 end


### PR DESCRIPTION
## DESCRIBE YOUR PR

Surfaces the new optional `diff_threshold` parameter in the iOS/Apple snapshots docs' Fastlane upload example.

[sentry-fastlane-plugin#509](https://github.com/getsentry/sentry-fastlane-plugin/pull/509) adds an optional `diff_threshold` param (Float, `0.0`–`1.0`) to the `sentry_upload_snapshots` action, which filters out sub-pixel rendering noise (font smoothing, anti-aliasing) that would otherwise flag mobile screenshots as changed on every run. The Fastlane path (Option B) was the only snapshot upload flow where this option wasn't discoverable — the CLI docs (Option A) already document `--diff-threshold`.

- Add `diff_threshold` as a commented-out line in the `Fastfile` example, keeping it discoverable without over-emphasizing a knob most users won't need.

> [!NOTE]
> This depends on sentry-fastlane-plugin#509 — the param doesn't exist in the plugin until that PR merges and ships. Hold/land this accordingly.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
