### PR TITLE
docs(ai): Document valid conversation ID format

### DIFF
--- a/docs/ai/monitoring/conversations/index.mdx
+++ b/docs/ai/monitoring/conversations/index.mdx
@@ -43,6 +43,15 @@ Some SDK integrations (such as OpenAI Agents SDK for Python and OpenAI SDK for N
 - [JavaScript/Node](/platforms/javascript/guides/node/ai-agent-monitoring/#tracking-conversations)
 - [Python](/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/#tracking-conversations)
 
+### Choosing a Conversation ID
+
+Use a short, opaque identifier — alphanumeric characters with dashes or underscores only. Don't use a URL, email address, or other free-form text as the conversation ID.
+
+Good examples:
+
+- A UUID: `48e35936-82ab-4f1a-beaf-b2fa4273ac5e`
+- A prefixed ID: `conv_5j66UpCpwteGg4YSxUnt7lPYU`, `asst_abc12345`, `sess_987654`
+
 ### Conversations and Traces
 
 Conversations and traces are independent concepts. A single conversation can span multiple traces. For example, if a user refreshes the page mid-conversation, the browser starts a new trace, but the conversation continues with the same ID.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents what makes a good `gen_ai.conversation.id` value for AI Conversations monitoring.

Conversation IDs are customer-instrumented and used as a URL path segment in the Sentry UI/API. A value containing a slash (e.g. a full page URL) breaks that routing — this is exactly what happened for a customer who set their conversation ID to a product page URL, resulting in a "failed to load conversation" error.

Rather than special-casing this server-side, this PR adds explicit guidance to the Conversations doc page so instrumentation steers customers toward safe values from the start:

- Use a short, opaque identifier — alphanumeric with dashes/underscores only
- Never a URL, email address, or other free-form text
- Good examples: UUIDs, and `conv_`/`asst_`/`sess_` prefixed IDs

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not unrgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)