### PR TITLE
docs(cloudflare): Clarify dataCollection defaults and Workers AI capture

### DIFF
--- a/docs/platforms/javascript/guides/cloudflare/features/workers-ai.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/workers-ai.mdx
@@ -5,9 +5,9 @@ description: "Learn how Sentry instruments Cloudflare Workers AI to capture gen_
 
 <AvailableSince version="10.67.0" />
 
-Sentry automatically instruments the [Cloudflare Workers AI binding](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/) (`env.AI`). Calls to `env.AI.run(...)` create `gen_ai` spans that follow Sentry's <PlatformLink to="/agent-tracing/">Agent Tracing</PlatformLink> conventions.
+Sentry automatically instruments the [Cloudflare Workers AI binding](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/) (`env.AI`). Calls to `env.AI.run(...)` create `gen_ai` spans that follow Sentry's <PlatformLink to="/agent-tracing/">Agent Tracing</PlatformLink> conventions, capturing the model, request parameters, and token usage.
 
-No extra instrumentation setup is required beyond initializing the SDK with `withSentry`. As long as your handler receives the instrumented `env`, the `AI` binding is wrapped for you:
+No extra setup is required beyond initializing the SDK with `withSentry`. As long as your handler receives the instrumented `env`, the `AI` binding is wrapped for you:
 
 ```typescript
 import * as Sentry from "@sentry/cloudflare";
@@ -16,9 +16,6 @@ export default Sentry.withSentry(
   (env) => ({
     dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
-    // {} enables prompts/responses on gen_ai spans and other permissive
-    // dataCollection defaults — tighten via configuration options
-    dataCollection: {},
   }),
   {
     async fetch(request, env) {
@@ -33,21 +30,11 @@ export default Sentry.withSentry(
 );
 ```
 
-With only `tracesSampleRate` and no `dataCollection`, you still get spans (model, operation, token usage). Prompt and response content is **off** unless you pass `dataCollection` (for example `dataCollection: {}`). Any `dataCollection` object turns on permissive defaults, including genAI inputs/outputs — tighten via <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+That is enough for spans. Prompt and response content is **off** unless you pass `dataCollection` (for example `dataCollection: {}`). Any `dataCollection` object also enables other permissive defaults — tighten them via <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+
+Only `env.AI.run` is instrumented. Streaming spans end when the stream is fully read or cancelled. With `returnRawResponse` or `websocket`, response body fields are not recorded.
 
 You can browse the full list of available models in the [Cloudflare Workers AI models directory](https://developers.cloudflare.com/ai/models/).
-
-## What Gets Instrumented
-
-| Topic | Behavior |
-| --- | --- |
-| Method | Only `env.AI.run(...)` |
-| Chat vs embeddings | Inputs with `messages` or `prompt` → `chat`; `text` → `embeddings`; otherwise `chat` |
-| Streaming | Span ends when the stream is fully read or cancelled |
-| `returnRawResponse` / `websocket` | Response body fields are not introspected |
-| Prompt / response content | Controlled by root `dataCollection.genAI` (defaults **on** when any `dataCollection` is set, **off** when it is absent) |
-
-There is no public per-binding options API on `@sentry/cloudflare`. Control AI input/output recording with root `dataCollection.genAI`.
 
 ## Next Steps
 

--- a/docs/platforms/javascript/guides/cloudflare/features/workers-ai.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/workers-ai.mdx
@@ -5,9 +5,9 @@ description: "Learn how Sentry instruments Cloudflare Workers AI to capture gen_
 
 <AvailableSince version="10.67.0" />
 
-Sentry automatically instruments the [Cloudflare Workers AI binding](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/) (`env.AI`). Calls to `env.AI.run(...)` create `gen_ai` spans that follow Sentry's <PlatformLink to="/agent-tracing/">Agent Tracing</PlatformLink> conventions, capturing the model, request parameters, and token usage.
+Sentry automatically instruments the [Cloudflare Workers AI binding](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/) (`env.AI`). Calls to `env.AI.run(...)` create `gen_ai` spans that follow Sentry's <PlatformLink to="/agent-tracing/">Agent Tracing</PlatformLink> conventions.
 
-No extra setup is required beyond initializing the SDK with `withSentry`. As long as your handler receives the instrumented `env`, the `AI` binding is wrapped for you:
+No extra instrumentation setup is required beyond initializing the SDK with `withSentry`. As long as your handler receives the instrumented `env`, the `AI` binding is wrapped for you:
 
 ```typescript
 import * as Sentry from "@sentry/cloudflare";
@@ -16,6 +16,9 @@ export default Sentry.withSentry(
   (env) => ({
     dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
+    // Capture prompts and responses on gen_ai spans (also enables other
+    // permissive dataCollection defaults — tighten as needed)
+    dataCollection: {},
   }),
   {
     async fetch(request, env) {
@@ -30,7 +33,29 @@ export default Sentry.withSentry(
 );
 ```
 
+With only `tracesSampleRate` set and no `dataCollection`, you still get spans (model, operation, token usage). Prompt and response content is **off** unless you pass `dataCollection` (for example `dataCollection: {}`) or set `dataCollection.genAI` explicitly:
+
+```typescript
+dataCollection: {
+  genAI: { inputs: true, outputs: true },
+},
+```
+
+To keep other `dataCollection` categories off while sending AI content, set only the categories you need and opt out of the rest. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+
 You can browse the full list of available models in the [Cloudflare Workers AI models directory](https://developers.cloudflare.com/ai/models/).
+
+## What Gets Instrumented
+
+| Topic | Behavior |
+| --- | --- |
+| Method | Only `env.AI.run(...)` |
+| Chat vs embeddings | Inputs with `messages` or `prompt` → `chat`; `text` → `embeddings`; otherwise `chat` |
+| Streaming | Span ends when the stream is fully read or cancelled |
+| `returnRawResponse` / `websocket` | Response body fields are not introspected |
+| Prompt / response content | Controlled by root `dataCollection.genAI` (defaults **on** when any `dataCollection` is set, **off** when it is absent) |
+
+There is no public per-binding options API on `@sentry/cloudflare`. Control AI input/output recording with root `dataCollection.genAI`.
 
 ## Next Steps
 

--- a/docs/platforms/javascript/guides/cloudflare/features/workers-ai.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/workers-ai.mdx
@@ -16,8 +16,8 @@ export default Sentry.withSentry(
   (env) => ({
     dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
-    // Capture prompts and responses on gen_ai spans (also enables other
-    // permissive dataCollection defaults — tighten as needed)
+    // {} enables prompts/responses on gen_ai spans and other permissive
+    // dataCollection defaults — tighten via configuration options
     dataCollection: {},
   }),
   {
@@ -33,15 +33,7 @@ export default Sentry.withSentry(
 );
 ```
 
-With only `tracesSampleRate` set and no `dataCollection`, you still get spans (model, operation, token usage). Prompt and response content is **off** unless you pass `dataCollection` (for example `dataCollection: {}`) or set `dataCollection.genAI` explicitly:
-
-```typescript
-dataCollection: {
-  genAI: { inputs: true, outputs: true },
-},
-```
-
-To keep other `dataCollection` categories off while sending AI content, set only the categories you need and opt out of the rest. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+With only `tracesSampleRate` and no `dataCollection`, you still get spans (model, operation, token usage). Prompt and response content is **off** unless you pass `dataCollection` (for example `dataCollection: {}`). Any `dataCollection` object turns on permissive defaults, including genAI inputs/outputs — tighten via <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
 
 You can browse the full list of available models in the [Cloudflare Workers AI models directory](https://developers.cloudflare.com/ai/models/).
 

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -126,11 +126,14 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
+    // Any dataCollection object (including {}) enables permissive defaults:
+    // genAI prompts/responses, userInfo, cookies, HTTP bodies, and more.
+    // Tighten categories as needed:
+    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
     dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
       // userInfo: false,
       // httpBodies: [],
+      // genAI: { inputs: false, outputs: false },
     },
     // ___PRODUCT_OPTION_START___ logs
 
@@ -181,11 +184,14 @@ export const onRequest = [
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
 
+    // Any dataCollection object (including {}) enables permissive defaults:
+    // genAI prompts/responses, userInfo, cookies, HTTP bodies, and more.
+    // Tighten categories as needed:
+    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
     dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
       // userInfo: false,
       // httpBodies: [],
+      // genAI: { inputs: false, outputs: false },
     },
     // ___PRODUCT_OPTION_START___ logs
 

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -126,10 +126,15 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // {} enables permissive defaults (genAI prompts/responses, userInfo,
-    // cookies, HTTP bodies, and more). Tighten via:
-    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    dataCollection: {},
+    dataCollection: {
+      // Any dataCollection object (including {}) uses permissive defaults:
+      // userInfo, cookies, HTTP bodies, genAI prompts/responses, and more.
+      // Uncomment to tighten. Details:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+      // genAI: { inputs: false, outputs: false },
+    },
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry
@@ -179,10 +184,15 @@ export const onRequest = [
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // {} enables permissive defaults (genAI prompts/responses, userInfo,
-    // cookies, HTTP bodies, and more). Tighten via:
-    // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    dataCollection: {},
+    dataCollection: {
+      // Any dataCollection object (including {}) uses permissive defaults:
+      // userInfo, cookies, HTTP bodies, genAI prompts/responses, and more.
+      // Uncomment to tighten. Details:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+      // genAI: { inputs: false, outputs: false },
+    },
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -126,15 +126,10 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // Any dataCollection object (including {}) enables permissive defaults:
-    // genAI prompts/responses, userInfo, cookies, HTTP bodies, and more.
-    // Tighten categories as needed:
+    // {} enables permissive defaults (genAI prompts/responses, userInfo,
+    // cookies, HTTP bodies, and more). Tighten via:
     // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    dataCollection: {
-      // userInfo: false,
-      // httpBodies: [],
-      // genAI: { inputs: false, outputs: false },
-    },
+    dataCollection: {},
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry
@@ -184,15 +179,10 @@ export const onRequest = [
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
 
-    // Any dataCollection object (including {}) enables permissive defaults:
-    // genAI prompts/responses, userInfo, cookies, HTTP bodies, and more.
-    // Tighten categories as needed:
+    // {} enables permissive defaults (genAI prompts/responses, userInfo,
+    // cookies, HTTP bodies, and more). Tighten via:
     // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    dataCollection: {
-      // userInfo: false,
-      // httpBodies: [],
-      // genAI: { inputs: false, outputs: false },
-    },
+    dataCollection: {},
     // ___PRODUCT_OPTION_START___ logs
 
     // Enable logs to be sent to Sentry


### PR DESCRIPTION
## DESCRIBE YOUR PR

Cloudflare Workers and Pages install samples include `dataCollection: {}`
without making clear that any `dataCollection` object turns on the SDK’s
permissive defaults — including generative AI prompts and responses, not
only user info and HTTP bodies. The Workers AI guide also read as if
tracing alone captured full AI content.

Install samples now call out those defaults and how to tighten them.
Workers AI documents that spans work with tracing alone, while prompt and
response content needs `dataCollection` / `genAI`, plus run-only coverage,
embeddings, streaming end conditions, and raw/websocket limits.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)