### PR TITLE
docs(data-collection): Allow `stackFrameVariables` to filter by variable name

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -2,12 +2,15 @@
 title: Data Collection
 description: Configuration for what data SDKs collect by default, including technical context, PII, and sensitive data.
 spec_id: sdk/foundations/client/data-collection
-spec_version: 0.8.0
+spec_version: 0.9.0
 spec_status: candidate
 spec_depends_on:
   - id: sdk/foundations/client
     version: ">=1.0.0"
 spec_changelog:
+  - version: 0.9.0
+    date: 2026-07-21
+    summary: Allow `stackFrameVariables` to accept a `KeyValueCollectionBehavior` for filtering by variable name in addition to the Boolean default.
   - version: 0.8.0
     date: 2026-07-13
     summary: Update name of `queryParams` to `urlQueryParams` to reduce ambiguity with other query types.
@@ -520,6 +523,16 @@ public enum BodyType {
 
 </Expandable>
 
+---
+
+#### Filtering Stack Frame Variables
+
+The `stackFrameVariables` option accepts a Boolean by default (`true` collects all local variables, `false` collects none). SDKs **MUST** also accept a `KeyValueCollectionBehavior` to filter which variables are sent by name. Filtering follows the same collection modes as [Key-Value Collection Behavior](#key-value-collection-behavior), matching against variable names.
+
+<Alert level="warning">
+  Filtering by variable name requires the developer to know the variable names **as they appear after bundling**. Minifiers and other build-time transforms frequently rename local variables (e.g., `password` becomes `a`), so allow/deny terms configured against source names may not match the names captured at runtime. Prefer the Boolean form unless you have verified the post-bundle variable names for your build.
+</Alert>
+
 </SpecSection>
 
 <SpecSection id="datacollection-options" status="candidate" since="0.2.0">
@@ -554,7 +567,7 @@ init({
     },
     databaseQueryData?: boolean,                   // default: true
     queues?: boolean,                              // default: true
-    stackFrameVariables?: boolean,                 // default: true
+    stackFrameVariables?: boolean | KeyValueCollectionBehavior, // default: true
     frameContextLines?: integer,                   // default: 5 (see boolean fallback below)
   },
 })
@@ -571,7 +584,7 @@ init({
 | `genAI` | `{ inputs?, outputs? }` | Both `true` | 0.1.0 | For `inputs`: Include the content of generative AI inputs (e.g. prompt text, tool call arguments). <br /><br /> For `outputs`: Include the content of generative AI outputs (e.g. completion text, tool call results). Metadata such as model name and token counts is always collected regardless of these settings. |
 | `databaseQueryData` | Boolean | `true` | 0.6.0 | Include data that's associated with database queries. This controls collection of bound query parameters, data payloads for write operations, and returned result data.<br /><br />Sanitized or parameterized DB statements (`db.query.text`) are **not** controlled by this property. Structural metadata such as the database system, query summary, operation name, or the table being acted upon is also **always** collected. |
 | `queues` | Boolean | `true` | 0.7.0 | Include arguments passed to tasks within queues. |
-| `stackFrameVariables` | Boolean | `true` | 0.1.0 | Include local variable values captured within stack frames. |
+| `stackFrameVariables` | Boolean or key-value collection | `true` | 0.1.0 | Include local variable values captured within stack frames. Accepts a Boolean (`true` collects all variables, `false` collects none) or a `KeyValueCollectionBehavior` to filter which variables are sent by name (see [Filtering Stack Frame Variables](#filtering-stack-frame-variables)). Key-value collection added in 0.9.0. |
 | `frameContextLines` | Integer (`Boolean` fallback) | `5` (`true`) | 0.1.0 | Number of source code lines to include above and below each stack frame. <br/> **`Boolean` fallback:** Not all platforms support integer configuration values. SDKs **MAY** accept a boolean, where `true` is equivalent to the platform default (typically `5`) and `false` is equivalent to `0` (no context lines). SDKs **SHOULD** prefer accepting an integer when their platform supports it. |
 
 


### PR DESCRIPTION
Updates the `dataCollection` spec so `stackFrameVariables` can filter which local variables are captured by name, in addition to the existing Boolean toggle. The default stays `true` (collect all variables).

- Bumped spec version `0.8.0` → `0.9.0` and added a changelog entry
- Changed the `stackFrameVariables` type to `boolean | KeyValueCollectionBehavior`
- Added a warning about the minification caveat: filtering by name requires knowing the post-bundle variable names, since minifiers rename locals