### PR TITLE
refactor: Extract DEVELOP_DOCS_INDEXABLE_ROOTS into shared module

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -13,6 +13,7 @@ import {PlatformContent} from 'sentry-docs/components/platformContent';
 import {SpecChangelog} from 'sentry-docs/components/specChangelog';
 import {isSpecStatus} from 'sentry-docs/components/specConstants';
 import {SpecMeta} from 'sentry-docs/components/specMeta';
+import {isDevelopDocsIndexablePath} from 'sentry-docs/developDocsConfig';
 import {
   DocNode,
   getCurrentPlatformOrGuide,
@@ -287,39 +288,6 @@ type MetadataProps = {
     path?: string[];
   }>;
 };
-
-// Develop docs section roots that should remain indexable by search engines.
-// All other develop docs pages get noindex to prevent them from competing
-// with docs.sentry.io in search results. These correspond to the left nav
-// top-level sections defined in src/components/sidebar/developDocsSidebar.tsx.
-const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
-  'getting-started',
-  'engineering-practices',
-  'application-architecture',
-  'development-infrastructure',
-  'backend',
-  'frontend',
-  'services',
-  'integrations',
-  'ingestion',
-  'sdk',
-  'sdk-setup-wizards',
-  'self-hosted',
-]);
-
-/**
- * Returns true if a develop docs path should remain indexable.
- * Only the homepage (no path) and the root page of each left nav section
- * (single-segment paths like ['getting-started']) are indexable.
- */
-function isDevelopDocsIndexablePath(path: string[] | undefined): boolean {
-  // Homepage
-  if (!path || path.length === 0) {
-    return true;
-  }
-  // Section root pages (e.g., /getting-started/, /backend/)
-  return path.length === 1 && DEVELOP_DOCS_INDEXABLE_ROOTS.has(path[0]);
-}
 
 // Helper function to clean up canonical tags missing leading or trailing slash
 function formatCanonicalTag(tag: string) {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,24 +1,7 @@
 import type {MetadataRoute} from 'next';
+import {DEVELOP_DOCS_INDEXABLE_ROOTS} from 'sentry-docs/developDocsConfig';
 import {type DocNode, getDocsRootNode} from 'sentry-docs/docTree';
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
-
-// Develop docs section roots that should be included in the sitemap.
-// Deep pages are excluded to match the noindex strategy -- search engines
-// should not discover pages we've told them not to index.
-const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
-  'getting-started',
-  'engineering-practices',
-  'application-architecture',
-  'development-infrastructure',
-  'backend',
-  'frontend',
-  'services',
-  'integrations',
-  'ingestion',
-  'sdk',
-  'sdk-setup-wizards',
-  'self-hosted',
-]);
 
 /**
  * Recursively extracts all slugs (paths) from a DocNode tree.

--- a/src/developDocsConfig.ts
+++ b/src/developDocsConfig.ts
@@ -1,11 +1,7 @@
 /**
- * Develop docs section roots that should remain indexable by search engines.
- * All other develop docs pages get noindex to prevent them from competing
- * with docs.sentry.io in search results. These correspond to the left nav
- * top-level sections defined in src/components/sidebar/developDocsSidebar.tsx.
- *
- * Used by both page.tsx (meta tags) and sitemap.ts (sitemap filtering) to
- * ensure consistent indexing behavior.
+ * Develop docs roots that should remain indexable by search engines.
+ * Noindex to prevent them from competing with docs.sentry.io in search results. 
+ * Used by both page.tsx (meta tags) and sitemap.ts (sitemap filtering)
  */
 export const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
   'getting-started',
@@ -24,8 +20,6 @@ export const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
 
 /**
  * Returns true if a develop docs path should remain indexable.
- * Only the homepage (no path) and the root page of each left nav section
- * (single-segment paths like ['getting-started']) are indexable.
  */
 export function isDevelopDocsIndexablePath(path: string[] | undefined): boolean {
   // Homepage

--- a/src/developDocsConfig.ts
+++ b/src/developDocsConfig.ts
@@ -1,6 +1,6 @@
 /**
  * Develop docs roots that should remain indexable by search engines.
- * Noindex to prevent them from competing with docs.sentry.io in search results. 
+ * Noindex to prevent them from competing with docs.sentry.io in search results.
  * Used by both page.tsx (meta tags) and sitemap.ts (sitemap filtering)
  */
 export const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([

--- a/src/developDocsConfig.ts
+++ b/src/developDocsConfig.ts
@@ -1,0 +1,37 @@
+/**
+ * Develop docs section roots that should remain indexable by search engines.
+ * All other develop docs pages get noindex to prevent them from competing
+ * with docs.sentry.io in search results. These correspond to the left nav
+ * top-level sections defined in src/components/sidebar/developDocsSidebar.tsx.
+ *
+ * Used by both page.tsx (meta tags) and sitemap.ts (sitemap filtering) to
+ * ensure consistent indexing behavior.
+ */
+export const DEVELOP_DOCS_INDEXABLE_ROOTS = new Set([
+  'getting-started',
+  'engineering-practices',
+  'application-architecture',
+  'development-infrastructure',
+  'backend',
+  'frontend',
+  'services',
+  'integrations',
+  'ingestion',
+  'sdk',
+  'sdk-setup-wizards',
+  'self-hosted',
+]);
+
+/**
+ * Returns true if a develop docs path should remain indexable.
+ * Only the homepage (no path) and the root page of each left nav section
+ * (single-segment paths like ['getting-started']) are indexable.
+ */
+export function isDevelopDocsIndexablePath(path: string[] | undefined): boolean {
+  // Homepage
+  if (!path || path.length === 0) {
+    return true;
+  }
+  // Section root pages (e.g., /getting-started/, /backend/)
+  return path.length === 1 && DEVELOP_DOCS_INDEXABLE_ROOTS.has(path[0]);
+}


### PR DESCRIPTION
## DESCRIBE YOUR PR

Follow-up to #18889. The `DEVELOP_DOCS_INDEXABLE_ROOTS` constant and `isDevelopDocsIndexablePath()` function were duplicated in `page.tsx` and `sitemap.ts`. This extracts them into `src/developDocsConfig.ts` so there is a single source of truth.

If a new develop docs section is added, it only needs to be updated in one place.

### Files Changed

| File | Change |
|---|---|
| `src/developDocsConfig.ts` | New -- shared constant and helper function |
| `app/[[...path]]/page.tsx` | Remove inline constant/function, import from shared module |
| `app/sitemap.ts` | Remove inline constant, import from shared module |

## IS YOUR CHANGE URGENT?

- [ ] None: Not urgent, cleanup from #18889

## PRE-MERGE CHECKLIST

- [x] Checked Vercel preview for correctness
- [ ] PR was reviewed and approved by a member of the Sentry docs team

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.