### PR TITLE
docs(issue-details): Update 'All Events' to 'View More Events' and note Team plan requirement

### DIFF
--- a/docs/product/issues/issue-details/index.mdx
+++ b/docs/product/issues/issue-details/index.mdx
@@ -29,7 +29,7 @@ The main area of the page displays information about a specific event that's par
 
 ## Event Search
 
-The embedded search bar allows you to search for events using any of the [event properties](/concepts/search/searchable-properties/events). Environment and time period can also be changed. Once the search is updated, the counts and graph below will be updated. Event navigations such as recommended, first, and last, and All Events will also be updated to only show matching events.
+The embedded search bar allows you to search for events using any of the [event properties](/concepts/search/searchable-properties/events). Environment and time period can also be changed. Once the search is updated, the counts and graph below will be updated. Event navigations such as recommended, first, and last, and **View More Events** will also be updated to only show matching events.
 
 ## Trends & Aggregates
 
@@ -71,9 +71,15 @@ By default, the **Issue Details** page displays the "Recommended" event with the
 - **Relevance**: The recommended event takes into account what terms you've searched for on your way to the issue.
 - **Content**: The recommended event prioritizes events that contain debugging tools such as replays, profiles, and traces.
 
-To view other events, you can use the dropdown to skip to the latest or oldest event, or view the full list of events. You can change the default event in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
+To view other events, you can use the dropdown to skip to the latest or oldest event, or click **View More Events** to see the full list. You can change the default event in your [User Settings](https://sentry.io/settings/account/details/#defaultIssueEvent).
 
-In addition, you can scroll between events chronologically or view all events. All event navigations will respect any search filter on the page, including search queries, environments, or date filters.
+<Note>
+
+**View More Events** is only available on [Team plan and above](https://sentry.io/pricing/). On the Free plan, this button will not appear.
+
+</Note>
+
+In addition, you can scroll between events chronologically. All event navigations will respect any search filter on the page, including search queries, environments, or date filters.
 
 ## Event Actions
 


### PR DESCRIPTION
## What changed

Two updates to the Issue Details docs page:

1. **Label rename** — The button previously labeled "All Events" was renamed to **"View More Events"** ("More Events" on narrow viewports) in the Sentry UI. Updated all references in the Event Search and Event Navigation sections.

2. **Plan gating note** — "View More Events" is gated behind the `discover-basic` feature flag, which is only available on Team plan and above. Free plan orgs will not see this button at all. Added a `<Note>` callout in the Event Navigation section to surface this for users who may be confused about the button's absence.

## Why

The docs still said "All Events" while the UI had already shipped the rename. Users on Free plan were confused about why the button wasn't appearing — there was no indication in the docs that it's a paid feature.

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B2KJG9B5Z%3A1782931439.839979/?project=4510944073809921)

<!-- junior-session-footer:end -->