### PR TITLE
docs(js): Update `include` option of `RequestData`

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
@@ -32,8 +32,6 @@ This integration only works inside server environments (Node.js, Bun, Deno).
 
 </Alert>
 
-<Include name="platforms/configuration/integrations/requestdata-v11-alert" />
-
 _Import name: `Sentry.requestDataIntegration`_
 
 This integration is enabled by default. If you'd like to modify your default integrations, read [this](./../#modifying-default-integrations).
@@ -46,11 +44,17 @@ This integration adds data from incoming requests to transaction and error event
 
 ### `include`
 
+<Alert level="warning">
+
+Use the <PlatformLink to="/configuration/options/#dataCollection">`dataCollection` option</PlatformLink> instead. The `include` option will likely be removed in a future SDK version.
+
+</Alert>
+
 By passing an `include` option, you can define what data from a request you want to capture:
 
 ```javascript
 requestDataIntegration({
-  // Controls what types of data are added to the event
+  // Controls what types of data are added to the event - consider using `dataCollection` in the `init()` options
   include: {
     cookies: boolean  // default: true,
     data: boolean  // default: true,
@@ -58,15 +62,6 @@ requestDataIntegration({
     ip: boolean  // default: false,
     query_string: boolean  // default: true,
     url: boolean  // default: true,
-    user: boolean | {
-      id: boolean  // default: true,
-      username: boolean  // default: true,
-      email: boolean  // default: true,
-    },
   },
-  // Controls how the transaction will be reported. Options are 'path' (`/some/route`),
-  // 'methodPath' (`GET /some/route`), and 'handler' (the name of the route handler
-  // function, if available)
-  transactionNamingScheme: string  // default: 'methodPath',
 })
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/requestdata.mdx
@@ -46,7 +46,7 @@ This integration adds data from incoming requests to transaction and error event
 
 <Alert level="warning">
 
-Use the <PlatformLink to="/configuration/options/#dataCollection">`dataCollection` option</PlatformLink> instead. The `include` option will likely be removed in a future SDK version.
+The `include` option will likely be removed in a future SDK version. Use the <PlatformLink to="/configuration/options/#dataCollection">`dataCollection` option</PlatformLink> instead. 
 
 </Alert>
 

--- a/docs/platforms/javascript/common/data-management/data-collected/index.mdx
+++ b/docs/platforms/javascript/common/data-management/data-collected/index.mdx
@@ -107,8 +107,6 @@ Without `dataCollection` (and with `sendDefaultPii` unset or `false`), Sentry on
 
 On the server-side, the <PlatformLink to="/configuration/integrations/requestdata/">RequestData Integration</PlatformLink> captures incoming request data including cookies, headers, query strings, request body (`data`), URL, and user information. By default, most of these fields are captured (except IP address).
 
-<Include name="platforms/configuration/integrations/requestdata-v11-alert" />
-
 </PlatformSection>
 
 ## Response Body

--- a/includes/platforms/configuration/integrations/requestdata-v11-alert.mdx
+++ b/includes/platforms/configuration/integrations/requestdata-v11-alert.mdx
@@ -1,5 +1,0 @@
-<Alert level="warning" title="Upcoming Changes in v11">
-
-In version 11, the default behavior of the RequestData integration will likely change to be more privacy-conscious. Fields like `cookies`, `data`, `headers`, `query_string`, and `user` will default to `false` instead of `true`. To continue capturing this data after upgrading to v11, you'll need to either explicitly configure the <PlatformLink to="/configuration/integrations/requestdata/">RequestData Integration</PlatformLink> or set <PlatformLink to="/configuration/options/#sendDefaultPii">`sendDefaultPii: true`</PlatformLink>.
-
-</Alert>


### PR DESCRIPTION
Removes the type options that are not available anymore (were already removed in v9). And also adds an Alert with a link to the data collection options.