### PR TITLE
style(rust): Format docs with Prettier

### DIFF
--- a/docs/platforms/rust/common/configuration/options.mdx
+++ b/docs/platforms/rust/common/configuration/options.mdx
@@ -32,7 +32,6 @@ Turns debug mode on or off. If debug is enabled, the SDK will attempt to print o
 
 Sets the release. This string is freeform and not set by default. Some formats are detected by Sentry and might be rendered differently. Learn more about how to send release data so Sentry can tell you about regressions between releases and identify the potential source in [the releases documentation](/product/releases/) or the <SandboxLink scenario="releases">sandbox</SandboxLink>.
 
-
 </SdkOption>
 
 <SdkOption name="environment" type='string' envVar='SENTRY_ENVIRONMENT'>
@@ -110,21 +109,21 @@ The default value of `MaxRequestBodySize::Medium` will capture request bodies up
 
 <SdkOption name="shutdown_timeout" type='Duration' defaultValue="Duration::from_secs(2)">
 
-  The timeout on client drop for draining events on shutdown. This controls how long the SDK will wait for pending events to be sent when shutting down.
+The timeout on client drop for draining events on shutdown. This controls how long the SDK will wait for pending events to be sent when shutting down.
 
 </SdkOption>
 
 <SdkOption name="integrations" type="Vec<Arc<dyn Integration>>">
 
-  A list of integrations to enable. This allows you to manually pick and choose the integrations to enable.
-  By default, only the default integrations are enabled.
+A list of integrations to enable. This allows you to manually pick and choose the integrations to enable.
+By default, only the default integrations are enabled.
 
 </SdkOption>
 
 <SdkOption name="default_integrations" type='bool' defaultValue='true'>
 
-  Whether to add default integrations. When set to `false`, no default integrations will be added automatically.
-  The list of default integrations depends on the feature flags of the `sentry` crate that are active.
+Whether to add default integrations. When set to `false`, no default integrations will be added automatically.
+The list of default integrations depends on the feature flags of the `sentry` crate that are active.
 
 </SdkOption>
 
@@ -132,7 +131,7 @@ The default value of `MaxRequestBodySize::Medium` will capture request bodies up
 
 <SdkOption name="sample_rate" type='f32' defaultValue='1.0'>
 
-  Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
+Configures the sample rate for error events, in the range of `0.0` to `1.0`. The default is `1.0`, which means that 100% of error events will be sent. If set to `0.1`, only 10% of error events will be sent. Events are picked randomly.
 
 </SdkOption>
 
@@ -140,10 +139,9 @@ The default value of `MaxRequestBodySize::Medium` will capture request bodies up
 
 This function is called with the event payload, and can return a modified event struct, or `None` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
-  By the time `before_send` is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
+By the time `before_send` is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
 </SdkOption>
-
 
 ## Tracing Options
 
@@ -159,18 +157,17 @@ If given, called with a `SamplingContext` for each transaction to determine the 
 
 </SdkOption>
 
-
 ## Transport Options
 
 <SdkOption name="http_proxy" type='string' envVar='HTTP_PROXY'>
 
-  When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https_proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `HTTP_PROXY` environment variable will be picked up.
+When set, a proxy can be configured that should be used for outbound requests. This is also used for HTTPS requests unless a separate `https_proxy` is configured. However, not all SDKs support a separate HTTPS proxy. SDKs will attempt to default to the system-wide configured proxy, if possible. For instance, on Unix systems, the `HTTP_PROXY` environment variable will be picked up.
 
 </SdkOption>
 
 <SdkOption name="https_proxy" type='string' envVar='HTTPS_PROXY'>
 
-  Configures a separate proxy for outgoing HTTPS requests. If this option is not provided but `http_proxy` is, then `http_proxy` is used for HTTPS requests too.
+Configures a separate proxy for outgoing HTTPS requests. If this option is not provided but `http_proxy` is, then `http_proxy` is used for HTTPS requests too.
 
 </SdkOption>
 
@@ -181,9 +178,9 @@ Setting this to `true` disables SSL certificate validation when sending outbound
 
 <SdkOption name="transport" type='Arc<dyn TransportFactory>'>
 
-  The transport to use to send envelopes to Sentry.
-  This is typically either a boxed function taking the client options by reference and returning a `Transport`, a boxed `Arc<Transport>` or alternatively the `DefaultTransportFactory`.
-  By default, the SDK uses a transport based on the `reqwest` crate running on a background thread.
+The transport to use to send envelopes to Sentry.
+This is typically either a boxed function taking the client options by reference and returning a `Transport`, a boxed `Arc<Transport>` or alternatively the `DefaultTransportFactory`.
+By default, the SDK uses a transport based on the `reqwest` crate running on a background thread.
 
 </SdkOption>
 
@@ -199,10 +196,9 @@ Determines whether captured structured logs should be sent to Sentry.
 
 <SdkOption name="before_send_log" type='Fn'>
 
-  Callback that is executed for each Log being captured. When `None` is returned from the function, the log record is dropped. To pass the log record through, return the log record itself.
+Callback that is executed for each Log being captured. When `None` is returned from the function, the log record is dropped. To pass the log record through, return the log record itself.
 
 </SdkOption>
-
 
 ## Session Tracking Options
 

--- a/docs/platforms/rust/common/configuration/sampling.mdx
+++ b/docs/platforms/rust/common/configuration/sampling.mdx
@@ -35,14 +35,13 @@ Choose a sampling rate with the goal of finding a balance between performance an
 The Sentry SDKs have two configuration options to control the volume of transactions sent to Sentry, allowing you to take a representative sample:
 
 1. Uniform sample rate (<PlatformIdentifier name="traces-sample-rate" />):
-
    - Provides an even cross-section of transactions, no matter where in your app or under what circumstances they occur.
    - Uses default [inheritance](#inheritance) and [precedence](#precedence) behavior
 
 2. Sampling function (<PlatformIdentifier name="traces-sampler" />) which:
    - Samples different transactions at different rates
-   - <PlatformLink to="/configuration/filtering/">Filters</PlatformLink> out some
-     transactions entirely
+   - <PlatformLink to="/configuration/filtering/">Filters</PlatformLink> out
+     some transactions entirely
    - Modifies default [precedence](#precedence) and [inheritance](#inheritance) behavior
 
 By default, none of these options are set, meaning no transactions will be sent to Sentry. You must set either one of the options to start sending transactions.

--- a/docs/platforms/rust/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/rust/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -59,6 +59,7 @@ For this integration to work as intended, only the OpenTelemetry tracing API sho
 Mixing it with the Sentry tracing API will result in incorrectly nested spans.
 
 To get started using the OpenTelemetry integration for the Sentry Rust SDK, add the necessary dependencies to your `Cargo.toml`:
+
 ```toml {filename:Cargo.toml}
 [dependencies]
 sentry = "{{@inject packages.version('sentry.rust') }}"

--- a/docs/platforms/rust/common/troubleshooting/index.mdx
+++ b/docs/platforms/rust/common/troubleshooting/index.mdx
@@ -16,6 +16,7 @@ Below is a list of common problems and how to solve them.
 Users have reported SDK initialization to panic when using the `debug-images` feature on machines with specific Linux platforms.
 
 Please open a GitHub [issue](https://github.com/getsentry/sentry-rust/issues/new/choose) with your OS and kernel version if you're affected by this.
+
 </Expandable>
 
 <Expandable title="Duplicated stack frames">
@@ -24,13 +25,14 @@ As there's a currently a hard limit of 200 frames in ingestion, this can cause e
 This happens when the stack trace is already symbolicated on the client (due to debug information being present at runtime) but gets resymbolicated on the server.
 
 There are two alternative ways to address this problem:
+
 - keep debug information in the binary, but disable the `debug-images` feature of the `sentry` crate;
 - strip debug information from the binary, and [upload debug files](/platforms/rust/source-context/#compile-and-create-debug-information-files) separately.
-</Expandable>
-
+  </Expandable>
 
 <Expandable title="'This frame has an unknown problem and can not be symbolicated' error in the UI for application stack frames">
 This can happen when your executable doesn't have a build ID, and therefore stack frames cannot be associated with any debug files by the Sentry backend.
 
 To ensure `cargo` embeds a build ID in your binary, set the following environment variable when building: `RUSTFLAGS="-Clink-args=-Wl,--build-id"`.
+
 </Expandable>

--- a/docs/platforms/rust/common/troubleshooting/index.mdx
+++ b/docs/platforms/rust/common/troubleshooting/index.mdx
@@ -28,7 +28,7 @@ There are two alternative ways to address this problem:
 
 - keep debug information in the binary, but disable the `debug-images` feature of the `sentry` crate;
 - strip debug information from the binary, and [upload debug files](/platforms/rust/source-context/#compile-and-create-debug-information-files) separately.
-  </Expandable>
+</Expandable>
 
 <Expandable title="'This frame has an unknown problem and can not be symbolicated' error in the UI for application stack frames">
 This can happen when your executable doesn't have a build ID, and therefore stack frames cannot be associated with any debug files by the Sentry backend.

--- a/docs/platforms/rust/guides/axum/index.mdx
+++ b/docs/platforms/rust/guides/axum/index.mdx
@@ -12,9 +12,7 @@ The integration actually supports any crate based on [tower](https://github.com/
 
 ## Install
 
-<OnboardingOptionButtons
-  options={["error-monitoring", "performance"]}
-/>
+<OnboardingOptionButtons options={["error-monitoring", "performance"]} />
 
 To add Sentry with the `axum` integration to your Rust project, add a new dependency to your `Cargo.toml`:
 

--- a/docs/platforms/rust/index.mdx
+++ b/docs/platforms/rust/index.mdx
@@ -35,7 +35,6 @@ The most convenient way to use this library is the `sentry::init` function, whic
 
 The `sentry::init` function returns a guard that when dropped, will flush Events that weren't yet sent to Sentry. It has a two-second deadline, so application shutdown may be slightly delayed as a result. Be sure to keep the guard or you won't be able to send events.
 
-
 ```rust {filename:main.rs}
 let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
     release: sentry::release_name!(),
@@ -94,7 +93,6 @@ tokio::runtime::Builder::new_multi_thread()
 ## Verify Setup
 
 The quickest way to verify Sentry in your Rust application is to cause a panic:
-
 
 ```rust {filename:main.rs}
 fn main() {

--- a/platform-includes/configuration/config-intro/rust.mdx
+++ b/platform-includes/configuration/config-intro/rust.mdx
@@ -2,7 +2,6 @@ Options are passed to the `init()` function as tuple where the first argument is
 
 Additionally, the `release_name` macro automatically generates the expected release based on the cargo metadata.
 
-
 ```rust
 let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
     release: sentry::release_name!(),

--- a/platform-includes/getting-started-config/rust.mdx
+++ b/platform-includes/getting-started-config/rust.mdx
@@ -1,6 +1,5 @@
 `sentry.init()` will return you a guard that when freed, will prevent process exit until all events have been sent (within a timeout):
 
-
 ```rust
 let _guard = sentry::init(("___PUBLIC_DSN___", sentry::ClientOptions {
     release: sentry::release_name!(),

--- a/platform-includes/set-release/rust.mdx
+++ b/platform-includes/set-release/rust.mdx
@@ -1,6 +1,5 @@
 The `release_name` macro automatically infers the release from the cargo metadata and is the preferred way to set a release.
 
-
 ```rust
 use sentry;
 


### PR DESCRIPTION
Normalize whitespace in Rust platform docs and includes before the ClientOptions and sampling content update.