### PR TITLE
fix: add missing hard stop 26.5.0

### DIFF
--- a/develop-docs/self-hosted/releases.mdx
+++ b/develop-docs/self-hosted/releases.mdx
@@ -54,6 +54,7 @@ These are the hard stops that one needs to go through:
 - 23.11.0
 - 24.8.0
 - 25.5.1
+- 26.5.0
 - 26.7.0
 
 Versions to avoid upgrading to:


### PR DESCRIPTION
## DESCRIBE YOUR PR

The [release notes of 26.6.0](https://github.com/getsentry/self-hosted/releases#release-26.6.0) mention that `26.5.0` is a hard stop, but it is not mentioned in this doc.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
