### PR TITLE
docs(unreal): Update session replay duration cap and document the 10 MiB size limit

### DIFF
--- a/docs/platforms/unreal/session-replay/index.mdx
+++ b/docs/platforms/unreal/session-replay/index.mdx
@@ -47,7 +47,7 @@ AttachSessionReplay=True
 The following settings are available under the **Session Replay** section in the plugin settings:
 
 - **Enable session replay (experimental)** (`AttachSessionReplay`, default `False`) — Master toggle for the feature.
-- **Replay duration (ms)** (`SessionReplayDurationMs`, default `5000`, range `1000`–`60000`) — The requested length of the retroactive replay window. On Windows, Linux, macOS, and iOS this is the rolling clip length kept on disk for crash attachment; on Xbox it's the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). This value is ignored on Android, where the underlying SDK determines the duration.
+- **Replay duration (ms)** (`SessionReplayDurationMs`, default `5000`, range `1000`–`20000`) — The requested length of the retroactive replay window. On Windows, Linux, macOS, and iOS this is the rolling clip length kept on disk for crash attachment; on Xbox it's the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). This value is ignored on Android, where the underlying SDK determines the duration.
 
 ### Advanced Recording Options (Windows, Linux, macOS & iOS)
 
@@ -64,6 +64,12 @@ AttachSessionReplay=True
 SessionReplayDurationMs=5000
 SessionReplayOptions=(FragmentSeconds=0.500000,RotationIntervalSeconds=1.000000,Framerate=30,BitrateKbps=2000)
 ```
+
+<Alert level="warning">
+
+Sentry rejects replay videos larger than **10 MiB**; oversized replays are dropped server-side without any client-visible error. Clip size grows with duration, bitrate, and framerate, and at high rendering resolutions (such as 4K) the encoder can significantly exceed its target bitrate — for example, a 20-second 4K clip at 60 fps can reach roughly twice the size of the same clip at the default 30 fps. The duration setting is capped at 20 seconds to keep clips within the limit at default settings — if you raise the bitrate or framerate, reduce the duration accordingly.
+
+</Alert>
 
 ## Platform Notes
 


### PR DESCRIPTION
Documents changes from getsentry/sentry-unreal#1478:

- The `SessionReplayDurationMs` range is now `1000`-`20000` (was `1000`-`60000`).
- Adds a warning that Sentry rejects replay videos larger than 10 MiB, that oversized replays are dropped without a client-visible error, and that recording settings (duration, bitrate, framerate) must be chosen so clips stay under that limit including the high-resolution caveat where the encoder can significantly exceed its target bitrate.
