### PR TITLE
Document replay.stop({ flush: false }) option

### DIFF
--- a/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
+++ b/docs/platforms/javascript/common/session-replay/understanding-sessions.mdx
@@ -116,6 +116,16 @@ await replay.stop();
 
 This will flush any pending recording data, stop the replay, and end the session.
 
+If you don't want the pending segment to be sent when stopping (for example, when a user withdraws consent for Session Replay), pass `{ flush: false }`:
+
+<AvailableSince version="10.67.0" />
+
+```javascript
+await replay.stop({ flush: false });
+```
+
+This stops recording and discards the buffered segment instead of uploading it. Note that `flush: false` only prevents the _pending_ (final) segment from being sent. It does not retract segments that were already sent earlier during `session` recording.
+
 ## Manually Flushing Recording Data
 
 You can flush any pending recording data with:


### PR DESCRIPTION
Documents the new `replay.stop({ flush: false })` option that stops Session Replay without sending the pending segment, for consent-withdrawal (GDPR) flows.

Depends on getsentry/sentry-javascript#22300, which adds the option. Assuming it lands next, the feature ships in 10.67.0, which is what the `AvailableSince` tag reflects. If the SDK release ends up being a different version, the tag needs updating before this merges.