### PR TITLE
docs(js/cf): Fix Agent Tracing and Vercel AI Cloudflare setup

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -36,7 +36,11 @@ With <Link to="/product/agents/dashboards/">Sentry Agent Tracing</Link>, you can
 
 ## Getting Started
 
-Enable <PlatformLink to="/tracing/">tracing</PlatformLink> and pass `dataCollection` so generative AI content can be collected according to the SDK defaults (including prompts and responses when you leave the categories unconfigured):
+Enable <PlatformLink to="/tracing/">tracing</PlatformLink> and pass `dataCollection` so generative AI content follows the SDK defaults (including prompts and responses when left unconfigured).
+
+`dataCollection: {}` also opts into other **permissive** defaults (bodies, cookies, user info, and more). Tighten via <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+
+<PlatformSection notSupported={["javascript.cloudflare"]}>
 
 ```javascript
 import * as Sentry from "___SDK_PACKAGE___";
@@ -48,17 +52,55 @@ Sentry.init({
 });
 ```
 
-See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink> to tighten or expand what is collected.
+</PlatformSection>
+
+<PlatformSection supported={["javascript.cloudflare"]}>
+
+```javascript
+import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    dataCollection: {},
+  }),
+  {
+    async fetch(request, env, ctx) {
+      // your worker
+    },
+  },
+);
+```
+
+Durable Objects / <PlatformLink to="/features/agents-sdk/">Agents SDK</PlatformLink>: use <PlatformLink to="/features/durableobject/">`instrumentDurableObjectWithSentry`</PlatformLink> with the same options.
+
+</PlatformSection>
 
 ## Instrumentation
 
-Pick the guide for your AI stack. Some libraries are instrumented automatically; others need a small amount of setup — each page covers the details.
+Pick your AI stack. Some libraries auto-instrument; others need a short setup — each page has the details.
 
 <PlatformSection supported={["javascript.cloudflare"]}>
-- <PlatformLink to="/features/workers-ai/">Cloudflare Workers AI</PlatformLink>
+
+On Cloudflare, setup differs by library—open the guide for your stack:
+
+- **Workers AI** — works automatically once Sentry wraps your worker.
+- **Vercel AI** — turn the integration on in your Sentry options, then enable telemetry on each AI call (details on that page).
+- **OpenAI, Anthropic, Google GenAI, LangChain, LangGraph** — not auto-instrumented here. Each guide shows how to wrap your client so AI spans show up. Tracing alone is not enough.
+
+- <PlatformLink to="/features/workers-ai/">Workers AI</PlatformLink>
+- <PlatformLink to="/features/agents-sdk/">Agents SDK</PlatformLink>
+- <PlatformLink to="/configuration/integrations/vercelai/">Vercel AI</PlatformLink>
+- <PlatformLink to="/configuration/integrations/openai/">OpenAI</PlatformLink>
+- <PlatformLink to="/configuration/integrations/anthropic/">Anthropic</PlatformLink>
+- <PlatformLink to="/configuration/integrations/google-genai/">Google Gen AI</PlatformLink>
+- <PlatformLink to="/configuration/integrations/langchain/">LangChain</PlatformLink>
+- <PlatformLink to="/configuration/integrations/langgraph/">LangGraph</PlatformLink>
+
 </PlatformSection>
 
-<PlatformSection notSupported={["javascript.deno"]}>
+<PlatformSection notSupported={["javascript.cloudflare", "javascript.deno"]}>
 - <PlatformLink to="/configuration/integrations/vercelai/">Vercel AI SDK</PlatformLink>
 - <PlatformLink to="/configuration/integrations/openai/">OpenAI</PlatformLink>
 - <PlatformLink to="/configuration/integrations/anthropic/">Anthropic</PlatformLink>
@@ -99,7 +141,9 @@ Any of `id`, `email`, or `username` is sufficient — Conversations displays whi
 
 ### Privacy Controls
 
-With `dataCollection: {}` (or any `dataCollection` config), generative AI inputs and outputs default to **on**. To turn prompt and response capture off:
+With `dataCollection: {}` (or any `dataCollection` config), generative AI inputs and outputs default to **on**. To turn them off:
+
+<PlatformSection notSupported={["javascript.cloudflare"]}>
 
 ```javascript
 Sentry.init({
@@ -112,11 +156,58 @@ Sentry.init({
 
 You can also set `recordInputs` / `recordOutputs` on a specific AI integration. See each integration page for the API that applies on your platform.
 
+</PlatformSection>
+
+<PlatformSection supported={["javascript.cloudflare"]}>
+
+```javascript
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    dataCollection: {
+      genAI: { inputs: false, outputs: false },
+    },
+  }),
+  { async fetch(request, env, ctx) { /* ... */ } },
+);
+```
+
+On the default CF entrypoint, control Vercel AI I/O with `experimental_telemetry` per call (or integration-level `record*` via `nodejs_compat`). See each integration page.
+
+</PlatformSection>
+
 ### Streaming Gen AI Spans
 
-`gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction by default (since SDK version `10.61.0`). This prevents AI spans with large inputs and outputs from hitting transaction payload size limits and being dropped, and is required for <Link to="/product/agents/conversations/">Conversations</Link> to work.
+From SDK `10.61.0`, `gen_ai` spans are sent as standalone envelope items (avoids large-payload drops; required for <Link to="/product/agents/conversations/">Conversations</Link>).
 
-Self-hosted Sentry users should set `streamGenAiSpans: false`, as standalone `gen_ai` spans may not be ingested by their Sentry instance.
+Self-hosted Sentry users should set `streamGenAiSpans: false` if standalone `gen_ai` spans may not be ingested.
+
+<PlatformSection notSupported={["javascript.cloudflare"]}>
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  streamGenAiSpans: false,
+});
+```
+
+</PlatformSection>
+
+<PlatformSection supported={["javascript.cloudflare"]}>
+
+```javascript
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    streamGenAiSpans: false,
+  }),
+  { async fetch(request, env, ctx) { /* ... */ } },
+);
+```
+
+</PlatformSection>
 
 ## Manual Instrumentation
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -50,6 +50,12 @@ Don't use the AI SDK's `registerTelemetry` API (AI SDK v7 and above) together wi
 
 </Alert>
 
+<Alert level="warning">
+
+`dataCollection: {}` enables the SDK's **permissive** defaults — generative AI inputs/outputs **and** other categories (user identity, cookies, headers, HTTP bodies, query parameters, and stack-frame locals) unless you override them. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+
+</Alert>
+
 _Import name: `Sentry.vercelAIIntegration`_
 
 The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
@@ -89,10 +95,10 @@ Sentry.init({
 </PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare']}>
-Not enabled by default. Register it on `withSentry`:
+Not enabled by default. For AI SDK v7, register it with the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint (requires the Wrangler `nodejs_compat` compatibility flag):
 
 ```javascript
-import * as Sentry from "@sentry/cloudflare";
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
 
 export default Sentry.withSentry(
   (env) => ({
@@ -104,6 +110,8 @@ export default Sentry.withSentry(
   { async fetch(request, env, ctx) { /* ... */ } },
 );
 ```
+
+For AI SDK versions before v7, import `@sentry/cloudflare` instead and use the same options.
 
 </PlatformSection>
 
@@ -160,6 +168,8 @@ Sentry.init({
 <PlatformSection supported={['javascript.cloudflare']}>
 
 ```javascript
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+
 export default Sentry.withSentry(
   (env) => ({
     dsn: "___PUBLIC_DSN___",

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -60,8 +60,9 @@ The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.
 
 ```javascript
 Sentry.init({
-  dsn: "____PUBLIC_DSN____"
+  dsn: "____PUBLIC_DSN____",
   tracesSampleRate: 1.0,
+  dataCollection: {},
   integrations: [
     Sentry.vercelAIIntegration({
       recordInputs: true,
@@ -73,15 +74,35 @@ Sentry.init({
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
+<PlatformSection supported={['javascript.deno']}>
 This integration is not enabled by default. You need to manually enable it by passing `Sentry.vercelAIIntegration()` to `Sentry.init`:
 
 ```javascript
 Sentry.init({
-  dsn: "____PUBLIC_DSN____"
+  dsn: "____PUBLIC_DSN____",
   tracesSampleRate: 1.0,
+  dataCollection: {},
   integrations: [Sentry.vercelAIIntegration()],
 });
+```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+Not enabled by default. Register it on `withSentry`:
+
+```javascript
+import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    dataCollection: {},
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  { async fetch(request, env, ctx) { /* ... */ } },
+);
 ```
 
 </PlatformSection>
@@ -91,8 +112,9 @@ This integration is enabled by default in the Node runtime, but not in the Edge 
 
 ```javascript {filename: 'sentry.edge.config.(js|ts)'}
 Sentry.init({
-  dsn: "____PUBLIC_DSN____"
+  dsn: "____PUBLIC_DSN____",
   tracesSampleRate: 1.0,
+  dataCollection: {},
   integrations: [Sentry.vercelAIIntegration()],
 });
 ```
@@ -125,11 +147,29 @@ Enables or disables truncation of recorded input messages. Truncation keeps larg
 
 Defaults to `true`.
 
+<PlatformSection notSupported={['javascript.cloudflare']}>
+
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
 });
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+```javascript
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
+  }),
+  { async fetch(request, env, ctx) { /* ... */ } },
+);
+```
+
+</PlatformSection>
 
 <PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 ### `force`
@@ -193,17 +233,23 @@ Sentry.init({
 <PlatformSection supported={['javascript.cloudflare']}>
 ### `recordInputs` and `recordOutputs`
 
-Setting `recordInputs` and `recordOutputs` on the integration is only supported with AI SDK v7 or higher through the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint. On the default entrypoint, Sentry only post-processes spans the AI SDK already emitted and can't decide whether inputs and outputs are recorded.
-
-To control input and output recording on the default entrypoint, set `experimental_telemetry.recordInputs` and `experimental_telemetry.recordOutputs` directly on each `ai` function call (for example, `generateText`), not on the Sentry integration (see [Configuration](#configuration)).
+Integration-level `recordInputs` / `recordOutputs` need AI SDK v7+ and the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint. On the default entrypoint, set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` instead (see [Configuration](#configuration)).
 
 ```javascript
-// Only in the `@sentry/cloudflare/nodejs_compat` entrypoint (AI SDK v7+)
-Sentry.init({
-  integrations: [
-    Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true }),
-  ],
-});
+// @sentry/cloudflare/nodejs_compat only (AI SDK v7+)
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    dataCollection: {},
+    integrations: [
+      Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true }),
+    ],
+  }),
+  { async fetch(request, env, ctx) { /* ... */ } },
+);
 ```
 
 </PlatformSection>


### PR DESCRIPTION
## DESCRIBE YOUR PR

Cloudflare readers following Agent Tracing or Vercel AI docs were steered at `Sentry.init` (not a public `@sentry/cloudflare` API) and at integration snippets that either wouldn't parse or implied Node-style auto-instrumentation.

Agent Tracing on Cloudflare now bootstraps with `withSentry` (and points Durable Objects / Agents at `instrumentDurableObjectWithSentry`), keeps `dataCollection: {}` with a short permissive-defaults warning, and uses a plain-language hub blurb so readers pick the right stack page instead of assuming OpenAI-style auto setup. Vercel AI Cloudflare samples register `vercelAIIntegration` on `withSentry`, keep Deno/`init` and Node paths separate, include `dataCollection: {}` on enable samples, and preserve the default entrypoint vs `nodejs_compat` `record*` distinction plus per-call `experimental_telemetry`.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)