### PR TITLE
docs(agents): Document conversation title generation

### DIFF
--- a/docs/product/agents/conversations/index.mdx
+++ b/docs/product/agents/conversations/index.mdx
@@ -110,7 +110,7 @@ If no title has been generated yet, the list shows the first user message text i
 
 3. **Message content actually sent to Sentry.** If inputs are omitted (for example `sendDefaultPii: false` without an override that captures gen AI inputs), or scrubbed to filtered values, title generation has nothing to work with. See [Data Privacy](/product/agents/privacy/).
 
-SDK integrations that already emit OTEL-shaped `gen_ai.*` spans typically meet these requirements once conversation IDs and input collection are enabled. For manual instrumentation, set the attributes on your agent or AI client spans — see the [span attribute tables](/platforms/javascript/common/agent-tracing/manual-instrumentation/).
+SDK integrations that already emit OTEL-shaped `gen_ai.*` spans typically meet these requirements once conversation IDs and input collection are enabled. For manual instrumentation, set the attributes on your agent or AI client spans — see the [span attribute tables](/platforms/javascript/guides/node/agent-tracing/manual-instrumentation/).
 
 ## Conversations List
 

--- a/docs/product/agents/conversations/index.mdx
+++ b/docs/product/agents/conversations/index.mdx
@@ -87,7 +87,7 @@ Any of `id`, `email`, or `username` is sufficient. If no user is set, the column
 
 Sentry generates a short title for each conversation so you can scan the list in **Explore > Conversations**. Titles come from the **first user message** in the conversation — the earliest span that carries both a conversation ID and extractable user input.
 
-Without a title, the list falls back to the first user message text, or **Untitled conversation**.
+If no title has been generated yet, the list shows the first user message text instead. If Sentry cannot find any user messages in the conversation, it shows **Untitled conversation**.
 
 ### What You Need for Titles
 
@@ -120,7 +120,7 @@ The [Conversations](https://sentry.io/orgredirect/organizations/:orgslug/explore
 
 Each row in the list displays:
 
-- **Title** — generated from the first user message (falls back to that message text, or **Untitled conversation**)
+- **Title** — generated from the first user message; uses that message text until a title is available, or **Untitled conversation** when there are no user messages
 - **User** — the user who initiated the conversation, populated by `setUser` / `set_user`
 - **Last output** — the most recent assistant response
 - **Cost** — estimated dollar cost and token usage

--- a/docs/product/agents/conversations/index.mdx
+++ b/docs/product/agents/conversations/index.mdx
@@ -14,6 +14,8 @@ keywords:
   - LLM conversations
   - setUser
   - user attribution
+  - conversation title
+  - gen_ai.input.messages
 ---
 
 <Alert>
@@ -33,6 +35,8 @@ Conversations are built on top of [Agent Tracing](/product/agents/). Before you 
 1. **Tracing enabled** with the Sentry SDK configured for your AI agent project. Follow the [Agent Tracing getting started guide](/product/agents/getting-started/) if you haven't already.
 
 2. **A conversation ID on your spans.** Sentry groups spans into conversations using the `gen_ai.conversation.id` attribute. You can set this manually, or some SDK integrations infer it automatically.
+
+For list titles, also send OTEL-shaped user input on those spans. See [Conversation Titles](#conversation-titles).
 
 ## Conversation ID
 
@@ -79,6 +83,35 @@ sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": 
 
 Any of `id`, `email`, or `username` is sufficient. If no user is set, the column displays "Unknown".
 
+## Conversation Titles
+
+Sentry generates a short title for each conversation so you can scan the list in **Explore > Conversations**. Titles come from the **first user message** in the conversation — the earliest span that carries both a conversation ID and extractable user input.
+
+Without a title, the list falls back to the first user message text, or **Untitled conversation**.
+
+### What You Need for Titles
+
+1. **`gen_ai.conversation.id`** on your AI spans (see [Conversation ID](#conversation-id)).
+
+2. **Input messages that follow the OpenTelemetry GenAI conventions.** Sentry reads `gen_ai.input.messages` (and the deprecated `gen_ai.request.messages` attribute) and takes the **first message with `role: "user"`**. System, assistant, and tool messages are skipped.
+
+   Prefer the OTEL message shape — for example `{role, parts}` with a `"user"` role:
+
+   ```json
+   [
+     {
+       "role": "user",
+       "parts": [{"type": "text", "content": "Help me debug this flaky test"}]
+     }
+   ]
+   ```
+
+   The legacy `{role, content}` format is also accepted. Put system prompts in `gen_ai.system_instructions` when you can, and keep the first **user** turn in the input messages with `role: "user"`. If the only content on the span is a system message, Sentry cannot derive a title.
+
+3. **Message content actually sent to Sentry.** If inputs are omitted (for example `sendDefaultPii: false` without an override that captures gen AI inputs), or scrubbed to filtered values, title generation has nothing to work with. See [Data Privacy](/product/agents/privacy/).
+
+SDK integrations that already emit OTEL-shaped `gen_ai.*` spans typically meet these requirements once conversation IDs and input collection are enabled. For manual instrumentation, set the attributes on your agent or AI client spans — see the [span attribute tables](/platforms/javascript/common/agent-tracing/manual-instrumentation/).
+
 ## Conversations List
 
 The [Conversations](https://sentry.io/orgredirect/organizations/:orgslug/explore/conversations/) page shows the most recent conversations that match your filters.
@@ -87,8 +120,8 @@ The [Conversations](https://sentry.io/orgredirect/organizations/:orgslug/explore
 
 Each row in the list displays:
 
+- **Title** — generated from the first user message (falls back to that message text, or **Untitled conversation**)
 - **User** — the user who initiated the conversation, populated by `setUser` / `set_user`
-- **First input** — the first user message in the conversation
 - **Last output** — the most recent assistant response
 - **Cost** — estimated dollar cost and token usage
 - **LLM calls** — number of LLM generation requests


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

Documents how conversation titles work in **Explore > Conversations**: Sentry derives a short list title from the first user message on OTEL-shaped `gen_ai` spans.

Adds a **Conversation Titles** section covering prerequisites (`gen_ai.conversation.id`, first `role: "user"` message in `gen_ai.input.messages`, and that message content must actually reach Sentry), plus list fallbacks when a title is missing. Updates the conversations list bullet from first input to title.

Closes [TET-2734: Document how do we summarize the title in customer facing docs](https://linear.app/getsentry/issue/TET-2734/document-how-do-we-summarize-the-title-in-customer-facing-docs)
## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+
