### PR TITLE
fix(SEO): Noindex non-production deployments and deep develop docs pages

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -288,6 +288,39 @@ type MetadataProps = {
   }>;
 };
 
+// Develop docs section roots that should remain indexable by search engines.
+// All other develop docs pages get noindex to prevent them from competing
+// with docs.sentry.io in search results. These correspond to the left nav
+// top-level sections defined in src/components/sidebar/developDocsSidebar.tsx.
+const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
+  'getting-started',
+  'engineering-practices',
+  'application-architecture',
+  'development-infrastructure',
+  'backend',
+  'frontend',
+  'services',
+  'integrations',
+  'ingestion',
+  'sdk',
+  'sdk-setup-wizards',
+  'self-hosted',
+]);
+
+/**
+ * Returns true if a develop docs path should remain indexable.
+ * Only the homepage (no path) and the root page of each left nav section
+ * (single-segment paths like ['getting-started']) are indexable.
+ */
+function isDevelopDocsIndexablePath(path: string[] | undefined): boolean {
+  // Homepage
+  if (!path || path.length === 0) {
+    return true;
+  }
+  // Section root pages (e.g., /getting-started/, /backend/)
+  return path.length === 1 && DEVELOP_DOCS_INDEXABLE_ROOTS.has(path[0]);
+}
+
 // Helper function to clean up canonical tags missing leading or trailing slash
 function formatCanonicalTag(tag: string) {
   if (tag.charAt(0) !== '/') {
@@ -372,6 +405,13 @@ export async function generateMetadata(props: MetadataProps): Promise<Metadata> 
       }
 
       noindex = pageNode.frontmatter.noindex;
+
+      // De-index deep develop docs pages to prevent them from competing with
+      // docs.sentry.io in search results. Only the homepage and the root page
+      // of each left nav section remain indexable.
+      if (isDeveloperDocs && !noindex) {
+        noindex = !isDevelopDocsIndexablePath(params.path);
+      }
 
       // Check for manual OG image override in frontmatter
       if (pageNode.frontmatter.og_image) {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,24 @@ import type {MetadataRoute} from 'next';
 import {type DocNode, getDocsRootNode} from 'sentry-docs/docTree';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
 
+// Develop docs section roots that should be included in the sitemap.
+// Deep pages are excluded to match the noindex strategy -- search engines
+// should not discover pages we've told them not to index.
+const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
+  'getting-started',
+  'engineering-practices',
+  'application-architecture',
+  'development-infrastructure',
+  'backend',
+  'frontend',
+  'services',
+  'integrations',
+  'ingestion',
+  'sdk',
+  'sdk-setup-wizards',
+  'self-hosted',
+]);
+
 /**
  * Recursively extracts all slugs (paths) from a DocNode tree.
  * This traverses the entire tree and collects the path from each node,
@@ -23,13 +41,28 @@ function extractSlugsFromDocTree(node: DocNode): string[] {
   return slugs;
 }
 
+/**
+ * For develop docs, returns only the section root paths (e.g., 'getting-started',
+ * 'backend') that should remain indexable. Deep pages are excluded from the
+ * sitemap to match the noindex meta tag strategy.
+ */
+function filterDevelopDocsPaths(paths: string[]): string[] {
+  return paths.filter(path => {
+    // Section root pages have no slashes (single segment like 'getting-started')
+    return !path.includes('/') && DEVELOP_DOCS_INDEXABLE_ROOTS.has(path);
+  });
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const rootNode = await getDocsRootNode();
   const baseUrl = isDeveloperDocs
     ? 'https://develop.sentry.dev'
     : 'https://docs.sentry.io';
 
-  const paths = extractSlugsFromDocTree(rootNode);
+  let paths = extractSlugsFromDocTree(rootNode);
+  if (isDeveloperDocs) {
+    paths = filterDevelopDocsPaths(paths);
+  }
   return docsToSitemap(paths, baseUrl);
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,6 +16,11 @@ const BASE_URL = isDeveloperDocs
   ? 'https://develop.sentry.dev'
   : 'https://docs.sentry.io';
 
+// Production domains whose content should be indexable by search engines.
+// All other hostnames (Vercel preview/deployment URLs, old production deployments)
+// get X-Robots-Tag: noindex to prevent search engines from indexing stale content.
+const INDEXABLE_HOSTNAMES = new Set(['docs.sentry.io', 'develop.sentry.dev', 'localhost']);
+
 export const config = {
   // learn more: https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher
   matcher: [
@@ -41,11 +46,31 @@ export function middleware(request: NextRequest) {
   // First, handle canonical URL redirects for deprecated paths
   const canonicalRedirect = handleRedirects(request);
   if (canonicalRedirect) {
-    return canonicalRedirect;
+    return applyNoindexForNonProductionDomains(request, canonicalRedirect);
   }
 
   // Then, check for AI/LLM clients and redirect to markdown if appropriate
-  return handleAIClientRedirect(request, classification);
+  const response = handleAIClientRedirect(request, classification);
+  return applyNoindexForNonProductionDomains(request, response);
+}
+
+/**
+ * Adds X-Robots-Tag: noindex to responses served from non-production domains.
+ * This prevents search engines from indexing stale Vercel deployment URLs
+ * (e.g., sentry-docs-<hash>.vercel.app) or old production deployments that
+ * are still accessible but no longer current.
+ *
+ * Production domains (docs.sentry.io, develop.sentry.dev) are not affected.
+ */
+function applyNoindexForNonProductionDomains(
+  request: NextRequest,
+  response: NextResponse
+): NextResponse {
+  const hostname = request.nextUrl.hostname;
+  if (!INDEXABLE_HOSTNAMES.has(hostname)) {
+    response.headers.set('X-Robots-Tag', 'noindex');
+  }
+  return response;
 }
 
 type TrafficClassification = ReturnType<typeof classifyTraffic>;


### PR DESCRIPTION
## DESCRIBE YOUR PR

Two SEO changes to control what search engines index:

### 1. Non-production domains get `X-Robots-Tag: noindex`

**Problem:** Old Vercel deployments remain accessible at their generated URLs (e.g., `sentry-docs-<hash>.vercel.app`) and can be crawled/indexed by search engines, serving stale content that competes with production pages. 

**Fix:** In `middleware.ts`, wrap all responses with `X-Robots-Tag: noindex` when the request hostname is not a production domain (`docs.sentry.io`, `develop.sentry.dev`, or `localhost`). This applies to all Vercel preview URLs, old deployment URLs, and any other non-production hostname.

### 2. Deep develop docs pages get `noindex`

**Problem:** Deep develop docs pages, for example, [`develop.sentry.dev/backend/some-deep-page/`](https://develop.sentry.dev/backend/application-domains/pii/#interactive-editing) appear in search results alongside (and sometimes above) docs.sentry.io product pages, causing SEO confusion and poor user experience.

**Fix:** In `generateMetadata()`, set `noindex` on all develop docs pages **except** the homepage and the root page of each left nav section (13 pages total). The sitemap is updated to match -- only indexable pages are included, so search engines get consistent signals.

**Pages that remain indexed on `develop.sentry.dev`:**
- `/` (homepage)
- `/getting-started/`
- `/engineering-practices/`
- `/application-architecture/`
- `/development-infrastructure/`
- `/backend/`
- `/frontend/`
- `/services/`
- `/integrations/`
- `/ingestion/`
- `/sdk/`
- `/sdk-setup-wizards/`
- `/self-hosted/`

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the Sentry docs team