### PR TITLE
docs(react-native): Document Expo Updates performance spans

### DIFF
--- a/docs/platforms/react-native/guides/expo/index.mdx
+++ b/docs/platforms/react-native/guides/expo/index.mdx
@@ -161,7 +161,7 @@ To verify that everything is working as expected, build the `Release` version of
 
 ## Expo-Specific Features
 
-- [Expo Updates](/platforms/react-native/guides/expo/manual-setup/expo/expo-updates/) — Automatic OTA update context, searchable tags, and emergency launch alerts
+- [Expo Updates](/platforms/react-native/guides/expo/manual-setup/expo/expo-updates/) — Automatic OTA update context, searchable tags, performance spans for update checks and downloads, and emergency launch alerts
 - [EAS Build Hooks](/platforms/react-native/guides/expo/manual-setup/expo/eas-build-hooks/) — Capture build failures and lifecycle events from EAS Build
 - [Sentry Android Gradle Plugin](/platforms/react-native/guides/expo/manual-setup/expo/gradle/) — Advanced Android build configuration
 - [Expo Router tracing](/platforms/react-native/guides/expo/tracing/instrumentation/expo-router/) — Navigation transitions, performance spans, prefetch instrumentation, and per-route `ErrorBoundary` capture

--- a/docs/platforms/react-native/guides/expo/manual-setup/expo/expo-updates.mdx
+++ b/docs/platforms/react-native/guides/expo/manual-setup/expo/expo-updates.mdx
@@ -1,10 +1,10 @@
 ---
 title: Expo Updates
-description: "Automatic context, breadcrumbs, and alerts for Expo OTA updates."
+description: "Automatic context, breadcrumbs, performance spans, and alerts for Expo OTA updates."
 sidebar_order: 20
 ---
 
-When you ship OTA updates with Expo Updates, events captured by Sentry are automatically enriched with information about which update is running. This lets you filter issues by update channel, runtime version, or update ID — and get alerted when an emergency launch occurs.
+When you ship OTA updates with Expo Updates, events captured by Sentry are automatically enriched with information about which update is running. This lets you filter issues by update channel, runtime version, or update ID — track how long update checks and downloads take — and get alerted when an emergency launch occurs.
 
 These integrations are enabled by default in Expo projects. No additional setup is required.
 
@@ -58,6 +58,28 @@ All breadcrumbs use the category `expo.updates` and include the following transi
 <Alert>
 
 Update lifecycle breadcrumbs only run in native builds, not in Expo Go.
+
+</Alert>
+
+## Performance Spans
+
+The SDK automatically creates performance spans that measure how long update checks and downloads take. These spans appear as standalone transactions in the **Performance** page and can be queried in **Discover**.
+
+| Span Name | Operation | Created When |
+|---|---|---|
+| `expo-updates check` | `app.update.check` | The app starts checking for an available update |
+| `expo-updates download` | `app.update.download` | The app starts downloading an update |
+
+Each span ends when the corresponding operation completes or fails:
+
+- **Success**: The span finishes with an `ok` status. If an update was found (check) or downloaded, the `expo.update.id` attribute is set to the manifest ID.
+- **Failure**: The span finishes with an `error` status and the error message from the Expo Updates state machine.
+
+Spans are created with `forceTransaction: true` because OTA update checks typically happen outside of user-interaction transactions (for example, at app startup). This means each check or download appears as its own transaction in Sentry rather than as a child span of another trace.
+
+<Alert>
+
+Performance spans only run in native builds, not in Expo Go.
 
 </Alert>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new `app.update.check` and `app.update.download` performance spans added to the Expo Updates listener integration in [sentry-react-native#6430](https://github.com/getsentry/sentry-react-native/pull/6430).

Changes:
- Added a **Performance Spans** section to the Expo Updates page covering span names, operations, success/failure behavior, `expo.update.id` attribute, and `forceTransaction` rationale
- Updated the page description and Expo guide index link to mention performance spans

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/6430 is shipped

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)