### PR TITLE
feat(apple): Mark swiftAsyncStacktraces as stable

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -1195,11 +1195,11 @@ If enabled, the view hierarchy attachment will contain view `accessibilityIdenti
 
 </SdkOption>
 
-<SdkOption name="swiftAsyncStacktraces" type="bool" defaultValue="false">
+<SdkOption name="swiftAsyncStacktraces" type="bool" defaultValue="false" availableSince="9.22.0">
 
 This feature is only available from Xcode 13 and from macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0.
 
-This is an experimental feature and may still have bugs. When enabled, the SDK stitches the call to Swift Async functions in one consecutive stack trace.
+When enabled, the SDK stitches the call to Swift Async functions in one consecutive stack trace.
 
 </SdkOption>
 


### PR DESCRIPTION
Mark swiftAsyncStacktraces as stable.

Merge only after releasing Cocoa 9.22.0. Related Cocoa PR https://github.com/getsentry/sentry-cocoa/pull/8373/