### PR TITLE
docs(react-native): Document enableMetricKit option

### DIFF
--- a/docs/platforms/react-native/common/configuration/app-hangs.mdx
+++ b/docs/platforms/react-native/common/configuration/app-hangs.mdx
@@ -46,3 +46,7 @@ Sentry.resumeAppHangTracking();
 ```
 
 To read more about how app hangs are detected, check out the `sentry-cocoa` [documentation](/platforms/apple/configuration/app-hangs/).
+
+## MetricKit Hang Diagnostics
+
+On iOS 15 and up, the operating system can also report hangs through MetricKit. These are separate from the app hangs described above, and the SDK reports them only if you enable the <PlatformLink to="/configuration/metric-kit/">MetricKit</PlatformLink> integration. If you enable both, a single unresponsive period may be reported twice, once from each source.

--- a/docs/platforms/react-native/common/configuration/metric-kit.mdx
+++ b/docs/platforms/react-native/common/configuration/metric-kit.mdx
@@ -1,0 +1,34 @@
+---
+title: MetricKit
+sidebar_order: 12
+description: "Learn how to subscribe to MetricKit diagnostic reports and send them to Sentry."
+---
+
+The [MetricKit](https://developer.apple.com/documentation/metrickit) integration subscribes to [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic), [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic), and [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic), which it converts to Sentry events.
+
+This feature is available on React Native SDK version 8.22.0 and up. The SDK supports it on iOS 15 and up and macOS 12 and up, because in these versions MetricKit delivers diagnostic reports immediately, which allows the SDK to apply current data from the scope. It isn't available on Android or tvOS.
+
+Enable this feature by setting the `enableMetricKit` option to `true`:
+
+```javascript
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  enableMetricKit: true,
+});
+```
+
+You can identify MetricKit events by looking at the `mx_hang_diagnostic`, `mx_cpu_exception`, and `mx_disk_write_exception` `mechanism.type`.
+
+## MetricKit Hangs and App Hangs
+
+MetricKit hang diagnostics are reported by the operating system and are separate from the app hangs the SDK detects itself with <PlatformLink to="/configuration/app-hangs/">App Hang Tracking</PlatformLink>. Both features can be enabled at the same time, but a single unresponsive period may then be reported twice, once from each source.
+
+If you only want the SDK's own detection, leave `enableMetricKit` disabled. If you want to rely on MetricKit alone, set `enableAppHangTracking` to `false`.
+
+## Limitations
+
+The SDK has no control over the stack traces provided by MetricKit. Some only offer a couple of frames. If these aren't useful to you, you can drop them in <PlatformLink to="/configuration/filtering/#filtering-error-events">`beforeSend`</PlatformLink>.
+
+To read more about how the underlying integration works, check out the `sentry-cocoa` [documentation](/platforms/apple/configuration/metric-kit/).

--- a/docs/platforms/react-native/common/configuration/options.mdx
+++ b/docs/platforms/react-native/common/configuration/options.mdx
@@ -430,6 +430,16 @@ Set this boolean to `false` to disable [out of memory](/platforms/apple/guides/i
 
 </SdkOption>
 
+<SdkOption name="enableMetricKit" type="boolean" defaultValue="false" availableSince="8.22.0">
+
+Set this boolean to `true` to subscribe to MetricKit diagnostic reports on iOS and macOS. When enabled, the SDK converts `MXHangDiagnostic`, `MXDiskWriteExceptionDiagnostic`, and `MXCPUExceptionDiagnostic` into Sentry events.
+
+Requires iOS 15 or macOS 12 and up. MetricKit hang diagnostics are reported by the operating system and are separate from <PlatformLink to="/configuration/app-hangs/">App Hang Tracking</PlatformLink>, so enabling both can report the same hang twice.
+
+Learn more in the <PlatformLink to="/configuration/metric-kit/">MetricKit</PlatformLink> documentation.
+
+</SdkOption>
+
 <SdkOption name="onReady" type="function">
 
 Set this callback, which is called after the Sentry React Native SDK initializes its Native SDKs (Android and iOS).


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new `enableMetricKit` option in the React Native SDK, added in getsentry/sentry-react-native#6540 (ships in 8.22.0).

Blocked on the SDK PR merging/releasing — happy to hold until 8.22.0 is out.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)