### PR TITLE
docs(feature-flags): add clear_feature_flags scope API spec (1.0.2)

### DIFF
--- a/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
+++ b/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
@@ -2,12 +2,15 @@
 title: Feature Flags
 description: Guidelines for tracking feature flag evaluations — scope storage, span attributes, the add_feature_flag API, and third-party integrations.
 spec_id: sdk/foundations/client/integrations/feature-flags
-spec_version: 1.0.1
+spec_version: 1.0.2
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/client/integrations
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.0.2
+    date: 2026-07-07
+    summary: Added `clear_feature_flags` scope API
   - version: 1.0.1
     date: 2026-06-05
     summary: Fixed `add_feature_flag` API specifying unsupported feature flag value types
@@ -44,6 +47,16 @@ When tracking on error feature flag evaluations, we record the 100 most recent, 
 ### The `add_feature_flag` API
 
 If an SDK supports feature flags it MUST expose a function `add_feature_flag` which has similar behavior to the `set_tag` function. It MUST accept a key of type string and a value of type `boolean`. Non-boolean values MUST be rejected.
+
+</SpecSection>
+
+<SpecSection id="clear-feature-flags" status="stable" since="1.0.2">
+
+### The `clear_feature_flags` API
+
+SDKs **MAY** expose a `clear_feature_flags` function on the scope. When called, it **MUST** remove all feature flag evaluations stored on the current scope. It **MUST NOT** affect feature flags on parent or sibling scopes.
+
+This API mirrors the `remove_breadcrumbs` pattern and is useful when an application runs many experiments and needs to discard stale flag evaluations before capturing an event.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
+++ b/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
@@ -56,8 +56,6 @@ If an SDK supports feature flags it MUST expose a function `add_feature_flag` wh
 
 SDKs **MAY** expose a `clear_feature_flags` function on the scope. When called, it **MUST** remove all feature flag evaluations stored on the current scope. It **MUST NOT** affect feature flags on parent or sibling scopes.
 
-This API mirrors the `clear_breadcrumbs` pattern and is useful when an application runs many experiments and needs to discard stale flag evaluations before capturing an event.
-
 </SpecSection>
 
 <SpecSection id="feature-flag-integrations" status="stable" since="1.0.0">

--- a/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
+++ b/develop-docs/sdk/foundations/client/integrations/feature-flags.mdx
@@ -56,7 +56,7 @@ If an SDK supports feature flags it MUST expose a function `add_feature_flag` wh
 
 SDKs **MAY** expose a `clear_feature_flags` function on the scope. When called, it **MUST** remove all feature flag evaluations stored on the current scope. It **MUST NOT** affect feature flags on parent or sibling scopes.
 
-This API mirrors the `remove_breadcrumbs` pattern and is useful when an application runs many experiments and needs to discard stale flag evaluations before capturing an event.
+This API mirrors the `clear_breadcrumbs` pattern and is useful when an application runs many experiments and needs to discard stale flag evaluations before capturing an event.
 
 </SpecSection>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a `clear_feature_flags` scope API section to the Feature Flags SDK spec, bumping the spec to **1.0.2**.

### What changed

- New `SpecSection` documenting the `clear_feature_flags` API on scope
- API is **MAY** (optional): SDKs may expose it; when they do, it **MUST** clear all feature flag evaluations on the current scope without affecting parent/sibling scopes
- Spec version bumped `1.0.1 → 1.0.2` with changelog entry

### Why

This surfaced during sentry-cocoa feature flag work (getsentry/sentry-cocoa#8364). sentry-java already ships this API (JAVA-512). Cocoa is aligning with Java, and the spec had no entry for it, leading to inconsistency across SDKs. The Slack thread in #team-sdks confirmed the team wants this as a scope-level API (not on spans) to help users — particularly those running large numbers of experiments — discard stale evaluations before capturing an error event.

### Verified

Content consistency review: frontmatter spec version and changelog entry are consistent; RFC 2119 keywords are uppercase and bold per AGENTS.md; `SpecSection` id/status/since attributes follow existing patterns.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3ACUCRT2B70%3A1783075327.788129/?project=4510944073809921)

<!-- junior-session-footer:end -->