### PR TITLE
docs(sdk): Make the client event pipeline the authoritative step ordering

### DIFF
--- a/develop-docs/sdk/foundations/client/hooks/index.mdx
+++ b/develop-docs/sdk/foundations/client/hooks/index.mdx
@@ -65,7 +65,7 @@ This system complements — not replaces — the `before_send` hook and event pr
 
 Hook called with the event (and on some platforms the hint) that allows the user to decide whether an event should be sent or not. This can also be used to further modify the event. This hook **MUST** only apply to `error` events. Other event types like transactions, check-ins, and feedbacks **MUST NOT** go through `beforeSend` — they have their own dedicated hooks.
 
-In the [event pipeline](/sdk/foundations/client/#event-pipeline), `before_send` is invoked after scope application and event processors. Returning `null` discards the event (client report reason: `before_send`).
+In the [event pipeline](/sdk/foundations/client/#event-pipeline), `before_send` is invoked after scope application and event processors, and before the session update and sampling. Returning `null` discards the event (client report reason: `before_send`).
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/hooks/index.mdx
+++ b/develop-docs/sdk/foundations/client/hooks/index.mdx
@@ -2,12 +2,15 @@
 title: Hooks
 description: Client lifecycle hooks, the on/emit subscription system, and user-facing hooks like before_send and before_breadcrumb.
 spec_id: sdk/foundations/client/hooks
-spec_version: 1.0.0
+spec_version: 1.0.1
 spec_status: candidate
 spec_depends_on:
   - id: sdk/foundations/client
-    version: ">=2.0.0"
+    version: ">=3.0.0"
 spec_changelog:
+  - version: 1.0.1
+    date: 2026-08-03
+    summary: Clarified before_send position relative to the session update; requires client spec 3.0.0
   - version: 1.0.0
     date: 2025-02-24
     summary: Initial spec, extracted from client spec v2.1.0 and expected features

--- a/develop-docs/sdk/foundations/client/hooks/index.mdx
+++ b/develop-docs/sdk/foundations/client/hooks/index.mdx
@@ -65,7 +65,7 @@ This system complements — not replaces — the `before_send` hook and event pr
 
 Hook called with the event (and on some platforms the hint) that allows the user to decide whether an event should be sent or not. This can also be used to further modify the event. This hook **MUST** only apply to `error` events. Other event types like transactions, check-ins, and feedbacks **MUST NOT** go through `beforeSend` — they have their own dedicated hooks.
 
-In the [event pipeline](/sdk/foundations/client/#event-pipeline), `before_send` is invoked after scope application and event processors, and before the session update and sampling. Returning `null` discards the event (client report reason: `before_send`).
+In the [event pipeline](/sdk/foundations/client/#event-pipeline), `before_send` is invoked after scope application and event processors, and before the session update. Returning `null` discards the event (client report reason: `before_send`).
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/index.mdx
+++ b/develop-docs/sdk/foundations/client/index.mdx
@@ -137,7 +137,7 @@ Steps 2 through 4 are developer-controlled filters: an event they discard **MUST
 
 SDKs that implement sessions **MUST** apply sampling after the session update, as ordered above.
 
-SDKs that do **not** implement sessions **MAY** apply sampling immediately after the disabled check, before scope application and `before_send`. With no session to update, moving sampling earlier has no effect on release health and avoids the cost of running event processors and `before_send` on events that will be discarded. These SDKs **MUST** still record the `sample_rate` client report.
+SDKs that do **not** implement sessions **MAY** apply sampling immediately after the disabled check. With no session to update, moving sampling earlier has no effect on release health and avoids the cost of running event processors and `before_send` on events that will be discarded. These SDKs **MUST** still record the `sample_rate` client report.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/index.mdx
+++ b/develop-docs/sdk/foundations/client/index.mdx
@@ -133,7 +133,7 @@ When `captureEvent`, `captureException`, or `captureMessage` is called, the Clie
 
 Ignored exception types, event processors, and `before_send` are developer-controlled filters: an event they discard **MUST NOT** update the session, because the developer chose to ignore it. Sampling and the transport discard events to save quota, so they **MUST NOT** prevent the session update — a sampled-out event still counts toward release health. This is the only reason sampling runs after `before_send`.
 
-SDKs that do not implement sessions therefore **MAY** apply sampling immediately after the disabled check, discarding events before event processors and `before_send` run. They **MUST** still record the `sample_rate` client report.
+SDKs without session support **MAY** instead apply sampling immediately after the disabled check. With no session to update, where sampling runs does not affect release health, and sampling early skips event processors and `before_send` for events that will never be sent. The `sample_rate` client report is **REQUIRED** either way.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/index.mdx
+++ b/develop-docs/sdk/foundations/client/index.mdx
@@ -124,20 +124,16 @@ See [Scopes: Client Resolution](/sdk/foundations/state-management/scopes/#client
 When `captureEvent`, `captureException`, or `captureMessage` is called, the Client processes the event through the following pipeline. The event **MAY** be discarded at any stage, stopping further processing.
 
 1. **Disabled check**: If the SDK is disabled (no transport / no DSN), discard immediately.
-2. **Ignored exception types**: Discard events matching `ignoreErrors` (client report reason: `event_processor`). See [Configuration](/sdk/foundations/client/configuration/#event-sampling).
+2. **Ignored exception types**: Discard events matching [`ignoreErrors`](/sdk/foundations/client/configuration/#event-sampling) (client report reason: `event_processor`).
 3. **Scope application**: Obtain the current, isolation, and global scopes. Merge scope data onto the event in the [defined order](/sdk/foundations/state-management/scopes/#applying-scope-data-to-events). Invoke scoped event processors first, then global event processors, each in registration order. Any processor returning `null` discards the event (client report reason: `event_processor`).
 4. **`before_send` hook**: Invoke the user-configured callback. Returning `null` discards the event (client report reason: `before_send`). This hook **MUST** only apply to error events. For transactions, use `before_send_transaction`. For logs, use `before_send_log`. See [Hooks](/sdk/foundations/client/hooks/) for details.
 5. **Session update**: SDKs that implement [Sessions](/sdk/telemetry/sessions/) **MUST** update the current session here — incrementing its `errors` count or setting its status. SDKs without session support skip this step.
 6. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`.
 7. **Transport**: Pass the event to the transport (or TelemetryProcessor). The transport **MAY** discard due to missing DSN, full queue, or [rate limiting](/sdk/foundations/transport/rate-limiting/).
 
-Steps 2 through 4 are developer-controlled filters: an event they discard **MUST NOT** update the session, because the developer chose to ignore it. Steps 6 and 7 discard events to save quota, so they **MUST NOT** prevent the session update. This is why sampling runs late — an event that is sampled out still counts toward release health.
+Ignored exception types, event processors, and `before_send` are developer-controlled filters: an event they discard **MUST NOT** update the session, because the developer chose to ignore it. Sampling and the transport discard events to save quota, so they **MUST NOT** prevent the session update — a sampled-out event still counts toward release health. This is the only reason sampling runs after `before_send`.
 
-#### Sampling Position
-
-SDKs that implement sessions **MUST** apply sampling after the session update, as ordered above.
-
-SDKs that do **not** implement sessions **MAY** apply sampling immediately after the disabled check. With no session to update, moving sampling earlier has no effect on release health and avoids the cost of running event processors and `before_send` on events that will be discarded. These SDKs **MUST** still record the `sample_rate` client report.
+SDKs that do not implement sessions therefore **MAY** apply sampling immediately after the disabled check, discarding events before event processors and `before_send` run. They **MUST** still record the `sample_rate` client report.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/index.mdx
+++ b/develop-docs/sdk/foundations/client/index.mdx
@@ -2,14 +2,19 @@
 title: Client
 description: The SDK component responsible for event creation, integration management, and transport dispatch.
 spec_id: sdk/foundations/client
-spec_version: 2.2.0
+spec_version: 3.0.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/state-management/scopes
     version: ">=1.0.0"
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
+  - id: sdk/telemetry/sessions
+    version: ">=1.4.0"
 spec_changelog:
+  - version: 3.0.0
+    date: 2026-08-03
+    summary: Breaking — event pipeline reordered to run sampling after before_send and the session update; added ignored exception types and session update steps
   - version: 2.2.0
     date: 2025-02-24
     summary: Restructured into sub-specs for integrations, hooks, and configuration
@@ -114,17 +119,21 @@ See [Scopes: Client Resolution](/sdk/foundations/state-management/scopes/#client
 
 </SpecSection>
 
-<SpecSection id="event-pipeline" status="stable" since="1.0.0">
+<SpecSection id="event-pipeline" status="stable" since="3.0.0">
 
 ### Event Pipeline
 
 When `captureEvent`, `captureException`, or `captureMessage` is called, the Client processes the event through the following pipeline. The event **MAY** be discarded at any stage, stopping further processing.
 
 1. **Disabled check**: If the SDK is disabled (no transport / no DSN), discard immediately.
-2. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`.
-3. **Scope application**: Obtain the current, isolation, and global scopes. Merge scope data onto the event in the [defined order](/sdk/foundations/state-management/scopes/#applying-scope-data-to-events). Invoke event processors in registration order. Any processor returning `null` discards the event (client report reason: `event_processor`).
+2. **Ignored exception types**: Discard events matching `ignoreErrors` (client report reason: `event_processor`). See [Configuration](/sdk/foundations/client/configuration/#event-sampling).
+3. **Scope application**: Obtain the current, isolation, and global scopes. Merge scope data onto the event in the [defined order](/sdk/foundations/state-management/scopes/#applying-scope-data-to-events). Invoke scoped event processors first, then global event processors, each in registration order. Any processor returning `null` discards the event (client report reason: `event_processor`).
 4. **`before_send` hook**: Invoke the user-configured callback. Returning `null` discards the event (client report reason: `before_send`). This hook **MUST** only apply to error events. For transactions, use `before_send_transaction`. For logs, use `before_send_log`. See [Hooks](/sdk/foundations/client/hooks/) for details.
-5. **Transport**: Pass the event to the transport (or TelemetryProcessor). The transport **MAY** discard due to missing DSN, full queue, or [rate limiting](/sdk/foundations/transport/rate-limiting/).
+5. **Session update**: If the event survived the preceding steps, update the current session — increment its `errors` count or set its status. See [Session Update Filtering](/sdk/telemetry/sessions/#session-update-filtering).
+6. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`. Sampling runs **after** the session update, so an event dropped here still counts toward release health.
+7. **Transport**: Pass the event to the transport (or TelemetryProcessor). The transport **MAY** discard due to missing DSN, full queue, or [rate limiting](/sdk/foundations/transport/rate-limiting/).
+
+Steps 2 through 4 are developer-controlled filters: an event they discard **MUST NOT** update the session. Steps 6 and 7 discard events to save quota, so they **MUST NOT** prevent the session update.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/index.mdx
+++ b/develop-docs/sdk/foundations/client/index.mdx
@@ -9,12 +9,10 @@ spec_depends_on:
     version: ">=1.0.0"
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
-  - id: sdk/telemetry/sessions
-    version: ">=1.4.0"
 spec_changelog:
   - version: 3.0.0
     date: 2026-08-03
-    summary: Breaking — event pipeline reordered to run sampling after before_send and the session update; added ignored exception types and session update steps
+    summary: Breaking — event pipeline is now the authoritative ordering; sampling runs after before_send and the session update for SDKs that support sessions; added ignored exception types and session update steps
   - version: 2.2.0
     date: 2025-02-24
     summary: Restructured into sub-specs for integrations, hooks, and configuration
@@ -129,11 +127,17 @@ When `captureEvent`, `captureException`, or `captureMessage` is called, the Clie
 2. **Ignored exception types**: Discard events matching `ignoreErrors` (client report reason: `event_processor`). See [Configuration](/sdk/foundations/client/configuration/#event-sampling).
 3. **Scope application**: Obtain the current, isolation, and global scopes. Merge scope data onto the event in the [defined order](/sdk/foundations/state-management/scopes/#applying-scope-data-to-events). Invoke scoped event processors first, then global event processors, each in registration order. Any processor returning `null` discards the event (client report reason: `event_processor`).
 4. **`before_send` hook**: Invoke the user-configured callback. Returning `null` discards the event (client report reason: `before_send`). This hook **MUST** only apply to error events. For transactions, use `before_send_transaction`. For logs, use `before_send_log`. See [Hooks](/sdk/foundations/client/hooks/) for details.
-5. **Session update**: If the event survived the preceding steps, update the current session — increment its `errors` count or set its status. See [Session Update Filtering](/sdk/telemetry/sessions/#session-update-filtering).
-6. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`. Sampling runs **after** the session update, so an event dropped here still counts toward release health.
+5. **Session update**: SDKs that implement [Sessions](/sdk/telemetry/sessions/) **MUST** update the current session here — incrementing its `errors` count or setting its status. SDKs without session support skip this step.
+6. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`.
 7. **Transport**: Pass the event to the transport (or TelemetryProcessor). The transport **MAY** discard due to missing DSN, full queue, or [rate limiting](/sdk/foundations/transport/rate-limiting/).
 
-Steps 2 through 4 are developer-controlled filters: an event they discard **MUST NOT** update the session. Steps 6 and 7 discard events to save quota, so they **MUST NOT** prevent the session update.
+Steps 2 through 4 are developer-controlled filters: an event they discard **MUST NOT** update the session, because the developer chose to ignore it. Steps 6 and 7 discard events to save quota, so they **MUST NOT** prevent the session update. This is why sampling runs late — an event that is sampled out still counts toward release health.
+
+#### Sampling Position
+
+SDKs that implement sessions **MUST** apply sampling after the session update, as ordered above.
+
+SDKs that do **not** implement sessions **MAY** apply sampling immediately after the disabled check, before scope application and `before_send`. With no session to update, moving sampling earlier has no effect on release health and avoids the cost of running event processors and `before_send` on events that will be discarded. These SDKs **MUST** still record the `sample_rate` client report.
 
 </SpecSection>
 

--- a/develop-docs/sdk/foundations/client/index.mdx
+++ b/develop-docs/sdk/foundations/client/index.mdx
@@ -12,7 +12,7 @@ spec_depends_on:
 spec_changelog:
   - version: 3.0.0
     date: 2026-08-03
-    summary: Breaking — event pipeline is now the authoritative ordering; sampling runs after before_send and the session update for SDKs that support sessions; added ignored exception types and session update steps
+    summary: Breaking — Sampling runs after before_send and the session update for SDKs that support sessions; added ignored exception types and session update steps
   - version: 2.2.0
     date: 2025-02-24
     summary: Restructured into sub-specs for integrations, hooks, and configuration
@@ -124,12 +124,14 @@ See [Scopes: Client Resolution](/sdk/foundations/state-management/scopes/#client
 When `captureEvent`, `captureException`, or `captureMessage` is called, the Client processes the event through the following pipeline. The event **MAY** be discarded at any stage, stopping further processing.
 
 1. **Disabled check**: If the SDK is disabled (no transport / no DSN), discard immediately.
-2. **Ignored exception types**: Discard events matching [`ignoreErrors`](/sdk/foundations/client/configuration/#event-sampling) (client report reason: `event_processor`).
-3. **Scope application**: Obtain the current, isolation, and global scopes. Merge scope data onto the event in the [defined order](/sdk/foundations/state-management/scopes/#applying-scope-data-to-events). Invoke scoped event processors first, then global event processors, each in registration order. Any processor returning `null` discards the event (client report reason: `event_processor`).
-4. **`before_send` hook**: Invoke the user-configured callback. Returning `null` discards the event (client report reason: `before_send`). This hook **MUST** only apply to error events. For transactions, use `before_send_transaction`. For logs, use `before_send_log`. See [Hooks](/sdk/foundations/client/hooks/) for details.
-5. **Session update**: SDKs that implement [Sessions](/sdk/telemetry/sessions/) **MUST** update the current session here — incrementing its `errors` count or setting its status. SDKs without session support skip this step.
-6. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`.
-7. **Transport**: Pass the event to the transport (or TelemetryProcessor). The transport **MAY** discard due to missing DSN, full queue, or [rate limiting](/sdk/foundations/transport/rate-limiting/).
+2. **Scope application and event processors**: Obtain the current, isolation, and global scopes, then apply in this order:
+   1. Merge scope data onto the event in the [defined order](/sdk/foundations/state-management/scopes/#applying-scope-data-to-events). Scope data **MUST** be merged before event processors run, so processors observe the fully populated event.
+   2. Invoke event processors — scoped first, then global, each in registration order. Any processor returning `null` discards the event (client report reason: `event_processor`).
+   3. Discard events matching [`ignoreErrors`](/sdk/foundations/client/configuration/#event-sampling) (client report reason: `event_processor`). SDKs **MAY** implement this as an event processor, in which case it runs as part of the previous step.
+3. **`before_send` hook**: Invoke the user-configured callback. Returning `null` discards the event (client report reason: `before_send`). This hook **MUST** only apply to error events. For transactions, use `before_send_transaction`. For logs, use `before_send_log`. See [Hooks](/sdk/foundations/client/hooks/) for details.
+4. **Session update**: SDKs that implement [Sessions](/sdk/telemetry/sessions/) **MUST** update the current session by incrementing its `errors` count or setting the appropriate status. SDKs without session support skip this step.
+5. **Sampling**: Apply the configured `sample_rate`. Events **MAY** be randomly discarded. When discarded, the Client **MUST** record a [client report](/sdk/telemetry/client-reports/) with discard reason `sample_rate`.
+6. **Transport**: Pass the event to the transport (or TelemetryProcessor). The transport **MAY** discard due to missing DSN, full queue, or [rate limiting](/sdk/foundations/transport/rate-limiting/).
 
 Ignored exception types, event processors, and `before_send` are developer-controlled filters: an event they discard **MUST NOT** update the session, because the developer chose to ignore it. Sampling and the transport discard events to save quota, so they **MUST NOT** prevent the session update — a sampled-out event still counts toward release health. This is the only reason sampling runs after `before_send`.
 

--- a/develop-docs/sdk/telemetry/sessions/index.mdx
+++ b/develop-docs/sdk/telemetry/sessions/index.mdx
@@ -7,10 +7,12 @@ spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
+  - id: sdk/foundations/client
+    version: ">=3.0.0"
 spec_changelog:
   - version: 1.7.1
     date: 2026-08-03
-    summary: Tied the session update filter order to the canonical client event pipeline and removed the contradictory apply_to_scope timing note
+    summary: Deferred filter ordering to the client event pipeline and removed the contradictory apply_to_scope timing note
   - version: 1.7.0
     date: 2025-10-16
     summary: Added error level impact rules for session error counting
@@ -215,13 +217,7 @@ When events are dropped by filtering mechanisms (sample rate, rate limiting, `be
 
 If the event has been dropped but the session was updated, the session update **SHOULD** be sent to the server without the event in case the session changed from healthy to errored or from any state to crashed (for user-attended sessions).
 
-**Filter order** — the session update sits between `beforeSend` and sampling in the [event pipeline](/sdk/foundations/client/#event-pipeline):
-1. Check for ignored exception types (`ignore_errors`)
-2. Apply scoped event processors
-3. Apply global event processors
-4. Apply `beforeSend`
-5. Update the session if the event made it this far
-6. Apply sampling rate
+For the exact position of the session update relative to these filters, see the [event pipeline](/sdk/foundations/client/#event-pipeline) in the Client spec, which is the authoritative ordering. In short: the session update sits after `beforeSend` and before sampling, so developer-controlled filters run first and quota-saving drops run after.
 
 </SpecSection>
 
@@ -229,7 +225,7 @@ If the event has been dropped but the session was updated, the session update **
 
 ### Session Updates and Sending
 
-SDKs **SHOULD** automatically update the current session whenever data is captured, incrementing the `errors` count or updating the session based on the distinct ID. The update happens after `beforeSend` and before sampling — see [Session Update Filtering](#session-update-filtering) for its exact position in the pipeline.
+SDKs **SHOULD** automatically update the current session whenever data is captured, incrementing the `errors` count or updating the session based on the distinct ID. The update happens after `beforeSend` and before sampling — see the [event pipeline](/sdk/foundations/client/#event-pipeline) for its exact position.
 
 SDKs **SHOULD** aim to minimize the number of envelopes sent upstream.
 

--- a/develop-docs/sdk/telemetry/sessions/index.mdx
+++ b/develop-docs/sdk/telemetry/sessions/index.mdx
@@ -2,12 +2,15 @@
 title: Sessions
 description: Release health tracking via session lifecycle updates and crash-free rate computation.
 spec_id: sdk/telemetry/sessions
-spec_version: 1.7.0
+spec_version: 1.7.1
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.7.1
+    date: 2026-08-03
+    summary: Tied the session update filter order to the canonical client event pipeline and removed the contradictory apply_to_scope timing note
   - version: 1.7.0
     date: 2025-10-16
     summary: Added error level impact rules for session error counting
@@ -212,7 +215,7 @@ When events are dropped by filtering mechanisms (sample rate, rate limiting, `be
 
 If the event has been dropped but the session was updated, the session update **SHOULD** be sent to the server without the event in case the session changed from healthy to errored or from any state to crashed (for user-attended sessions).
 
-**Filter order** (Python SDK as reference):
+**Filter order** — the session update sits between `beforeSend` and sampling in the [event pipeline](/sdk/foundations/client/#event-pipeline):
 1. Check for ignored exception types (`ignore_errors`)
 2. Apply scoped event processors
 3. Apply global event processors
@@ -226,7 +229,7 @@ If the event has been dropped but the session was updated, the session update **
 
 ### Session Updates and Sending
 
-SDKs **SHOULD** automatically update the current session whenever data is captured (at the same point where `apply_to_scope` is called) to increment the `errors` count or update the session based on the distinct ID.
+SDKs **SHOULD** automatically update the current session whenever data is captured, incrementing the `errors` count or updating the session based on the distinct ID. The update happens after `beforeSend` and before sampling — see [Session Update Filtering](#session-update-filtering) for its exact position in the pipeline.
 
 SDKs **SHOULD** aim to minimize the number of envelopes sent upstream.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Client and Sessions specs disagreed on the event pipeline order: the Client spec sampled at step 2 and had no session update step, while the Sessions spec put the session update after `before_send` with sampling last. We ratified the Sessions ordering, so this aligns the Client spec to it and makes that the only place the order is stated — Sessions now defers to it instead of restating it.

As discussed internally:
Sampling runs late only so that sampled-out events still count toward release health, so SDKs without session support **MAY** keep sampling immediately after the disabled check.

Client spec bumped to `3.0.0` as a breaking reorder — happy to drop it to `2.3.0` if you read this as correcting a spec that never matched real SDK behavior.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)