### PR TITLE
docs(cli): Share disambiguation banner across CLI pages

### DIFF
--- a/docs/cli/code-mappings.mdx
+++ b/docs/cli/code-mappings.mdx
@@ -3,6 +3,9 @@ title: "Code Mappings"
 sidebar_order: 5
 description: "Upload code mappings to Sentry via the CLI. Code mappings link stack trace paths to source code paths in your repository, enabling source context, suspect commits, and code owners."
 ---
+
+<Include name="cli-looking-for-sentry-cli" />
+
 _Available in version 3.3.4 of Sentry CLI_
 
 Code mappings link stack trace paths to source code paths in your repository. They enable features like [source context](/platforms/java/source-context/), [suspect commits](/product/issues/suspect-commits/), [stack trace linking](/integrations/source-code-mgmt/github/#stack-trace-linking), and [code owners](/product/issues/ownership-rules/).

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -4,6 +4,8 @@ sidebar_order: 1
 description: "Learn about the functionality of Sentry’s command line interface, including installation, configuration, and authentication."
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 For most functionality you need to authenticate with Sentry. Setting this up can be done either automatically, using `sentry-cli`, or manually via [Organization Tokens](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/).
 
 ## To use the automatic option:

--- a/docs/cli/crons.mdx
+++ b/docs/cli/crons.mdx
@@ -4,6 +4,8 @@ sidebar_order: 200
 description: "Follow this guide to set up and manage monitors using the Sentry CLI."
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 <Alert title="Deprecation Notice">
 
 Starting with v2.16.1 of the Sentry CLI, the ability to monitor check-ins using an auth token for authorization has been deprecated. Read on to learn how to update your CLI and use your project's DSN instead.

--- a/docs/cli/dif.mdx
+++ b/docs/cli/dif.mdx
@@ -4,6 +4,8 @@ sidebar_order: 3
 description: "Debug information files allow Sentry to extract stack traces and provide more information about crash reports for most compiled platforms. Sentry's CLI can be used to validate and upload debug information files. "
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 Debug information files allow Sentry to extract stack traces and provide more
 information about crash reports for most compiled platforms. `sentry-cli` can be
 used to validate and upload debug information files. For more general

--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -12,11 +12,7 @@ keywords:
 description: "Learn how to use the `sentry-cli` command line executable."
 ---
 
-<Alert level="info" title="Looking for the Sentry CLI?">
-
-These docs cover `sentry-cli`, used in CI/CD pipelines and build processes. If you're looking for the interactive developer CLI with issue management, AI-powered analysis, and API access for humans and agents, check out the new [Sentry CLI](https://cli.sentry.dev/).
-
-</Alert>
+<Include name="cli-looking-for-sentry-cli" />
 
 For certain actions, you can use the `sentry-cli` command line executable. It can connect to the Sentry API and manage some data for your projects. It’s primarily used for managing debug information files for iOS, Android, release and source maps management, as well as code mappings for other platforms.
 

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -4,6 +4,8 @@ sidebar_order: 0
 description: "Learn about the different methods available to install `sentry-cli`."
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 Depending on your platform, there are different methods available to install `sentry-cli`.
 
 ## Manual Download

--- a/docs/cli/logs.mdx
+++ b/docs/cli/logs.mdx
@@ -4,6 +4,8 @@ sidebar_order: 5
 description: "Learn how to view and stream logs using the Sentry CLI."
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 The `sentry-cli` tool can be used to view and stream logs from your Sentry projects. This allows you to monitor your application logs directly from the command line.
 
 ## Requirements

--- a/docs/cli/releases.mdx
+++ b/docs/cli/releases.mdx
@@ -4,6 +4,8 @@ sidebar_order: 2
 description: "Sentry's command line interface can be used for release management. The CLI allows you to create, edit and delete releases as well as upload release artifacts."
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 The `sentry-cli` tool can be used for release management on Sentry. It allows you to create, edit and delete releases as well as upload release artifacts for them. Note that releases are global per organization. If you want the releases in different projects to be treated as separate entities, make the version name unique across the organization. For example, if you have projectA and projectB that share version numbers, you can name the releases `projectA-1.0` and `projectB-1.0` respectively.
 
 <Alert>

--- a/docs/cli/send-event.mdx
+++ b/docs/cli/send-event.mdx
@@ -4,6 +4,8 @@ sidebar_order: 4
 description: "Learn how Sentry's command line interface can be used for sending events."
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 The `sentry-cli` tool can also be used for sending events. If you want to use it, you need to export the `SENTRY_DSN` environment variable and point it to the DSN of a project of yours:
 
 

--- a/docs/cli/snapshots.mdx
+++ b/docs/cli/snapshots.mdx
@@ -5,6 +5,8 @@ description: "Upload snapshot images to Sentry with sentry-cli for visual diffin
 beta: true
 ---
 
+<Include name="cli-looking-for-sentry-cli" />
+
 <Include name="feature-stage-beta.mdx" />
 
 The `sentry-cli snapshots upload` command uploads a directory of images to [Snapshots](/product/snapshots/) for visual diffing against a base build.

--- a/includes/cli-looking-for-sentry-cli.mdx
+++ b/includes/cli-looking-for-sentry-cli.mdx
@@ -1,4 +1,4 @@
-<Alert level="info" title="Looking for the Sentry CLI?">
+<Alert level="info" title="Looking for the new Sentry CLI?">
 
 These docs cover `sentry-cli`, used in CI/CD pipelines and build processes. If you're looking for the interactive developer CLI with issue management, AI-powered analysis, and API access for humans and agents, check out the new [Sentry CLI](https://cli.sentry.dev/).
 

--- a/includes/cli-looking-for-sentry-cli.mdx
+++ b/includes/cli-looking-for-sentry-cli.mdx
@@ -1,0 +1,5 @@
+<Alert level="info" title="Looking for the Sentry CLI?">
+
+These docs cover `sentry-cli`, used in CI/CD pipelines and build processes. If you're looking for the interactive developer CLI with issue management, AI-powered analysis, and API access for humans and agents, check out the new [Sentry CLI](https://cli.sentry.dev/).
+
+</Alert>


### PR DESCRIPTION
## DESCRIBE YOUR PR

The "Looking for the Sentry CLI?" info banner on `/cli/` only appeared on the index page. CLI subpages like Installation and Configuration had no equivalent notice, so readers could land on `sentry-cli` docs when they meant the interactive developer CLI at cli.sentry.dev.

This extracts the banner into `includes/cli-looking-for-sentry-cli.mdx` and adds `<Include name="cli-looking-for-sentry-cli" />` to all 10 CLI pages. Page-specific alerts (crons deprecation, snapshots beta, etc.) stay below the shared banner.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## Test plan

- Open Vercel preview for `/cli/` and confirm the info banner still renders
- Spot-check `/cli/installation/` and `/cli/crons/` — shared banner at top, page-specific alerts below on crons

Made with [Cursor](https://cursor.com)