### PR TITLE
docs(rust): logs and metrics features enabled by default

### DIFF
--- a/docs/platforms/rust/common/configuration/options.mdx
+++ b/docs/platforms/rust/common/configuration/options.mdx
@@ -198,11 +198,11 @@ By default, the SDK uses a transport based on the `reqwest` crate running on a b
 
 ## Logging Options
 
-The following features and options are only available when the `logs` feature of the `sentry` crate is enabled. This is not a default feature.
-
 <SdkOption name="enable_logs" type='bool' defaultValue='true'>
 
 Determines whether captured structured logs should be sent to Sentry.
+
+Sending logs requires Sentry to be compiled with the `logs` feature. As the `logs` feature is included in the default feature set, you only explicitly need to enable `logs` when compiling without default features.
 
 </SdkOption>
 

--- a/docs/platforms/rust/common/logs/index.mdx
+++ b/docs/platforms/rust/common/logs/index.mdx
@@ -11,22 +11,16 @@ With Sentry Structured Logs, you can send text-based log information from your a
 ## Requirements
 
 Logs in Rust are supported in Sentry Rust SDK version `0.42.0` and above.
-Additionally, the `logs` feature flag needs to be enabled.
-
-```toml {filename:Cargo.toml}
-[dependencies]
-sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["logs"] }
-```
 
 ## Setup
 
-To enable logging, just add the `sentry` dependency with the `logs` feature flag.
-This will set `enable_logs: true` by default in your `sentry::ClientOptions`.
-You can opt-out from sending logs even while using the `logs` feature flag by explicitly initializing the SDK with `enable_logs: false`.
+Logs are enabled by default in the Rust SDK.
+
+If you compile `sentry` without default features, you must explicitly enable the `logs` feature flag to send logs.
 
 ## Usage
 
-Once the feature is enabled and the SDK is initialized, you can send logs by using the logging macros.
+Once the SDK is initialized, you can send logs by using the logging macros.
 The `sentry` crate exposes macros that support six different log levels:
 `logger_trace`, `logger_debug`, `logger_info`, `logger_warn`, `logger_error` and `logger_fatal`.
 The macros support logging a simple message, or a message with parameters, with `format` syntax:
@@ -68,7 +62,7 @@ To use the `tracing` integration with logs, add the necessary dependencies to yo
 
 ```toml {filename:Cargo.toml}
 [dependencies]
-sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["tracing", "logs"] }
+sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["tracing"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 ```
@@ -111,7 +105,7 @@ The fields of `tracing` events are automatically captured as attributes in Sentr
 By default, `tracing` events at or above info level are captured as Sentry logs.
 
 This behavior can be customized by applying a custom `event_filter` when creating the layer.
-The following snippet shows the default `event_filter` that's applied when using the `sentry` crate with the `logs` feature flag.
+The following snippet shows the default `event_filter`:
 
 ```rust
 use sentry::integrations::tracing::EventFilter;
@@ -133,7 +127,7 @@ To use the `log` integration with logs, add the necessary dependencies to your `
 
 ```toml {filename:Cargo.toml}
 [dependencies]
-sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["log", "logs"] }
+sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["log"] }
 log = "0.4"
 # optional: use any log implementation you prefer
 env_logger = "0.11"
@@ -149,8 +143,7 @@ fn main() {
     let _guard = sentry::init(
         sentry::ClientOptions::new()
             .dsn("___PUBLIC_DSN___")
-            .maybe_release(sentry::release_name!())
-            .enable_logs(true),
+            .maybe_release(sentry::release_name!()),
     );
 
     let logger = sentry::integrations::log::SentryLogger::with_dest(
@@ -181,7 +174,6 @@ let _guard = sentry::init(
     sentry::ClientOptions::new()
         .dsn("___PUBLIC_DSN___")
         .maybe_release(sentry::release_name!())
-        .enable_logs(true)
         .before_send_log(|log| {
             // filter out all trace level logs
             if log.level == sentry::protocol::LogLevel::Trace {

--- a/docs/platforms/rust/common/logs/index.mdx
+++ b/docs/platforms/rust/common/logs/index.mdx
@@ -78,8 +78,7 @@ fn main() {
     let _guard = sentry::init(
         sentry::ClientOptions::new()
             .dsn("___PUBLIC_DSN___")
-            .maybe_release(sentry::release_name!())
-            .enable_logs(true),
+            .maybe_release(sentry::release_name!()),
     );
 
     tracing_subscriber::registry()

--- a/docs/platforms/rust/guides/tracing/index.mdx
+++ b/docs/platforms/rust/guides/tracing/index.mdx
@@ -82,7 +82,7 @@ async fn fail() {
 
 By default, error-level events from `tracing` are captured as Sentry events, while events at or above info level are added to the current scope as breadcrumbs.
 
-Additionally, the SDK captures [logs](https://docs.sentry.io/product/logs/ for `tracing` events at the info level or above, unless logs were disabled when initializing the SDK.
+Additionally, the SDK captures [logs](https://docs.sentry.io/product/logs/) for `tracing` events at the info level or above, unless logs were disabled when initializing the SDK.
 
 This behavior can be customized by applying a custom `event_filter` when creating the layer.
 The following snippet shows the default `event_filter` that's applied when using the `sentry` crate with the `tracing` feature flag.

--- a/docs/platforms/rust/guides/tracing/index.mdx
+++ b/docs/platforms/rust/guides/tracing/index.mdx
@@ -22,10 +22,7 @@ To add Sentry with the `tracing` integration to your Rust project, add the neces
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = [
-  "tracing",
-  # ___PRODUCT_OPTION_START___ logs
-  "logs",
-  # ___PRODUCT_OPTION_END___ logs
+  "tracing"
 ] }
 tokio = { version = "1.45.0", features = ["full"] }
 ```
@@ -53,9 +50,6 @@ fn main() {
             // Capture all traces and spans. Set to a lower value in production
             .traces_sample_rate(1.0)
             # ___PRODUCT_OPTION_END___ performance
-            # ___PRODUCT_OPTION_START___ logs
-            .enable_logs(true),
-            # ___PRODUCT_OPTION_END___ logs
     );
 
     // Register the Sentry tracing layer
@@ -88,10 +82,10 @@ async fn fail() {
 
 By default, error-level events from `tracing` are captured as Sentry events, while events at or above info level are added to the current scope as breadcrumbs.
 
-Additionally, if the `logs` feature flag of the `sentry` crate is enabled and the SDK is initialized with `enable_logs: true`, then events from `tracing` at info level or above are also captured as [structured logs](https://docs.sentry.io/product/logs/).
+Additionally, the SDK captures [logs](https://docs.sentry.io/product/logs/ for `tracing` events at the info level or above, unless logs were disabled when initializing the SDK.
 
 This behavior can be customized by applying a custom `event_filter` when creating the layer.
-The following snippet shows the default `event_filter` that's applied when using the `sentry` crate with the `logs` feature flag.
+The following snippet shows the default `event_filter` that's applied when using the `sentry` crate with the `tracing` feature flag.
 
 ```rust
 use sentry::integrations::tracing::EventFilter;

--- a/platform-includes/metrics/options/rust.mdx
+++ b/platform-includes/metrics/options/rust.mdx
@@ -20,7 +20,7 @@ let _guard = sentry::init(
 
 ### Disabling Metrics
 
-Metrics are enabled by default when the `sentry` crate is compiled with the `metrics` feature. To stop sending metrics, call [`.enable_metrics(false)`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html#method.enable_metrics) on [`ClientOptions`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html).
+To stop sending metrics, call [`.enable_metrics(false)`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html#method.enable_metrics) on [`ClientOptions`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html) when initialzing the SDK.
 
 ```rust {filename:main.rs}
 let _guard = sentry::init(

--- a/platform-includes/metrics/options/rust.mdx
+++ b/platform-includes/metrics/options/rust.mdx
@@ -20,7 +20,7 @@ let _guard = sentry::init(
 
 ### Disabling Metrics
 
-To stop sending metrics, call [`.enable_metrics(false)`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html#method.enable_metrics) on [`ClientOptions`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html) when initialzing the SDK.
+To stop sending metrics, call [`.enable_metrics(false)`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html#method.enable_metrics) on [`ClientOptions`](https://docs.rs/sentry/latest/sentry/struct.ClientOptions.html) when initializing the SDK.
 
 ```rust {filename:main.rs}
 let _guard = sentry::init(

--- a/platform-includes/metrics/requirements/rust.mdx
+++ b/platform-includes/metrics/requirements/rust.mdx
@@ -1,8 +1,2 @@
-Metrics for Rust are supported in Sentry Rust SDK version `0.48.0` or later when compiled with the `metrics` feature.
-
-```toml {filename:Cargo.toml}
-[dependencies]
-sentry = { version = "{{@inject packages.version('sentry.rust') }}", features = ["metrics"] }
-```
-
-Metrics are enabled by default.
+Metrics for Rust are supported in Sentry Rust SDK version `0.48.0` or later.
+The `metrics` feature is enabled by default in the top-level `sentry` crate, and metrics are enabled by default at runtime.


### PR DESCRIPTION
Correct the Rust SDK docs to reflect that the `logs` and `metrics` crate features are now enabled by default. Also, correct any stale references that imply that either of these options need to be enabled at runtime.

Resolves getsentry/sentry-docs#18863  <br>Resolves getsentry/sentry-docs#18863