### PR TITLE
docs: Update Copilot Cloud Agent billing terminology

### DIFF
--- a/docs/integrations/coding-agents/copilot/index.mdx
+++ b/docs/integrations/coding-agents/copilot/index.mdx
@@ -21,7 +21,7 @@ Sentry Owner, Manager, or Admin permissions are required to install this integra
 </Alert>
 
 <Alert>
-You'll need the Copilot Cloud Agent feature enabled in your GitHub account before connecting to Sentry. The integration consumes GitHub Actions minutes and Copilot premium requests. See the [GitHub Copilot cloud agent docs](https://docs.github.com/en/enterprise-cloud@latest/copilot/concepts/agents/cloud-agent/about-cloud-agent) for more information, including [usage costs](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent#copilot-cloud-agent-usage-costs).
+You'll need the Copilot Cloud Agent feature enabled in your GitHub account before connecting to Sentry. The integration consumes GitHub Actions minutes and GitHub AI credits. See the [GitHub Copilot cloud agent docs](https://docs.github.com/en/enterprise-cloud@latest/copilot/concepts/agents/cloud-agent/about-cloud-agent) for more information, including [usage costs](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent#copilot-cloud-agent-usage-costs).
 
 </Alert>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates the GitHub Copilot Cloud Agent integration documentation to reflect current billing terminology. Changes "Copilot premium requests" to "GitHub AI credits" to accurately describe the resource consumption model.

This is a documentation-only change that clarifies billing information for users setting up the Copilot integration with Sentry.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): 
- [ ] Other deadline: 
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

https://claude.ai/code/session_011PkkmKMzRHcwgZnkG39XWE