### PR TITLE
docs(snapshots): Document canvas_theme sidecar metadata

### DIFF
--- a/docs/platforms/apple/common/snapshots/snapshotpreviews-metadata.mdx
+++ b/docs/platforms/apple/common/snapshots/snapshotpreviews-metadata.mdx
@@ -35,6 +35,7 @@ import SnapshotPreferences
       ],
     ])
     .snapshotDiffThreshold(0.01)
+    .snapshotCanvasTheme(.dark)
 }
 ```
 
@@ -45,6 +46,7 @@ import SnapshotPreferences
 | `.snapshotTags([String: String])`           | Adds top-level `tags` to the sidecar for filtering or grouping snapshots.                                                                             |
 | `.snapshotAdditionalContext([String: Any])` | Adds arbitrary key-value context to the sidecar `context` object. Values can be strings, numbers, booleans, or nested objects.                        |
 | `.snapshotDiffThreshold(Float?)`            | Adds a local `diff_threshold` for this preview. Sentry reports the image as changed only when the share of changed pixels is greater than this value. |
+| `.snapshotCanvasTheme(SnapshotCanvasTheme)` | Sets the top-level `canvas_theme` (`.light` or `.dark`) used behind the image in Sentry's web UI. Display metadata only; it doesn't change the rendered snapshot image. |
 
 ## Generated Sidecar Metadata
 
@@ -59,6 +61,7 @@ SnapshotPreviews generates default sidecar metadata for each preview. The exact 
     "team": "growth"
   },
   "diff_threshold": 0.01,
+  "canvas_theme": "dark",
   "context": {
     "test_name": "-[YourAppSnapshotTest portrait-Checkout Preview-1-6]",
     "accessibility_enabled": false,

--- a/docs/product/snapshots/uploading-snapshots/index.mdx
+++ b/docs/product/snapshots/uploading-snapshots/index.mdx
@@ -53,6 +53,7 @@ You can include an optional JSON file to add metadata to each image:
     "team": "growth"
   },
   "diff_threshold": 0.01,
+  "canvas_theme": "dark",
   "context": {
     "component": "BillingPage",
     "variant": {
@@ -69,6 +70,7 @@ You can include an optional JSON file to add metadata to each image:
 | `group`          | string | Groups related snapshots in the UI sidebar.                                                                                                                            |
 | `tags`           | object | Key-value string labels attached to the snapshot. Use them to filter and group snapshots in the viewer, for example by theme, viewport, or component variant.          |
 | `diff_threshold` | number | Value from `0.0` to `1.0`. Sentry reports the image as changed only when the share of changed pixels is greater than this value. `0.01` ignores changes of 1% or less. |
+| `canvas_theme`   | string | `"light"` or `"dark"`. Controls the background canvas Sentry renders behind the snapshot image in the web UI. Display metadata only; it doesn't change the rendered image. |
 | `context`        | object | Arbitrary key-value context that tools and LLMs can use to help diagnose changes. Values can be strings, numbers, booleans, or nested objects.                         |
 
 ![Example of how metadata impacts the Sentry UI](../img/sentry_ui_metadata.png)


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new `canvas_theme` snapshot metadata introduced in [SnapshotPreviews#273](https://github.com/getsentry/SnapshotPreviews/pull/273). The field sets the light or dark canvas Sentry renders behind a snapshot image in the web UI — it's display metadata only and doesn't change the rendered image.

- Add `canvas_theme` to the platform-agnostic sidecar schema (JSON example + field table) in `uploading-snapshots`
- Add the `.snapshotCanvasTheme(...)` modifier and `canvas_theme` sidecar field to the Apple SnapshotPreviews metadata doc (example, modifier table, sidecar JSON)

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)