### PR TITLE
ref(conventions): Update conventions guide for sentry backend changes

### DIFF
--- a/develop-docs/engineering-practices/sentry-conventions.mdx
+++ b/develop-docs/engineering-practices/sentry-conventions.mdx
@@ -57,7 +57,7 @@ yarn create:attribute \
   - `"private"` if the attribute should not be visible in the UI (but will be returned by the debug endpoint).
 - Add a `changelog` entry with `"version": "next"`.
 - Run `yarn generate` to regenerate the JS and Python code.
-- Run `npx vitest run` to verify all tests pass (including alias symmetry, name template validation, etc.).
+- Run `yarn test` to verify all tests pass (including alias symmetry, name template validation, etc.).
 
 ### Merge process
 
@@ -124,13 +124,14 @@ They're sent by SDKs and flow through as-is. Deprecation backfills with `backfil
 [Step 3](#sentry-backend) is only required when the attribute needs special adjustments in the Sentry UI.
 
 The [`SPAN_ATTRIBUTE_DEFINITIONS`](https://github.com/getsentry/sentry/blob/master/src/sentry/search/eap/spans/attributes.py) needs an entry when:
-1. The public alias differs from the internal name (e.g., public alias: span.duration -> internal name: sentry.duration_ms)
-2. The attribute needs a special search type that is not a primitive, like for example currency, byte, millisecond, percentage.
-3. The attribute has a validator or normalizer (e.g., validate_span_id, validate_event_id) or value normalization (e.g., normalize_event_id_strict) only runs through an explicit definition
-4. The attribute has a processor (post-processing transforms on query results require an explicit definition)
-5. The attribute is private (private=True restricts access to callers with the attribute in their fields_acl; this flag only works through an explicit definition)
-6. The attribute is a secondary alias (secondary_alias=True marks compatibility aliases that shouldn't be preferred in reverse lookups)
-7. The attribute has context (context=AttributeContext(brief=...) provides human-readable descriptions exposed through the API)
+1. The attribute is prefixed with `sentry.*`. To avoid divergence between Explore and the trace waterfall, add a public alias for the attribute (e.g. the attribute without the `sentry.*` prefix)
+2. The public alias differs from the internal name (e.g., public alias: span.duration -> internal name: sentry.duration_ms)
+3. The attribute needs a special search type that is not a primitive, like for example currency, byte, millisecond, percentage.
+4. The attribute has a validator or normalizer (e.g., validate_span_id, validate_event_id) or value normalization (e.g., normalize_event_id_strict) only runs through an explicit definition
+5. The attribute has a processor (post-processing transforms on query results require an explicit definition)
+6. The attribute is private (private=True restricts access to callers with the attribute in their fields_acl; this flag only works through an explicit definition)
+7. The attribute is a secondary alias (secondary_alias=True marks compatibility aliases that shouldn't be preferred in reverse lookups)
+8. The attribute has context (context=AttributeContext(brief=...) provides human-readable descriptions exposed through the API)
 
 If none of these apply, no entry is required.
 


### PR DESCRIPTION


<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Found another common case where we currently need to make manual changes to the sentry backend: `sentry.*`-prefixed attributes always need a public alias. 

Also adjusts a small inconsistency how to best run tests in the repo

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
