### PR TITLE
feat(agent tracing): Reference Agent Tracing in more pages

### DIFF
--- a/docs/concepts/key-terms/tracing/index.mdx
+++ b/docs/concepts/key-terms/tracing/index.mdx
@@ -81,6 +81,10 @@ While everyone is sharing Lighthouse scores, we all know that the true determina
 
 Tracing can even give you the power to debug unfamiliar codebases. Although this benefit is not often discussed, a lot of time can be saved when debugging applications instrumented with Tracing, even if the codebase is completely new to you. Being able to trace actual user journeys throughout your application and see what happens across your entire stack contextualizes issues without even needing to recreate the issue locally. Read about other ways [tracing helps developers debug various issues](https://blog.sentry.io/everyone-needs-to-know-how-to-trace/).
 
+### Trace AI Agent Workflows
+
+If you're building with AI agents, LLMs, or MCP servers, Sentry's [Agent Tracing](/ai/observability/agents/) extends your existing tracing setup to capture the full picture — model calls, tool executions, token usage, and agent handoffs — all connected to the same traces as your HTTP requests, database queries, and application errors. Learn more about [setting up Agent Tracing](/ai/observability/agents/getting-started/).
+
 ## Learn More
 
 <PageGrid />

--- a/docs/concepts/key-terms/tracing/index.mdx
+++ b/docs/concepts/key-terms/tracing/index.mdx
@@ -83,7 +83,7 @@ Tracing can even give you the power to debug unfamiliar codebases. Although this
 
 ### Trace AI Agent Workflows
 
-If you're building with AI agents, LLMs, or MCP servers, Sentry's [Agent Tracing](/ai/observability/agents/) extends your existing tracing setup to capture the full picture — model calls, tool executions, token usage, and agent handoffs — all connected to the same traces as your HTTP requests, database queries, and application errors. Learn more about [setting up Agent Tracing](/ai/observability/agents/getting-started/).
+If you're building with AI agents, LLMs, or MCP servers, Sentry's [Agent Tracing](/product/agents/) extends your existing tracing setup to capture the full picture — model calls, tool executions, token usage, and agent handoffs — all connected to the same traces as your HTTP requests, database queries, and application errors. Learn more about [setting up Agent Tracing](/product/agents/getting-started/).
 
 ## Learn More
 

--- a/docs/platforms/dotnet/common/tracing/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/index.mdx
@@ -64,6 +64,12 @@ Test out tracing by starting and finishing a transaction, which you _must_ do so
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry. Once testing is complete, you may want to set a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switch to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
 
+## Agent Tracing
+
+If you're building with AI agents or LLMs, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, the .NET SDK can automatically instrument AI agents built with `Microsoft.Extensions.AI`.
+
+<PlatformLink to="/tracing/instrumentation/ai-agents-module/">Set up Agent Tracing</PlatformLink> to get started.
+
 ## Next Steps
 
 <PageGrid />

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -55,6 +55,24 @@ You can find more in-depth explanations and examples about sampling configuratio
 
 Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. Learn more about our model in [Distributed Tracing](/concepts/key-terms/tracing/distributed-tracing/).
 
+## Agent Tracing
+
+<PlatformCategorySection supported={["server", "serverless"]}>
+
+If you're building with AI agents or LLMs, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, the SDK can automatically instrument supported AI libraries and connect agent activity to the rest of your application traces.
+
+<PlatformLink to="/agent-tracing/">Set up Agent Tracing</PlatformLink> to get started.
+
+</PlatformCategorySection>
+
+<PlatformCategorySection supported={["browser"]}>
+
+If you're making AI or LLM calls from the browser, you can extend your tracing setup to capture model requests and token usage. With tracing already enabled, you can manually instrument AI spans and connect them to the rest of your application traces.
+
+<PlatformLink to="/agent-tracing-browser/">Set up Agent Tracing</PlatformLink> to get started.
+
+</PlatformCategorySection>
+
 ## Verify
 
 <PlatformSection supported={["javascript"]} notSupported={["javascript.cordova"]}>

--- a/docs/platforms/javascript/common/tracing/index.mdx
+++ b/docs/platforms/javascript/common/tracing/index.mdx
@@ -55,23 +55,35 @@ You can find more in-depth explanations and examples about sampling configuratio
 
 Sentry captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. Learn more about our model in [Distributed Tracing](/concepts/key-terms/tracing/distributed-tracing/).
 
-## Agent Tracing
+<PlatformSection supported={["javascript.node", "javascript.aws-lambda", "javascript.azure-functions", "javascript.connect", "javascript.express", "javascript.fastify", "javascript.gcp-functions", "javascript.hapi", "javascript.hono", "javascript.koa", "javascript.nestjs", "javascript.bun", "javascript.deno", "javascript.cloudflare", "javascript.nitro", "javascript.tanstackstart-react"]}>
 
-<PlatformCategorySection supported={["server", "serverless"]}>
+## Agent Tracing
 
 If you're building with AI agents or LLMs, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, the SDK can automatically instrument supported AI libraries and connect agent activity to the rest of your application traces.
 
 <PlatformLink to="/agent-tracing/">Set up Agent Tracing</PlatformLink> to get started.
 
-</PlatformCategorySection>
+</PlatformSection>
 
-<PlatformCategorySection supported={["browser"]}>
+<PlatformSection supported={["javascript.nextjs", "javascript.nuxt", "javascript.astro", "javascript.solidstart", "javascript.sveltekit", "javascript.remix"]}>
+
+## Agent Tracing
+
+If you're building with AI agents or LLMs, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, the SDK can automatically instrument supported AI libraries on the server and connect agent activity to the rest of your application traces.
+
+<PlatformLink to="/agent-tracing/">Set up Agent Tracing</PlatformLink> to get started.
+
+</PlatformSection>
+
+<PlatformSection supported={["javascript", "javascript.angular", "javascript.ember", "javascript.gatsby", "javascript.react", "javascript.solid", "javascript.svelte", "javascript.vue", "javascript.wasm"]}>
+
+## Agent Tracing
 
 If you're making AI or LLM calls from the browser, you can extend your tracing setup to capture model requests and token usage. With tracing already enabled, you can manually instrument AI spans and connect them to the rest of your application traces.
 
 <PlatformLink to="/agent-tracing-browser/">Set up Agent Tracing</PlatformLink> to get started.
 
-</PlatformCategorySection>
+</PlatformSection>
 
 ## Verify
 

--- a/docs/platforms/php/common/tracing/index.mdx
+++ b/docs/platforms/php/common/tracing/index.mdx
@@ -46,6 +46,16 @@ Follow the instructions in the Relay docs to send a test event through Relay to 
 Don't forget to update your `DSN` to point to your running Relay instance.
 After you set up Relay, you should see a dramatic improvement to the impact on your server.
 
+<PlatformSection supported={["php.laravel"]}>
+
+## Agent Tracing
+
+If you're building with AI agents or LLMs in Laravel, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, the Laravel SDK automatically instruments the [Laravel AI](https://laravel.com/docs/13.x/ai-sdk) package.
+
+<PlatformLink to="/agent-tracing/">Set up Agent Tracing</PlatformLink> to get started.
+
+</PlatformSection>
+
 ## Next Steps
 
 <PageGrid />

--- a/docs/platforms/python/tracing/index.mdx
+++ b/docs/platforms/python/tracing/index.mdx
@@ -35,6 +35,12 @@ If you’re adopting Tracing in a high-throughput environment, we recommend test
 
 Learn more about tracing <PlatformLink to="/configuration/options/#tracing-options">options</PlatformLink>, how to use the <PlatformLink to="/configuration/sampling/#setting-a-sampling-function">traces_sampler</PlatformLink> function, or how to <PlatformLink to="/configuration/sampling/#sampling-transaction-events">sample transactions</PlatformLink>.
 
+## Agent Tracing
+
+If you're building with AI agents or LLMs, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, the Python SDK automatically instruments supported libraries like OpenAI, Anthropic, LangChain, and others.
+
+<PlatformLink to="/tracing/instrumentation/custom-instrumentation/ai-agents-module/">Set up Agent Tracing</PlatformLink> to get started.
+
 ## Next Steps
 
 <PageGrid />

--- a/docs/platforms/react-native/common/tracing/index.mdx
+++ b/docs/platforms/react-native/common/tracing/index.mdx
@@ -37,6 +37,12 @@ Verify that tracing is working correctly by using our <PlatformLink to="/tracing
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry. Once testing is complete, you may want to set a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switch to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
 
+## Agent Tracing
+
+If your app makes AI or LLM calls, you can extend your tracing setup to capture model requests and token usage. With tracing already enabled, you can manually instrument AI spans and connect them to the rest of your application traces.
+
+<PlatformLink to="/agent-tracing/">Set up Agent Tracing</PlatformLink> to get started.
+
 ## Next Steps
 
 <PageGrid />

--- a/docs/platforms/ruby/common/tracing/index.mdx
+++ b/docs/platforms/ruby/common/tracing/index.mdx
@@ -37,6 +37,12 @@ Test out tracing by starting and finishing a transaction, which you _must_ do so
 
 While you're testing, set <PlatformIdentifier name="traces-sample-rate" /> to `1.0`, as that ensures that every transaction will be sent to Sentry. Once testing is complete, you may want to set a lower <PlatformIdentifier name="traces-sample-rate" /> value, or switch to using <PlatformIdentifier name="traces-sampler" /> to selectively sample and filter your transactions, based on contextual data.
 
+## Agent Tracing
+
+If you're building with AI agents or LLMs, you can extend your tracing setup to capture agent workflows, model calls, tool executions, and token usage. With tracing already enabled, you can use custom instrumentation to capture AI agent spans and connect them to the rest of your application traces.
+
+<PlatformLink to="/tracing/instrumentation/custom-instrumentation/ai-agents-module/">Set up Agent Tracing</PlatformLink> to get started.
+
 ## Next Steps
 
 <PageGrid />

--- a/docs/product/sentry-basics/performance-monitoring.mdx
+++ b/docs/product/sentry-basics/performance-monitoring.mdx
@@ -51,6 +51,7 @@ Performance data in Sentry isn't siloed. Every trace connects to:
 - **[Logs](/product/logs/)** — see what your application logged during a slow request
 - **[Session Replay](/product/session-replay/)** — watch the user experience during a performance issue
 - **[Profiling](/product/profiling/)** — drill from a slow span into the exact functions consuming CPU time
+- **[Agent Tracing](/ai/observability/agents/)** — trace AI agent workflows, LLM calls, and tool executions alongside your application traces
 - **[Seer](/product/ai-in-sentry/seer/)** — get AI-powered root cause analysis for performance regressions
 
 ## How It Works Under the Hood

--- a/docs/product/sentry-basics/performance-monitoring.mdx
+++ b/docs/product/sentry-basics/performance-monitoring.mdx
@@ -51,7 +51,7 @@ Performance data in Sentry isn't siloed. Every trace connects to:
 - **[Logs](/product/logs/)** — see what your application logged during a slow request
 - **[Session Replay](/product/session-replay/)** — watch the user experience during a performance issue
 - **[Profiling](/product/profiling/)** — drill from a slow span into the exact functions consuming CPU time
-- **[Agent Tracing](/ai/observability/agents/)** — trace AI agent workflows, LLM calls, and tool executions alongside your application traces
+- **[Agent Tracing](/product/agents/)** — trace AI agent workflows, LLM calls, and tool executions alongside your application traces
 - **[Seer](/product/ai-in-sentry/seer/)** — get AI-powered root cause analysis for performance regressions
 
 ## How It Works Under the Hood


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds cross-links to Agent Tracing from every SDK tracing page that supports it, plus relevant product and concept pages. The goal is to surface Agent Tracing as a natural next step for users who already have tracing enabled.

### SDK tracing pages — new "Agent Tracing" section

Each section briefly explains that with tracing already enabled, the SDK can extend to capture AI agent workflows, and links to the platform's agent tracing setup page.

| Platform | Placement | Notes |
|---|---|---|
| **JavaScript** | After "Distributed Tracing", before "Verify" | Uses `PlatformCategorySection` to show server vs browser copy with different links |
| **Python** | Before "Next Steps" | Mentions auto-instrumentation of OpenAI, Anthropic, LangChain |
| **.NET** | Before "Next Steps" | Mentions `Microsoft.Extensions.AI` |
| **Ruby** | Before "Next Steps" | Mentions custom instrumentation |
| **React Native** | Before "Next Steps" | Mentions manual instrumentation for AI calls |
| **PHP/Laravel** | Before "Next Steps" | Scoped to `php.laravel` via `PlatformSection`; mentions Laravel AI package |

### Product/concept pages

| Page | Change |
|---|---|
| **Tracing concepts** (`/concepts/key-terms/tracing/`) | New "Trace AI Agent Workflows" subsection under "How Tracing Can Help You Debug" |
| **Performance Monitoring** (`/product/sentry-basics/performance-monitoring/`) | Added Agent Tracing bullet to "Connected Context" list |

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
