### PR TITLE
fix(platform): Restore middleware spans at 1% with request attributes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -108,16 +108,16 @@ function annotateMiddlewareSpan(
   }
 
   const outcome = middlewareOutcome(response);
+  const rootSpan = Sentry.getRootSpan(activeSpan);
 
-  Sentry.getRootSpan(activeSpan)
-    .updateName(`middleware ${request.method} ${outcome}`)
-    .setAttributes({
-      [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-      'middleware.outcome': outcome,
-      'url.path': request.nextUrl.pathname,
-      traffic_type: classification.trafficType,
-      device_type: classification.deviceType,
-    });
+  rootSpan.updateName(`middleware ${request.method} ${outcome}`);
+  rootSpan.setAttributes({
+    [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+    'middleware.outcome': outcome,
+    'url.path': request.nextUrl.pathname,
+    traffic_type: classification.trafficType,
+    device_type: classification.deviceType,
+  });
 }
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -88,14 +88,18 @@ function middlewareOutcome(response: NextResponse): MiddlewareOutcome {
 }
 
 /**
- * Next.js names this span `middleware GET` with no route detail, and the
- * tracesSampler can't classify it. Both are fixable here, where the request is
- * in hand: `sentry.source: 'custom'` stops the SDK reclaiming the name, and
- * `traffic_type` keeps bots filterable at query time.
+ * The tracesSampler can't classify this span (no request data at sampling time),
+ * so the detail it needs to stay useful is attached here instead, where the
+ * request is in hand. `traffic_type` keeps bots filterable at query time and
+ * `middleware.outcome` gives the redirect/rewrite/passthrough breakdown.
  *
- * Named by outcome, not path — the docs site has thousands of paths (plus every
- * file under /mdx-images/), so naming by URL would blow up transaction-name
- * cardinality. The path stays queryable as `url.path`.
+ * Attributes only — deliberately no `updateName`. The SDK's
+ * `enhanceMiddlewareRootSpan` rewrites the name of every `Middleware.execute`
+ * span to `middleware {METHOD}` on the send path, reading Next.js'
+ * `next.span_name` attribute and ignoring `sentry.source`, so any name set here
+ * is silently discarded. Outcome and path live as attributes rather than in the
+ * transaction name — which also keeps name cardinality flat, since the docs
+ * site has thousands of paths plus every file under /mdx-images/.
  */
 function annotateMiddlewareSpan(
   request: NextRequest,
@@ -107,13 +111,10 @@ function annotateMiddlewareSpan(
     return;
   }
 
-  const outcome = middlewareOutcome(response);
   const rootSpan = Sentry.getRootSpan(activeSpan);
 
-  rootSpan.updateName(`middleware ${request.method} ${outcome}`);
   rootSpan.setAttributes({
-    [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-    'middleware.outcome': outcome,
+    'middleware.outcome': middlewareOutcome(response),
     'url.path': request.nextUrl.pathname,
     traffic_type: classification.trafficType,
     device_type: classification.deviceType,

--- a/middleware.ts
+++ b/middleware.ts
@@ -43,15 +43,16 @@ export function middleware(request: NextRequest) {
   const classification = classifyTraffic(request);
   recordClassification(request, classification);
 
-  // First, handle canonical URL redirects for deprecated paths
-  const canonicalRedirect = handleRedirects(request);
-  if (canonicalRedirect) {
-    return applyNoindexForNonProductionDomains(request, canonicalRedirect);
-  }
+  // First handle canonical URL redirects for deprecated paths, then check for
+  // AI/LLM clients and redirect to markdown if appropriate.
+  const response = applyNoindexForNonProductionDomains(
+    request,
+    handleRedirects(request) ?? handleAIClientRedirect(request, classification)
+  );
 
-  // Then, check for AI/LLM clients and redirect to markdown if appropriate
-  const response = handleAIClientRedirect(request, classification);
-  return applyNoindexForNonProductionDomains(request, response);
+  annotateMiddlewareSpan(request, classification, response);
+
+  return response;
 }
 
 /**
@@ -74,6 +75,50 @@ function applyNoindexForNonProductionDomains(
 }
 
 type TrafficClassification = ReturnType<typeof classifyTraffic>;
+
+type MiddlewareOutcome = 'redirect' | 'rewrite' | 'passthrough';
+
+function middlewareOutcome(response: NextResponse): MiddlewareOutcome {
+  if (response.status >= 300 && response.status < 400) {
+    return 'redirect';
+  }
+  // Set by NextResponse.rewrite(). If Next.js renames it we degrade to
+  // 'passthrough' rather than throwing.
+  return response.headers.has('x-middleware-rewrite') ? 'rewrite' : 'passthrough';
+}
+
+/**
+ * Next.js names this span `middleware GET` with no route detail, and the
+ * tracesSampler can't classify it. Both are fixable here, where the request is
+ * in hand: `sentry.source: 'custom'` stops the SDK reclaiming the name, and
+ * `traffic_type` keeps bots filterable at query time.
+ *
+ * Named by outcome, not path — the docs site has thousands of paths (plus every
+ * file under /mdx-images/), so naming by URL would blow up transaction-name
+ * cardinality. The path stays queryable as `url.path`.
+ */
+function annotateMiddlewareSpan(
+  request: NextRequest,
+  classification: TrafficClassification,
+  response: NextResponse
+): void {
+  const activeSpan = Sentry.getActiveSpan();
+  if (!activeSpan) {
+    return;
+  }
+
+  const outcome = middlewareOutcome(response);
+
+  Sentry.getRootSpan(activeSpan)
+    .updateName(`middleware ${request.method} ${outcome}`)
+    .setAttributes({
+      [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+      'middleware.outcome': outcome,
+      'url.path': request.nextUrl.pathname,
+      traffic_type: classification.trafficType,
+      device_type: classification.deviceType,
+    });
+}
 
 /**
  * Records the per-request traffic classification as a counter metric.

--- a/src/lib/trafficClassification.ts
+++ b/src/lib/trafficClassification.ts
@@ -34,6 +34,13 @@ export const SAMPLE_RATES: Record<TrafficType, number> = {
 };
 
 /**
+ * Middleware root spans can't be classified at sampling time (see
+ * src/tracesSampler.ts), so this rate is applied blind to all traffic.
+ * ~1% of 2.4M requests/day ≈ 24k spans/day.
+ */
+export const MIDDLEWARE_SAMPLE_RATE = 0.01;
+
+/**
  * Checks if the input matches the pattern.
  * Returns the matched substring (lowercase), or undefined if no match.
  */

--- a/src/tracesSampler.ts
+++ b/src/tracesSampler.ts
@@ -53,15 +53,26 @@ function getForwardedTrafficType(
 }
 
 /**
+ * Ops the SDK has used for the Next.js middleware root span. `http.server.middleware`
+ * is the v10 op; v11 renames it to the `@sentry/conventions` `middleware`. Both are
+ * matched so the detection survives the upgrade.
+ */
+const MIDDLEWARE_SPAN_OPS = new Set(['http.server.middleware', 'middleware']);
+
+/**
  * Middleware root spans are created by Next.js itself ('Middleware.execute')
  * before any request data reaches Sentry, so they can never be classified here —
  * no headers, no user-agent. They get a low blind rate instead; middleware.ts
- * names them and stamps `traffic_type` so bots stay filterable at query time.
+ * stamps `traffic_type` on them so bots stay filterable at query time.
+ *
+ * `next.span_type` is the load-bearing check — it's set by Next.js at span
+ * creation, so it's the one attribute reliably present this early. The op and
+ * name checks are fallbacks for runtimes that get there another way.
  */
 function isMiddlewareRootSpan(samplingContext: SamplingContext): boolean {
   return (
     samplingContext.attributes?.['next.span_type'] === 'Middleware.execute' ||
-    samplingContext.attributes?.['sentry.op'] === 'http.server.middleware' ||
+    MIDDLEWARE_SPAN_OPS.has(samplingContext.attributes?.['sentry.op'] as string) ||
     samplingContext.name === 'middleware' ||
     Boolean(samplingContext.name?.startsWith('middleware '))
   );

--- a/src/tracesSampler.ts
+++ b/src/tracesSampler.ts
@@ -2,6 +2,7 @@ import {
   AI_AGENT_PATTERN,
   BOT_PATTERN,
   matchPattern,
+  MIDDLEWARE_SAMPLE_RATE,
   SAMPLE_RATES,
   type TrafficType,
 } from './lib/trafficClassification';
@@ -53,10 +54,9 @@ function getForwardedTrafficType(
 
 /**
  * Middleware root spans are created by Next.js itself ('Middleware.execute')
- * before any request data reaches Sentry, so they can never be classified
- * here — and they carry no useful detail (the name is collapsed to
- * `middleware GET`). Per-request traffic classification is recorded as the
- * `docs.request.classified` metric in middleware.ts instead.
+ * before any request data reaches Sentry, so they can never be classified here —
+ * no headers, no user-agent. They get a low blind rate instead; middleware.ts
+ * names them and stamps `traffic_type` so bots stay filterable at query time.
  */
 function isMiddlewareRootSpan(samplingContext: SamplingContext): boolean {
   return (
@@ -71,8 +71,8 @@ function isMiddlewareRootSpan(samplingContext: SamplingContext): boolean {
  * Determines trace sample rate based on traffic classification.
  *
  * Sample rates (from shared config):
- * - Middleware root spans: 0% (unclassifiable by architecture and information-free;
- *   traffic counting happens in middleware.ts via the docs.request.classified metric)
+ * - Middleware root spans: 1% (unclassifiable by architecture, so sampled blind
+ *   at a low rate for latency visibility; named and tagged in middleware.ts)
  * - AI agents: 100% (full visibility into agentic docs consumption)
  * - Bots/crawlers: 0% (filter out noise)
  * - Real users: 30%
@@ -85,7 +85,7 @@ function isMiddlewareRootSpan(samplingContext: SamplingContext): boolean {
  */
 export function tracesSampler(samplingContext: SamplingContext): number {
   if (isMiddlewareRootSpan(samplingContext)) {
-    return 0;
+    return MIDDLEWARE_SAMPLE_RATE;
   }
 
   const headers = samplingContext.normalizedRequest?.headers;


### PR DESCRIPTION
## DESCRIBE YOUR PR

#18775 dropped middleware root spans entirely; this restores them at a blind 1% (~24k/day), blind because Next.js creates the `Middleware.execute` root in a detached sandbox before any request data reaches Sentry, so `tracesSampler` can never classify it. `middleware.ts` tags that span with `middleware.outcome` (redirect/rewrite/passthrough), `url.path`, `traffic_type`, and `device_type` — attributes rather than a span name, because the SDK's `enhanceMiddlewareRootSpan` unconditionally rewrites `Middleware.execute` names to `middleware {METHOD}` on the send path and ignores `sentry.source`. `isMiddlewareRootSpan` now matches both `http.server.middleware` (SDK v10) and `middleware` (v11) so detection survives the upgrade.

Note that v10 still emits a duplicate nested middleware span, so volume may be ~2x until getsentry/sentry-javascript#22904 lands — unrelated to this rate, and a non-zero rate is what makes that fix observable here at all. To verify after deploy: `spans · span.op:http.server.middleware · release:<new sha>` is non-zero at ~1% of request volume with `middleware.outcome` populated, and `docs.request.classified` grouped by `traffic_type` is unchanged.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
