### PR TITLE
docs(js): Add liability note to testkit docs

### DIFF
--- a/docs/platforms/javascript/common/best-practices/sentry-testkit.mdx
+++ b/docs/platforms/javascript/common/best-practices/sentry-testkit.mdx
@@ -12,6 +12,7 @@ When building tests for your application, you want to assert that the right flow
 
 Sentry Testkit is community-maintained and not officially supported by Sentry.
 Please open an issue in the [Sentry Testkit repository](https://zivl.github.io/sentry-testkit/) if you have any questions or feedback.
+Sentry makes no representations or warranties and disclaims all liability arising from, out of or in connection with the use of Sentry Testkit.
 
 </Alert>
 


### PR DESCRIPTION
Adds a liability note to the existing callout.

surfaced in https://github.com/getsentry/sentry-docs/pull/18841