### PR TITLE
fix(changelog): Fetch PRs by merge date instead of update date

### DIFF
--- a/.github/workflows/update-docs-changelog.yml
+++ b/.github/workflows/update-docs-changelog.yml
@@ -1,9 +1,9 @@
 name: Update Docs Changelog
 
 on:
-  # Run daily at midnight UTC
+  # Run weekly on Monday at midnight UTC
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1'
   # Allow manual trigger
   workflow_dispatch:
 

--- a/scripts/update-docs-changelog.mjs
+++ b/scripts/update-docs-changelog.mjs
@@ -181,11 +181,15 @@ async function fetchMergedPRs() {
     headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
   }
 
-  // Fetch recently merged PRs
-  const searchQuery = `repo:${REPO_OWNER}/${REPO_NAME} is:pr is:merged sort:updated-desc`;
-  const url = `https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}&per_page=${PR_LIMIT}`;
+  // Limit to PRs merged in the last 30 days to avoid pulling in old PRs
+  // that were recently "updated" by bot comments or label changes
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const mergedSince = thirtyDaysAgo.toISOString().split('T')[0];
 
-  console.log('Fetching merged PRs...');
+  const searchQuery = `repo:${REPO_OWNER}/${REPO_NAME} is:pr is:merged merged:>=${mergedSince}`;
+  const url = `https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}&sort=created&order=desc&per_page=${PR_LIMIT}`;
+
+  console.log(`Fetching PRs merged since ${mergedSince}...`);
 
   const response = await fetch(url, {headers});
 

--- a/scripts/update-docs-changelog.mjs
+++ b/scripts/update-docs-changelog.mjs
@@ -159,8 +159,10 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const REPO_OWNER = 'getsentry';
 const REPO_NAME = 'sentry-docs';
 
-// Number of PRs to fetch
-const PR_LIMIT = 50;
+// Number of recently closed PRs to fetch (the List PRs API returns them
+// sorted by most recently updated, so this grabs the latest batch and we
+// filter to only merged ones client-side).
+const PR_LIMIT = 100;
 
 // PRs to exclude (bot PRs, CI updates, etc.)
 const EXCLUDED_AUTHORS = ['github-actions[bot]', 'dependabot[bot]', 'getsentry-bot'];
@@ -181,11 +183,13 @@ async function fetchMergedPRs() {
     headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
   }
 
-  // Fetch recently merged PRs
-  const searchQuery = `repo:${REPO_OWNER}/${REPO_NAME} is:pr is:merged sort:updated-desc`;
-  const url = `https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}&per_page=${PR_LIMIT}`;
+  // Use the List Pull Requests API instead of Search. It returns PRs sorted
+  // by most recently updated and lets us filter to state=closed + base=master.
+  // We then keep only the ones that were actually merged (merged_at != null).
+  // This avoids the Search API's sort limitations that caused stale entries.
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=closed&base=master&sort=updated&direction=desc&per_page=${PR_LIMIT}`;
 
-  console.log('Fetching merged PRs...');
+  console.log('Fetching recently closed PRs...');
 
   const response = await fetch(url, {headers});
 
@@ -193,10 +197,12 @@ async function fetchMergedPRs() {
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
   }
 
-  const data = await response.json();
-  console.log(`Found ${data.items.length} merged PRs`);
+  const allPRs = await response.json();
+  const mergedPRs = allPRs.filter(pr => pr.merged_at !== null);
 
-  return data.items;
+  console.log(`Fetched ${allPRs.length} closed PRs, ${mergedPRs.length} were merged`);
+
+  return mergedPRs;
 }
 
 async function fetchPRDetails(prNumber) {


### PR DESCRIPTION
## Problem

An edge case was found that was pulling PRs in from creation date + last updated rather than just merge date. 

PR #18898 is one example.

## Root Cause

The changelog script (`scripts/update-docs-changelog.mjs`) uses `sort:updated-desc` in the GitHub Search API query. This fetches PRs sorted by their **last update time**, not their merge time. Old PRs that were recently touched by bot comments, label changes, or cross-references get pulled in instead of truly recent merged PRs.

## Fix

- Switch from the Search API to the List Pull Requests API (/repos/{owner}/{repo}/pulls?state=closed&base=master), which returns the 100 most recently updated closed PRs. We filter to merged ones client-side.
- Change the schedule from daily to weekly (Mondays at midnight UTC). Manual trigger via workflow_dispatch is still available.