### PR TITLE
Update roles to lowercase

### DIFF
--- a/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
+++ b/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
@@ -109,13 +109,20 @@ Here's how to assign an organization-level role to an Okta group:
     ![Okta Set Role](./img/okta-set-group-attribute.png)
 
 - If the `sentryOrgField` field is left blank, group members will be provisioned with the default organization-level role. This default role can be configured in Sentry, under Settings -> Organization -> Auth. Otherwise, the role must be one of the following:
-  - Admin
-  - Manager
-  - Billing
-  - Member
+  - admin
+  - manager
+  - billing
+  - member
 - Invalid role names will prevent group members from being provisioned. To try again, you'll need to remove the group first.
 - For security reasons, the "Owner" role cannot be provisioned through SCIM. However, you <i>can</i> deprovision users who have the "Owner" role in Sentry, but aren't provisioned through SCIM.
   - For self-hosted users with custom roles, this extends to any role with the `org:admin` permission
+
+<Alert>
+
+Set the roles in the `sentryOrgField` field using lowercase characters only to prevent validation errors in Okta when provisioning users.
+
+</Alert>
+
 
 <Alert>
 

--- a/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
+++ b/docs/organization/authentication/sso/okta-sso/okta-scim.mdx
@@ -108,7 +108,7 @@ Here's how to assign an organization-level role to an Okta group:
 3.  In the form, enter the string for the org-level role
     ![Okta Set Role](./img/okta-set-group-attribute.png)
 
-- If the `sentryOrgField` field is left blank, group members will be provisioned with the default organization-level role. This default role can be configured in Sentry, under Settings -> Organization -> Auth. Otherwise, the role must be one of the following:
+- If the `sentryOrgRole` field is left blank, group members will be provisioned with the default organization-level role. This default role can be configured in Sentry, under Settings -> Organization -> Auth. Otherwise, the role must be one of the following:
   - admin
   - manager
   - billing
@@ -119,7 +119,7 @@ Here's how to assign an organization-level role to an Okta group:
 
 <Alert>
 
-Set the roles in the `sentryOrgField` field using lowercase characters only to prevent validation errors in Okta when provisioning users.
+Set the roles in the `sentryOrgRole` field using lowercase characters only to prevent validation errors in Okta when provisioning users.
 
 </Alert>
 


### PR DESCRIPTION
When using mixed case setting roles in Okta (Admin, Member), Okta can throw validation errors:
```
Error setting property, appUser-[REDACTED]
property=sentryOrgRole error=[Error in object 'appUser': codes
[invalidValueTypeForProperty.appUser,invalidValueTypeForProp
erty]; arguments [sentryOrgRole]; default message
[Unsupported data type value for given key]]
```

Changing the list of options to lowercase and adding a note to prevent this error while eng works in the validation issue. [Reference issue.](https://app.intercom.com/a/inbox/onh0p2wm/inbox/admin/10046696/conversation/215474792036537?view=List)