### PR TITLE
docs(unreal): Session Replay capturing on iOS

### DIFF
--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -26,7 +26,7 @@ Unreal Engine SDK builds on top of other Sentry SDKs and extends them with Unrea
   - Compatibility with the default [Crash Reporter Client](/platforms/unreal/configuration/crash-reporter/crash-reporter-client/) provided along with Unreal Engine
 - [PlayStation](/platforms/playstation/), [Xbox](/platforms/xbox/) and [Nintendo Switch](/platforms/nintendo-switch/) support
 - [Release health](/platforms/unreal/configuration/releases/) to keep track of crash free users and sessions
-- [Session Replay](/platforms/unreal/session-replay/) (experimental) to attach gameplay video to crash reports on Windows, macOS, Linux, and Xbox, and native session replay on Android
+- [Session Replay](/platforms/unreal/session-replay/) (experimental) to attach gameplay video to crash reports on Windows, macOS, Linux, iOS (UE 5.8+), and Xbox, and native session replay on Android
 - [Structured Logging](/platforms/unreal/logs/) to capture and send log messages with additional context
 - [Metrics](/platforms/unreal/metrics/) to track counters, gauges, and distributions
 - [Offline Caching](/platforms/unreal/configuration/options/#EnableOfflineCaching) stores event data to disk in case the device is not online

--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -94,6 +94,19 @@ On iOS, Session Replay uses the same recording pipeline as desktop, encoding the
 
 iOS requires **Unreal Engine 5.8 or newer** — earlier engine versions don't ship the AVCodecs plugins for iOS, and the setting is a no-op there.
 
+Session Replay assumes your game runs in a **fixed screen orientation** (typical for games). The recording orientation is determined once when the SDK initializes; if your game supports both portrait and landscape and the device is rotated mid-session, the recording stays locked to the initial orientation and subsequent footage may appear squeezed or stretched. Crash reporting itself is unaffected.
+
+<Alert>
+
+The AVCodecs plugins link Apple's `AVFoundation` framework, which references camera and microphone APIs. App Store submissions will be rejected with `ITMS-90683: Missing purpose string in Info.plist` unless your `Info.plist` contains `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` entries — even though Session Replay never accesses the camera or microphone. Add them via **Project Settings > Platforms > iOS > Extra PList Data**, or in your `DefaultEngine.ini`:
+
+```ini
+[/Script/IOSRuntimeSettings.IOSRuntimeSettings]
+AdditionalPlistData=<key>NSCameraUsageDescription</key><string>This app does not use the camera. A system video-encoding framework used for crash replay recording references camera APIs.</string><key>NSMicrophoneUsageDescription</key><string>This app does not use the microphone. A system video-encoding framework used for crash replay recording references microphone APIs.</string>
+```
+
+</Alert>
+
 ### Xbox
 
 On Xbox, Session Replay uses the operating system's game-capture facility to grab a clip of recent gameplay at crash time. This is supported on **development kits only** and is not available in retail builds.

--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -27,9 +27,9 @@ Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/
 | **Xbox**    | An OS-captured gameplay clip, attached to crash reports.                        | Development kits only.                                                                               |
 | **Android** | A full-session replay via the Android SDK, with default text and image masking. | None beyond the standard Android setup.                                                             |
 
-\* See the [platform notes](#desktop-and-ios) below for the exact engine version, plugin, GPU, and driver requirements.
+\* See the [Platform Notes](#platform-notes) below for the exact engine version, plugin, GPU, and driver requirements.
 
-PlayStation and Nintendo Switch are not currently supported. On those platforms (and on iOS with engine versions older than 5.8) the setting is a no-op.
+PlayStation and Nintendo Switch are not currently supported. On those platforms the setting is a no-op.
 
 ## Enabling Session Replay
 
@@ -49,7 +49,7 @@ The following settings are available under the **Session Replay** section in the
 - **Enable session replay (experimental)** (`AttachSessionReplay`, default `False`) — Master toggle for the feature.
 - **Replay duration (ms)** (`SessionReplayDurationMs`, default `5000`, range `1000`–`60000`) — The requested length of the retroactive replay window. On Windows, Linux, macOS, and iOS this is the rolling clip length kept on disk for crash attachment; on Xbox it's the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). This value is ignored on Android, where the underlying SDK determines the duration.
 
-### Advanced Recording Options (Windows, macOS, Linux & iOS)
+### Advanced Recording Options (Windows, Linux, macOS & iOS)
 
 The **Advanced recording options** group (`SessionReplayOptions`) provides low-level encoder and muxer tuning for the desktop and iOS recorders. The defaults are sensible for most projects.
 
@@ -67,28 +67,32 @@ SessionReplayOptions=(FragmentSeconds=0.500000,RotationIntervalSeconds=1.000000,
 
 ## Platform Notes
 
-### Desktop and iOS
+### Desktop (Windows, macOS, and Linux)
 
-On desktop platforms and iOS, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
+On desktop platforms, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
 
-| Platform    | Encoder            | Engine plugins              | Requirements                                                                                     |
+| Platform    | Encoder            | Engine plugins              | GPU and driver requirements                                                                     |
 | ----------- | ------------------ | --------------------------- | ----------------------------------------------------------------------------------------------- |
 | **Windows** | NVIDIA NVENC       | `AVCodecsCore`, `NVCodecs`  | NVIDIA GPU with driver **531.61** or newer.                                                      |
 | **Windows** | AMD AMF            | `AVCodecsCore`, `AMFCodecs` | AMD GPU with a recent Adrenalin driver. D3D11/D3D12 RHI only — not available when running with `-vulkan`. |
 | **Linux**   | NVIDIA NVENC       | `AVCodecsCore`, `NVCodecs`  | NVIDIA GPU with proprietary driver **530.41** or newer — NVENC isn't available with the open-source Nouveau driver. |
 | **macOS**   | Apple VideoToolbox | `AVCodecsCore`, `VTCodecs`  | None — uses the dedicated hardware media engine on Apple Silicon and a software fallback on Intel Macs. |
-| **iOS**     | Apple VideoToolbox | `AVCodecsCore`, `VTCodecs`  | Unreal Engine **5.8 or newer** — earlier engine versions don't ship the AVCodecs plugins for iOS. Hardware-accelerated on all devices. |
 
 - **Enable the codec plugins for every GPU vendor you want to cover.** The Sentry plugin only compiles the recorder when `AVCodecsCore` is present. On Windows, `NVCodecs` and `AMFCodecs` can be enabled side by side — the encoder matching the player's GPU is selected at runtime.
 - **A plugin rebuild is required after toggling the setting.** Whether Session Replay is compiled in is decided at build time from `AttachSessionReplay`, so after enabling or disabling it, delete your project's `Binaries` and `Intermediate` directories and rebuild.
 - **Machines without a compatible encoder fall back to no recording.** The feature self-disables for the session and logs a warning; crash reporting itself is unaffected.
-- **On macOS and iOS, the clip is uploaded on the next app launch.** The Windows and Linux crash handlers attach the clip at crash time, while on Apple platforms the crash of the previous run is detected during the next SDK initialization, which is when the recorded clip is attached and uploaded.
 
 <Alert>
 
 The most recent fraction of a second of footage (up to one fragment duration) may be missing from the attached clip, since the fragment being encoded at the moment of the crash isn't yet finalized.
 
 </Alert>
+
+### iOS
+
+On iOS, Session Replay uses the same recording pipeline as desktop, encoding the game's backbuffer with Apple VideoToolbox via the `AVCodecsCore` and `VTCodecs` engine plugins. Encoding is hardware-accelerated on all devices, and the desktop notes above (plugin rebuild, encoder fallback) apply equally.
+
+iOS requires **Unreal Engine 5.8 or newer** — earlier engine versions don't ship the AVCodecs plugins for iOS, and the setting is a no-op there.
 
 ### Xbox
 

--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -14,7 +14,7 @@ Session Replay for Unreal Engine is **experimental** and currently limited to a 
 
 Session Replay records what was happening on screen in the moments leading up to a crash, giving you a visual reproduction to pair with the captured event.
 
-Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/android/session-replay/) Session Replay experiences, which reconstruct the UI from the view hierarchy and aggressively mask text and images by default, the Unreal Engine SDK captures the rendered output of your game directly. On desktop and console, it continuously encodes the rendered frames into a short rolling video clip and attaches that clip to crash reports. On Android, the feature delegates to the underlying [Android SDK's Session Replay](/platforms/android/session-replay/).
+Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/android/session-replay/) Session Replay experiences, which reconstruct the UI from the view hierarchy and aggressively mask text and images by default, the Unreal Engine SDK captures the rendered output of your game directly. On desktop, iOS, and console, it continuously encodes the rendered frames into a short rolling video clip and attaches that clip to crash reports. On Android, the feature delegates to the underlying [Android SDK's Session Replay](/platforms/android/session-replay/).
 
 ## Platform Support
 
@@ -23,12 +23,13 @@ Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/
 | **Windows** | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins matching the GPU vendor (NVIDIA or AMD) and a plugin rebuild.\*                |
 | **Linux**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins, an NVIDIA GPU, and a plugin rebuild.\*                                        |
 | **macOS**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins and a plugin rebuild.\*                                                        |
+| **iOS**     | A rolling video clip of the game's backbuffer, attached to crash reports.       | Unreal Engine **5.8 or newer**, engine codec plugins, and a plugin rebuild.\*                       |
 | **Xbox**    | An OS-captured gameplay clip, attached to crash reports.                        | Development kits only.                                                                               |
 | **Android** | A full-session replay via the Android SDK, with default text and image masking. | None beyond the standard Android setup.                                                             |
 
-\* See the [Desktop platform notes](#desktop-windows-macos-and-linux) below for the exact plugin, GPU, and driver requirements.
+\* See the [platform notes](#desktop-and-ios) below for the exact engine version, plugin, GPU, and driver requirements.
 
-All other platforms (iOS, PlayStation, and Nintendo Switch) are not currently supported. On those platforms the setting is a no-op.
+PlayStation and Nintendo Switch are not currently supported. On those platforms (and on iOS with engine versions older than 5.8) the setting is a no-op.
 
 ## Enabling Session Replay
 
@@ -46,11 +47,11 @@ AttachSessionReplay=True
 The following settings are available under the **Session Replay** section in the plugin settings:
 
 - **Enable session replay (experimental)** (`AttachSessionReplay`, default `False`) — Master toggle for the feature.
-- **Replay duration (ms)** (`SessionReplayDurationMs`, default `5000`, range `1000`–`60000`) — The requested length of the retroactive replay window. On Windows, Linux, and macOS this is the rolling clip length kept on disk for crash attachment; on Xbox it's the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). This value is ignored on Android, where the underlying SDK determines the duration.
+- **Replay duration (ms)** (`SessionReplayDurationMs`, default `5000`, range `1000`–`60000`) — The requested length of the retroactive replay window. On Windows, Linux, macOS, and iOS this is the rolling clip length kept on disk for crash attachment; on Xbox it's the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). This value is ignored on Android, where the underlying SDK determines the duration.
 
-### Advanced Recording Options (Windows, macOS & Linux)
+### Advanced Recording Options (Windows, macOS, Linux & iOS)
 
-The **Advanced recording options** group (`SessionReplayOptions`) provides low-level encoder and muxer tuning for the desktop recorders. The defaults are sensible for most projects.
+The **Advanced recording options** group (`SessionReplayOptions`) provides low-level encoder and muxer tuning for the desktop and iOS recorders. The defaults are sensible for most projects.
 
 - **Fragment duration (seconds)** (`FragmentSeconds`, default `0.5`, range `0.1`–`2.0`) — Length of each video fragment. Shorter values reduce the worst-case amount of footage lost at crash time, but increase keyframe frequency and lower compression efficiency.
 - **Rotation interval (seconds)** (`RotationIntervalSeconds`, default `1.0`, range `0.25`–`5.0`) — How often the on-disk attachment file is refreshed.
@@ -66,20 +67,22 @@ SessionReplayOptions=(FragmentSeconds=0.500000,RotationIntervalSeconds=1.000000,
 
 ## Platform Notes
 
-### Desktop (Windows, macOS, and Linux)
+### Desktop and iOS
 
-On desktop platforms, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports captured by the native crash handler. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
+On desktop platforms and iOS, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
 
-| Platform    | Encoder            | Engine plugins              | GPU and driver requirements                                                                     |
+| Platform    | Encoder            | Engine plugins              | Requirements                                                                                     |
 | ----------- | ------------------ | --------------------------- | ----------------------------------------------------------------------------------------------- |
 | **Windows** | NVIDIA NVENC       | `AVCodecsCore`, `NVCodecs`  | NVIDIA GPU with driver **531.61** or newer.                                                      |
 | **Windows** | AMD AMF            | `AVCodecsCore`, `AMFCodecs` | AMD GPU with a recent Adrenalin driver. D3D11/D3D12 RHI only — not available when running with `-vulkan`. |
 | **Linux**   | NVIDIA NVENC       | `AVCodecsCore`, `NVCodecs`  | NVIDIA GPU with proprietary driver **530.41** or newer — NVENC isn't available with the open-source Nouveau driver. |
 | **macOS**   | Apple VideoToolbox | `AVCodecsCore`, `VTCodecs`  | None — uses the dedicated hardware media engine on Apple Silicon and a software fallback on Intel Macs. |
+| **iOS**     | Apple VideoToolbox | `AVCodecsCore`, `VTCodecs`  | Unreal Engine **5.8 or newer** — earlier engine versions don't ship the AVCodecs plugins for iOS. Hardware-accelerated on all devices. |
 
 - **Enable the codec plugins for every GPU vendor you want to cover.** The Sentry plugin only compiles the recorder when `AVCodecsCore` is present. On Windows, `NVCodecs` and `AMFCodecs` can be enabled side by side — the encoder matching the player's GPU is selected at runtime.
 - **A plugin rebuild is required after toggling the setting.** Whether Session Replay is compiled in is decided at build time from `AttachSessionReplay`, so after enabling or disabling it, delete your project's `Binaries` and `Intermediate` directories and rebuild.
 - **Machines without a compatible encoder fall back to no recording.** The feature self-disables for the session and logs a warning; crash reporting itself is unaffected.
+- **On macOS and iOS, the clip is uploaded on the next app launch.** The Windows and Linux crash handlers attach the clip at crash time, while on Apple platforms the crash of the previous run is detected during the next SDK initialization, which is when the recorded clip is attached and uploaded.
 
 <Alert>
 
@@ -99,7 +102,7 @@ On Android, enabling the setting turns on the [Android SDK's Session Replay](/pl
 
 <Alert level="warning">
 
-On Windows, Linux, macOS, and Xbox, Session Replay records the rendered game frames as-is — there is **no automatic masking**. Any sensitive information shown on screen (player names, chat, email addresses, in-game purchases, and so on) will be present in the captured video. Only enable this feature if the content rendered by your game is safe to record, and make sure your data-handling and privacy policies account for it.
+On Windows, Linux, macOS, iOS, and Xbox, Session Replay records the rendered game frames as-is — there is **no automatic masking**. Any sensitive information shown on screen (player names, chat, email addresses, in-game purchases, and so on) will be present in the captured video. Only enable this feature if the content rendered by your game is safe to record, and make sure your data-handling and privacy policies account for it.
 
 </Alert>
 


### PR DESCRIPTION
This PR adds iOS-specific details to the Session Replay docs for Unreal SDK.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1462