### PR TITLE
docs(attributes): Include examples for logs, metrics and spans

### DIFF
--- a/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/javascript/common/enriching-events/attributes/index.mdx
@@ -5,8 +5,8 @@ description: "Attributes automatically enrich your telemetry with typed key-valu
 
 <AvailableSince version="10.61.0" />
 
-**Attributes** are key-value pairs you can attach to your telemetry (like spans, logs and metrics). Unlike [tags](../tags/),
-which only accept `string` values, attributes support `string`, `number` and `boolean` values.
+**Attributes** are key-value pairs you can attach to your telemetry (like [spans](../../tracing/instrumentation/), [logs](../../logs/), and [metrics](../../metrics/)).
+Unlike [tags](../tags/), which only accept `string` values, attributes support `string`, `number` and `boolean` values.
 
 Common uses include subscription tier, feature flags, or any business context that helps you filter and query your telemetry.
 Check out [Sending Span Metrics](../../tracing/span-metrics/) for an example of how to use attributes to enrich your spans.
@@ -14,11 +14,11 @@ Check out [Sending Span Metrics](../../tracing/span-metrics/) for an example of 
 Setting attributes will bind them to the [isolation scope](../scopes/#isolation-scope). This ensures they'll automatically be included on future telemetry for the current request or page view:
 
 ```javascript
-Sentry.setAttribute('is_admin', true);
+Sentry.setAttribute("is_admin", true);
 
 Sentry.setAttributes({
-  'user.num_orders': user.numOrders,
-  'subscription.tier': 'pro',
+  "user.num_orders": user.numOrders,
+  "subscription.tier": "pro",
 });
 ```
 
@@ -28,14 +28,57 @@ Use the global scope for attributes that should appear on all telemetry across t
 ```javascript
 // Applied to everything across the entire application
 Sentry.getGlobalScope().setAttributes({
-  'app.version': '1.2.3',
+  "app.version": "1.2.3",
 });
 
 // Applied to a single operation only
 Sentry.withScope((scope) => {
-  scope.setAttribute('checkout.step', 'payment');
-  Sentry.logger.info('Processing payment');
+  scope.setAttribute("checkout.step", "payment");
+  Sentry.logger.info("Processing payment");
 });
 ```
 
 Learn more about how scope data is applied to events in [Scopes](../scopes/).
+
+## Setting Attributes on Individual Telemetry
+
+The scope APIs above are the easiest way to enrich everything at once. But you can also attach attributes to a single span, log, or metric directly.
+Useful when the data only makes sense for that one item.
+
+### Spans
+
+Add attributes to the currently active span with `setAttribute` or `setAttributes`. See <PlatformLink to="/tracing/span-metrics/">Sending Span Metrics</PlatformLink> for more.
+
+```javascript
+const span = Sentry.getActiveSpan();
+if (span) {
+  span.setAttributes({
+    "checkout.step": "payment",
+    "cart.item_count": 3,
+  });
+}
+```
+
+### Logs
+
+Pass attributes as the second argument to any `Sentry.logger` call. See <PlatformLink to="/logs/">Logs</PlatformLink> for more.
+
+```javascript
+Sentry.logger.info("Order created", {
+  "order.id": order.id,
+  "subscription.tier": "pro",
+});
+```
+
+### Metrics
+
+Pass attributes in the `attributes` option of any metric. See <PlatformLink to="/metrics/">Metrics</PlatformLink> for more.
+
+```javascript
+Sentry.metrics.count("orders_created", 1, {
+  attributes: {
+    "subscription.tier": "pro",
+    region: "us-west",
+  },
+});
+```

--- a/docs/platforms/javascript/common/logs/index.mdx
+++ b/docs/platforms/javascript/common/logs/index.mdx
@@ -109,6 +109,8 @@ Use `Sentry.setAttribute` and `Sentry.setAttributes` to attach attributes that a
 
 To attach attributes to a broader or narrower context, set them on a specific scope instead. Use the global scope for app-wide attributes and the current scope for a single operation.
 
+See <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> for more information.
+
 </SplitSectionText>
 <SplitSectionCode>
 
@@ -230,3 +232,4 @@ Any attributes set via `Sentry.setAttribute()` / `Sentry.setAttributes()` (or di
 - <PlatformLink to="/tracing/">Tracing</PlatformLink> — Logs are automatically linked to traces, so you can see logs in the context of the request or operation that produced them.
 - <PlatformSection notSupported={["javascript.node", "javascript.aws-lambda", "javascript.azure-functions", "javascript.connect", "javascript.express", "javascript.fastify", "javascript.gcp-functions", "javascript.hapi", "javascript.hono", "javascript.koa", "javascript.nestjs", "javascript.nitro", "javascript.bun", "javascript.cloudflare"]}><PlatformLink to="/session-replay/">Session Replay</PlatformLink> — Logs are automatically linked to replays, letting you jump from a log entry to see what the user was doing.</PlatformSection>
 - <PlatformLink to="/usage/">Error Monitoring</PlatformLink> — Use logs to add diagnostic context that helps you understand what led to an error.
+- <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> — Set attributes once and have them automatically included on all your logs.

--- a/docs/platforms/javascript/common/metrics/index.mdx
+++ b/docs/platforms/javascript/common/metrics/index.mdx
@@ -50,3 +50,5 @@ With [Sentry's Application Metrics](/product/metrics/), you can send counters, g
   </PlatformSection>
 - <PlatformLink to="/usage/">Error Monitoring</PlatformLink> — Use metrics
   alongside error tracking to understand the impact of issues.
+- <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> —
+  Set attributes once and have them automatically included on all your metrics.

--- a/platform-includes/metrics/usage/javascript.mdx
+++ b/platform-includes/metrics/usage/javascript.mdx
@@ -78,7 +78,9 @@ Use `Sentry.setAttribute` and `Sentry.setAttributes` to attach attributes that a
 
 To target a specific scope instead, use the scope APIs.
 
+<PlatformSection notSupported={["react-native"]}>
 See <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> for more information.
+</PlatformSection>
 
 </SplitSectionText>
 <SplitSectionCode>

--- a/platform-includes/metrics/usage/javascript.mdx
+++ b/platform-includes/metrics/usage/javascript.mdx
@@ -78,6 +78,8 @@ Use `Sentry.setAttribute` and `Sentry.setAttributes` to attach attributes that a
 
 To target a specific scope instead, use the scope APIs.
 
+See <PlatformLink to="/enriching-events/attributes/">Attributes</PlatformLink> for more information.
+
 </SplitSectionText>
 <SplitSectionCode>
 


### PR DESCRIPTION

## DESCRIBE YOUR PR
Follow-up on this PR: 
- https://github.com/getsentry/sentry-docs/pull/18729

This PR now adds more examples and also links back to metrics/logs/attributes.

