### PR TITLE
fix(ci): Resolve double `JSON.parse` in redirect chain lint workflow

### DIFF
--- a/.github/workflows/lint-redirect-chains.yml
+++ b/.github/workflows/lint-redirect-chains.yml
@@ -68,11 +68,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
-            const lintResultJsonString = ${{ toJSON(steps.lint.outputs.lint_result) }};
+            const lintResultRaw = ${{ toJSON(steps.lint.outputs.lint_result) }};
             let lintResult;
             try {
-              const jsonString = JSON.parse(lintResultJsonString);
-              lintResult = JSON.parse(jsonString);
+              lintResult = typeof lintResultRaw === 'string' ? JSON.parse(lintResultRaw) : lintResultRaw;
             } catch (e) {
               console.error('Failed to parse lint result:', e);
               core.setFailed('Failed to parse redirect chain lint output');


### PR DESCRIPTION
Fix a regression in CI (breaks on every new PR right now)

Workflow added in: https://github.com/getsentry/sentry-docs/pull/18620



Fix `SyntaxError: "[object Object]" is not valid JSON` in the redirect chain lint CI step by removing redundant double-parse of the lint result output.