### PR TITLE
fix(webhooks): correct project_url description in issue webhook docs

### DIFF
--- a/docs/integrations/integration-platform/webhooks/issues.mdx
+++ b/docs/integrations/integration-platform/webhooks/issues.mdx
@@ -35,7 +35,7 @@ Sentry integrations that have subscribed to issue webhooks can receive informati
 ### data['issue']['project_url']
 
 - type: string
-- description: the api url to the project the issue is a part of
+- description: the web url for the issue stream of the project the issue is a part of
 
 ## Payload
 


### PR DESCRIPTION
## DESCRIBE YOUR PR
Very small change to clarify what URLs are send with issue lifecycle webhooks. Related to https://github.com/getsentry/sentry/pull/119680 — before this PR, we don't actually send this URL for all webhooks, and now we do.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
