### PR TITLE
docs(agents): Link Cloudflare from product Set Up and Conversations

### DIFF
--- a/docs/product/agents/conversations/index.mdx
+++ b/docs/product/agents/conversations/index.mdx
@@ -41,6 +41,8 @@ A conversation is a collection of spans that share the same `gen_ai.conversation
 Some SDK integrations (such as OpenAI Agents SDK for Python and OpenAI SDK for Node) automatically infer the conversation ID. For all other integrations, you need to set it manually. See your platform's Agent tracing guide for setup instructions:
 
 - [JavaScript/Node](/platforms/javascript/guides/node/agent-tracing/#tracking-conversations)
+- [Cloudflare](/platforms/javascript/guides/cloudflare/agent-tracing/#tracking-conversations)
+- [Cloudflare Agents SDK](/platforms/javascript/guides/cloudflare/features/agents-sdk/)
 - [Python](/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/#tracking-conversations)
 - [Laravel](/platforms/php/guides/laravel/agent-tracing/#conversations)
 

--- a/docs/product/agents/getting-started.mdx
+++ b/docs/product/agents/getting-started.mdx
@@ -14,6 +14,7 @@ keywords:
   - JavaScript AI
   - React Native AI
   - Next.js AI
+  - Cloudflare AI
   - .NET AI
   - dotnet AI
 ---
@@ -31,6 +32,7 @@ To start sending AI agent data to Sentry, make sure you've created a Sentry proj
 - [React](/platforms/javascript/guides/react/agent-tracing-browser/)
 - [React Native](/platforms/react-native/agent-tracing/)
 - [Next.js](/platforms/javascript/guides/nextjs/agent-tracing/)
+- [Cloudflare](/platforms/javascript/guides/cloudflare/agent-tracing/)
 - [.NET](/platforms/dotnet/tracing/instrumentation/ai-agents-module/)
 - [Ruby](/platforms/ruby/tracing/instrumentation/custom-instrumentation/ai-agents-module/)
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Agent Tracing set up and Conversations setup lists pointed at Node and other
runtimes but not Cloudflare, even though Workers AI and the Agents SDK already
have platform docs. Cloudflare is linked from product Set Up and from the
Conversations platform list (including the Agents SDK conversation-ID guide)
so CF readers can reach the correct instrumentation path.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)