### PR TITLE
fix(ci): Batch Algolia record uploads to stop heap OOM on master

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -53,8 +53,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # NODE_OPTIONS is scoped to the indexing script, NOT the job: setting it job-wide (as #17283
+      # did) let `next build` claim more heap than the runner has and got the whole runner
+      # OOM-killed. The script itself batches its uploads, so this is headroom, not a requirement.
       - name: Build index for user docs
-        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && npx tsx --tsconfig ./scripts/tsconfig.json ./scripts/algolia.ts
+        run: pnpm enforce-redirects && pnpm generate-doctree && pnpm next build && NODE_OPTIONS=--max-old-space-size=8192 npx tsx --tsconfig ./scripts/tsconfig.json ./scripts/algolia.ts
         if: steps.filter.outputs.docs == 'true'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}

--- a/scripts/algolia.ts
+++ b/scripts/algolia.ts
@@ -48,9 +48,13 @@ const index =
     : null;
 
 const CONCURRENCY = 50;
+// Pages are generated and uploaded in batches so peak heap stays flat as the corpus grows.
+// Holding every record from every page in one array is what previously OOM'd the job: ~10k pages
+// produce ~240k records, which blows past Node's default ~4GB old-space limit.
+const UPLOAD_BATCH_PAGES = 500;
 // In dry-run we only need enough pages to exercise the build + import graph, not the full corpus.
-// Processing all ~10k pages cold (no warm cache) exhausts the heap, so cap it.
-const DRY_RUN_PAGE_LIMIT = 200;
+// Raise it (ALGOLIA_DRY_RUN_PAGE_LIMIT) to load-test the full corpus without touching the index.
+const DRY_RUN_PAGE_LIMIT = Number(process.env.ALGOLIA_DRY_RUN_PAGE_LIMIT ?? 200);
 const CACHE_VERSION = 1;
 const CACHE_DIR = join(process.cwd(), '.next', 'cache', 'algolia-records');
 
@@ -78,19 +82,64 @@ async function indexAndUpload() {
     frontMatter => !frontMatter.draft && !frontMatter.noindex && frontMatter.title
   );
   const pages = DRY_RUN ? allPages.slice(0, DRY_RUN_PAGE_LIMIT) : allPages;
+  const uploadIndex = DRY_RUN ? null : index;
   console.log(
-    `📄 Processing ${pages.length}${DRY_RUN ? ` of ${allPages.length} (dry-run cap)` : ''} pages with concurrency ${CONCURRENCY}`
+    `📄 Processing ${pages.length}${DRY_RUN ? ` of ${allPages.length} (dry-run cap)` : ''} pages in batches of ${UPLOAD_BATCH_PAGES} with concurrency ${CONCURRENCY}`
   );
 
-  const {records, cacheHits, cacheMisses} = await generateAlgoliaRecords(pages);
-  const generateTime = performance.now();
-  const generateSeconds = (generateTime - startTime) / 1000;
+  // Read the pre-existing objectIDs *before* uploading anything: record objectIDs are
+  // auto-generated per run, so every run writes a fresh set and deletes the previous one.
+  let existingRecordIds: string[] = [];
+  if (uploadIndex) {
+    existingRecordIds = await fetchExistingRecordIds(uploadIndex);
+    console.log(
+      `🔥 Found ${existingRecordIds.length} existing records in \`${DOCS_INDEX_NAME}\``
+    );
+    console.log(`🔥 Saving records to \`${DOCS_INDEX_NAME}\`...`);
+  }
+
+  const newRecordIDs = new Set<string>();
+  let recordCount = 0;
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  let generateSeconds = 0;
+
+  for (let offset = 0; offset < pages.length; offset += UPLOAD_BATCH_PAGES) {
+    const batch = pages.slice(offset, offset + UPLOAD_BATCH_PAGES);
+
+    const batchStart = performance.now();
+    const batchResult = await generateAlgoliaRecords(batch);
+    generateSeconds += (performance.now() - batchStart) / 1000;
+
+    cacheHits += batchResult.cacheHits;
+    cacheMisses += batchResult.cacheMisses;
+    recordCount += batchResult.records.length;
+
+    if (uploadIndex) {
+      const saveResult = await uploadIndex.saveObjects(batchResult.records, {
+        batchSize: 10000,
+        autoGenerateObjectIDIfNotExist: true,
+      });
+      saveResult.objectIDs.forEach(id => newRecordIDs.add(id));
+    }
+
+    // `batchResult` is the only reference to this batch's records, so dropping it here lets the
+    // GC reclaim them before the next batch is generated. This is what keeps peak heap flat.
+    console.log(
+      `   ↳ ${Math.min(offset + batch.length, pages.length)}/${pages.length} pages, ${recordCount} records`
+    );
+  }
+
+  if (!DRY_RUN) {
+    cleanupStaleCacheFiles();
+  }
+
   console.log(
-    `🔥 Generated ${records.length} records from ${pages.length} pages in ${generateSeconds.toFixed(1)}s (cache: ${cacheHits} hits, ${cacheMisses} misses)`
+    `🔥 Generated ${recordCount} records from ${pages.length} pages in ${generateSeconds.toFixed(1)}s (cache: ${cacheHits} hits, ${cacheMisses} misses)`
   );
 
   Sentry.metrics.gauge('algolia.pages_total', pages.length, {attributes: metricTags});
-  Sentry.metrics.gauge('algolia.records_total', records.length, {attributes: metricTags});
+  Sentry.metrics.gauge('algolia.records_total', recordCount, {attributes: metricTags});
   Sentry.metrics.distribution('algolia.generate_duration', generateSeconds, {
     attributes: metricTags,
     unit: 'second',
@@ -98,32 +147,19 @@ async function indexAndUpload() {
   Sentry.metrics.gauge('algolia.cache_hits', cacheHits, {attributes: metricTags});
   Sentry.metrics.gauge('algolia.cache_misses', cacheMisses, {attributes: metricTags});
 
-  if (DRY_RUN || !index) {
-    console.log(
-      `🧪 Dry run: generated ${records.length} records, skipping Algolia upload`
-    );
+  if (!uploadIndex) {
+    console.log(`🧪 Dry run: generated ${recordCount} records, skipping Algolia upload`);
   } else {
-    const existingRecordIds = await fetchExistingRecordIds(index);
-    console.log(
-      `🔥 Found ${existingRecordIds.length} existing records in \`${DOCS_INDEX_NAME}\``
-    );
-
-    console.log(`🔥 Saving records to \`${DOCS_INDEX_NAME}\`...`);
-    const saveResult = await index.saveObjects(records, {
-      batchSize: 10000,
-      autoGenerateObjectIDIfNotExist: true,
-    });
-    const newRecordIDs = new Set(saveResult.objectIDs);
     console.log(`🔥 Saved ${newRecordIDs.size} records`);
 
     const recordsToDelete = existingRecordIds.filter(id => !newRecordIDs.has(id));
     if (recordsToDelete.length > 0) {
       console.log(`🔥 Deleting ${recordsToDelete.length} stale records...`);
-      await index.deleteObjects(recordsToDelete);
+      await uploadIndex.deleteObjects(recordsToDelete);
     }
 
     if (!isDeveloperDocs) {
-      await index.setSettings({
+      await uploadIndex.setSettings({
         ...sentryAlgoliaIndexSettings,
         searchableAttributes: [
           'unordered(title)',
@@ -190,20 +226,21 @@ async function generateAlgoliaRecords(pages: FrontMatter[]) {
     )
   );
 
-  // Skip cleanup in dry-run: we only processed a subset of pages, so most cache files would look
-  // "stale" and get wrongly deleted, poisoning the shared cache.
-  if (!DRY_RUN) {
-    const allFiles = fs.readdirSync(CACHE_DIR);
-    const stale = allFiles.filter(f => !usedCacheFiles.has(f));
-    for (const f of stale) {
-      fs.unlinkSync(join(CACHE_DIR, f));
-    }
-    if (stale.length > 0) {
-      console.log(`🧹 Cleaned up ${stale.length} stale cache files`);
-    }
-  }
-
   return {records: results.flat(), cacheHits, cacheMisses};
+}
+
+// Must run only after every batch has been generated, otherwise pages from later batches would
+// still look unused and get their cache files deleted. Skipped in dry-run: we only process a
+// subset of pages there, so most cache files would look "stale" and poison the shared cache.
+function cleanupStaleCacheFiles() {
+  const allFiles = fs.readdirSync(CACHE_DIR);
+  const stale = allFiles.filter(f => !usedCacheFiles.has(f));
+  for (const f of stale) {
+    fs.unlinkSync(join(CACHE_DIR, f));
+  }
+  if (stale.length > 0) {
+    console.log(`🧹 Cleaned up ${stale.length} stale cache files`);
+  }
 }
 
 const frameworkPopularity: Record<string, number> = {

--- a/scripts/algolia.ts
+++ b/scripts/algolia.ts
@@ -52,9 +52,17 @@ const CONCURRENCY = 50;
 // Holding every record from every page in one array is what previously OOM'd the job: ~10k pages
 // produce ~240k records, which blows past Node's default ~4GB old-space limit.
 const UPLOAD_BATCH_PAGES = 500;
+const DEFAULT_DRY_RUN_PAGE_LIMIT = 200;
 // In dry-run we only need enough pages to exercise the build + import graph, not the full corpus.
 // Raise it (ALGOLIA_DRY_RUN_PAGE_LIMIT) to load-test the full corpus without touching the index.
-const DRY_RUN_PAGE_LIMIT = Number(process.env.ALGOLIA_DRY_RUN_PAGE_LIMIT ?? 200);
+// A missing, non-numeric, or non-positive override falls back to the default: `slice(0, NaN)` and
+// `slice(0, 0)` would silently process zero pages and report a green dry run that checked nothing.
+const dryRunPageLimitOverride = Number.parseInt(
+  process.env.ALGOLIA_DRY_RUN_PAGE_LIMIT ?? '',
+  10
+);
+const DRY_RUN_PAGE_LIMIT =
+  dryRunPageLimitOverride > 0 ? dryRunPageLimitOverride : DEFAULT_DRY_RUN_PAGE_LIMIT;
 const CACHE_VERSION = 1;
 const CACHE_DIR = join(process.cwd(), '.next', 'cache', 'algolia-records');
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The user-docs Algolia index has not been updated since **2026-05-15**. Every master push touching `docs/**`, `includes/**`, or `platform-includes/**` fails the `Build index for user docs` step with exit 134 (V8 heap limit), ~40s into record generation and after a ~10 minute build — ~70 consecutive runs, ~13 min of CI burned each. `develop-docs` pushes still pass because that corpus is 306 pages vs 10,219.

### Root cause

`scripts/algolia.ts` generated every record for all ~10.2k pages into a single array before uploading — ~244k records — which exceeds Node's default ~4GB old-space limit.

- This ran fine under Bun, which has no comparable heap cap, and started failing when the script moved to tsx in #17772.
- The `ERR_PACKAGE_PATH_NOT_EXPORTED` failure fixed in #18265 masked the OOM for three weeks; it has been 100% since Jun 8.
- The content-hash cache from #17722 was never protection here: it keys on the *built* HTML, so it hits on 2 of ~9,940 pages on every run.
- The PR smoke test can't catch it — it caps at 200 pages and skips `next build`.

### Corroborated in Sentry (`sentry/docs`, metrics dataset, 90d)

| Metric | `docs_type:user-docs` | `docs_type:developer-docs` |
|---|---|---|
| `algolia.pages_total` | 9,882 — 2026-05-12, nothing since | 305–306, through 2026-07-10 |
| `algolia.records_total` | 237,987 — 2026-05-12 | 10,199 → 10,356, through 2026-07-21 |
| `algolia.cache_misses` | 9,880 / 9,881 | — |

User-docs telemetry flatlines on 2026-05-13 while develop-docs keeps reporting weekly — the same
boundary the CI logs show, arrived at independently. The gauges only emit if the process reaches
`Sentry.flush()`, and the heap OOM is a V8 SIGABRT, so there is also no error event: zero issues in
the `docs` project mention algolia in 90d. A 10-week outage left no signal except red checks on
master.

### Changes

- Generate and upload in batches of 500 pages, so each batch's records are reclaimed before the next is built. Peak heap is now flat as the corpus grows.
- Read existing objectIDs once up front (record objectIDs are auto-generated per run, so the pre-existing set must be captured before any upload).
- Move stale-cache-file cleanup after the batch loop — inside it, it would delete cache files for pages in later batches.
- Add `ALGOLIA_DRY_RUN_PAGE_LIMIT` so the full corpus can be load-tested without touching the index.
- Add heap headroom **scoped to the indexing script only**. Setting `NODE_OPTIONS` job-wide (#17283) let `next build` outgrow the runner and got the runner OOM-killed, which #17711 then had to undo.

### Verification

Full 10,099-page corpus, cold cache:

| | Heap cap | Result | Peak RSS |
|---|---|---|---|
| Before | 4096 MB | `FATAL ERROR: Reached heap limit` at 4,095 MB — same signature as CI | 2.05 GB |
| After | **1024 MB** | 244,085 records / 10,099 pages in 37s | **1.33 GB** |

The upload path needs the Algolia keys, so batched `saveObjects` is only exercised on merge. Note it widens a pre-existing window: stale records are deleted only after all batches upload, so a mid-run failure leaves old + partial-new records in the index until the next green run (previously a failure wrote nothing).

### Follow-ups not in this PR

- The content-hash cache is still effectively a no-op (2 hits / ~9,940 misses). Either fix it (hash MDX source, rolling `actions/cache` key, namespace the dir per docs type) or remove it.
- No alerting on index staleness — this ran red for 10 weeks unnoticed. The alert should read the
  Algolia index's own last-updated timestamp rather than these gauges, which the failure itself
  suppresses. (Also unresolved: the aggregate query reports 48 `algolia.pages_total` rows over 90d
  while the samples view returns 6, so row counts here aren't yet trustworthy.)

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): search index is 10 weeks stale
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
