### PR TITLE
doc(relay): No scrubbing on `/minidump` endpoint

### DIFF
--- a/docs/security-legal-pii/scrubbing/attachment-scrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/attachment-scrubbing.mdx
@@ -46,7 +46,7 @@ Sentry currently only has limited support for scrubbing attachments that are not
 [Remove] [IP Addresses] from [$attachments.**]
 ```
 
-In addition, plain attachments that are submitted by the via the [Crashpad](https://docs.sentry.io/platforms/native/configuration/backends/crashpad/) backend by the Native, Unreal, Godot or Unity SDK can not be scrubbed.
+In addition, plain attachments that are submitted via the [Crashpad](https://docs.sentry.io/platforms/native/configuration/backends/crashpad/) backend by the Native, Unreal, Godot or Unity SDK can not be scrubbed.
 
 </Alert>
 

--- a/docs/security-legal-pii/scrubbing/attachment-scrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/attachment-scrubbing.mdx
@@ -46,7 +46,7 @@ Sentry currently only has limited support for scrubbing attachments that are not
 [Remove] [IP Addresses] from [$attachments.**]
 ```
 
-Plain attachments that are submitted via the native [Crashpad](https://docs.sentry.io/platforms/native/configuration/backends/crashpad/) backend can not be scrubbed.
+In addition, plain attachments that are submitted by the via the [Crashpad](https://docs.sentry.io/platforms/native/configuration/backends/crashpad/) backend by the Native, Unreal, Godot or Unity SDK can not be scrubbed.
 
 </Alert>
 

--- a/docs/security-legal-pii/scrubbing/attachment-scrubbing.mdx
+++ b/docs/security-legal-pii/scrubbing/attachment-scrubbing.mdx
@@ -46,6 +46,8 @@ Sentry currently only has limited support for scrubbing attachments that are not
 [Remove] [IP Addresses] from [$attachments.**]
 ```
 
+Plain attachments that are submitted via the native [Crashpad](https://docs.sentry.io/platforms/native/configuration/backends/crashpad/) backend can not be scrubbed.
+
 </Alert>
 
 ### Minidump Selectors


### PR DESCRIPTION
Added note about plain attachments not being scrubbed when submitted via the `/minidump` endpoint.

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [x] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

ref: INGEST-996