### PR TITLE
fix(ci): fix JSON parsing in lint-redirect-chains workflow

### DIFF
--- a/.github/workflows/lint-redirect-chains.yml
+++ b/.github/workflows/lint-redirect-chains.yml
@@ -66,12 +66,14 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINT_RESULT: ${{ toJSON(steps.lint.outputs.lint_result) }}
         with:
           script: |
-            const lintResultRaw = ${{ toJSON(steps.lint.outputs.lint_result) }};
             let lintResult;
             try {
-              lintResult = typeof lintResultRaw === 'string' ? JSON.parse(lintResultRaw) : lintResultRaw;
+              // First parse unwraps the toJSON() encoding, second parse converts the JSON string to an object
+              const jsonString = JSON.parse(process.env.LINT_RESULT);
+              lintResult = JSON.parse(jsonString);
             } catch (e) {
               console.error('Failed to parse lint result:', e);
               core.setFailed('Failed to parse redirect chain lint output');


### PR DESCRIPTION
## Problem

The `Lint Redirect Chains` CI check fails with:

```
Failed to parse lint result: SyntaxError: "[object Object]" is not valid JSON
Error: Failed to parse redirect chain lint output
```

This affects any PR that triggers the redirect chain linter and has issues to report (e.g., [#18662](https://github.com/getsentry/sentry-docs/pull/18662)).

## Root Cause

The workflow uses `toJSON()` inline interpolation to embed the lint result directly into the `github-script` JavaScript:

```javascript
const lintResultRaw = ${{ toJSON(steps.lint.outputs.lint_result) }};
```

When `toJSON()` processes the multiline JSON step output and it gets interpolated into the script body, GitHub Actions' expression evaluation can produce a JavaScript object literal rather than a JSON string. This causes `JSON.parse()` to receive `[object Object]` (the `.toString()` of a JS object) instead of valid JSON.

## Fix

Pass the lint result through an environment variable instead of inline `toJSON()` interpolation. Environment variables are always strings, so `JSON.parse(process.env.LINT_RESULT)` reliably parses the JSON in a single step.