### PR TITLE
docs(build-distribution): Clarify install-group overlap is an OR match

### DIFF
--- a/docs/platforms/android/build-distribution/install-groups.mdx
+++ b/docs/platforms/android/build-distribution/install-groups.mdx
@@ -59,7 +59,7 @@ sentry_upload_build(
 
 ## How Install Groups Work With the Auto-Update SDK
 
-When the Auto-Update SDK checks for updates, the API returns the single latest build (highest semver version, with build number as tiebreaker) whose install groups overlap with the filter:
+When the Auto-Update SDK checks for updates, the API returns the single latest build (highest semver version, with build number as tiebreaker) that shares **at least one** install group with the filter. Install group filters are based on OR matches:
 
 - If the SDK **provides groups explicitly**, the API uses those to filter.
 - If the SDK **doesn't provide groups**, the API falls back to looking up the uploaded build by `buildVersion` and `buildNumber` and using that build's install groups. If multiple builds share the same version and build number, the API picks the most recently uploaded one, which may lead to unexpected results.

--- a/docs/platforms/apple/guides/ios/build-distribution/install-groups.mdx
+++ b/docs/platforms/apple/guides/ios/build-distribution/install-groups.mdx
@@ -37,7 +37,7 @@ sentry_upload_build(
 
 ## How Install Groups Work With the Auto-Update SDK
 
-When the [Auto-Update SDK](/platforms/apple/guides/ios/build-distribution/auto-update/) checks for updates, the API returns the single latest build (highest semver version, with build number as tiebreaker) whose install groups overlap with the filter:
+When the [Auto-Update SDK](/platforms/apple/guides/ios/build-distribution/auto-update/) checks for updates, the API returns the single latest build (highest semver version, with build number as tiebreaker) that shares **at least one** install group with the filter. Install group filters are based on OR matches:
 
 - If the SDK **provides groups explicitly**, the API uses those to filter.
 - If the SDK **doesn't provide groups**, the API looks up the uploaded build using the UUID of the app binary and uses that build's upload groups for filtering.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarifies the auto-update SDK section of the install-groups docs. The previous wording said a build matches when its install groups "overlap" with the filter, which readers interpreted as requiring the build to share *every* group. The filter is actually an OR of per-group containment — a build is eligible if it shares **at least one** install group with the filter.

Updated both the iOS and Android install-groups pages with matching wording.

- `docs/platforms/apple/guides/ios/build-distribution/install-groups.mdx`
- `docs/platforms/android/build-distribution/install-groups.mdx`

Refs EME-1238

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)