### PR TITLE
docs(data-collection): Clarify what `genAI.input` covers

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -2,12 +2,15 @@
 title: Data Collection
 description: Configuration for what data SDKs collect by default, including technical context, PII, and sensitive data.
 spec_id: sdk/foundations/client/data-collection
-spec_version: 0.9.0
+spec_version: 0.9.1
 spec_status: candidate
 spec_depends_on:
   - id: sdk/foundations/client
     version: ">=1.0.0"
 spec_changelog:
+  - version: 0.9.1
+    date: 2026-07-29
+    summary: Clarify that `genAI.inputs` gates system instructions in addition to prompt messages and tool call arguments/definitions.
   - version: 0.9.0
     date: 2026-07-21
     summary: Allow `stackFrameVariables` to accept a `KeyValueCollectionBehavior` for filtering by variable name in addition to the Boolean default.
@@ -73,7 +76,7 @@ Non-identifying context used for debugging and performance. Examples include, bu
 - Performance and error context (stack frames, breadcrumbs, span metadata)
 - Framework/routing context where it does not contain PII or secrets
 - Generative AI metadata (model name, token counts, tool names, etc.)
-- Generative AI inputs and outputs (prompt content, completion content)
+- Generative AI inputs and outputs (system instructions, prompt content, tool definitions, completion content)
 
 For the full list of supported context types (device, OS, runtime, app, browser, GPU, culture, cloud resource, memory info, and more), see the [Contexts Interface](/sdk/foundations/transport/event-payloads/contexts/).
 
@@ -581,7 +584,7 @@ init({
 | `httpBodies` | `string[]` (body types) | all valid body types | 0.1.0 | List of body types to collect. Omitted = all body types valid for the platform; empty array (`[]`) = off. Valid values: `"incomingRequest"`, `"outgoingRequest"`, `"incomingResponse"`, `"outgoingResponse"`. Default changed from `[]` (off) to all valid body types in 0.2.0. |
 | `urlQueryParams` | Key-value collection | `{ mode: "denyList" }` | 0.8.0 | Collect URL query parameters. All key names are always included; the SDK scrubs values for keys matching the sensitive denylist or custom allow/deny terms. |
 | `graphQL` | `{ document?, variables? }` | Both `true` | 0.5.0 | For `document`: Collect the GraphQL document. <br /><br /> For `variables`: Collect the variables that are passed to GraphQL operations. |
-| `genAI` | `{ inputs?, outputs? }` | Both `true` | 0.1.0 | For `inputs`: Include the content of generative AI inputs (e.g. prompt text, tool call arguments). <br /><br /> For `outputs`: Include the content of generative AI outputs (e.g. completion text, tool call results). Metadata such as model name and token counts is always collected regardless of these settings. |
+| `genAI` | `{ inputs?, outputs? }` | Both `true` | 0.1.0 | For `inputs`: Include the content of generative AI inputs. This gates system instructions, prompt messages, tool definitions, and tool call arguments. <br /><br /> For `outputs`: Include the content of generative AI outputs (e.g. completion text, tool call results). <br /><br /> Metadata such as model name and token counts is always collected regardless of these settings. |
 | `databaseQueryData` | Boolean | `true` | 0.6.0 | Include data that's associated with database queries. This controls collection of bound query parameters, data payloads for write operations, and returned result data.<br /><br />Sanitized or parameterized DB statements (`db.query.text`) are **not** controlled by this property. Structural metadata such as the database system, query summary, operation name, or the table being acted upon is also **always** collected. |
 | `queues` | Boolean | `true` | 0.7.0 | Include arguments passed to tasks within queues. |
 | `stackFrameVariables` | Boolean or key-value collection | `true` | 0.1.0 | Include local variable values captured within stack frames. Accepts a Boolean (`true` collects all variables, `false` collects none) or a `KeyValueCollectionBehavior` to filter which variables are sent by name (see [Filtering Stack Frame Variables](#filtering-stack-frame-variables)). Key-value collection added in 0.9.0. |


### PR DESCRIPTION

## DESCRIBE YOUR PR
based on what Vercel AI is also gating with `recordInputs`: https://ai-sdk.dev/docs/ai-sdk-core/telemetry#genai-semantic-conventions