### PR TITLE
docs(cloudflare): Add new /nodejs_compat entrypoint

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -34,6 +34,16 @@ Requires SDK version `10.12.0` or higher for Deno.
 
 </Alert>
 
+<PlatformSection supported={['javascript.cloudflare']}>
+
+<Alert>
+
+On Cloudflare, AI SDK v7 support requires SDK version `10.64.0` or higher and the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint.
+
+</Alert>
+
+</PlatformSection>
+
 <Alert level="warning">
 
 Don't use the AI SDK's `registerTelemetry` API (AI SDK v7 and above) together with this integration. Sentry's `vercelAIIntegration` already instruments the AI SDK, so registering telemetry separately will result in duplicate spans.
@@ -185,7 +195,9 @@ Pass `experimental_telemetry` with `isEnabled: true` to the `ToolLoopAgent` cons
 ```javascript
 const agent = new ToolLoopAgent({
   model: openai("gpt-4o"),
-  tools: { /* ... */ },
+  tools: {
+    /* ... */
+  },
   experimental_telemetry: { isEnabled: true },
 });
 
@@ -213,7 +225,9 @@ For `ToolLoopAgent`, set `functionId` in the constructor:
 ```javascript
 const agent = new ToolLoopAgent({
   model: openai("gpt-4o"),
-  tools: { /* ... */ },
+  tools: {
+    /* ... */
+  },
   experimental_telemetry: {
     isEnabled: true,
     functionId: "weather-agent",

--- a/docs/platforms/javascript/guides/cloudflare/configuration/integrations/prisma.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/configuration/integrations/prisma.mdx
@@ -1,0 +1,42 @@
+---
+title: Prisma
+description: "Adds instrumentation for Prisma ORM queries on Cloudflare Workers running with Node.js compatibility."
+---
+
+<Alert>
+
+On Cloudflare, the `prismaIntegration` is only available through the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint, which requires SDK version `10.64.0` or higher.
+
+</Alert>
+
+_Import name: `Sentry.prismaIntegration`_
+
+Sentry supports tracing [Prisma ORM](https://www.prisma.io/) queries with the Prisma integration. The integration creates a span for each query and reports relevant details to Sentry.
+
+To enable it on Cloudflare, import Sentry from the `@sentry/cloudflare/nodejs_compat` entrypoint and add the `prismaIntegration` to your `Sentry.init` call:
+
+```javascript {3,5}
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+
+Sentry.init({
+  tracesSampleRate: 1.0,
+  integrations: [Sentry.prismaIntegration()],
+});
+```
+
+This integration supports Prisma versions 5, 6, and 7. In Prisma v5, you also need to add the `tracing` preview feature to the `generator` block of your Prisma schema:
+
+```txt {tabTitle: Prisma Schema} {filename: schema.prisma} {3}
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["tracing"]
+}
+```
+
+## Supported Versions
+
+- `prisma`: `5.x`, `6.x`, `7.x`
+
+## Learn More
+
+For details on the span structure that Prisma's OpenTelemetry tracing produces (e.g., `prisma:client:operation`, `prisma:engine:db_query`), see the [Prisma trace output documentation](https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing#trace-output).

--- a/docs/platforms/javascript/guides/cloudflare/features/nodejs-compat.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/nodejs-compat.mdx
@@ -1,0 +1,44 @@
+---
+title: Node.js Compatibility Entrypoint
+description: "Learn how the nodejs_compat entrypoint unlocks additional Node.js SDK features on Cloudflare Workers, such as Prisma instrumentation."
+---
+
+Cloudflare Workers can run with Node.js APIs enabled through the [`nodejs_compat` compatibility flag](https://developers.cloudflare.com/workers/runtime-apis/nodejs/). To take advantage of this, the Cloudflare SDK ships a dedicated `@sentry/cloudflare/nodejs_compat` entrypoint that unlocks Node.js SDK features which aren't available in the default Workers runtime.
+
+<Alert>
+
+The `@sentry/cloudflare/nodejs_compat` entrypoint requires SDK version `10.64.0` or higher. It will become the default entrypoint in the next major version (v11).
+
+</Alert>
+
+## What It Unlocks
+
+The `/nodejs_compat` entrypoint enables Node.js-only integrations and features on Cloudflare, including:
+
+- The <PlatformLink to="/configuration/integrations/prisma">`prismaIntegration`</PlatformLink> for tracing Prisma ORM queries.
+- Vercel AI SDK v7 support for the <PlatformLink to="/configuration/integrations/vercelai">`vercelAIIntegration`</PlatformLink>.
+
+## Usage
+
+The entrypoint is a drop-in replacement for `@sentry/cloudflare`, so switching over only requires changing your imports:
+
+```javascript {tabTitle:After}
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+```
+
+```javascript {tabTitle:Before}
+import * as Sentry from "@sentry/cloudflare";
+```
+
+To use the entrypoint, your Worker must set the `nodejs_compat` compatibility flag in your Wrangler configuration:
+
+
+```jsonc {tabTitle:JSON} {filename:wrangler.jsonc}
+{
+  "compatibility_flags": ["nodejs_compat"],
+}
+```
+
+```toml {tabTitle:Toml} {filename:wrangler.toml}
+compatibility_flags = ["nodejs_compat"]
+```

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -58,6 +58,12 @@ Run the command for your preferred package manager to add the Sentry SDK to your
 </SplitSection>
 </SplitLayout>
 
+<Alert>
+
+Importing Sentry from the `@sentry/cloudflare/nodejs_compat` entrypoint unlocks additional Node.js SDK features on Cloudflare. It requires SDK version `10.64.0` or higher and will become the default in the next major version. [Learn more](./features/nodejs-compat).
+
+</Alert>
+
 ## Configure
 
 The main Sentry configuration should happen as early as possible in your app's lifecycle.

--- a/platform-includes/configuration/integrations/javascript.cloudflare.mdx
+++ b/platform-includes/configuration/integrations/javascript.cloudflare.mdx
@@ -1,7 +1,7 @@
 ### Integrations
 
 |                                                     | **Auto Enabled** | **Errors** | **Tracing** | **Cron** | **Additional Context** |
-|-----------------------------------------------------|:----------------:|:----------:|:-----------:|:--------:|:----------------------:|
+| --------------------------------------------------- | :--------------: | :--------: | :---------: | :------: | :--------------------: |
 | [`dedupeIntegration`](./dedupe)                     |        ✓         |     ✓      |             |          |                        |
 | [`fetchIntegration`](./fetchIntegration)            |        ✓         |     ✓      |      ✓      |          |                        |
 | [`functionToStringIntegration`](./functiontostring) |        ✓         |            |             |          |                        |
@@ -13,4 +13,7 @@
 | [`rewriteFramesIntegration`](./rewriteframes)       |                  |     ✓      |             |          |                        |
 | [`supabaseIntegration`](./supabase)                 |                  |     ✓      |      ✓      |          |                        |
 | [`instrumentPostgresJsSql`](./postgresjs)           |                  |            |      ✓      |          |                        |
+| [`prismaIntegration`](./prisma)                     |                  |            |      ✓      |          |                        |
 | [`honoIntegration`](./hono)                         |        ✓         |     ✓      |             |          |                        |
+
+The [`prismaIntegration`](./prisma) is only available through the [`@sentry/cloudflare/nodejs_compat`](../../features/nodejs-compat) entrypoint.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

This adds a new page for the `/nodejs_compat` entrypoint. There is also a tiny note in the quickstart that this can be unlocked, making sure that people know by just reading the quickstart

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
