### PR TITLE
Align Expo Router ErrorBoundary auto-wrap docs with the SDK default

### DIFF
--- a/docs/platforms/react-native/guides/expo/tracing/instrumentation/expo-router.mdx
+++ b/docs/platforms/react-native/guides/expo/tracing/instrumentation/expo-router.mdx
@@ -110,21 +110,13 @@ Because React considers the error handled once the boundary renders the fallback
 
 ### Automatic Wrapping (Recommended)
 
-If you use `getSentryExpoConfig` in your `metro.config.js`, the SDK auto-wraps `export { ErrorBoundary } from 'expo-router'` re-exports at build time:
+If you use `getSentryExpoConfig` in your `metro.config.js`, the SDK can auto-wrap `export { ErrorBoundary } from 'expo-router'` re-exports at build time. This is opt-in — enable it with `autoWrapExpoRouterErrorBoundary: true` (requires SDK `8.17.2` or later):
 
 ```javascript {filename: metro.config.js}
 const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 
-module.exports = getSentryExpoConfig(__dirname);
-```
-
-Auto-wrapping is on by default with `getSentryExpoConfig`. Aliased re-exports (`export { ErrorBoundary as Foo }`) keep the user-chosen name, and mixed re-exports (`export { ErrorBoundary, Stack }`) preserve the non-boundary specifiers.
-
-To opt out:
-
-```javascript {filename: metro.config.js}
 module.exports = getSentryExpoConfig(__dirname, {
-  autoWrapExpoRouterErrorBoundary: false,
+  autoWrapExpoRouterErrorBoundary: true,
 });
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Aligns the Expo Router `ErrorBoundary` auto-wrap docs with the SDK's default value.

`autoWrapExpoRouterErrorBoundary` defaults to `false` (opt-in) in both `getSentryExpoConfig` and `withSentryConfig`. This updates the setup section to match:

- The `getSentryExpoConfig` example now enables the option explicitly (`autoWrapExpoRouterErrorBoundary: true`).
- Copy reflects that auto-wrapping is opt-in, available since SDK `8.17.2`.

Manual wrapping and the rest of the section are unchanged.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
