### PR TITLE
docs(apple): Add replay overmask troubleshooting

### DIFF
--- a/docs/platforms/apple/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/apple/common/session-replay/troubleshooting.mdx
@@ -45,6 +45,36 @@ Text views, input views, images, video players and webviews are all masked by de
 
 </Expandable>
 
+<Expandable title="Why are parts of my replay completely masked?" permalink>
+
+Session Replay may mask an entire layer subtree if Core Animation raises an exception while the SDK inspects it. This privacy-safe fallback prevents the exception from crashing your app and avoids exposing content that the SDK could not inspect for sensitive data.
+
+A malformed `CABasicAnimation` is one possible cause. The animation's `fromValue` and `toValue` must use types compatible with each other and with the animated key path. For example, a `position` animation must use `CGPoint` values for both endpoints:
+
+```swift
+// Incorrect: mixes a scalar value with a CGPoint value.
+let animation = CABasicAnimation(keyPath: "position")
+animation.fromValue = NSNumber(value: 0)
+animation.toValue = NSValue(cgPoint: CGPoint(x: 100, y: 100))
+```
+
+```swift
+// Correct: both endpoints contain CGPoint values.
+let animation = CABasicAnimation(keyPath: "position")
+animation.fromValue = NSValue(cgPoint: CGPoint(x: 0, y: 0))
+animation.toValue = NSValue(cgPoint: CGPoint(x: 100, y: 100))
+```
+
+If your code creates the animation, correct the endpoint types. If a third-party UI library creates it, update the library and check its release notes for animation-related fixes.
+
+When SDK debug logging is enabled, a warning similar to the following confirms that Session Replay used this fallback:
+
+```text
+Caught Objective-C exception NSInvalidArgumentException: -[NSConcreteValue doubleValue]: unrecognized selector
+```
+
+</Expandable>
+
 <Expandable title="What's the lowest version of iOS supported?" permalink>
 
 Session Replay recording happens even on the lowest version supported by the Sentry SDK, which is aligned with App Store support.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Add troubleshooting guidance for Session Replay regions that become completely masked when Core Animation raises during layer traversal.

The entry explains the privacy-safe fallback, identifies mismatched `CABasicAnimation` endpoint types as a possible cause, provides incorrect and corrected Swift examples, and shows the related SDK warning. This documents the behavior introduced by getsentry/sentry-cocoa#8537.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.

- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
  Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
