### PR TITLE
ref(js): Add `profileSessionSampleRate` default value

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -836,9 +836,11 @@ A number between `0` and `1`, controlling the percentage chance a given sampled 
 
 <PlatformSection notSupported={["javascript.electron"]}>
 
-<SdkOption name="profileSessionSampleRate" type='number' availableSince="10.27.0">
+<SdkOption name="profileSessionSampleRate" type='number' availableSince="10.27.0" defaultValue="0">
 
-A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none. The sampling decision is made once at the beginning of a session. This option is required to enable profiling.
+A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none. 
+The sampling decision is made once at the beginning of a session. 
+This option is required to enable profiling (default is `0`).
 
 <PlatformCategorySection categorySupported={["server", "serverless"]}>
   In a server environment, a profiling session starts when the Sentry SDK is

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -807,9 +807,11 @@ The sample rate for replays that are recorded when an error happens. This type o
 
 <PlatformSection supported={["javascript.electron"]}>
 
-<SdkOption name="profileSessionSampleRate" type='number' availableSince="7.4.0">
+<SdkOption name="profileSessionSampleRate" type='number' availableSince="7.4.0" defaultValue="0">
 
-A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none. The sampling decision is made once at the beginning of a session. This option is required to enable profiling.
+A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none. 
+The sampling decision is made once at the beginning of a session. 
+This option is required to enable profiling (default is `0`).
 
 </SdkOption>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR

The default value was missing from docs. It said the option is required but not that it defaults to 0. For anyone who doesn't read the fine print (me lol), this should make it a bit more apparent.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
