### PR TITLE
docs(js): Restructure Vercel AI integration docs

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -59,17 +59,15 @@ That difference decides where you configure the integration and which options do
 
 <PlatformSection supported={['javascript.cloudflare']}>
 
-Cloudflare Workers can't load OpenTelemetry instrumentation, so `@sentry/cloudflare` uses a reduced implementation that reads the spans the AI SDK emits on its own. The <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint runs the full Node implementation instead.
+Cloudflare Workers can't load OpenTelemetry instrumentation. On both entrypoints, Sentry reads the spans the AI SDK emits on its own instead of patching your call sites, so you must pass `experimental_telemetry` on every call. The <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint adds the Node.js APIs the AI SDK v7 telemetry channel needs.
 
-Your entrypoint decides which options do anything:
+Your entrypoint decides the rest:
 
-|                                   | `@sentry/cloudflare`              | `@sentry/cloudflare/nodejs_compat` |
-| --------------------------------- | --------------------------------- | ---------------------------------- |
-| Enabled by default                | No                                | No                                 |
-| `experimental_telemetry` per call | Required, or no spans are created | Required, or no spans are created   |
-| Record inputs and outputs         | Per call only                     | Integration or per call             |
-| AI SDK v7                         | Not supported                     | Supported                           |
-| Minimum Sentry SDK                | `10.6.0`                          | `10.64.0`                           |
+|                            | `@sentry/cloudflare` | `@sentry/cloudflare/nodejs_compat` |
+| -------------------------- | -------------------- | ---------------------------------- |
+| Record inputs and outputs  | Per call only        | Integration or per call            |
+| AI SDK v7                  | Not supported        | Supported                          |
+| Minimum Sentry SDK         | `10.6.0`             | `10.64.0`                          |
 
 </PlatformSection>
 
@@ -189,7 +187,7 @@ export default Sentry.withSentry(
 );
 ```
 
-On both entrypoints, adding the integration is not enough on its own. You must also pass `experimental_telemetry` on every call.
+On both entrypoints, adding the integration is not enough on its own. Cloudflare can't patch your call sites, so you must also pass `experimental_telemetry` on every call — including on `nodejs_compat`. See [Turn on telemetry](#turn-on-telemetry).
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -39,7 +39,7 @@ Don't use the AI SDK's `registerTelemetry` API (AI SDK v7 and above) together wi
 
 <PlatformSection supported={['javascript.nextjs', 'javascript.cloudflare']}>
 
-## Runtime differences
+## Runtime Differences
 
 <PlatformSection supported={['javascript.nextjs']}>
 
@@ -92,7 +92,7 @@ Prompts and completions are not captured until you opt in. See [Record inputs an
 
 <PlatformSection supported={['javascript.nextjs']}>
 
-### Node runtime
+### Node Runtime
 
 The integration is enabled by default. No setup code is needed beyond enabling tracing:
 
@@ -105,7 +105,7 @@ Sentry.init({
 
 If spans are missing here, your build most likely bundled the `ai` package so module detection fails. See [Troubleshooting](#troubleshooting).
 
-### Edge runtime
+### Edge Runtime
 
 The integration is not enabled by default. Add it yourself:
 
@@ -166,7 +166,7 @@ export default Sentry.withSentry(
 }
 ```
 
-### AI SDK v6 and below
+### AI SDK v6 and Below
 
 Import `@sentry/cloudflare` instead:
 
@@ -191,7 +191,7 @@ On both entrypoints, adding the integration is not enough on its own. Cloudflare
 
 </PlatformSection>
 
-## Record inputs and outputs
+## Record Inputs and Outputs
 
 Prompts and completions are not captured by default, because they usually contain user data. Turn recording on with `recordInputs` and `recordOutputs`.
 
@@ -236,7 +236,7 @@ const result = await generateText({
 
 <PlatformSection supported={['javascript.nextjs']}>
 
-### Node runtime
+### Node Runtime
 
 Set the options on the integration to cover every call. Re-adding the integration replaces the default instance and configures it:
 
@@ -368,7 +368,7 @@ Every instrumented `ai` function takes an `experimental_telemetry` object. Use i
 
 <PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
-### Turn on telemetry
+### Turn on Telemetry
 
 <PlatformSection supported={['javascript.nextjs']}>
 
@@ -389,7 +389,7 @@ For `ToolLoopAgent`, set it on the constructor instead. See [ToolLoopAgent](#too
 
 </PlatformSection>
 
-### Skip a call
+### Skip a Call
 
 To capture no span for one call, set `isEnabled` to `false`:
 
@@ -400,7 +400,7 @@ const result = await generateText({
 });
 ```
 
-### Identify your call sites
+### Identify Your Call Sites
 
 Spans carry the AI SDK function name, not yours, so a trace with several `generateText` calls is hard to read. Set `functionId` to label the call site. It appears on the span as `gen_ai.function_id`:
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -155,6 +155,8 @@ Record prompts and completions on the integration and/or per call via `experimen
 
 <PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
+The integration is enabled by default. Re-add it to `integrations` with options to configure it (this replaces the default instance):
+
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
@@ -315,6 +317,38 @@ const result = await generateText({
 
 ## Options
 
+Configure these on `Sentry.vercelAIIntegration()` when you initialize Sentry.
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+On Cloudflare, pass options in `withSentry` (AI SDK v7 + <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink>). On the default `@sentry/cloudflare` entrypoint, set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` instead.
+
+```javascript
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    dataCollection: {},
+    integrations: [
+      Sentry.vercelAIIntegration({
+        enableTruncation: false,
+        recordInputs: true,
+        recordOutputs: true,
+      }),
+    ],
+  }),
+  {
+    async fetch(request, env, ctx) {
+      /* your worker */
+    },
+  },
+);
+```
+
+</PlatformSection>
+
 ### `enableTruncation`
 
 _Type: `boolean`_
@@ -323,11 +357,15 @@ Enables or disables truncation of recorded input messages. Truncation keeps larg
 
 Defaults to `true`.
 
+<PlatformSection notSupported={['javascript.cloudflare']}>
+
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
 });
 ```
+
+</PlatformSection>
 
 ### `force`
 
@@ -371,11 +409,15 @@ Records inputs to the `ai` function call.
 
 Defaults to `true` if `dataCollection.genAI.inputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordInputs`.
 
+<PlatformSection notSupported={['javascript.cloudflare']}>
+
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ recordInputs: true })],
 });
 ```
+
+</PlatformSection>
 
 ### `recordOutputs`
 
@@ -387,15 +429,13 @@ Records outputs from the `ai` function call.
 
 Defaults to `true` if `dataCollection.genAI.outputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordOutputs`.
 
+<PlatformSection notSupported={['javascript.cloudflare']}>
+
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ recordOutputs: true })],
 });
 ```
-
-<PlatformSection supported={['javascript.cloudflare']}>
-
-On Cloudflare, prefer the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint for integration-level `recordInputs` / `recordOutputs`. Otherwise set them on each call’s `experimental_telemetry`.
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -324,7 +324,9 @@ Enables or disables truncation of recorded input messages. Truncation keeps larg
 Defaults to `true`.
 
 ```javascript
-Sentry.vercelAIIntegration({ enableTruncation: false });
+Sentry.init({
+  integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
+});
 ```
 
 ### `force`
@@ -340,7 +342,9 @@ Defaults to `false`.
 <PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 
 ```javascript
-Sentry.vercelAIIntegration({ force: true });
+Sentry.init({
+  integrations: [Sentry.vercelAIIntegration({ force: true })],
+});
 ```
 
 <PlatformSection supported={["javascript.nextjs"]}>
@@ -368,7 +372,9 @@ Records inputs to the `ai` function call.
 Defaults to `true` if `dataCollection.genAI.inputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordInputs`.
 
 ```javascript
-Sentry.vercelAIIntegration({ recordInputs: true });
+Sentry.init({
+  integrations: [Sentry.vercelAIIntegration({ recordInputs: true })],
+});
 ```
 
 ### `recordOutputs`
@@ -382,7 +388,9 @@ Records outputs from the `ai` function call.
 Defaults to `true` if `dataCollection.genAI.outputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordOutputs`.
 
 ```javascript
-Sentry.vercelAIIntegration({ recordOutputs: true });
+Sentry.init({
+  integrations: [Sentry.vercelAIIntegration({ recordOutputs: true })],
+});
 ```
 
 <PlatformSection supported={['javascript.cloudflare']}>

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -472,13 +472,13 @@ Pass these to `Sentry.vercelAIIntegration()`. The Edge runtime accepts `enableTr
 
 <PlatformSection supported={['javascript.cloudflare']}>
 
-Pass these to `Sentry.vercelAIIntegration()`. The default `@sentry/cloudflare` entrypoint accepts `enableTruncation` only.
+Pass these to `Sentry.vercelAIIntegration()`. The default `@sentry/cloudflare` entrypoint accepts `enableTruncation` only; <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> also accepts `recordInputs` and `recordOutputs`. Neither has module detection to override, so `force` does not apply.
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.deno']}>
 
-Pass these to `Sentry.vercelAIIntegration()`. Deno accepts `enableTruncation` and `force` only.
+Pass these to `Sentry.vercelAIIntegration()`. Deno accepts `enableTruncation` only. It has no module detection to override, so `force` does not apply.
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -153,9 +153,43 @@ const result = await generateText({
 
 Record prompts and completions on the integration and/or per call via `experimental_telemetry` (see [Configuration](#configuration)).
 
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
 ```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  dataCollection: {},
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
+});
+```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+On **Node**, set integration options in `sentry.server.config.ts` (re-adding the default integration configures it). On **Edge**, set them in `sentry.edge.config.js` when you enable the integration:
+
+```javascript {filename: 'sentry.server.config.(js|ts)'}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  dataCollection: {},
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
+});
+```
+
+```javascript {filename: 'sentry.edge.config.(js|ts)'}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -35,7 +35,7 @@ The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.
 
 <PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
 
-This integration is enabled by default and captures spans for `ai` function calls. Requires SDK version `10.6.0` or higher.
+This integration is enabled by default and captures spans for `ai` function calls. Requires SDK version `10.6.0` or higher. To set integration options, re-add it in `integrations` (see [Capture inputs and outputs](#capture-inputs-and-outputs) and [Options](#options)).
 
 ```javascript
 Sentry.init({

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -124,13 +124,13 @@ In the examples above, `dataCollection: {}` turns on the SDK’s permissive defa
 
 <PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
 
-Pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `streamText`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). Without it, AI spans are not created.
+Pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `generateObject`, `streamText`, `streamObject`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). Without it, AI spans are not created.
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.nextjs']}>
 
-On the **Edge** runtime, pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `streamText`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). On the **Node** runtime this is usually automatic.
+On the **Edge** runtime, pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `generateObject`, `streamText`, `streamObject`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). On the **Node** runtime this is usually automatic.
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -27,65 +27,33 @@ supported:
   - javascript.tanstackstart-react
 ---
 
-<Alert>
-
-Requires SDK version `10.6.0` or higher for Node.js, Cloudflare Workers, Vercel Edge Functions and Bun.
-Requires SDK version `10.12.0` or higher for Deno.
-
-</Alert>
-
-<PlatformSection supported={['javascript.cloudflare']}>
-
-<Alert>
-
-On Cloudflare, AI SDK v7 support requires SDK version `10.64.0` or higher and the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint.
-
-</Alert>
-
-</PlatformSection>
-
-<Alert level="warning">
-
-Don't use the AI SDK's `registerTelemetry` API (AI SDK v7 and above) together with this integration. Sentry's `vercelAIIntegration` already instruments the AI SDK, so registering telemetry separately will result in duplicate spans.
-
-</Alert>
-
-<Alert level="warning">
-
-`dataCollection: {}` enables the SDK's **permissive** defaults — generative AI inputs/outputs **and** other categories (user identity, cookies, headers, HTTP bodies, query parameters, and stack-frame locals) unless you override them. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
-
-</Alert>
-
 _Import name: `Sentry.vercelAIIntegration`_
 
 The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
 
+## Setup
+
 <PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
-  It is enabled by default and will automatically capture spans for all `ai`
-  function calls. You can opt-in to capture inputs and outputs by setting `recordInputs` and `recordOutputs` in the integration config:
+
+This integration is enabled by default and captures spans for `ai` function calls. Requires SDK version `10.6.0` or higher.
 
 ```javascript
 Sentry.init({
-  dsn: "____PUBLIC_DSN____",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
   dataCollection: {},
-  integrations: [
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
-  ],
 });
 ```
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.deno']}>
-This integration is not enabled by default. You need to manually enable it by passing `Sentry.vercelAIIntegration()` to `Sentry.init`:
+
+This integration is not enabled by default. Requires SDK version `10.12.0` or higher.
 
 ```javascript
 Sentry.init({
-  dsn: "____PUBLIC_DSN____",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
   dataCollection: {},
   integrations: [Sentry.vercelAIIntegration()],
@@ -95,7 +63,14 @@ Sentry.init({
 </PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare']}>
-Not enabled by default. For AI SDK v7, register it with the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint (requires the Wrangler `nodejs_compat` compatibility flag):
+
+This integration is not enabled by default. For AI SDK v7, use the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint (SDK `10.64.0` or higher) and enable the Wrangler `nodejs_compat` flag.
+
+```jsonc {filename:wrangler.jsonc}
+{
+  "compatibility_flags": ["nodejs_compat"]
+}
+```
 
 ```javascript
 import * as Sentry from "@sentry/cloudflare/nodejs_compat";
@@ -105,32 +80,61 @@ export default Sentry.withSentry(
     dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
     dataCollection: {},
-    integrations: [Sentry.vercelAIIntegration()],
+    integrations: [
+      Sentry.vercelAIIntegration({
+        recordInputs: true,
+        recordOutputs: true,
+      }),
+    ],
   }),
-  { async fetch(request, env, ctx) { /* ... */ } },
+  {
+    async fetch(request, env, ctx) {
+      /* your worker */
+    },
+  },
 );
 ```
 
-For AI SDK versions before v7, import `@sentry/cloudflare` instead and use the same options.
+For AI SDK versions before v7, import `@sentry/cloudflare` instead (SDK `10.6.0` or higher). Keep `vercelAIIntegration()` in `integrations`. Set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` rather than on the integration (those integration options need the `nodejs_compat` entrypoint).
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.nextjs']}>
-This integration is enabled by default in the Node runtime, but not in the Edge runtime. You need to manually enable it by passing `Sentry.vercelAIIntegration()` to `Sentry.init` in your `sentry.edge.config.js` file:
+
+This integration is enabled by default in the Node runtime. On the Edge runtime it is not; add it in `sentry.edge.config.js`. Requires SDK version `10.6.0` or higher.
 
 ```javascript {filename: 'sentry.edge.config.(js|ts)'}
 Sentry.init({
-  dsn: "____PUBLIC_DSN____",
+  dsn: "___PUBLIC_DSN___",
   tracesSampleRate: 1.0,
   dataCollection: {},
   integrations: [Sentry.vercelAIIntegration()],
 });
 ```
 
+On the **Node** runtime, spans are usually automatic. If they are missing, see [Troubleshooting](#troubleshooting) and the `force` option.
+
 </PlatformSection>
 
+In the examples above, `dataCollection: {}` turns on the SDK’s permissive defaults. That includes generative AI inputs and outputs **and** other categories (user identity, cookies, headers, HTTP bodies, query parameters, and stack-frame locals) unless you override them. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+
 <PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
-To correctly capture spans, pass the `experimental_telemetry` object with `isEnabled: true` to every `generateText`, `generateObject`, `streamText`, and `ToolLoopAgent` call. For more details, see the [AI SDK Telemetry Metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
+
+## Enable telemetry on calls
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
+
+Pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `streamText`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). Without it, AI spans are not created.
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+On the **Edge** runtime, pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `streamText`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). On the **Node** runtime this is usually automatic.
+
+</PlatformSection>
+
+See the [AI SDK Telemetry Metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
 
 ```javascript
 const result = await generateText({
@@ -145,140 +149,66 @@ const result = await generateText({
 
 </PlatformSection>
 
-## Options
+## Capture inputs and outputs
 
-### `enableTruncation`
-
-_Type: `boolean`_
-
-Enables or disables truncation of recorded input messages. Truncation keeps large payloads within span size limits.
-
-Defaults to `true`.
-
-<PlatformSection notSupported={['javascript.cloudflare']}>
-
-```javascript
-Sentry.init({
-  integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
-});
-```
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.cloudflare']}>
-
-```javascript
-import * as Sentry from "@sentry/cloudflare/nodejs_compat";
-
-export default Sentry.withSentry(
-  (env) => ({
-    dsn: "___PUBLIC_DSN___",
-    integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
-  }),
-  { async fetch(request, env, ctx) { /* ... */ } },
-);
-```
-
-</PlatformSection>
+Record prompts and completions on the integration and/or per call via `experimental_telemetry` (see [Configuration](#configuration)).
 
 <PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
-### `force`
-
-Requires SDK version `9.29.0` or higher.
-
-_Type: `boolean`_
-
-Forces the integration to be active, even when the `ai` module is not detected or available. This is useful when you want to ensure the integration is always enabled regardless of module detection.
-
-Defaults to `false`.
 
 ```javascript
 Sentry.init({
-  integrations: [Sentry.vercelAIIntegration({ force: true })],
-});
-```
-
-<PlatformSection supported={["javascript.nextjs"]}>
-  This option is not available in the Edge runtime. There, the integration is
-  forced when it is enabled.
-</PlatformSection>
-
-</PlatformSection>
-
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.nextjs']}>
-### `recordInputs`
-
-Requires SDK version `9.27.0` or higher.
-
-_Type: `boolean`_
-
-Records inputs to the `ai` function call.
-
-Defaults to `true` if `dataCollection.genAI.inputs` is `true` (which is the default when using `dataCollection`), if the deprecated `sendDefaultPii` is `true`, or if you explicitly set `experimental_telemetry.isEnabled` to `true` in your `ai` function callsites.
-
-```javascript
-Sentry.init({
-  integrations: [Sentry.vercelAIIntegration({ recordInputs: true })],
-});
-```
-
-### `recordOutputs`
-
-Requires SDK version `9.27.0` or higher.
-
-_Type: `boolean`_
-
-Records outputs to the `ai` function call.
-
-Defaults to `true` if `dataCollection.genAI.outputs` is `true` (which is the default when using `dataCollection`), if the deprecated `sendDefaultPii` is `true`, or if you explicitly set `experimental_telemetry.isEnabled` to `true` in your `ai` function callsites.
-
-```javascript
-Sentry.init({
-  integrations: [Sentry.vercelAIIntegration({ recordOutputs: true })],
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  dataCollection: {},
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
 });
 ```
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare']}>
-### `recordInputs` and `recordOutputs`
 
-Integration-level `recordInputs` / `recordOutputs` need AI SDK v7+ and the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint. On the default entrypoint, set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` instead (see [Configuration](#configuration)).
+On Cloudflare, set integration-level `recordInputs` / `recordOutputs` in [Setup](#setup) (AI SDK v7 + <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink>). On the default `@sentry/cloudflare` entrypoint, set them on each call’s `experimental_telemetry` instead.
 
-```javascript
-// @sentry/cloudflare/nodejs_compat only (AI SDK v7+)
-import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+</PlatformSection>
 
-export default Sentry.withSentry(
-  (env) => ({
-    dsn: "___PUBLIC_DSN___",
-    tracesSampleRate: 1.0,
-    dataCollection: {},
-    integrations: [
-      Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true }),
-    ],
-  }),
-  { async fetch(request, env, ctx) { /* ... */ } },
-);
-```
+<PlatformSection supported={['javascript.deno']}>
+
+On Deno, set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)).
 
 </PlatformSection>
 
 ## ToolLoopAgent
 
-The integration also captures spans for the [`ToolLoopAgent`](https://ai-sdk.dev/docs/agents/overview#toolloopagent-class) class. Each call to `generate()` or `stream()` creates an agent span with individual LLM requests and tool executions as child spans.
+The integration captures spans for the [`ToolLoopAgent`](https://ai-sdk.dev/docs/agents/overview#toolloopagent-class) class. Each call to `generate()` or `stream()` creates an agent span with individual LLM requests and tool executions as child spans.
 
 <PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
 
-No additional configuration is needed — `ToolLoopAgent` spans are captured automatically.
+No additional configuration is needed — spans are captured automatically.
+
+```javascript
+const agent = new ToolLoopAgent({
+  model: openai("gpt-4o"),
+  tools: {
+    /* ... */
+  },
+});
+
+const result = await agent.generate({
+  prompt: "What is the weather in San Francisco?",
+});
+```
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
-Pass `experimental_telemetry` with `isEnabled: true` to the `ToolLoopAgent` constructor to correctly capture spans:
-
-</PlatformSection>
+Pass `experimental_telemetry` as in [Enable telemetry on calls](#enable-telemetry-on-calls):
 
 ```javascript
 const agent = new ToolLoopAgent({
@@ -294,9 +224,11 @@ const result = await agent.generate({
 });
 ```
 
+</PlatformSection>
+
 ## Identifying functions
 
-In order to make it easier to correlate captured spans with the function calls we recommend setting `functionId` in `experimental_telemetry` in all generation function calls:
+Set `functionId` in `experimental_telemetry` so spans are easier to correlate with call sites. It appears on the agent span as `gen_ai.function_id`.
 
 ```javascript
 const result = await generateText({
@@ -308,7 +240,7 @@ const result = await generateText({
 });
 ```
 
-For `ToolLoopAgent`, set `functionId` in the constructor:
+For `ToolLoopAgent`, set `functionId` on the constructor:
 
 ```javascript
 const agent = new ToolLoopAgent({
@@ -325,7 +257,7 @@ const agent = new ToolLoopAgent({
 
 ## Configuration
 
-By default this integration adds tracing support to all `ai` function callsites. If you need to disable span collection for a specific call, you can do so by setting `experimental_telemetry.isEnabled` to `false` in the first argument of the function call.
+To skip span collection for a specific call, set `experimental_telemetry.isEnabled` to `false`:
 
 ```javascript
 const result = await generateText({
@@ -334,7 +266,7 @@ const result = await generateText({
 });
 ```
 
-If you set `experimental_telemetry.recordInputs` and `experimental_telemetry.recordOutputs` it will override the default behavior of collecting inputs and outputs for that function call.
+`experimental_telemetry.recordInputs` and `experimental_telemetry.recordOutputs` override the integration defaults for that call:
 
 ```javascript
 const result = await generateText({
@@ -347,11 +279,92 @@ const result = await generateText({
 });
 ```
 
+## Options
+
+### `enableTruncation`
+
+_Type: `boolean`_
+
+Enables or disables truncation of recorded input messages. Truncation keeps large payloads within span size limits.
+
+Defaults to `true`.
+
+```javascript
+Sentry.vercelAIIntegration({ enableTruncation: false });
+```
+
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
+
+### `force`
+
+Requires SDK version `9.29.0` or higher.
+
+_Type: `boolean`_
+
+Forces the integration to be active, even when the `ai` module is not detected or available. Useful when you want the integration always on regardless of module detection.
+
+Defaults to `false`.
+
+```javascript
+Sentry.vercelAIIntegration({ force: true });
+```
+
+<PlatformSection supported={["javascript.nextjs"]}>
+
+This option is not available in the Edge runtime. There, the integration is forced when it is enabled.
+
+</PlatformSection>
+
+</PlatformSection>
+
+### `recordInputs`
+
+Requires SDK version `9.27.0` or higher.
+
+_Type: `boolean`_
+
+Records inputs to the `ai` function call.
+
+Defaults to `true` if `dataCollection.genAI.inputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordInputs`.
+
+```javascript
+Sentry.vercelAIIntegration({ recordInputs: true });
+```
+
+### `recordOutputs`
+
+Requires SDK version `9.27.0` or higher.
+
+_Type: `boolean`_
+
+Records outputs from the `ai` function call.
+
+Defaults to `true` if `dataCollection.genAI.outputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordOutputs`.
+
+```javascript
+Sentry.vercelAIIntegration({ recordOutputs: true });
+```
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+On Cloudflare, prefer the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint for integration-level `recordInputs` / `recordOutputs`. Otherwise set them on each call’s `experimental_telemetry`.
+
+</PlatformSection>
+
 ## Supported Versions
 
 - `ai`: `>=3.0.0 <=7`
+- Sentry SDK: `10.6.0`+ (Node.js, Cloudflare Workers, Vercel Edge Functions, Bun); `10.12.0`+ (Deno)
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+- Cloudflare + AI SDK v7: Sentry SDK `10.64.0`+ with `@sentry/cloudflare/nodejs_compat`
+
+</PlatformSection>
 
 ## Troubleshooting
+
+Do not call the AI SDK’s `registerTelemetry` API (AI SDK v7+) alongside this integration. `vercelAIIntegration` already hooks the AI SDK; registering telemetry separately creates duplicate spans.
 
 <PlatformSection supported={['javascript.nextjs']}>
 
@@ -365,7 +378,7 @@ To fix this, explicitly enable the integration with `force: true` in your `sentr
 
 ```javascript
 Sentry.init({
-  dsn: "____PUBLIC_DSN____",
+  dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.vercelAIIntegration({ force: true })],
 });
 ```

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -327,8 +327,6 @@ Defaults to `true`.
 Sentry.vercelAIIntegration({ enableTruncation: false });
 ```
 
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
-
 ### `force`
 
 Requires SDK version `9.29.0` or higher.
@@ -339,6 +337,8 @@ Forces the integration to be active, even when the `ai` module is not detected o
 
 Defaults to `false`.
 
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
+
 ```javascript
 Sentry.vercelAIIntegration({ force: true });
 ```
@@ -348,6 +348,12 @@ Sentry.vercelAIIntegration({ force: true });
 This option is not available in the Edge runtime. There, the integration is forced when it is enabled.
 
 </PlatformSection>
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
+
+This option is not available on Cloudflare or Deno. Those runtimes do not use module detection for this integration — it runs when you add it to `integrations`.
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -349,6 +349,12 @@ export default Sentry.withSentry(
 
 </PlatformSection>
 
+<PlatformSection supported={['javascript.deno']}>
+
+On Deno, set `recordInputs` / `recordOutputs` per call with `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)). Other options go on the integration in `Sentry.init`.
+
+</PlatformSection>
+
 ### `enableTruncation`
 
 _Type: `boolean`_
@@ -364,6 +370,12 @@ Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
 });
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+See the Cloudflare example at the start of [Options](#options).
 
 </PlatformSection>
 
@@ -409,13 +421,25 @@ Records inputs to the `ai` function call.
 
 Defaults to `true` if `dataCollection.genAI.inputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordInputs`.
 
-<PlatformSection notSupported={['javascript.cloudflare']}>
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ recordInputs: true })],
 });
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+On Cloudflare, prefer the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint and the example at the start of [Options](#options). On the default `@sentry/cloudflare` entrypoint, set this on each call’s `experimental_telemetry` instead.
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.deno']}>
+
+On Deno, set this on each call’s `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)).
 
 </PlatformSection>
 
@@ -429,13 +453,25 @@ Records outputs from the `ai` function call.
 
 Defaults to `true` if `dataCollection.genAI.outputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordOutputs`.
 
-<PlatformSection notSupported={['javascript.cloudflare']}>
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ recordOutputs: true })],
 });
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+On Cloudflare, prefer the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint and the example at the start of [Options](#options). On the default `@sentry/cloudflare` entrypoint, set this on each call’s `experimental_telemetry` instead.
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.deno']}>
+
+On Deno, set this on each call’s `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)).
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -29,48 +29,121 @@ supported:
 
 _Import name: `Sentry.vercelAIIntegration`_
 
-The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [`AI SDK's built-in Telemetry`](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
+The `vercelAIIntegration` adds instrumentation for the [`ai`](https://www.npmjs.com/package/ai) SDK by Vercel to capture spans using the [AI SDK's built-in telemetry](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
 
-## Setup
+<Alert level="warning">
 
-<PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
+Don't use the AI SDK's `registerTelemetry` API (AI SDK v7 and above) together with this integration. `vercelAIIntegration` already instruments the AI SDK, so registering telemetry separately produces duplicate spans.
 
-This integration is enabled by default and captures spans for `ai` function calls. Requires SDK version `10.6.0` or higher. To set integration options, re-add it in `integrations` (see [Capture inputs and outputs](#capture-inputs-and-outputs) and [Options](#options)).
+</Alert>
 
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-  dataCollection: {},
-});
-```
+<PlatformSection supported={['javascript.nextjs', 'javascript.cloudflare']}>
 
-</PlatformSection>
+## Runtime differences
 
-<PlatformSection supported={['javascript.deno']}>
+<PlatformSection supported={['javascript.nextjs']}>
 
-This integration is not enabled by default. Requires SDK version `10.12.0` or higher.
+Next.js runs your server code in two runtimes, and Sentry ships a different implementation for each. The Node implementation patches the `ai` module through OpenTelemetry. The Edge runtime can't load OpenTelemetry instrumentation, so it uses a reduced implementation that reads the spans the AI SDK emits on its own.
 
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-  dataCollection: {},
-  integrations: [Sentry.vercelAIIntegration()],
-});
-```
+That difference decides where you configure the integration and which options do anything:
+
+|                                   | Node runtime                | Edge runtime                            |
+| --------------------------------- | --------------------------- | --------------------------------------- |
+| Enabled by default                | Yes                         | No — add it to `sentry.edge.config`     |
+| `experimental_telemetry` per call | Not needed                  | Required, or no spans are created       |
+| Record inputs and outputs         | Integration or per call     | Per call only                           |
+| `force`                           | Available                   | Not available — always active           |
+| AI SDK v7                         | Supported                   | Not supported                           |
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare']}>
 
-This integration is not enabled by default. For AI SDK v7, use the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint (SDK `10.64.0` or higher) and enable the Wrangler `nodejs_compat` flag.
+Cloudflare Workers can't load OpenTelemetry instrumentation, so `@sentry/cloudflare` uses a reduced implementation that reads the spans the AI SDK emits on its own. The <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint runs the full Node implementation instead.
 
-```jsonc {filename:wrangler.jsonc}
-{
-  "compatibility_flags": ["nodejs_compat"]
-}
+Your entrypoint decides which options do anything:
+
+|                                   | `@sentry/cloudflare`              | `@sentry/cloudflare/nodejs_compat` |
+| --------------------------------- | --------------------------------- | ---------------------------------- |
+| Enabled by default                | No                                | No                                 |
+| `experimental_telemetry` per call | Required, or no spans are created | Required, or no spans are created   |
+| Record inputs and outputs         | Per call only                     | Integration or per call             |
+| AI SDK v7                         | Not supported                     | Supported                           |
+| Minimum Sentry SDK                | `10.6.0`                          | `10.64.0`                           |
+
+</PlatformSection>
+
+</PlatformSection>
+
+## Setup
+
+<PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
+
+The integration is enabled by default and captures spans for all `ai` function calls. No setup code is needed beyond enabling tracing:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+});
 ```
+
+Prompts and completions are not captured until you opt in. See [Record inputs and outputs](#record-inputs-and-outputs).
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+### Node runtime
+
+The integration is enabled by default. No setup code is needed beyond enabling tracing:
+
+```javascript {filename:sentry.server.config.ts}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+});
+```
+
+If spans are missing here, your build most likely bundled the `ai` package so module detection fails. See [Troubleshooting](#troubleshooting).
+
+### Edge runtime
+
+The integration is not enabled by default. Add it yourself:
+
+```javascript {filename:sentry.edge.config.ts}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  integrations: [Sentry.vercelAIIntegration()],
+});
+```
+
+Adding the integration is not enough on its own. The Edge runtime can't patch your call sites, so you must also pass `experimental_telemetry` on every call. See [Turn on telemetry](#turn-on-telemetry).
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.deno']}>
+
+The integration is not enabled by default. Add it yourself:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  integrations: [Sentry.vercelAIIntegration()],
+});
+```
+
+Deno can't load OpenTelemetry instrumentation, so Sentry can't patch your call sites. Adding the integration is not enough on its own — you must also pass `experimental_telemetry` on every call. See [Turn on telemetry](#turn-on-telemetry).
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+### AI SDK v7
+
+Use the <PlatformLink to="/features/nodejs-compat">`@sentry/cloudflare/nodejs_compat`</PlatformLink> entrypoint and enable the Wrangler `nodejs_compat` flag:
 
 ```javascript
 import * as Sentry from "@sentry/cloudflare/nodejs_compat";
@@ -79,7 +152,155 @@ export default Sentry.withSentry(
   (env) => ({
     dsn: "___PUBLIC_DSN___",
     tracesSampleRate: 1.0,
-    dataCollection: {},
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(request, env, ctx) {
+      /* your worker */
+    },
+  },
+);
+```
+
+```jsonc {filename:wrangler.jsonc}
+{
+  "compatibility_flags": ["nodejs_compat"]
+}
+```
+
+### AI SDK v6 and below
+
+Import `@sentry/cloudflare` instead:
+
+```javascript
+import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(request, env, ctx) {
+      /* your worker */
+    },
+  },
+);
+```
+
+On both entrypoints, adding the integration is not enough on its own. You must also pass `experimental_telemetry` on every call.
+
+</PlatformSection>
+
+## Record inputs and outputs
+
+Prompts and completions are not captured by default, because they usually contain user data. Turn recording on with `recordInputs` and `recordOutputs`.
+
+Sentry resolves both settings in this order, and stops at the first one that is set:
+
+1. The integration option — applies to every call.
+2. The call's `experimental_telemetry` — applies to that call.
+3. <PlatformLink to="/configuration/options/#dataCollection">`dataCollection.genAI`</PlatformLink> — applies to every call.
+
+The integration option wins over the call, not the other way around. If you set `recordInputs: false` on the integration, no call site can turn it back on.
+
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
+
+Set the options on the integration to cover every call. Re-adding the integration replaces the default instance and configures it:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
+});
+```
+
+To record only some calls, leave the integration options unset and set them per call instead:
+
+```javascript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_telemetry: {
+    recordInputs: true,
+    recordOutputs: true,
+  },
+});
+```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+### Node runtime
+
+Set the options on the integration to cover every call. Re-adding the integration replaces the default instance and configures it:
+
+```javascript {filename:sentry.server.config.ts}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
+});
+```
+
+To record only some calls, leave the integration options unset and set them per call instead:
+
+```javascript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_telemetry: {
+    recordInputs: true,
+    recordOutputs: true,
+  },
+});
+```
+
+### Edge runtime
+
+<Alert level="warning">
+
+The Edge runtime ignores `recordInputs` and `recordOutputs` on the integration. It accepts no error and logs no warning — your prompts are simply missing. Set both per call.
+
+</Alert>
+
+```javascript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_telemetry: {
+    isEnabled: true,
+    recordInputs: true,
+    recordOutputs: true,
+  },
+});
+```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+### `@sentry/cloudflare/nodejs_compat`
+
+Set the options on the integration to cover every call:
+
+```javascript
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    tracesSampleRate: 1.0,
     integrations: [
       Sentry.vercelAIIntegration({
         recordInputs: true,
@@ -95,46 +316,13 @@ export default Sentry.withSentry(
 );
 ```
 
-For AI SDK versions before v7, import `@sentry/cloudflare` instead (SDK `10.6.0` or higher). Keep `vercelAIIntegration()` in `integrations`. Set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` rather than on the integration (those integration options need the `nodejs_compat` entrypoint).
+### `@sentry/cloudflare`
 
-</PlatformSection>
+<Alert level="warning">
 
-<PlatformSection supported={['javascript.nextjs']}>
+The default entrypoint ignores `recordInputs` and `recordOutputs` on the integration. It accepts no error and logs no warning — your prompts are simply missing. Set both per call.
 
-This integration is enabled by default in the Node runtime. On the Edge runtime it is not; add it in `sentry.edge.config.js`. Requires SDK version `10.6.0` or higher.
-
-```javascript {filename: 'sentry.edge.config.(js|ts)'}
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-  dataCollection: {},
-  integrations: [Sentry.vercelAIIntegration()],
-});
-```
-
-On the **Node** runtime, spans are usually automatic. If they are missing, see [Troubleshooting](#troubleshooting) and the `force` option.
-
-</PlatformSection>
-
-In the examples above, `dataCollection: {}` turns on the SDK’s permissive defaults. That includes generative AI inputs and outputs **and** other categories (user identity, cookies, headers, HTTP bodies, query parameters, and stack-frame locals) unless you override them. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
-
-<PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
-
-## Enable telemetry on calls
-
-<PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
-
-Pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `generateObject`, `streamText`, `streamObject`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). Without it, AI spans are not created.
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.nextjs']}>
-
-On the **Edge** runtime, pass `experimental_telemetry: { isEnabled: true }` on every `generateText`, `generateObject`, `streamText`, `streamObject`, and `ToolLoopAgent` call (on the `ToolLoopAgent` constructor). On the **Node** runtime this is usually automatic.
-
-</PlatformSection>
-
-See the [AI SDK Telemetry Metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
+</Alert>
 
 ```javascript
 const result = await generateText({
@@ -149,134 +337,113 @@ const result = await generateText({
 
 </PlatformSection>
 
-## Capture inputs and outputs
-
-Record prompts and completions on the integration and/or per call via `experimental_telemetry` (see [Configuration](#configuration)).
-
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
-
-The integration is enabled by default. Re-add it to `integrations` with options to configure it (this replaces the default instance):
-
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-  dataCollection: {},
-  integrations: [
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
-  ],
-});
-```
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.nextjs']}>
-
-On **Node**, set integration options in `sentry.server.config.ts` (re-adding the default integration configures it). On **Edge**, set them in `sentry.edge.config.js` when you enable the integration:
-
-```javascript {filename: 'sentry.server.config.(js|ts)'}
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-  dataCollection: {},
-  integrations: [
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
-  ],
-});
-```
-
-```javascript {filename: 'sentry.edge.config.(js|ts)'}
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  tracesSampleRate: 1.0,
-  dataCollection: {},
-  integrations: [
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
-  ],
-});
-```
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.cloudflare']}>
-
-On Cloudflare, set integration-level `recordInputs` / `recordOutputs` in [Setup](#setup) (AI SDK v7 + <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink>). On the default `@sentry/cloudflare` entrypoint, set them on each call’s `experimental_telemetry` instead.
-
-</PlatformSection>
-
 <PlatformSection supported={['javascript.deno']}>
 
-On Deno, set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)).
+<Alert level="warning">
 
-</PlatformSection>
+Deno ignores `recordInputs` and `recordOutputs` on the integration. It accepts no error and logs no warning — your prompts are simply missing. Set both per call.
 
-## ToolLoopAgent
-
-The integration captures spans for the [`ToolLoopAgent`](https://ai-sdk.dev/docs/agents/overview#toolloopagent-class) class. Each call to `generate()` or `stream()` creates an agent span with individual LLM requests and tool executions as child spans.
-
-<PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
-
-No additional configuration is needed — spans are captured automatically.
-
-```javascript
-const agent = new ToolLoopAgent({
-  model: openai("gpt-4o"),
-  tools: {
-    /* ... */
-  },
-});
-
-const result = await agent.generate({
-  prompt: "What is the weather in San Francisco?",
-});
-```
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
-
-Pass `experimental_telemetry` as in [Enable telemetry on calls](#enable-telemetry-on-calls):
-
-```javascript
-const agent = new ToolLoopAgent({
-  model: openai("gpt-4o"),
-  tools: {
-    /* ... */
-  },
-  experimental_telemetry: { isEnabled: true },
-});
-
-const result = await agent.generate({
-  prompt: "What is the weather in San Francisco?",
-});
-```
-
-</PlatformSection>
-
-## Identifying functions
-
-Set `functionId` in `experimental_telemetry` so spans are easier to correlate with call sites. It appears on the agent span as `gen_ai.function_id`.
+</Alert>
 
 ```javascript
 const result = await generateText({
   model: openai("gpt-4o"),
   experimental_telemetry: {
     isEnabled: true,
-    functionId: "my-awesome-function",
+    recordInputs: true,
+    recordOutputs: true,
   },
 });
 ```
 
-For `ToolLoopAgent`, set `functionId` on the constructor:
+</PlatformSection>
+
+<Alert level="warning">
+
+`dataCollection: {}` also turns recording on, but it opts you into the SDK's permissive defaults for every other category too: user identity, cookies, headers, HTTP bodies, query parameters, and stack-frame locals. Prefer the integration and per-call options above unless you want all of it. See <PlatformLink to="/configuration/options/#dataCollection">`dataCollection`</PlatformLink>.
+
+</Alert>
+
+## Configure individual calls
+
+Every instrumented `ai` function takes an `experimental_telemetry` object. Use it to control one call instead of all of them. For the full list of fields, see the [AI SDK telemetry metadata docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#telemetry-metadata).
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
+
+### Turn on telemetry
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+This applies to the **Edge** runtime only. On the Node runtime, Sentry patches your call sites for you.
+
+</PlatformSection>
+
+Set `isEnabled` to `true` on every instrumented call. Without it, the AI SDK emits no spans and Sentry has nothing to capture:
+
+```javascript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_telemetry: { isEnabled: true },
+});
+```
+
+For `ToolLoopAgent`, set it on the constructor instead. See [ToolLoopAgent](#toolloopagent).
+
+</PlatformSection>
+
+### Skip a call
+
+To capture no span for one call, set `isEnabled` to `false`:
+
+```javascript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_telemetry: { isEnabled: false },
+});
+```
+
+### Identify your call sites
+
+Spans carry the AI SDK function name, not yours, so a trace with several `generateText` calls is hard to read. Set `functionId` to label the call site. It appears on the span as `gen_ai.function_id`:
+
+```javascript
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_telemetry: {
+    functionId: "summarize-ticket",
+  },
+});
+```
+
+### ToolLoopAgent
+
+The integration captures spans for the [`ToolLoopAgent`](https://ai-sdk.dev/docs/agents/overview#toolloopagent-class) class. Each call to `generate()` or `stream()` creates an agent span, with the individual LLM requests and tool executions as child spans.
+
+`ToolLoopAgent` takes its telemetry settings on the constructor, not on `generate()` or `stream()`:
+
+<PlatformSection notSupported={["javascript.cloudflare", "javascript.deno", "javascript.nextjs"]}>
+
+```javascript
+const agent = new ToolLoopAgent({
+  model: openai("gpt-4o"),
+  tools: {
+    /* ... */
+  },
+  experimental_telemetry: {
+    functionId: "weather-agent",
+  },
+});
+
+const result = await agent.generate({
+  prompt: "What is the weather in San Francisco?",
+});
+```
+
+Spans are captured without the `experimental_telemetry` block. Pass it only to set `functionId` or the recording options.
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
 ```javascript
 const agent = new ToolLoopAgent({
@@ -289,69 +456,31 @@ const agent = new ToolLoopAgent({
     functionId: "weather-agent",
   },
 });
-```
 
-## Configuration
-
-To skip span collection for a specific call, set `experimental_telemetry.isEnabled` to `false`:
-
-```javascript
-const result = await generateText({
-  model: openai("gpt-4o"),
-  experimental_telemetry: { isEnabled: false },
+const result = await agent.generate({
+  prompt: "What is the weather in San Francisco?",
 });
 ```
 
-`experimental_telemetry.recordInputs` and `experimental_telemetry.recordOutputs` override the integration defaults for that call:
-
-```javascript
-const result = await generateText({
-  model: openai("gpt-4o"),
-  experimental_telemetry: {
-    isEnabled: true,
-    recordInputs: true,
-    recordOutputs: true,
-  },
-});
-```
+</PlatformSection>
 
 ## Options
 
-Configure these on `Sentry.vercelAIIntegration()` when you initialize Sentry.
+<PlatformSection supported={['javascript.nextjs']}>
+
+Pass these to `Sentry.vercelAIIntegration()`. The Edge runtime accepts `enableTruncation` only.
+
+</PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare']}>
 
-On Cloudflare, pass options in `withSentry` (AI SDK v7 + <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink>). On the default `@sentry/cloudflare` entrypoint, set `recordInputs` / `recordOutputs` on each call’s `experimental_telemetry` instead.
-
-```javascript
-import * as Sentry from "@sentry/cloudflare/nodejs_compat";
-
-export default Sentry.withSentry(
-  (env) => ({
-    dsn: "___PUBLIC_DSN___",
-    tracesSampleRate: 1.0,
-    dataCollection: {},
-    integrations: [
-      Sentry.vercelAIIntegration({
-        enableTruncation: false,
-        recordInputs: true,
-        recordOutputs: true,
-      }),
-    ],
-  }),
-  {
-    async fetch(request, env, ctx) {
-      /* your worker */
-    },
-  },
-);
-```
+Pass these to `Sentry.vercelAIIntegration()`. The default `@sentry/cloudflare` entrypoint accepts `enableTruncation` only.
 
 </PlatformSection>
 
 <PlatformSection supported={['javascript.deno']}>
 
-On Deno, set `recordInputs` / `recordOutputs` per call with `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)). Other options go on the integration in `Sentry.init`.
+Pass these to `Sentry.vercelAIIntegration()`. Deno accepts `enableTruncation` and `force` only.
 
 </PlatformSection>
 
@@ -359,11 +488,9 @@ On Deno, set `recordInputs` / `recordOutputs` per call with `experimental_teleme
 
 _Type: `boolean`_
 
-Enables or disables truncation of recorded input messages. Truncation keeps large payloads within span size limits.
+Truncates recorded input messages so large payloads stay within span size limits. Affects inputs only, not outputs.
 
 Defaults to `true`.
-
-<PlatformSection notSupported={['javascript.cloudflare']}>
 
 ```javascript
 Sentry.init({
@@ -371,25 +498,15 @@ Sentry.init({
 });
 ```
 
-</PlatformSection>
-
-<PlatformSection supported={['javascript.cloudflare']}>
-
-See the Cloudflare example at the start of [Options](#options).
-
-</PlatformSection>
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 
 ### `force`
 
-Requires SDK version `9.29.0` or higher.
-
 _Type: `boolean`_
 
-Forces the integration to be active, even when the `ai` module is not detected or available. Useful when you want the integration always on regardless of module detection.
+Registers the integration's span processors even when the `ai` module can't be detected. Set this when your build bundles `ai`, which defeats module detection. See [Troubleshooting](#troubleshooting).
 
 Defaults to `false`.
-
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 
 ```javascript
 Sentry.init({
@@ -399,96 +516,79 @@ Sentry.init({
 
 <PlatformSection supported={["javascript.nextjs"]}>
 
-This option is not available in the Edge runtime. There, the integration is forced when it is enabled.
+Not available in the Edge runtime, where the integration is always active once you add it.
 
 </PlatformSection>
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
-
-This option is not available on Cloudflare or Deno. Those runtimes do not use module detection for this integration — it runs when you add it to `integrations`.
 
 </PlatformSection>
 
 ### `recordInputs`
 
-Requires SDK version `9.27.0` or higher.
-
 _Type: `boolean`_
 
-Records inputs to the `ai` function call.
-
-Defaults to `true` if `dataCollection.genAI.inputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordInputs`.
-
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
-
-```javascript
-Sentry.init({
-  integrations: [Sentry.vercelAIIntegration({ recordInputs: true })],
-});
-```
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.cloudflare']}>
-
-On Cloudflare, prefer the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint and the example at the start of [Options](#options). On the default `@sentry/cloudflare` entrypoint, set this on each call’s `experimental_telemetry` instead.
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.deno']}>
-
-On Deno, set this on each call’s `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)).
-
-</PlatformSection>
+Records inputs to the `ai` function call. See [Record inputs and outputs](#record-inputs-and-outputs) for the full resolution order and the per-call alternative.
 
 ### `recordOutputs`
 
-Requires SDK version `9.27.0` or higher.
-
 _Type: `boolean`_
 
-Records outputs from the `ai` function call.
+Records outputs from the `ai` function call. See [Record inputs and outputs](#record-inputs-and-outputs) for the full resolution order and the per-call alternative.
 
-Defaults to `true` if `dataCollection.genAI.outputs` is `true` (the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`. You can also set recording per call with `experimental_telemetry.recordOutputs`.
+## Supported Operations
 
-<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
-```javascript
-Sentry.init({
-  integrations: [Sentry.vercelAIIntegration({ recordOutputs: true })],
-});
-```
+Spans are captured for these `ai` functions:
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.cloudflare']}>
+<PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
-On Cloudflare, prefer the <PlatformLink to="/features/nodejs-compat">`nodejs_compat`</PlatformLink> entrypoint and the example at the start of [Options](#options). On the default `@sentry/cloudflare` entrypoint, set this on each call’s `experimental_telemetry` instead.
-
-</PlatformSection>
-
-<PlatformSection supported={['javascript.deno']}>
-
-On Deno, set this on each call’s `experimental_telemetry` (see [Enable telemetry on calls](#enable-telemetry-on-calls)).
+Spans are captured for these `ai` functions. Pass `experimental_telemetry` to each one, as described in [Turn on telemetry](#turn-on-telemetry):
 
 </PlatformSection>
+
+- `generateText()`
+- `streamText()`
+- `generateObject()`
+- `streamObject()`
+- `embed()`
+- `embedMany()`
+- `rerank()`
+
+Plus `generate()` and `stream()` on [`ToolLoopAgent`](#toolloopagent).
 
 ## Supported Versions
 
 - `ai`: `>=3.0.0 <=7`
-- Sentry SDK: `10.6.0`+ (Node.js, Cloudflare Workers, Vercel Edge Functions, Bun); `10.12.0`+ (Deno)
+
+<PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
+
+- Sentry SDK: `10.6.0`+
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.nextjs']}>
+
+- Sentry SDK: `10.6.0`+
+- Edge runtime: `ai` v7 is not supported. Use v6 or below, or run the call in the Node runtime.
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.deno']}>
+
+- Sentry SDK: `10.12.0`+
+
+</PlatformSection>
 
 <PlatformSection supported={['javascript.cloudflare']}>
 
-- Cloudflare + AI SDK v7: Sentry SDK `10.64.0`+ with `@sentry/cloudflare/nodejs_compat`
+- Sentry SDK: `10.6.0`+ with `@sentry/cloudflare`
+- Sentry SDK: `10.64.0`+ with `@sentry/cloudflare/nodejs_compat`, required for `ai` v7
 
 </PlatformSection>
 
 ## Troubleshooting
-
-Do not call the AI SDK’s `registerTelemetry` API (AI SDK v7+) alongside this integration. `vercelAIIntegration` already hooks the AI SDK; registering telemetry separately creates duplicate spans.
 
 <PlatformSection supported={['javascript.nextjs']}>
 
@@ -500,7 +600,7 @@ This happens because the `ai` package is bundled (not externalized) in Next.js p
 
 To fix this, explicitly enable the integration with `force: true` in your `sentry.server.config.ts`:
 
-```javascript
+```javascript {filename:sentry.server.config.ts}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   integrations: [Sentry.vercelAIIntegration({ force: true })],
@@ -512,3 +612,13 @@ The `force` option ensures the integration registers its span processors regardl
 </Expandable>
 
 </PlatformSection>
+
+<Expandable title="Why are my prompts and completions missing?">
+
+Recording is off unless you turn it on. Check, in order:
+
+1. `recordInputs` and `recordOutputs` are set. See [Record inputs and outputs](#record-inputs-and-outputs).
+2. You set them in a place the runtime reads. Some runtimes ignore the integration options and take them per call only.
+3. No integration option is overriding your per-call value. The integration option wins.
+
+</Expandable>

--- a/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/vercelai.mdx
@@ -443,6 +443,12 @@ Spans are captured without the `experimental_telemetry` block. Pass it only to s
 
 <PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
 
+<PlatformSection supported={['javascript.nextjs']}>
+
+This applies to the **Edge** runtime only. On the Node runtime, Sentry patches your call sites for you — pass `experimental_telemetry` only to set `functionId` or the recording options.
+
+</PlatformSection>
+
 ```javascript
 const agent = new ToolLoopAgent({
   model: openai("gpt-4o"),
@@ -490,11 +496,35 @@ Truncates recorded input messages so large payloads stay within span size limits
 
 Defaults to `true`.
 
+<PlatformSection notSupported={['javascript.cloudflare']}>
+
 ```javascript
 Sentry.init({
   integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
 });
 ```
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare']}>
+
+```javascript
+import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "___PUBLIC_DSN___",
+    integrations: [Sentry.vercelAIIntegration({ enableTruncation: false })],
+  }),
+  {
+    async fetch(request, env, ctx) {
+      /* your worker */
+    },
+  },
+);
+```
+
+</PlatformSection>
 
 <PlatformSection notSupported={['javascript.cloudflare', 'javascript.deno']}>
 
@@ -540,7 +570,13 @@ Spans are captured for these `ai` functions:
 
 </PlatformSection>
 
-<PlatformSection supported={['javascript.cloudflare', 'javascript.deno', 'javascript.nextjs']}>
+<PlatformSection supported={['javascript.nextjs']}>
+
+Spans are captured for these `ai` functions. On the Edge runtime, pass `experimental_telemetry` to each one, as described in [Turn on telemetry](#turn-on-telemetry):
+
+</PlatformSection>
+
+<PlatformSection supported={['javascript.cloudflare', 'javascript.deno']}>
 
 Spans are captured for these `ai` functions. Pass `experimental_telemetry` to each one, as described in [Turn on telemetry](#turn-on-telemetry):
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

The Vercel AI integration page now walks setup → enable telemetry → capture I/O → options, with shared guidance once and platform sections only where behavior actually differs (Cloudflare entrypoints, Deno/Edge telemetry, Next.js Edge init).

Readers should get a single clear path per runtime without near-duplicate Cloudflare vs non-Cloudflare snippets. Alerts for version floors, `dataCollection`, and `registerTelemetry` are folded into the relevant sections.

Part of [TET-2704: Audit Vercel AI on Cloudflare Workers](https://linear.app/getsentry/issue/TET-2704/audit-vercel-ai-on-cloudflare-workers)

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)