### PR TITLE
fix(platform): Move instrumentation.ts to repo root so prod builds load it

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 
-import {tracesSampler} from './tracesSampler';
+import {tracesSampler} from 'sentry-docs/tracesSampler';
 
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {


### PR DESCRIPTION
## DESCRIBE YOUR PR

Production builds of both docs.sentry.io and develop.sentry.dev have emitted **zero server-side Sentry telemetry since Mar 5, 2026** — no middleware spans, no `http.server` spans, no `docs.trace.sampled` metrics, and no AI-agent/bot/user traffic classification. This one-file move fixes it.

**Root cause:** Next.js production builds discover `middleware.ts` and `instrumentation.ts` by scanning only `rootDir` — the parent of the `pages/` (or `app/`) directory — with no `src/` fallback (`next/dist/build/index.js`, identical logic in 15.1 and 15.5). For two years the repo had `src/pages`, so `rootDir` was `src/` and both `src/middleware.ts` and `src/instrumentation.ts` were found. When #16687 moved `pages/` to the repo root, `rootDir` flipped to the repo root: middleware broke visibly (redirects died) and was moved to the root in that same PR, but `src/instrumentation.ts` was left behind and silently dropped from the build — `register()` and `Sentry.init` stopped running in the node and edge runtimes entirely. Dev was unaffected because the dev bundler *does* check `src/`, which hid the breakage locally.

This also explains why the SDK bump in #18723 changed nothing in production: the sampler it fixed never executes, because the file that installs it is not in the build.

- Move `instrumentation.ts` from `src/` to the repo root (next to `middleware.ts`), importing `tracesSampler` via the `sentry-docs` path alias
- `instrumentation-client.ts` intentionally stays in `src/` — Next resolves it through a webpack alias that checks `src/` first, which is why browser telemetry never broke

**Verified with a local `next build`:** before the move, `.next/server/` contains no instrumentation entries; after it, `instrumentation.js` and `edge-instrumentation.js` are emitted and the edge bundle contains the DSN, `tracesSampler`, and the `docs.trace.sampled` metric emission.

**Post-deploy verification** (in `sentry/docs` and `sentry/develop-docs`):
- `spans · span.op:http.server.middleware · group by sdk.version, release` → should show the current release on SDK 10.65
- `metrics · docs.trace.sampled · group by traffic_type` → should split into `ai_agent` / `bot` / `user` instead of being absent

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)