### PR TITLE
docs(unreal): Session Replay product integration

### DIFF
--- a/docs/platforms/unreal/index.mdx
+++ b/docs/platforms/unreal/index.mdx
@@ -26,7 +26,7 @@ Unreal Engine SDK builds on top of other Sentry SDKs and extends them with Unrea
   - Compatibility with the default [Crash Reporter Client](/platforms/unreal/configuration/crash-reporter/crash-reporter-client/) provided along with Unreal Engine
 - [PlayStation](/platforms/playstation/), [Xbox](/platforms/xbox/) and [Nintendo Switch](/platforms/nintendo-switch/) support
 - [Release health](/platforms/unreal/configuration/releases/) to keep track of crash free users and sessions
-- [Session Replay](/platforms/unreal/session-replay/) (experimental) to attach gameplay video to crash reports on Windows, macOS, Linux, iOS (UE 5.8+), and Xbox, and native session replay on Android
+- [Session Replay](/platforms/unreal/session-replay/) (experimental) to capture gameplay video of the moments before a crash
 - [Structured Logging](/platforms/unreal/logs/) to capture and send log messages with additional context
 - [Metrics](/platforms/unreal/metrics/) to track counters, gauges, and distributions
 - [Offline Caching](/platforms/unreal/configuration/options/#EnableOfflineCaching) stores event data to disk in case the device is not online

--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -1,31 +1,31 @@
 ---
 title: Set Up Session Replay
 sidebar_title: Session Replay
-description: "Learn how to capture gameplay video and attach it to crash reports with Sentry's Unreal Engine SDK."
+description: "Learn how to capture gameplay video of the moments leading up to a crash with Sentry's Unreal Engine SDK."
 sidebar_order: 5500
 sidebar_section: features
 ---
 
 <Alert level="warning">
 
-Session Replay for Unreal Engine is **experimental** and currently limited to a small set of platforms (see [Platform Support](#platform-support)). The API and behavior may change in future releases.
+Session Replay for Unreal Engine is **experimental**. The API and behavior may change in future releases.
 
 </Alert>
 
 Session Replay records what was happening on screen in the moments leading up to a crash, giving you a visual reproduction to pair with the captured event.
 
-Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/android/session-replay/) Session Replay experiences, which reconstruct the UI from the view hierarchy and aggressively mask text and images by default, the Unreal Engine SDK captures the rendered output of your game directly. On desktop, iOS, and console, it continuously encodes the rendered frames into a short rolling video clip and attaches that clip to crash reports. On Android, the feature delegates to the underlying [Android SDK's Session Replay](/platforms/android/session-replay/).
+Unlike the [web](/platforms/javascript/session-replay/) and [mobile](/platforms/android/session-replay/) Session Replay experiences, which reconstruct the UI from the view hierarchy and aggressively mask text and images by default, the Unreal Engine SDK captures the rendered output of your game directly. When a crash occurs, the recording is sent to Sentry as a session replay that's linked to the crash event and viewable on the [**Replays**](https://sentry.io/orgredirect/organizations/:orgslug/replays/) page. Capture and delivery differ per platform — see [Platform Notes](#platform-notes) for the details.
 
 ## Platform Support
 
-| Platform    | What gets captured                                                              | Requirements                                                                                        |
-| ----------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **Windows** | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins matching the GPU vendor (NVIDIA or AMD) and a plugin rebuild.\*                |
-| **Linux**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins, an NVIDIA GPU, and a plugin rebuild.\*                                        |
-| **macOS**   | A rolling video clip of the game's backbuffer, attached to crash reports.       | Engine codec plugins and a plugin rebuild.\*                                                        |
-| **iOS**     | A rolling video clip of the game's backbuffer, attached to crash reports.       | Unreal Engine **5.8 or newer**, engine codec plugins, and a plugin rebuild.\*                       |
-| **Xbox**    | An OS-captured gameplay clip, attached to crash reports.                        | Development kits only.                                                                               |
-| **Android** | A full-session replay via the Android SDK, with default text and image masking. | None beyond the standard Android setup.                                                             |
+| Platform    | What gets captured                                               | Requirements                                                                           |
+| ----------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Windows** | A rolling video clip of the game's backbuffer.                   | Engine codec plugins matching the GPU vendor (NVIDIA or AMD) and a plugin rebuild.\*   |
+| **Linux**   | A rolling video clip of the game's backbuffer.                   | Engine codec plugins, an NVIDIA GPU, and a plugin rebuild.\*                           |
+| **macOS**   | A rolling video clip of the game's backbuffer.                   | Engine codec plugins and a plugin rebuild.\*                                           |
+| **iOS**     | A rolling video clip of the game's backbuffer.                   | Unreal Engine **5.8 or newer**, engine codec plugins, and a plugin rebuild.\*          |
+| **Android** | A sequence of periodic screenshots stitched into a video.        | None beyond the standard Android setup.                                                |
+| **Xbox**    | An OS-captured gameplay clip, attached to crash reports only.    | Development kits only.                                                                 |
 
 \* See the [Platform Notes](#platform-notes) below for the exact engine version, plugin, GPU, and driver requirements.
 
@@ -69,7 +69,7 @@ SessionReplayOptions=(FragmentSeconds=0.500000,RotationIntervalSeconds=1.000000,
 
 ### Desktop (Windows, macOS, and Linux)
 
-On desktop platforms, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's attached to crash reports. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
+On desktop platforms, Session Replay continuously encodes the game's backbuffer into a rolling video clip that's delivered to Sentry when a crash occurs. Encoding is hardware-accelerated; the SDK automatically picks an encoder at runtime from the codec plugins enabled in your project:
 
 | Platform    | Encoder            | Engine plugins              | GPU and driver requirements                                                                     |
 | ----------- | ------------------ | --------------------------- | ----------------------------------------------------------------------------------------------- |
@@ -81,6 +81,7 @@ On desktop platforms, Session Replay continuously encodes the game's backbuffer 
 - **Enable the codec plugins for every GPU vendor you want to cover.** The Sentry plugin only compiles the recorder when `AVCodecsCore` is present. On Windows, `NVCodecs` and `AMFCodecs` can be enabled side by side — the encoder matching the player's GPU is selected at runtime.
 - **A plugin rebuild is required after toggling the setting.** Whether Session Replay is compiled in is decided at build time from `AttachSessionReplay`, so after enabling or disabling it, delete your project's `Binaries` and `Intermediate` directories and rebuild.
 - **Machines without a compatible encoder fall back to no recording.** The feature self-disables for the session and logs a warning; crash reporting itself is unaffected.
+- **The replay may arrive after the next app launch.** With the default backends (Crashpad on Windows and Linux, sentry-cocoa on macOS), the replay is uploaded on the next application launch after the crash. With the opt-in native backend, it's uploaded during the crashed session.
 
 <Alert>
 
@@ -93,6 +94,8 @@ The most recent fraction of a second of footage (up to one fragment duration) ma
 On iOS, Session Replay uses the same recording pipeline as desktop, encoding the game's backbuffer with Apple VideoToolbox via the `AVCodecsCore` and `VTCodecs` engine plugins. Encoding is hardware-accelerated on all devices, and the desktop notes above (plugin rebuild, encoder fallback) apply equally.
 
 iOS requires **Unreal Engine 5.8 or newer** — earlier engine versions don't ship the AVCodecs plugins for iOS, and the setting is a no-op there.
+
+The replay is uploaded on the next app launch, together with the crash report.
 
 Session Replay assumes your game runs in a **fixed screen orientation** (typical for games). The recording orientation is determined once when the SDK initializes; if your game supports both portrait and landscape and the device is rotated mid-session, the recording stays locked to the initial orientation and subsequent footage may appear squeezed or stretched. Crash reporting itself is unaffected.
 
@@ -107,22 +110,22 @@ AdditionalPlistData=<key>NSCameraUsageDescription</key><string>This app does not
 
 </Alert>
 
+### Android
+
+On Android, enabling the setting turns on the [Android SDK's Session Replay](/platforms/android/session-replay/), which records the full session rather than a short pre-crash clip. It works differently from the desktop and iOS recorders: instead of encoding the game's rendered frames, it periodically captures screenshots of the game surface and stitches them into a video. See the [Android Session Replay docs](/platforms/android/session-replay/) for details on sampling and configuration.
+
 ### Xbox
 
 On Xbox, Session Replay uses the operating system's game-capture facility to grab a clip of recent gameplay at crash time. This is supported on **development kits only** and is not available in retail builds.
-
-### Android
-
-On Android, enabling the setting turns on the [Android SDK's Session Replay](/platforms/android/session-replay/), recording the full session rather than a crash-attached clip. As with the standalone Android SDK, all text and images are masked by default. See the [Android Session Replay docs](/platforms/android/session-replay/) for details on masking, sampling, and privacy.
 
 ## Privacy
 
 <Alert level="warning">
 
-On Windows, Linux, macOS, iOS, and Xbox, Session Replay records the rendered game frames as-is — there is **no automatic masking**. Any sensitive information shown on screen (player names, chat, email addresses, in-game purchases, and so on) will be present in the captured video. Only enable this feature if the content rendered by your game is safe to record, and make sure your data-handling and privacy policies account for it.
+On Windows, Linux, macOS, iOS, Android, and Xbox, Session Replay records the rendered game frames as-is — there is **no automatic masking**. Any sensitive information shown on screen (player names, chat, email addresses, in-game purchases, and so on) will be present in the captured video. Only enable this feature if the content rendered by your game is safe to record, and make sure your data-handling and privacy policies account for it.
 
 </Alert>
 
-On Android, the underlying SDK masks all text and images by default. Review the [Android Session Replay privacy documentation](/platforms/android/session-replay/privacy/) before adjusting those defaults.
+On Android, the SDK's default text and image masking applies to the native Android view hierarchy, not to the game's rendering surface, which is captured directly. Review the [Android Session Replay privacy documentation](/platforms/android/session-replay/privacy/) for details on masking any native UI your game overlays.
 
 If you run into issues or have feedback about Session Replay on Unreal Engine, please open a [GitHub issue](https://github.com/getsentry/sentry-unreal/issues).


### PR DESCRIPTION
This PR updates the Unreal SDK Session Replay documentation now that the feature is fully integrated with the corresponding Sentry product.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1445
- https://github.com/getsentry/sentry-unreal/pull/1468