### PR TITLE
feat(devdocs): Add guidance for updating `sample_rate`

### DIFF
--- a/develop-docs/sdk/foundations/trace-propagation/index.mdx
+++ b/develop-docs/sdk/foundations/trace-propagation/index.mdx
@@ -2,7 +2,7 @@
 title: Trace Propagation
 description: How SDKs propagate trace context between services via headers, metadata, and environment variables.
 spec_id: sdk/foundations/trace-propagation
-spec_version: 1.9.0
+spec_version: 1.10.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes

--- a/develop-docs/sdk/foundations/trace-propagation/index.mdx
+++ b/develop-docs/sdk/foundations/trace-propagation/index.mdx
@@ -12,7 +12,7 @@ spec_depends_on:
 spec_changelog:
   - version: 1.10.0
     date: 2026-07-06
-    summary: Added sample_rate updating in baggage
+    summary: Added Sampling Rate Propagation section
   - version: 1.9.0
     date: 2026-02-24
     summary: Consolidated into foundations/trace-propagation
@@ -251,11 +251,11 @@ A transaction's sampling decision **MUST** be passed to all of its children, inc
 
 </SpecSection>
 
-<SpecSection id="sampling-decision-propagation" status="stable" since="1.0.0">
+<SpecSection id="sampling-decision-propagation" status="stable" since="1.10.0">
 
 ### Sampling Rate Propagation
 
-If there is an incoming `sample_rate`, it SHOULD be updated in the baggage if:
+If there is an incoming `sample_rate`, it **SHOULD** be updated in the baggage if:
 - an explicit sampling decision is forced, e.g. `startTransaction(sampled: true)`
 - the `tracesSampler` is invoked
 - the `tracesSampleRate` is used

--- a/develop-docs/sdk/foundations/trace-propagation/index.mdx
+++ b/develop-docs/sdk/foundations/trace-propagation/index.mdx
@@ -10,6 +10,9 @@ spec_depends_on:
   - id: sdk/foundations/state-management/scopes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.10.0
+    date: 2026-07-06
+    summary: Added sample_rate updating in baggage
   - version: 1.9.0
     date: 2026-02-24
     summary: Consolidated into foundations/trace-propagation
@@ -245,6 +248,20 @@ tracesSampler: ({ name, parentSampleRate }) => {
 ### Sampling Decision Propagation
 
 A transaction's sampling decision **MUST** be passed to all of its children, including across service boundaries. This can be accomplished in the `startChild` method for same-service children and using the `sentry-trace` header for children in a different service.
+
+</SpecSection>
+
+<SpecSection id="sampling-decision-propagation" status="stable" since="1.0.0">
+
+### Sampling Rate Propagation
+
+If there is an incoming `sample_rate`, it SHOULD be updated in the baggage if:
+- an explicit sampling decision is forced, e.g. `startTransaction(sampled: true)`
+- the `tracesSampler` is invoked
+- the `tracesSampleRate` is used
+- the SDK downsamples due to backpressure
+
+In other words, whenever the SDK's effective sampling rate overrides the incoming `sample_rate`, it needs to be updated, even if the baggage is considered immutable.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/trace-propagation/index.mdx
+++ b/develop-docs/sdk/foundations/trace-propagation/index.mdx
@@ -263,7 +263,7 @@ If there is an incoming `sample_rate`, it **SHOULD** be updated in the baggage i
 
 In other words, whenever the SDK's effective sampling rate overrides the incoming `sample_rate`, it needs to be updated, even if the baggage is considered immutable.
 
-Note that this rule only takes into account the effective sampling rate. If there is a `tracesSampleRate` defined, and there's an incoming sampling decision, the local `tracesSampleRate` is not the effective sampling rate -- it's ignored as the parent sampling decision takes precedence. In that case, the incoming `sample_rate` MUST NOT be updated.
+Note that this rule only takes into account the effective sampling rate, i.e., the sampling rate that was actually used to make the sampling decision. If there is a `tracesSampleRate` defined, and there's an incoming sampling decision, the local `tracesSampleRate` is not the effective sampling rate -- it's ignored as the parent sampling decision takes precedence. In that case, the incoming `sample_rate` MUST NOT be updated.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/trace-propagation/index.mdx
+++ b/develop-docs/sdk/foundations/trace-propagation/index.mdx
@@ -251,7 +251,7 @@ A transaction's sampling decision **MUST** be passed to all of its children, inc
 
 </SpecSection>
 
-<SpecSection id="sampling-decision-propagation" status="stable" since="1.10.0">
+<SpecSection id="sampling-rate-propagation" status="stable" since="1.10.0">
 
 ### Sampling Rate Propagation
 

--- a/develop-docs/sdk/foundations/trace-propagation/index.mdx
+++ b/develop-docs/sdk/foundations/trace-propagation/index.mdx
@@ -263,6 +263,8 @@ If there is an incoming `sample_rate`, it **SHOULD** be updated in the baggage i
 
 In other words, whenever the SDK's effective sampling rate overrides the incoming `sample_rate`, it needs to be updated, even if the baggage is considered immutable.
 
+Note that this rule only takes into account the effective sampling rate. If there is a `tracesSampleRate` defined, and there's an incoming sampling decision, the local `tracesSampleRate` is not the effective sampling rate -- it's ignored as the parent sampling decision takes precedence. In that case, the incoming `sample_rate` MUST NOT be updated.
+
 </SpecSection>
 
 <SpecSection id="default-propagation" status="stable" since="1.5.0">


### PR DESCRIPTION
At some point last year, we implemented sample rate updating under specific conditions in most SDKs. This is missing from the spec.

Original implementation ticket: https://github.com/getsentry/team-sdks/issues/117


## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

