### PR TITLE
docs: remove warning about equation support for app metrics

### DIFF
--- a/docs/product/metrics/index.mdx
+++ b/docs/product/metrics/index.mdx
@@ -132,10 +132,6 @@ You can pin any metric query as a widget on a [Dashboard](/product/dashboards/) 
 - From the Metrics Explorer, open **Save As → Dashboard widget** and choose the metric query you want to visualize.
 - If you have multiple metric queries on the page, you can add them individually or pick **All Metrics** to create a single widget containing all of them.
 
-<Alert level="info">
-  Equations can't currently be added as dashboard widgets — add the underlying metric queries instead.
-</Alert>
-
 ## Saving Queries
 
 Frequently-used metric queries can be saved and re-opened from the [Explorer](https://sentry.io/explore/metrics/):


### PR DESCRIPTION
We just GAd support for equations in application metrics.