### PR TITLE
chore(dart,js): Point agent-assisted span streaming migration to docs page

### DIFF
--- a/docs/platforms/dart/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/dart/common/tracing/streamed-spans/index.mdx
@@ -58,6 +58,14 @@ If you use custom instrumentation or transaction-specific configuration, follow 
 
 See the <PlatformLink to="/tracing/streamed-spans/migration-guide/">Migration Guide</PlatformLink> for complete before-and-after examples.
 
+### Agent-Assisted Migration
+
+Copy the following prompt and paste it into your AI agent:
+
+```txt
+Follow ___CURRENT_URL___ to enable and migrate to span streaming in the Sentry SDK.
+```
+
 ## Enable Stream Mode
 
 <SplitLayout>

--- a/docs/platforms/dart/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/dart/common/tracing/streamed-spans/index.mdx
@@ -58,14 +58,6 @@ If you use custom instrumentation or transaction-specific configuration, follow 
 
 See the <PlatformLink to="/tracing/streamed-spans/migration-guide/">Migration Guide</PlatformLink> for complete before-and-after examples.
 
-### Agent-Assisted Migration
-
-Copy the following prompt and paste it into your AI agent:
-
-```txt
-Use curl to download, read and follow https://raw.githubusercontent.com/getsentry/sentry-for-ai/refs/heads/main/skills-legacy/sentry-span-streaming-dart/SKILL.md to enable and migrate to span streaming in the Sentry SDK.
-```
-
 ## Enable Stream Mode
 
 <SplitLayout>

--- a/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
@@ -39,11 +39,8 @@ Trace
           └── Child span
 ```
 
-
-
 Span stream mode will be enabled by default in version `11.0.0` of the SDK.
 You can already opt into stream mode in version 10 by following the migration guide below.
-
 
 ## Prerequisites
 
@@ -63,6 +60,14 @@ If you use `beforeSendSpan` or `beforeSendTransaction`, follow these steps:
 3. [Replace `beforeSendTransaction` with `ignoreSpans` to drop spans](#drop-spans)
 4. [Migrate tags (`Sentry.setTag(s)`) to attributes (`Sentry.setAttribute(s)`)](#shared-attributes)
 5. [Verify the migration](#verify-your-setup)
+
+### Agent-Assisted Migration
+
+Copy the following prompt and paste it into your AI agent:
+
+```txt
+Follow ___CURRENT_URL___ to enable and migrate to span streaming in the Sentry SDK.
+```
 
 ## Enable Stream Mode
 
@@ -208,7 +213,7 @@ Find more examples in our <PlatformLink to="/tracing/span-metrics/">Sending Span
 ### Shared Attributes
 
 Previously, transaction mode applied shared tags (`Sentry.setTag(s)`) to the service span (transaction).
-In Stream mode, tags are no longer applied to spans. 
+In Stream mode, tags are no longer applied to spans.
 Set shared attributes on a specific scope instead.
 You don't need to remove tags from your code, since they still apply to errors.
 Instead, add attributes for all data that's relevant for spans, logs metrics.
@@ -217,7 +222,7 @@ Instead, add attributes for all data that's relevant for spans, logs metrics.
 <SplitSection>
 <SplitSectionText>
 
-Use `Sentry.setAttribute` and `Sentry.setAttributes` to attach attributes that are automatically included in all spans (as well as your logs and metrics). 
+Use `Sentry.setAttribute` and `Sentry.setAttributes` to attach attributes that are automatically included in all spans (as well as your logs and metrics).
 These work just like <PlatformLink to="/apis/#setTag">`Sentry.setTag` and `Sentry.setTags`</PlatformLink>, but they accept `string`, `number`, and `boolean` values.
 
 To attach attributes to a broader or narrower context, set them on a specific scope instead. Use the global scope for app-wide attributes and the current scope for a single operation.
@@ -428,7 +433,6 @@ If you're auto-instrumenting and don't know what the initial name of a span is w
 
 Distributed tracing works out of the box when tracing is enabled and works the same way in stream mode. If you need to manually propagate trace context, for example,
 when the SDK can't instrument automatically, see <PlatformLink to="/tracing/distributed-tracing/custom-instrumentation/">Custom Trace Propagation</PlatformLink>.
-
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
@@ -64,15 +64,6 @@ If you use `beforeSendSpan` or `beforeSendTransaction`, follow these steps:
 4. [Migrate tags (`Sentry.setTag(s)`) to attributes (`Sentry.setAttribute(s)`)](#shared-attributes)
 5. [Verify the migration](#verify-your-setup)
 
-
-### Agent-Assisted migration
-
-Copy the following prompt and paste it into your AI agent:
-
-```txt
-Use curl to download, read and follow https://raw.githubusercontent.com/getsentry/sentry-for-ai/refs/heads/main/skills-legacy/sentry-span-streaming-js/SKILL.md to enable and migrate to span streaming in the Sentry SDK.
-```
-
 ## Enable Stream Mode
 
 <PlatformContent includePath="performance/enable-stream-mode" />

--- a/scripts/generate-md-exports.mjs
+++ b/scripts/generate-md-exports.mjs
@@ -28,6 +28,7 @@ import {unified} from 'unified';
 import {remove} from 'unist-util-remove';
 
 import {rehypeExpandCodeTabs} from './rehype-expand-code-tabs.mjs';
+import {replaceCurrentUrlTokens} from './markdown-keywords.mjs';
 
 // Default values for code keyword placeholders (e.g. ___PUBLIC_DSN___) that are
 // normally replaced client-side by codeKeywords.tsx. These must stay in sync with
@@ -1166,7 +1167,10 @@ async function processTaskList({id, tasks, cacheDir, noCache, usedCacheFiles}) {
       // expensive HTML → markdown conversion output:
       //   - applyKeywordDefaults: replaces ___KEYWORD___ placeholders with defaults
       //   - formatYamlFrontmatter: prepends YAML metadata
-      const resolved = applyKeywordDefaults(data);
+      const resolved = replaceCurrentUrlTokens(
+        applyKeywordDefaults(data),
+        frontmatter?.url
+      );
       const output = frontmatter
         ? formatYamlFrontmatter(frontmatter) + resolved
         : resolved;

--- a/scripts/markdown-keywords.mjs
+++ b/scripts/markdown-keywords.mjs
@@ -1,0 +1,10 @@
+const CURRENT_URL_TOKEN = '___CURRENT_URL___';
+
+export function replaceCurrentUrlTokens(markdown, currentUrl) {
+  if (!currentUrl) {
+    return markdown;
+  }
+
+  const url = new URL(currentUrl);
+  return markdown.replaceAll(CURRENT_URL_TOKEN, `${url.origin}${url.pathname}`);
+}

--- a/scripts/markdown-keywords.test.mjs
+++ b/scripts/markdown-keywords.test.mjs
@@ -1,0 +1,20 @@
+import {describe, expect, it} from 'vitest';
+
+import {replaceCurrentUrlTokens} from './markdown-keywords.mjs';
+
+describe('replaceCurrentUrlTokens', () => {
+  it('replaces the current URL placeholder without query parameters or fragments', () => {
+    expect(
+      replaceCurrentUrlTokens(
+        'Follow ___CURRENT_URL___ to continue.',
+        'https://docs.sentry.io/platforms/javascript/?source=agent#setup'
+      )
+    ).toBe('Follow https://docs.sentry.io/platforms/javascript/ to continue.');
+  });
+
+  it('leaves the placeholder unchanged without a canonical URL', () => {
+    expect(replaceCurrentUrlTokens('Follow ___CURRENT_URL___.')).toBe(
+      'Follow ___CURRENT_URL___.'
+    );
+  });
+});

--- a/src/components/codeKeywords/codeKeywords.spec.tsx
+++ b/src/components/codeKeywords/codeKeywords.spec.tsx
@@ -1,0 +1,16 @@
+import {describe, expect, it} from 'vitest';
+
+import {replaceCurrentUrlTokens} from './codeKeywords';
+
+describe('replaceCurrentUrlTokens', () => {
+  it('replaces the current URL placeholder without query parameters or fragments', () => {
+    const result = replaceCurrentUrlTokens(
+      'Follow ___CURRENT_URL___ to continue.',
+      'https://docs.sentry.io/platforms/javascript/?source=agent#setup'
+    );
+
+    expect(result).toBe(
+      'Follow https://docs.sentry.io/platforms/javascript/ to continue.'
+    );
+  });
+});

--- a/src/components/codeKeywords/codeKeywords.tsx
+++ b/src/components/codeKeywords/codeKeywords.tsx
@@ -8,6 +8,7 @@ import {OrgAuthTokenCreator} from './orgAuthTokenCreator';
 export const KEYWORDS_REGEX = /\b___(?:([A-Z_][A-Z0-9_]*)\.)?([A-Z_][A-Z0-9_]*)___\b/g;
 export const ORG_AUTH_TOKEN_REGEX = /___ORG_AUTH_TOKEN___/g;
 export const SDK_PACKAGE_REGEX = /___SDK_PACKAGE___/g;
+const CURRENT_URL_TOKEN = '___CURRENT_URL___';
 
 type ChildrenItem = ReturnType<typeof Children.toArray>[number] | React.ReactNode;
 
@@ -33,25 +34,34 @@ export function makeKeywordsClickable(
       return arr;
     }
 
+    const text = child.includes(CURRENT_URL_TOKEN)
+      ? replaceCurrentUrlTokens(child, window.location.href)
+      : child;
+
     // Reset regex lastIndex before testing to avoid stale state from previous matches
     ORG_AUTH_TOKEN_REGEX.lastIndex = 0;
     KEYWORDS_REGEX.lastIndex = 0;
     SDK_PACKAGE_REGEX.lastIndex = 0;
 
-    if (ORG_AUTH_TOKEN_REGEX.test(child)) {
-      makeOrgAuthTokenClickable(arr, child);
-    } else if (SDK_PACKAGE_REGEX.test(child)) {
+    if (ORG_AUTH_TOKEN_REGEX.test(text)) {
+      makeOrgAuthTokenClickable(arr, text);
+    } else if (SDK_PACKAGE_REGEX.test(text)) {
       // Simple string replacement for SDK package (fallback to @sentry/browser on non-platform pages)
-      arr.push(child.replace(SDK_PACKAGE_REGEX, sdkPackage || '@sentry/browser'));
-    } else if (KEYWORDS_REGEX.test(child)) {
-      const isDSNKeyword = /___PUBLIC_DSN___/.test(child);
-      makeProjectKeywordsClickable(arr, child, isDSNKeyword);
+      arr.push(text.replace(SDK_PACKAGE_REGEX, sdkPackage || '@sentry/browser'));
+    } else if (KEYWORDS_REGEX.test(text)) {
+      const isDSNKeyword = /___PUBLIC_DSN___/.test(text);
+      makeProjectKeywordsClickable(arr, text, isDSNKeyword);
     } else {
-      arr.push(child);
+      arr.push(text);
     }
 
     return arr;
   }, [] as ChildrenItem[]);
+}
+
+export function replaceCurrentUrlTokens(value: string, currentUrl: string) {
+  const url = new URL(currentUrl);
+  return value.replaceAll(CURRENT_URL_TOKEN, `${url.origin}${url.pathname}`);
 }
 
 function makeOrgAuthTokenClickable(arr: ChildrenItem[], str: string) {


### PR DESCRIPTION
We'll no longer maintain and publish skills for the span streaming migration. Instead the span streaming migration guide in docs should be used. For convenience, this PR provides a copy-able prompt on the Dart and JS span streaming guide that points to the respective guide URL.

Since we have a lot of sub-guides in JS, this also adds a new placeholder `__CURRENT_URL__` that can be used to inject the current URL into a code block. This ensures that the correct guide URL is shown in the prompt on every page. 