### PR TITLE
fix(platform-redirect): Restrict redirects to same-origin paths

### DIFF
--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -124,9 +124,19 @@ export default async function Page(props: {
     }
   }
 
+  // make the Sidebar aware of the current path
+  setServerContext({rootNode, path: ['platform-redirect']});
+
+  // Only redirect to doctree-resolved URLs. Never redirect based on `next` alone
   if (platformOrGuideList.length === 0) {
-    // Never redirect to the raw, attacker-controlled `next`
-    return redirect(pathname || '/');
+    return (
+      <DocPage frontMatter={{title: defaultTitle, description: ''}}>
+        <Alert level="warning">
+          We couldn't find documentation for this path on any platform.{' '}
+          <SmartLink to="/">Go to the docs home</SmartLink>.
+        </Alert>
+      </DocPage>
+    );
   }
 
   const requestedPlatform = Array.isArray(platform) ? platform[0] : platform;
@@ -143,9 +153,6 @@ export default async function Page(props: {
     title,
     description,
   };
-
-  // make the Sidebar aware of the current path
-  setServerContext({rootNode, path: ['platform-redirect']});
 
   return (
     <DocPage frontMatter={frontMatter}>

--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -125,8 +125,7 @@ export default async function Page(props: {
   }
 
   if (platformOrGuideList.length === 0) {
-    // Only ever redirect to the sanitized path — the raw `next` param is
-    // attacker controlled and must not be used as a redirect target.
+    // Never redirect to the raw, attacker-controlled `next`
     return redirect(pathname || '/');
   }
 

--- a/app/platform-redirect/page.tsx
+++ b/app/platform-redirect/page.tsx
@@ -125,8 +125,9 @@ export default async function Page(props: {
   }
 
   if (platformOrGuideList.length === 0) {
-    // try to redirect the user to the page directly, might result in 404
-    return redirect(next);
+    // Only ever redirect to the sanitized path — the raw `next` param is
+    // attacker controlled and must not be used as a redirect target.
+    return redirect(pathname || '/');
   }
 
   const requestedPlatform = Array.isArray(platform) ? platform[0] : platform;

--- a/app/platform-redirect/utils.spec.ts
+++ b/app/platform-redirect/utils.spec.ts
@@ -9,6 +9,38 @@ describe('sanitizeNext', () => {
     expect(sanitizeNext('//example.com')).toBe('');
   });
 
+  it('should reject backslash-based external URLs', () => {
+    // Browsers normalize backslashes to forward slashes, so these would
+    // otherwise resolve to an external origin.
+    expect(sanitizeNext('/\\devco.re')).toBe('');
+    expect(sanitizeNext('/\\/devco.re')).toBe('');
+    expect(sanitizeNext('\\\\devco.re')).toBe('');
+    expect(sanitizeNext('\\/devco.re')).toBe('');
+    expect(sanitizeNext('%2F%5Cdevco.re')).toBe('');
+    expect(sanitizeNext('///devco.re')).toBe('');
+  });
+
+  it('should never return a protocol-relative path', () => {
+    // Stripping unsafe characters must not leave adjacent slashes behind
+    expect(sanitizeNext('/,/devco.re')).toBe('/devcore');
+    expect(sanitizeNext('/a//b')).toBe('/a/b');
+  });
+
+  it('should reject non-http schemes', () => {
+    // eslint-disable-next-line no-script-url -- asserting this is rejected
+    expect(sanitizeNext('javascript:alert(1)')).toBe('');
+    expect(sanitizeNext('data:text/html,x')).toBe('');
+  });
+
+  it('should resolve dot segments', () => {
+    expect(sanitizeNext('/a/./b')).toBe('/a/b');
+    expect(sanitizeNext('/a/../../b')).toBe('/b');
+  });
+
+  it('should normalize backslashes within a path', () => {
+    expect(sanitizeNext('/path\\to/resource')).toBe('/path/to/resource');
+  });
+
   it('should prepend a slash if missing', () => {
     expect(sanitizeNext('path/to/resource')).toBe('/path/to/resource');
   });

--- a/app/platform-redirect/utils.spec.ts
+++ b/app/platform-redirect/utils.spec.ts
@@ -20,6 +20,13 @@ describe('sanitizeNext', () => {
     expect(sanitizeNext('///devco.re')).toBe('');
   });
 
+  it('should reject control characters that resolve to an external origin', () => {
+    // The URL parser strips tabs and newlines, so `/<tab>/host` becomes `//host`
+    expect(sanitizeNext('/%09/devco.re')).toBe('');
+    expect(sanitizeNext('/%0a/devco.re')).toBe('');
+    expect(sanitizeNext('/%0d/devco.re')).toBe('');
+  });
+
   it('should never return a protocol-relative path', () => {
     // Stripping unsafe characters must not leave adjacent slashes behind
     expect(sanitizeNext('/,/devco.re')).toBe('/devcore');

--- a/app/platform-redirect/utils.spec.ts
+++ b/app/platform-redirect/utils.spec.ts
@@ -12,24 +12,24 @@ describe('sanitizeNext', () => {
   it('should reject backslash-based external URLs', () => {
     // Browsers normalize backslashes to forward slashes, so these would
     // otherwise resolve to an external origin.
-    expect(sanitizeNext('/\\devco.re')).toBe('');
-    expect(sanitizeNext('/\\/devco.re')).toBe('');
-    expect(sanitizeNext('\\\\devco.re')).toBe('');
-    expect(sanitizeNext('\\/devco.re')).toBe('');
-    expect(sanitizeNext('%2F%5Cdevco.re')).toBe('');
-    expect(sanitizeNext('///devco.re')).toBe('');
+    expect(sanitizeNext('/\\example.com')).toBe('');
+    expect(sanitizeNext('/\\/example.com')).toBe('');
+    expect(sanitizeNext('\\\\example.com')).toBe('');
+    expect(sanitizeNext('\\/example.com')).toBe('');
+    expect(sanitizeNext('%2F%5Cexample.com')).toBe('');
+    expect(sanitizeNext('///example.com')).toBe('');
   });
 
   it('should reject control characters that resolve to an external origin', () => {
     // The URL parser strips tabs and newlines, so `/<tab>/host` becomes `//host`
-    expect(sanitizeNext('/%09/devco.re')).toBe('');
-    expect(sanitizeNext('/%0a/devco.re')).toBe('');
-    expect(sanitizeNext('/%0d/devco.re')).toBe('');
+    expect(sanitizeNext('/%09/example.com')).toBe('');
+    expect(sanitizeNext('/%0a/example.com')).toBe('');
+    expect(sanitizeNext('/%0d/example.com')).toBe('');
   });
 
   it('should never return a protocol-relative path', () => {
     // Stripping unsafe characters must not leave adjacent slashes behind
-    expect(sanitizeNext('/,/devco.re')).toBe('/devcore');
+    expect(sanitizeNext('/,/example.com')).toBe('/examplecom');
     expect(sanitizeNext('/a//b')).toBe('/a/b');
   });
 

--- a/app/platform-redirect/utils.ts
+++ b/app/platform-redirect/utils.ts
@@ -1,33 +1,46 @@
+// Only used to resolve `next` into an absolute URL so it can be origin
+// checked. It never forms part of the returned value.
+const BASE_ORIGIN = 'https://docs.sentry.io';
+
 export const sanitizeNext = (next: string) => {
-  // Safely decode URI component
-  let sanitizedNext: string;
+  // Links are built with `encodeURIComponent`, so the path arrives encoded
+  let decoded: string;
   try {
-    sanitizedNext = decodeURIComponent(next);
+    decoded = decodeURIComponent(next);
   } catch {
     // Return empty string if decoding fails
     return '';
   }
 
-  // Validate that next is an internal path
-  if (
-    sanitizedNext.startsWith('//') ||
-    sanitizedNext.startsWith('http') ||
-    sanitizedNext.includes(':')
-  ) {
-    // Reject potentially malicious redirects
-    sanitizedNext = '';
+  // No legitimate docs path contains a colon, and it keeps scheme-like input
+  // (`javascript:`, `data:`) from ever reaching the parser
+  if (decoded.includes(':')) {
+    return '';
   }
 
-  // Ensure next starts with a forward slash and only contains safe characters
-  if (sanitizedNext && !sanitizedNext.startsWith('/')) {
-    sanitizedNext = '/' + sanitizedNext;
+  let url: URL;
+  try {
+    // The WHATWG parser applies the same normalization a browser would —
+    // backslashes become slashes, `//host` and `/\host` resolve to an external
+    // host, dot segments collapse — so anything escaping our origin shows up
+    // as a differing `origin` rather than as a path we would have to untangle
+    // ourselves.
+    url = new URL(decoded, BASE_ORIGIN);
+  } catch {
+    return '';
   }
 
-  // Discard hash and path parameters
-  const [pathname] = sanitizedNext.split('#')[0].split('?');
+  if (url.origin !== BASE_ORIGIN) {
+    return '';
+  }
 
-  // Only allow alphanumeric, hyphens
-  sanitizedNext = pathname.replace(/[^\w\-\/]/g, '');
+  // Drop query and hash (`url.pathname` excludes both), and allow only
+  // alphanumeric, hyphens and slashes
+  const pathname = url.pathname
+    .replace(/[^\w\-\/]/g, '')
+    // Stripping characters can leave adjacent slashes behind (`/,/evil` ->
+    // `//evil`), which would resolve as protocol-relative. Collapse them.
+    .replace(/\/{2,}/g, '/');
 
-  return sanitizedNext === '/' ? '' : sanitizedNext;
+  return pathname === '/' ? '' : pathname;
 };

--- a/app/platform-redirect/utils.ts
+++ b/app/platform-redirect/utils.ts
@@ -1,45 +1,36 @@
-// Only used to resolve `next` into an absolute URL so it can be origin
-// checked. It never forms part of the returned value.
-const BASE_ORIGIN = 'https://docs.sentry.io';
+// Parse base only — never part of the return value, and only compared against itself
+const PARSE_BASE = 'https://sanitize.invalid';
 
 export const sanitizeNext = (next: string) => {
-  // Links are built with `encodeURIComponent`, so the path arrives encoded
   let decoded: string;
   try {
     decoded = decodeURIComponent(next);
   } catch {
-    // Return empty string if decoding fails
     return '';
   }
 
-  // No legitimate docs path contains a colon, and it keeps scheme-like input
-  // (`javascript:`, `data:`) from ever reaching the parser
+  // No docs path contains a colon; also keeps `javascript:`/`data:` out of the parser
   if (decoded.includes(':')) {
     return '';
   }
 
   let url: URL;
   try {
-    // The WHATWG parser applies the same normalization a browser would —
-    // backslashes become slashes, `//host` and `/\host` resolve to an external
-    // host, dot segments collapse — so anything escaping our origin shows up
-    // as a differing `origin` rather than as a path we would have to untangle
-    // ourselves.
-    url = new URL(decoded, BASE_ORIGIN);
+    // WHATWG normalization matches the browser: backslashes and control chars
+    // become/collapse to slashes and dot segments resolve, so anything escaping
+    // our origin shows up as a foreign `origin` rather than as a path to untangle
+    url = new URL(decoded, PARSE_BASE);
   } catch {
     return '';
   }
 
-  if (url.origin !== BASE_ORIGIN) {
+  if (url.origin !== PARSE_BASE) {
     return '';
   }
 
-  // Drop query and hash (`url.pathname` excludes both), and allow only
-  // alphanumeric, hyphens and slashes
   const pathname = url.pathname
     .replace(/[^\w\-\/]/g, '')
-    // Stripping characters can leave adjacent slashes behind (`/,/evil` ->
-    // `//evil`), which would resolve as protocol-relative. Collapse them.
+    // stripping can leave `//`, which would resolve as protocol-relative
     .replace(/\/{2,}/g, '/');
 
   return pathname === '/' ? '' : pathname;


### PR DESCRIPTION
Restricts the `/platform-redirect` endpoint to same-origin destinations. Ref VULN-2173.

- Redirect to the sanitized path rather than the raw `next` query param
- Rebuild `sanitizeNext` on the WHATWG `URL` parser so target validation matches browser URL resolution semantics
- Add test coverage for same-origin enforcement