### PR TITLE
docs(javascript): Add "Attributes" to enriching events

### DIFF
--- a/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
@@ -3,7 +3,7 @@ title: Attributes
 description: "Attributes automatically enrich your telemetry with typed key-value data. Use them to add business context that you can filter and search in Sentry."
 ---
 
-**Attributes** are key-value pairs you can attach to all your logs and metrics. Unlike [tags](../tags/), which only accept string values, attributes support `string`, `number`, `boolean`, and array values.
+**Attributes** are key-value pairs you can attach to all your telemetry (like spans, logs and metrics). Unlike [tags](../tags/), which only accept string values, attributes support `string`, `number`, `boolean`, and array values.
 
 Common uses include subscription tier, feature flags, or any business context that helps you filter and query your telemetry.
 Check out [Sending Span Metrics](../../tracing/span-metrics/) for an example of how to use attributes to enrich your spans.
@@ -12,7 +12,7 @@ Check out [Sending Span Metrics](../../tracing/span-metrics/) for an example of 
 `Sentry.setAttribute` and `Sentry.setAttributes` require SDK version `10.61.0` or above.
 </Alert>
 
-Setting attributes will bind them to the [isolation scope](../scopes/#isolation-scope). This ensures they'll automatically be included on all future logs and metrics for the current request or page view:
+Setting attributes will bind them to the [isolation scope](../scopes/#isolation-scope). This ensures they'll automatically be included on all future telemetry for the current request or page view:
 
 ```javascript
 Sentry.setAttribute('is_admin', true);
@@ -23,7 +23,7 @@ Sentry.setAttributes({
 });
 ```
 
-To attach attributes to a broader or narrower context, you can set them on a specific scope instead. Use the global scope for attributes that should appear on all logs and metrics across the entire application, and `withScope` for a single operation only:
+To attach attributes to a broader or narrower context, you can set them on a specific scope instead. Use the global scope for attributes that should appear on all telemetry across the entire application, and `withScope` for a single operation only:
 
 ```javascript
 // Applied to everything across the entire application

--- a/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
@@ -6,7 +6,7 @@ description: "Attributes automatically enrich your telemetry with typed key-valu
 **Attributes** are key-value pairs you can attach to all your logs and metrics. Unlike [tags](../tags/), which only accept string values, attributes support `string`, `number`, `boolean`, and array values.
 
 Common uses include subscription tier, feature flags, or any business context that helps you filter and query your telemetry.
-Check out [Sending Span Metrics](../../performance/span-metrics/) for an example of how to use attributes to enrich your spans.
+Check out [Sending Span Metrics](../../tracing/span-metrics/) for an example of how to use attributes to enrich your spans.
 
 <Alert>
 `Sentry.setAttribute` and `Sentry.setAttributes` require SDK version `10.61.0` or above.

--- a/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
@@ -3,16 +3,15 @@ title: Attributes
 description: "Attributes automatically enrich your telemetry with typed key-value data. Use them to add business context that you can filter and search in Sentry."
 ---
 
-**Attributes** are key-value pairs you can attach to all your telemetry (like spans, logs and metrics). Unlike [tags](../tags/), which only accept string values, attributes support `string`, `number`, `boolean`, and array values.
+<AvailableSince version="10.61.0" />
+
+**Attributes** are key-value pairs you can attach to your telemetry (like spans, logs and metrics). Unlike [tags](../tags/),
+which only accept `string` values, attributes support `string`, `number` and `boolean` values.
 
 Common uses include subscription tier, feature flags, or any business context that helps you filter and query your telemetry.
 Check out [Sending Span Metrics](../../tracing/span-metrics/) for an example of how to use attributes to enrich your spans.
 
-<Alert>
-`Sentry.setAttribute` and `Sentry.setAttributes` require SDK version `10.61.0` or above.
-</Alert>
-
-Setting attributes will bind them to the [isolation scope](../scopes/#isolation-scope). This ensures they'll automatically be included on all future telemetry for the current request or page view:
+Setting attributes will bind them to the [isolation scope](../scopes/#isolation-scope). This ensures they'll automatically be included on future telemetry for the current request or page view:
 
 ```javascript
 Sentry.setAttribute('is_admin', true);
@@ -23,7 +22,8 @@ Sentry.setAttributes({
 });
 ```
 
-To attach attributes to a broader or narrower context, you can set them on a specific scope instead. Use the global scope for attributes that should appear on all telemetry across the entire application, and `withScope` for a single operation only:
+To attach attributes to a broader or narrower context, you can set them on a specific scope instead.
+Use the global scope for attributes that should appear on all telemetry across the entire application, and `withScope` for a single operation only:
 
 ```javascript
 // Applied to everything across the entire application

--- a/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Attributes
+description: "Attributes automatically enrich your telemetry with typed key-value data. Use them to add business context that you can filter and search in Sentry."
+---
+
+**Attributes** are key-value pairs you can attach to all your logs and metrics. Unlike [tags](../tags/), which only accept string values, attributes support `string`, `number`, `boolean`, and array values.
+
+Common uses include subscription tier, feature flags, or any business context that helps you filter and query your telemetry.
+Check out [Sending Span Metrics](../../performance/span-metrics/) for an example of how to use attributes to enrich your spans.
+
+<Alert>
+`Sentry.setAttribute` and `Sentry.setAttributes` require SDK version `10.61.0` or above.
+</Alert>
+
+Setting attributes will bind them to the [isolation scope](../scopes/#isolation-scope). This ensures they'll automatically be included on all future logs and metrics for the current request or page view:
+
+```javascript
+Sentry.setAttribute('is_admin', true);
+
+Sentry.setAttributes({
+  'user.num_orders': user.numOrders,
+  'subscription.tier': 'pro',
+});
+```
+
+To attach attributes to a broader or narrower context, you can set them on a specific scope instead. Use the global scope for attributes that should appear on all logs and metrics across the entire application, and `withScope` for a single operation only:
+
+```javascript
+// Applied to everything across the entire application
+Sentry.getGlobalScope().setAttributes({
+  'app.version': '1.2.3',
+});
+
+// Applied to a single operation only
+Sentry.withScope((scope) => {
+  scope.setAttribute('checkout.step', 'payment');
+  Sentry.logger.info('Processing payment');
+});
+```
+
+Learn more about how scope data is applied to events in [Scopes](../scopes/).

--- a/docs/platforms/javascript/common/enriching-events/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/index.mdx
@@ -16,6 +16,11 @@ There are many ways to enrich events with additional data:
 You can add user information to events to help you identify the user that is experiencing an issue.
 See <PlatformLink to="/apis/#setUser">setUser</PlatformLink> to learn how to to set the user on Sentry events.
 
+### Setting Attributes
+
+Attributes are a way to add additional metadata to telemetry (like spans, logs and metrics). See <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> to learn more,
+or <PlatformLink to="/apis/#setAttribute">setAttribute</PlatformLink> & <PlatformLink to="/apis/#setAttributes">setAttributes</PlatformLink> to learn how to set attributes.
+
 ### Setting Tags
 
 Tags are a way to add additional metadata to events. They can be used to filter events in the Sentry UI. See <PlatformLink to="/enriching-events/tags/">Tags</PlatformLink> to learn more about tags, or <PlatformLink to="/apis/#setTag">setTag</PlatformLink> & <PlatformLink to="/apis/#setTags">setTags</PlatformLink> to learn how to set tags on Sentry events.

--- a/docs/platforms/javascript/common/enriching-events/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/index.mdx
@@ -18,6 +18,8 @@ See <PlatformLink to="/apis/#setUser">setUser</PlatformLink> to learn how to to 
 
 ### Setting Attributes
 
+<AvailableSince version="10.61.0" />
+
 Attributes are a way to add additional metadata to telemetry (like spans, logs and metrics). See <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> to learn more,
 or <PlatformLink to="/apis/#setAttribute">setAttribute</PlatformLink> & <PlatformLink to="/apis/#setAttributes">setAttributes</PlatformLink> to learn how to set attributes.
 

--- a/docs/platforms/javascript/common/enriching-events/tags/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/tags/index.mdx
@@ -7,13 +7,17 @@ description: "Tags power UI features such as filters and tag-distribution maps. 
 
 We’ll automatically index all tags for an event, as well as the frequency and the last time that Sentry has seen a tag. We also keep track of the number of distinct tags and can assist you in determining hotspots for various issues.
 
+<Alert level="warning">
+  Tags are **not** applied to logs or metrics. If you're using SDK version `10.61.0` or above and want to attach context to logs or metrics, use <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> instead.
+</Alert>
+
 _Tag keys_ have a maximum length of 200 characters and can contain only letters (`a-zA-Z`), numbers (`0-9`), underscores (`_`), periods (`.`), colons (`:`), and dashes (`-`).
 
 <Alert level="warning">Spaces in tag keys are not allowed.</Alert>
 
 _Tag values_ have a maximum length of 200 characters and they cannot contain the newline (`\n`) character.
 
-Defining tags is easy, and will bind them to the [isolation scope](../scopes/) ensuring all future events within scope contain the same tags.
+Defining tags is easy, and will bind them to the [isolation scope](../scopes/#isolation-scope) ensuring all future events within scope contain the same tags.
 
 You'll first need to import the SDK, as usual:
 


### PR DESCRIPTION

## DESCRIBE YOUR PR
Adds docs for "Attributes" (similar to the docs for "Tags") based on those changelog entries:
- [10.32.0](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#10320)
- [10.33.0](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#10330)

And this PR: 
- https://github.com/getsentry/sentry-javascript/pull/21705 (shipped with 10.61.0)

Related to:  https://github.com/getsentry/sentry-javascript/issues/21218