### PR TITLE
feat(react-native): Document Android NDK app hang tracking options

### DIFF
--- a/docs/platforms/react-native/common/configuration/app-hangs.mdx
+++ b/docs/platforms/react-native/common/configuration/app-hangs.mdx
@@ -4,7 +4,7 @@ sidebar_order: 11
 description: "Learn about how to add app hang detection reporting."
 ---
 
-This integration tracks app hangs. This feature is available on iOS, tvOS, and macOS.
+This integration tracks app hangs. It's available on iOS, tvOS, and macOS, and on Android through NDK-based detection (see [App Hang Tracking on Android](#app-hang-tracking-on-android)).
 
 Trying to use an unresponsive app is extremely frustrating for users. There are many reasons why an app may become unresponsive, such as long-running code, infinite loop bugs, and so on. With app hang tracking you can detect and fix them.
 
@@ -27,6 +27,31 @@ import * as Sentry from "@sentry/react-native";
 Sentry.init({
   dsn: "DSN",
   appHangTimeoutInterval: 1,
+});
+```
+
+### App Hang Tracking on Android
+
+The `enableAppHangTracking` and `appHangTimeoutInterval` options above apply to iOS only. On Android, you can enable `sentry-native`'s heartbeat-based app hang detection with the `enableNdkAppHangTracking` option. This is independent of the JVM-based ANR detection and requires NDK to be enabled. It's disabled by default:
+
+```javascript
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "DSN",
+  enableNdkAppHangTracking: true,
+});
+```
+
+The default timeout is 5000 milliseconds. This represents the minimum amount of time the app can be unresponsive before it's classified as hanging. You can change the timeout by setting the `ndkAppHangTimeoutIntervalMillis` option:
+
+```javascript
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "DSN",
+  enableNdkAppHangTracking: true,
+  ndkAppHangTimeoutIntervalMillis: 3000,
 });
 ```
 

--- a/docs/platforms/react-native/common/configuration/app-hangs.mdx
+++ b/docs/platforms/react-native/common/configuration/app-hangs.mdx
@@ -32,7 +32,7 @@ Sentry.init({
 
 ### App Hang Tracking on Android
 
-The `enableAppHangTracking` and `appHangTimeoutInterval` options above apply to iOS only. On Android, you can enable `sentry-native`'s heartbeat-based app hang detection with the `enableNdkAppHangTracking` option. This is independent of the JVM-based ANR detection and requires NDK to be enabled. It's disabled by default:
+The `enableAppHangTracking` and `appHangTimeoutInterval` options above apply to iOS, tvOS, and macOS. On Android, you can enable `sentry-native`'s heartbeat-based app hang detection with the `enableNdkAppHangTracking` option. This is independent of the JVM-based ANR detection and requires NDK to be enabled. It's disabled by default:
 
 ```javascript
 import * as Sentry from "@sentry/react-native";

--- a/docs/platforms/react-native/common/configuration/app-hangs.mdx
+++ b/docs/platforms/react-native/common/configuration/app-hangs.mdx
@@ -4,7 +4,7 @@ sidebar_order: 11
 description: "Learn about how to add app hang detection reporting."
 ---
 
-This integration tracks app hangs. It's available on iOS, tvOS, and macOS, and on Android through NDK-based detection (see [App Hang Tracking on Android](#app-hang-tracking-on-android)).
+This integration tracks app hangs. It's available on iOS, tvOS, macOS, and on Android through NDK-based detection (see [App Hang Tracking on Android](#app-hang-tracking-on-android)).
 
 Trying to use an unresponsive app is extremely frustrating for users. There are many reasons why an app may become unresponsive, such as long-running code, infinite loop bugs, and so on. With app hang tracking you can detect and fix them.
 

--- a/docs/platforms/react-native/common/configuration/options.mdx
+++ b/docs/platforms/react-native/common/configuration/options.mdx
@@ -418,6 +418,18 @@ When enabled, ANR events whose stacktraces contain only system frames (for examp
 
 </SdkOption>
 
+<SdkOption name="enableNdkAppHangTracking" type="boolean" defaultValue="false">
+
+Set this boolean to `true` to enable `sentry-native`'s heartbeat-based app hang detection on Android. This is independent of the JVM-based ANR detection and requires NDK to be enabled. Use `ndkAppHangTimeoutIntervalMillis` to configure the threshold.
+
+</SdkOption>
+
+<SdkOption name="ndkAppHangTimeoutIntervalMillis" type="number" defaultValue="5000">
+
+The minimum amount of time (in milliseconds) an app must be unresponsive before it's classified as an app hang when using NDK app hang detection on Android. Only has an effect if `enableNdkAppHangTracking` is `true`.
+
+</SdkOption>
+
 <SdkOption name="enableAutoPerformanceTracing" type="boolean" defaultValue="true">
 
 Set this boolean to `false` to disable auto [performance monitoring](/product/dashboards/sentry-dashboards/) tracking.

--- a/docs/platforms/react-native/common/configuration/options.mdx
+++ b/docs/platforms/react-native/common/configuration/options.mdx
@@ -426,7 +426,7 @@ Set this boolean to `true` to enable `sentry-native`'s heartbeat-based app hang 
 
 <SdkOption name="ndkAppHangTimeoutIntervalMillis" type="number" defaultValue="5000">
 
-The minimum amount of time (in milliseconds) an app must be unresponsive before it's classified as an app hang when using NDK app hang detection on Android. Only has an effect if `enableNdkAppHangTracking` is `true`.
+The minimum amount of time (in milliseconds) an app must be unresponsive before it's classified as an app hang when using NDK app hang detection on Android. This only has an effect if `enableNdkAppHangTracking` is `true`.
 
 </SdkOption>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents two new Android-only React Native SDK options that surface `sentry-native`'s heartbeat-based app-hang detection:

- `enableNdkAppHangTracking` (boolean, default `false`)
- `ndkAppHangTimeoutIntervalMillis` (number, default `5000`)

Changes:
- `configuration/options.mdx` — added `<SdkOption>` entries for both options, next to the other Android options.
- `configuration/app-hangs.mdx` — added an "App Hang Tracking on Android" section with init examples, and clarified that the existing `enableAppHangTracking` / `appHangTimeoutInterval` options are iOS-only.

Accompanies the SDK change in getsentry/sentry-react-native#6548.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/6548 is released

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)