### PR TITLE
fix(changelog): Fix broken workflow that never successfully created a PR

### DIFF
--- a/.github/workflows/update-docs-changelog.yml
+++ b/.github/workflows/update-docs-changelog.yml
@@ -48,6 +48,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         run: |
+          set -euxo pipefail
+
           git config user.email "bot@getsentry.com"
           git config user.name "getsentry-bot"
 
@@ -64,7 +66,6 @@ jobs:
           else
             gh pr create \
               --title "chore: Update docs changelog" \
-              --body "Automated update of the docs changelog from recent merged PRs." \
-              --label "Type: Maintenance"
-            gh pr merge --squash --auto
+              --body "Automated update of the docs changelog from recent merged PRs."
+            gh pr merge "$branch" --squash --auto
           fi


### PR DESCRIPTION
## Problem

The `Update Docs Changelog` workflow has been failing on **every single run** since it was introduced (April 3, 2026 -- 118 consecutive failures). The changelog page has been stuck showing March 2026 content.

## Root Cause

Two bugs in the "Create PR with changes" step of `.github/workflows/update-docs-changelog.yml`:

1. **`--label 'Type: Maintenance'` references a label that doesn't exist** in this repo. `gh pr create` exits with code 1 when given a nonexistent label, killing the step immediately.

2. **`gh pr merge` was called without a PR reference**, so it couldn't determine which PR to merge (even if bug #1 were fixed).

## Fix

- Remove the `--label 'Type: Maintenance'` flag
- Pass `"$branch"` to `gh pr merge` so it knows which PR to merge
- Add `set -euxo pipefail` for better diagnostics on any future failures

## Cleanup

Deleted all **118 orphaned `bot/update-docs-changelog-*` branches** that accumulated from the daily failing runs.

## Verification

- Ran `node scripts/update-docs-changelog.mjs` locally -- script generates 20 changelog entries successfully
- Verified `gh pr merge` accepts a branch name argument (`gh pr merge [<number> | <url> | <branch>]`)
- Confirmed "Type: Maintenance" label does not exist in the repo's 156 labels

## Next Steps

After merging, trigger the workflow manually via the Actions tab (`workflow_dispatch`) to verify the full end-to-end flow works in CI.