### PR TITLE
docs(python): Lean Agent Tracing hub and richer manual instrumentation

### DIFF
--- a/docs/platforms/python/agent-tracing/index.mdx
+++ b/docs/platforms/python/agent-tracing/index.mdx
@@ -4,17 +4,30 @@ sidebar_title: Agent Tracing
 sidebar_order: 7
 sidebar_section: features
 description: "Monitor AI agents with token usage, latency, tool execution, and error tracking."
+new: true
 ---
 
-With <Link to="/product/agents/dashboards/">Sentry Agent Tracing</Link>, you can monitor and debug your AI systems with full-stack context. You'll be able to track key insights like token usage, latency, tool usage, and error rates. Agent Tracing data will be fully connected to your other Sentry data like logs, errors, and traces.
+With <Link to="/product/agents/dashboards/">Sentry Agent Tracing</Link>, you can monitor and debug your AI systems with full-stack context. You'll be able to track key insights like token usage, latency, tool usage, and error rates — and group multi-turn chats in <Link to="/product/agents/conversations/">Conversations</Link>. Agent Tracing data is fully connected to your other Sentry data like logs, errors, and traces.
 
 <AgentSetupCallout skill="sentry-setup-ai-monitoring" platformName="Python" />
 
-As a prerequisite to setting up Agent Tracing with Python, you'll need to first <PlatformLink to="/tracing/">set up tracing</PlatformLink>. Once this is done, the Python SDK will automatically instrument AI agents created with supported libraries. If that doesn't fit your use case, you can use custom instrumentation described below.
+## Getting Started
 
-## Automatic Instrumentation
+Enable <PlatformLink to="/tracing/">tracing</PlatformLink>. Supported AI libraries are instrumented automatically when their packages are installed. Prompt and response content is off by default — set `send_default_pii=True` to capture it (or configure `include_prompts` per integration).
 
-The Python SDK supports automatic instrumentation for some AI libraries. We recommend adding their integrations to your Sentry configuration to automatically capture spans for AI agents.
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    traces_sample_rate=1.0,
+    send_default_pii=True,
+)
+```
+
+## Instrumentation
+
+Pick your AI stack. Each page has install and verify details.
 
 - <PlatformLink to="/integrations/anthropic/">Anthropic</PlatformLink>
 - <PlatformLink to="/integrations/google-genai/">Google Gen AI</PlatformLink>
@@ -24,154 +37,7 @@ The Python SDK supports automatic instrumentation for some AI libraries. We reco
 - <PlatformLink to="/integrations/langgraph/">LangGraph</PlatformLink>
 - <PlatformLink to="/integrations/litellm/">LiteLLM</PlatformLink>
 - <PlatformLink to="/integrations/pydantic-ai/">Pydantic AI</PlatformLink>
-
-## Manual Instrumentation
-
-For your AI agents data to show up in the [AI Agents Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/?filter=onlyPrebuilt&query=agents&sort=mostPopular), at least one of the AI spans needs to be created and have well-defined names and data attributes. See below.
-
-The [@sentry_sdk.trace()](/platforms/python/tracing/instrumentation/custom-instrumentation/#span-templates) decorator can also be used to create these spans.
-
-## Span Hierarchy
-
-When instrumenting an agent loop, spans nest like this:
-
-```
-── invoke_agent My Agent          (gen_ai.invoke_agent)
-   ├── chat gpt-4o                (gen_ai.chat)         ← 1st LLM call
-   ├── execute_tool get_weather   (gen_ai.execute_tool)  ← tool run
-   ├── chat gpt-4o                (gen_ai.chat)         ← 2nd LLM call
-   └── ...
-```
-
-`gen_ai.invoke_agent` is the container. `gen_ai.chat` and `gen_ai.execute_tool` spans are its children (siblings of each other). A `gen_ai.chat` span can also appear without an agent parent for standalone LLM calls.
-
-## Spans
-
-### AI Request span
-
-This span represents a request to an LLM model or service that generates a response based on the input prompt.
-
-<Expandable title="AI Request span attributes">
-  <Include name="tracing/ai-agents-module/ai-client-span" />
-</Expandable>
-
-#### Example AI Request span
-
-```python
-import json
-import sentry_sdk
-
-messages = [{"role": "user", "parts": [{"type": "text", "content": "Tell me a joke"}]}]
-
-with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
-    span.set_data("gen_ai.operation.name", "chat")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.provider.name", "openai")
-    span.set_data("gen_ai.input.messages", json.dumps(messages))
-
-    result = client.chat.completions.create(model="o3-mini", messages=messages)
-
-    span.set_data("gen_ai.response.model", result.model)
-    span.set_data("gen_ai.output.messages", json.dumps([
-        {"role": "assistant", "parts": [{"type": "text", "content": result.choices[0].message.content}]}
-    ]))
-    span.set_data("gen_ai.response.finish_reasons", json.dumps([result.choices[0].finish_reason]))
-    span.set_data("gen_ai.usage.input_tokens", result.usage.prompt_tokens)
-    span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
-```
-
-#### Thinking / reasoning messages
-
-Models with extended thinking (such as Anthropic's `thinking` blocks, Gemini's `thought`, or DeepSeek's `reasoning_content`) produce internal reasoning that isn't part of the user-visible reply. Represent this content as a `reasoning` part inside the assistant message, alongside the user-facing `text` part. Sentry surfaces reasoning parts separately and filters them out of the user-facing <Link to="/product/agents/conversations/">Conversations</Link> view, so don't fold thinking into a `text` part.
-
-```python
-import json
-import sentry_sdk
-
-messages = [{"role": "user", "parts": [{"type": "text", "content": "What is 6 * 7?"}]}]
-
-with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
-    span.set_data("gen_ai.operation.name", "chat")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.provider.name", "openai")
-    span.set_data("gen_ai.input.messages", json.dumps(messages))
-
-    result = client.chat.completions.create(model="o3-mini", messages=messages)
-
-    span.set_data("gen_ai.response.model", result.model)
-    span.set_data("gen_ai.output.messages", json.dumps([
-        {
-            "role": "assistant",
-            "parts": [
-                {"type": "reasoning", "content": "6 times 7 is 42."},
-                {"type": "text", "content": "The answer is 42."},
-            ],
-        }
-    ]))
-    span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
-    # If the provider reports reasoning tokens, record them as a subset of output tokens
-    span.set_data("gen_ai.usage.reasoning.output_tokens", result.usage.completion_tokens_details.reasoning_tokens)
-```
-
-When previous thinking is fed back into a multi-turn request, include the same `reasoning` parts in the assistant messages within `gen_ai.input.messages`.
-
-### Invoke Agent Span
-
-This span represents the execution of an AI agent, capturing the full lifecycle from receiving a task to producing a final response.
-
-<Expandable title="Invoke Agent span attributes">
-  <Include name="tracing/ai-agents-module/invoke-agent-span" />
-</Expandable>
-
-<Alert>
-
-For a complete guide on naming agents across all supported frameworks, see [Naming Your Agents](/product/agents/naming/).
-
-</Alert>
-
-#### Example of an Invoke Agent Span:
-
-```python
-import json
-import sentry_sdk
-
-with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as span:
-    span.set_data("gen_ai.operation.name", "invoke_agent")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.agent.name", "Weather Agent")
-
-    final_output = my_agent.run()
-
-    span.set_data("gen_ai.output.messages", json.dumps([
-        {"role": "assistant", "parts": [{"type": "text", "content": str(final_output)}]}
-    ]))
-    span.set_data("gen_ai.usage.input_tokens", final_output.usage.input_tokens)
-    span.set_data("gen_ai.usage.output_tokens", final_output.usage.output_tokens)
-```
-
-### Execute Tool Span
-
-This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.
-
-<Expandable title="Execute Tool span attributes">
-  <Include name="tracing/ai-agents-module/execute-tool-span" />
-</Expandable>
-
-#### Example Execute Tool span
-
-```python
-import json
-import sentry_sdk
-
-with sentry_sdk.start_span(op="gen_ai.execute_tool", name="execute_tool get_weather") as span:
-    span.set_data("gen_ai.operation.name", "execute_tool")
-    span.set_data("gen_ai.tool.name", "get_weather")
-    span.set_data("gen_ai.tool.call.arguments", json.dumps({"location": "Paris"}))
-
-    result = get_weather(location="Paris")
-
-    span.set_data("gen_ai.tool.call.result", json.dumps(result))
-```
+- <PlatformLink to="/integrations/huggingface_hub/">Hugging Face Hub</PlatformLink>
 
 ## Tracking Conversations
 
@@ -179,38 +45,19 @@ with sentry_sdk.start_span(op="gen_ai.execute_tool", name="execute_tool get_weat
   Tracking Conversations has **beta** stability. Configuration options and behavior may change.
 </Alert>
 
-For AI applications that involve multi-turn conversations, you can use `sentry_sdk.ai.set_conversation_id()` to associate all AI spans from the same conversation. This enables you to track and analyze complete <Link to="/product/agents/conversations/">conversation</Link> flows within Sentry.
+[Conversations](/product/agents/conversations/) groups multi-turn AI activity into a single replay of messages and tool calls. Use `set_conversation_id()` so every AI span in a chat session shares the same `gen_ai.conversation.id`.
 
-The conversation ID is set as the `gen_ai.conversation.id` attribute on all AI-related spans in the current scope. To remove the conversation ID, use the `remove_conversation_id()` method on the `Scope`.
+Some integrations (for example OpenAI) infer a conversation ID automatically. For everything else, set it yourself at the start of **every request or operation that makes AI calls**, before those calls run. Reuse the same session ID across messages in the chat. The ID is applied to AI-related spans on the current scope. Call `Scope.remove_conversation_id()` to unset it.
 
 ```python
 import sentry_sdk.ai
 
 sentry_sdk.ai.set_conversation_id("conv_abc123")
-
-# All subsequent AI calls will be linked to this conversation
 ```
 
-Some integrations, like the OpenAI integration, will automatically set the conversation ID for you, when you use APIs that expose that.
+### Identifying Users in Conversations
 
-```python
-import sentry_sdk
-import openai
-
-sentry_sdk.init(...)
-
-conversation = openai.conversations.create()
-
-response = openai.responses.create(
-    model="gpt-4.1",
-    input=[{"role": "user", "content": "What are the 5 Ds of dodgeball?"}],
-    conversation=conversation.id  # this will automatically set `gen_ai.conversation.id` on the span
-)
-```
-
-## Identifying Users in Conversations
-
-The [Conversations](/product/agents/conversations/) view includes a **User** column. To populate it, call `sentry_sdk.set_user` once per request or session, before any AI calls:
+The [Conversations](/product/agents/conversations/) view includes a **User** column. To populate it, call `set_user` once per request or session, before any AI calls:
 
 ```python
 import sentry_sdk
@@ -220,4 +67,46 @@ sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": 
 
 Any of `id`, `email`, or `username` is sufficient — Conversations displays whichever fields are present.
 
-<Include name="tracing/ai-agents-module/token-cost-gotchas" />
+## Options
+
+### Privacy Controls
+
+LLM inputs and outputs are treated as PII and are **off** by default. Set `send_default_pii=True` to capture them. To keep other PII on but turn AI content off, set `include_prompts=False` on the integration:
+
+```python
+import sentry_sdk
+from sentry_sdk.integrations.openai import OpenAIIntegration
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    send_default_pii=True,
+    integrations=[
+        OpenAIIntegration(include_prompts=False),
+    ],
+)
+```
+
+See each integration page for the options that apply to your stack.
+
+### Streaming Gen AI Spans
+
+From SDK `2.64.0`, `gen_ai` spans are sent as standalone envelope items (avoids large-payload drops; required for <Link to="/product/agents/conversations/">Conversations</Link>).
+
+Self-hosted Sentry users should set `stream_gen_ai_spans=False` if standalone `gen_ai` spans may not be ingested.
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    stream_gen_ai_spans=False,
+)
+```
+
+## Manual Instrumentation
+
+You can also instrument agent spans yourself. See <PlatformLink to="/agent-tracing/manual-instrumentation/">manual instrumentation</PlatformLink>.
+
+## MCP Server Monitoring
+
+If you're building MCP (Model Context Protocol) servers, Sentry can also track tool executions, prompt retrievals, and resource access. See <PlatformLink to="/integrations/mcp/">MCP integration</PlatformLink> or <PlatformLink to="/tracing/instrumentation/custom-instrumentation/mcp-module/">manual MCP instrumentation</PlatformLink>.

--- a/docs/platforms/python/agent-tracing/index.mdx
+++ b/docs/platforms/python/agent-tracing/index.mdx
@@ -47,7 +47,7 @@ Pick your AI stack. Each page has install and verify details.
 
 [Conversations](/product/agents/conversations/) groups multi-turn AI activity into a single replay of messages and tool calls. Use `set_conversation_id()` so every AI span in a chat session shares the same `gen_ai.conversation.id`.
 
-Some integrations (for example OpenAI) infer a conversation ID automatically. For everything else, set it yourself at the start of **every request or operation that makes AI calls**, before those calls run. Reuse the same session ID across messages in the chat. The ID is applied to AI-related spans on the current scope. Call `Scope.remove_conversation_id()` to unset it.
+Some integrations (for example OpenAI) infer a conversation ID automatically. For everything else, set it yourself at the start of **every request or operation that makes AI calls**, before those calls run. Reuse the same session ID across messages in the chat. The ID is applied to AI-related spans on the current scope. Call `Scope.remove_conversation_id()` to unset it. For ID format recommendations and limitations, see [Choosing a Conversation ID](/product/agents/conversations/#choosing-a-conversation-id).
 
 ```python
 import sentry_sdk.ai

--- a/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
@@ -9,6 +9,8 @@ If your AI library does not have automatic instrumentation, create spans manuall
 
 The [@sentry_sdk.trace()](/platforms/python/tracing/instrumentation/custom-instrumentation/#span-templates) decorator can also create these spans via templates.
 
+For conversations and privacy (`set_conversation_id`, `set_user`, `send_default_pii`), see the <PlatformLink to="/agent-tracing/">Agent Tracing hub</PlatformLink>.
+
 ## Span Hierarchy
 
 When instrumenting an agent loop, spans nest like this:
@@ -23,6 +25,19 @@ When instrumenting an agent loop, spans nest like this:
 
 `gen_ai.invoke_agent` is the container. `gen_ai.chat` and `gen_ai.execute_tool` spans are its children (siblings of each other). A `gen_ai.chat` span can also appear without an agent parent for standalone LLM calls.
 
+## Common Attributes
+
+Set these **when the span starts** (before the model or tool call), so head-based sampling can see them:
+
+- `gen_ai.operation.name` — required; classifies the span (`chat`, `invoke_agent`, `execute_tool`, …)
+- `gen_ai.provider.name` — e.g. `openai`, `anthropic`
+- `gen_ai.request.model` — requested model (pass the **raw** provider string)
+- `gen_ai.agent.name` / `gen_ai.tool.name` — when applicable
+
+Complex values (messages, tool definitions, arrays) must be **JSON strings** — span attributes only accept primitives.
+
+Prompt, response, and tool content are treated as PII. They are only captured when `send_default_pii=True` (or per-integration `include_prompts`). See <PlatformLink to="/agent-tracing/#privacy-controls">Privacy Controls</PlatformLink>.
+
 ## AI Request Span
 
 This span represents a request to an LLM model or service that generates a response based on the input prompt.
@@ -32,62 +47,124 @@ import json
 import sentry_sdk
 
 messages = [{"role": "user", "parts": [{"type": "text", "content": "Tell me a joke"}]}]
+tools = [{"name": "get_weather", "description": "Get weather for a city"}]
 
-with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
-    span.set_data("gen_ai.operation.name", "chat")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.provider.name", "openai")
-    span.set_data("gen_ai.input.messages", json.dumps(messages))
-
+with sentry_sdk.start_span(
+    op="gen_ai.chat",
+    name="chat o3-mini",
+    attributes={
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": "o3-mini",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.agent.name": "Weather Agent",  # when this call is under an agent
+        "gen_ai.system_instructions": "You are a helpful assistant.",
+        "gen_ai.tool.definitions": json.dumps(tools),
+        "gen_ai.input.messages": json.dumps(messages),
+    },
+) as span:
     result = client.chat.completions.create(model="o3-mini", messages=messages)
 
     span.set_data("gen_ai.response.model", result.model)
+    span.set_data("gen_ai.response.id", result.id)
     span.set_data("gen_ai.output.messages", json.dumps([
         {"role": "assistant", "parts": [{"type": "text", "content": result.choices[0].message.content}]}
     ]))
     span.set_data("gen_ai.response.finish_reasons", json.dumps([result.choices[0].finish_reason]))
     span.set_data("gen_ai.usage.input_tokens", result.usage.prompt_tokens)
     span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
+    # If the provider reports cached tokens, record them as a subset of input tokens
+    if getattr(result.usage, "prompt_tokens_details", None):
+        span.set_data(
+            "gen_ai.usage.cache_read.input_tokens",
+            result.usage.prompt_tokens_details.cached_tokens,
+        )
 ```
+
+Keep system prompts in `gen_ai.system_instructions`, not inside `gen_ai.input.messages`, so they do not pollute conversation titles.
 
 <Expandable title="AI Request span attributes">
   <Include name="tracing/ai-agents-module/ai-client-span" />
 </Expandable>
 
-### Thinking / reasoning messages
+### Message parts
 
-Models with extended thinking (such as Anthropic's `thinking` blocks, Gemini's `thought`, or DeepSeek's `reasoning_content`) produce internal reasoning that isn't part of the user-visible reply. Represent this content as a `reasoning` part inside the assistant message, alongside the user-facing `text` part. Sentry surfaces reasoning parts separately and filters them out of the user-facing <Link to="/product/agents/conversations/">Conversations</Link> view, so don't fold thinking into a `text` part.
+Messages use `{role, parts}` where each part has a `type`. Common types:
+
+- `text` — user-visible content
+- `reasoning` — internal thinking (not shown in the user-facing Conversations view)
+- `tool_call` / `tool_call_response` — tool invocations linked by a shared `id`
+
+#### Thinking / reasoning
+
+Models with extended thinking (such as Anthropic's `thinking` blocks, Gemini's `thought`, or DeepSeek's `reasoning_content`) produce internal reasoning that isn't part of the user-visible reply. Represent this as a `reasoning` part alongside the user-facing `text` part — don't fold thinking into `text`.
 
 ```python
-import json
-import sentry_sdk
-
-messages = [{"role": "user", "parts": [{"type": "text", "content": "What is 6 * 7?"}]}]
-
-with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
-    span.set_data("gen_ai.operation.name", "chat")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.provider.name", "openai")
-    span.set_data("gen_ai.input.messages", json.dumps(messages))
-
-    result = client.chat.completions.create(model="o3-mini", messages=messages)
-
-    span.set_data("gen_ai.response.model", result.model)
-    span.set_data("gen_ai.output.messages", json.dumps([
-        {
-            "role": "assistant",
-            "parts": [
-                {"type": "reasoning", "content": "6 times 7 is 42."},
-                {"type": "text", "content": "The answer is 42."},
-            ],
-        }
-    ]))
-    span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
-    # If the provider reports reasoning tokens, record them as a subset of output tokens
-    span.set_data("gen_ai.usage.reasoning.output_tokens", result.usage.completion_tokens_details.reasoning_tokens)
+span.set_data("gen_ai.output.messages", json.dumps([
+    {
+        "role": "assistant",
+        "parts": [
+            {"type": "reasoning", "content": "6 times 7 is 42."},
+            {"type": "text", "content": "The answer is 42."},
+        ],
+    }
+]))
+span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
+# Reasoning tokens are a subset of output tokens
+span.set_data(
+    "gen_ai.usage.reasoning.output_tokens",
+    result.usage.completion_tokens_details.reasoning_tokens,
+)
 ```
 
-When previous thinking is fed back into a multi-turn request, include the same `reasoning` parts in the assistant messages within `gen_ai.input.messages`.
+When previous thinking is fed back into a multi-turn request, include the same `reasoning` parts in assistant messages within `gen_ai.input.messages`.
+
+#### Tool calls in messages
+
+Link a tool request to its result with the same `id`:
+
+```python
+# Model asked to call a tool
+span.set_data("gen_ai.output.messages", json.dumps([
+    {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "tool_call",
+                "id": "call_abc",
+                "name": "get_weather",
+                "arguments": {"location": "Paris"},
+            }
+        ],
+    }
+]))
+
+# Later turn: tool result fed back to the model (on input messages)
+input_with_tool = [
+    {"role": "user", "parts": [{"type": "text", "content": "Weather in Paris?"}]},
+    {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "tool_call",
+                "id": "call_abc",
+                "name": "get_weather",
+                "arguments": {"location": "Paris"},
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "parts": [
+            {
+                "type": "tool_call_response",
+                "id": "call_abc",
+                "name": "get_weather",
+                "content": "{\"temp_c\": 18}",
+            }
+        ],
+    },
+]
+```
 
 ## Invoke Agent Span
 
@@ -103,11 +180,22 @@ For a complete guide on naming agents across all supported frameworks, see [Nami
 import json
 import sentry_sdk
 
-with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as span:
-    span.set_data("gen_ai.operation.name", "invoke_agent")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.agent.name", "Weather Agent")
+messages = [{"role": "user", "parts": [{"type": "text", "content": "What's the weather in Paris?"}]}]
+tools = [{"name": "get_weather", "description": "Get weather for a city"}]
 
+with sentry_sdk.start_span(
+    op="gen_ai.invoke_agent",
+    name="invoke_agent Weather Agent",
+    attributes={
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Weather Agent",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.request.model": "o3-mini",
+        "gen_ai.system_instructions": "You are a weather assistant.",
+        "gen_ai.tool.definitions": json.dumps(tools),
+        "gen_ai.input.messages": json.dumps(messages),
+    },
+) as span:
     final_output = my_agent.run()
 
     span.set_data("gen_ai.output.messages", json.dumps([
@@ -116,6 +204,8 @@ with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather 
     span.set_data("gen_ai.usage.input_tokens", final_output.usage.input_tokens)
     span.set_data("gen_ai.usage.output_tokens", final_output.usage.output_tokens)
 ```
+
+Child `gen_ai.chat` spans should also set `gen_ai.agent.name` so model usage can be attributed per agent.
 
 <Expandable title="Invoke Agent span attributes">
   <Include name="tracing/ai-agents-module/invoke-agent-span" />
@@ -129,18 +219,42 @@ This span represents the execution of a tool or function that was requested by a
 import json
 import sentry_sdk
 
-with sentry_sdk.start_span(op="gen_ai.execute_tool", name="execute_tool get_weather") as span:
-    span.set_data("gen_ai.operation.name", "execute_tool")
-    span.set_data("gen_ai.tool.name", "get_weather")
-    span.set_data("gen_ai.tool.call.arguments", json.dumps({"location": "Paris"}))
-
-    result = get_weather(location="Paris")
-
-    span.set_data("gen_ai.tool.call.result", json.dumps(result))
+with sentry_sdk.start_span(
+    op="gen_ai.execute_tool",
+    name="execute_tool get_weather",
+    attributes={
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "get_weather",
+        "gen_ai.tool.description": "Get weather for a city",
+        "gen_ai.tool.call.arguments": json.dumps({"location": "Paris"}),
+    },
+) as span:
+    try:
+        result = get_weather(location="Paris")
+        span.set_data("gen_ai.tool.call.result", json.dumps(result))
+    except Exception as exc:
+        span.set_status("internal_error")
+        span.set_data("error.type", type(exc).__name__)
+        raise
 ```
+
+Marking failed tools with an error status populates the Tool Errors widget.
 
 <Expandable title="Execute Tool span attributes">
   <Include name="tracing/ai-agents-module/execute-tool-span" />
 </Expandable>
 
+## Streaming Responses
+
+When the model streams tokens, keep the span open until the stream finishes (including when you yield chunks to the client). Set response attributes when you have the final usage and text:
+
+- `gen_ai.response.streaming` — `True`
+- `gen_ai.response.time_to_first_chunk` — seconds until the first chunk
+- `gen_ai.response.tokens_per_second` — output throughput, if you can measure it
+- `gen_ai.output.messages`, token usage, and `gen_ai.response.model` — same as a non-streaming call, once the stream completes
+
+How you hold the span open depends on your stack (generator, async iterator, callback). Instrument that path yourself so the span ends on completion or error.
+
 <Include name="tracing/ai-agents-module/token-cost-gotchas" />
+
+Sentry derives [model cost](/product/agents/costs/) from the model name and token counts. You do not need to set `gen_ai.cost.*` attributes. Pass the raw provider model string unchanged so pricing can resolve.

--- a/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
@@ -1,0 +1,146 @@
+---
+title: Manual Instrumentation
+sidebar_title: Manual Instrumentation
+sidebar_order: 10
+description: "Learn how to manually instrument your AI agents to capture spans, token usage, and tool execution."
+---
+
+If your AI library does not have automatic instrumentation, create spans manually. Spans need well-defined names and data attributes so agent data shows up correctly.
+
+The [@sentry_sdk.trace()](/platforms/python/tracing/instrumentation/custom-instrumentation/#span-templates) decorator can also create these spans via templates.
+
+## Span Hierarchy
+
+When instrumenting an agent loop, spans nest like this:
+
+```
+── invoke_agent My Agent          (gen_ai.invoke_agent)
+   ├── chat gpt-4o                (gen_ai.chat)         ← 1st LLM call
+   ├── execute_tool get_weather   (gen_ai.execute_tool)  ← tool run
+   ├── chat gpt-4o                (gen_ai.chat)         ← 2nd LLM call
+   └── ...
+```
+
+`gen_ai.invoke_agent` is the container. `gen_ai.chat` and `gen_ai.execute_tool` spans are its children (siblings of each other). A `gen_ai.chat` span can also appear without an agent parent for standalone LLM calls.
+
+## AI Request Span
+
+This span represents a request to an LLM model or service that generates a response based on the input prompt.
+
+```python
+import json
+import sentry_sdk
+
+messages = [{"role": "user", "parts": [{"type": "text", "content": "Tell me a joke"}]}]
+
+with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
+    span.set_data("gen_ai.operation.name", "chat")
+    span.set_data("gen_ai.request.model", "o3-mini")
+    span.set_data("gen_ai.provider.name", "openai")
+    span.set_data("gen_ai.input.messages", json.dumps(messages))
+
+    result = client.chat.completions.create(model="o3-mini", messages=messages)
+
+    span.set_data("gen_ai.response.model", result.model)
+    span.set_data("gen_ai.output.messages", json.dumps([
+        {"role": "assistant", "parts": [{"type": "text", "content": result.choices[0].message.content}]}
+    ]))
+    span.set_data("gen_ai.response.finish_reasons", json.dumps([result.choices[0].finish_reason]))
+    span.set_data("gen_ai.usage.input_tokens", result.usage.prompt_tokens)
+    span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
+```
+
+<Expandable title="AI Request span attributes">
+  <Include name="tracing/ai-agents-module/ai-client-span" />
+</Expandable>
+
+### Thinking / reasoning messages
+
+Models with extended thinking (such as Anthropic's `thinking` blocks, Gemini's `thought`, or DeepSeek's `reasoning_content`) produce internal reasoning that isn't part of the user-visible reply. Represent this content as a `reasoning` part inside the assistant message, alongside the user-facing `text` part. Sentry surfaces reasoning parts separately and filters them out of the user-facing <Link to="/product/agents/conversations/">Conversations</Link> view, so don't fold thinking into a `text` part.
+
+```python
+import json
+import sentry_sdk
+
+messages = [{"role": "user", "parts": [{"type": "text", "content": "What is 6 * 7?"}]}]
+
+with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
+    span.set_data("gen_ai.operation.name", "chat")
+    span.set_data("gen_ai.request.model", "o3-mini")
+    span.set_data("gen_ai.provider.name", "openai")
+    span.set_data("gen_ai.input.messages", json.dumps(messages))
+
+    result = client.chat.completions.create(model="o3-mini", messages=messages)
+
+    span.set_data("gen_ai.response.model", result.model)
+    span.set_data("gen_ai.output.messages", json.dumps([
+        {
+            "role": "assistant",
+            "parts": [
+                {"type": "reasoning", "content": "6 times 7 is 42."},
+                {"type": "text", "content": "The answer is 42."},
+            ],
+        }
+    ]))
+    span.set_data("gen_ai.usage.output_tokens", result.usage.completion_tokens)
+    # If the provider reports reasoning tokens, record them as a subset of output tokens
+    span.set_data("gen_ai.usage.reasoning.output_tokens", result.usage.completion_tokens_details.reasoning_tokens)
+```
+
+When previous thinking is fed back into a multi-turn request, include the same `reasoning` parts in the assistant messages within `gen_ai.input.messages`.
+
+## Invoke Agent Span
+
+This span represents the execution of an AI agent, capturing the full lifecycle from receiving a task to producing a final response.
+
+<Alert>
+
+For a complete guide on naming agents across all supported frameworks, see [Naming Your Agents](/product/agents/naming/).
+
+</Alert>
+
+```python
+import json
+import sentry_sdk
+
+with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as span:
+    span.set_data("gen_ai.operation.name", "invoke_agent")
+    span.set_data("gen_ai.request.model", "o3-mini")
+    span.set_data("gen_ai.agent.name", "Weather Agent")
+
+    final_output = my_agent.run()
+
+    span.set_data("gen_ai.output.messages", json.dumps([
+        {"role": "assistant", "parts": [{"type": "text", "content": str(final_output)}]}
+    ]))
+    span.set_data("gen_ai.usage.input_tokens", final_output.usage.input_tokens)
+    span.set_data("gen_ai.usage.output_tokens", final_output.usage.output_tokens)
+```
+
+<Expandable title="Invoke Agent span attributes">
+  <Include name="tracing/ai-agents-module/invoke-agent-span" />
+</Expandable>
+
+## Execute Tool Span
+
+This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.
+
+```python
+import json
+import sentry_sdk
+
+with sentry_sdk.start_span(op="gen_ai.execute_tool", name="execute_tool get_weather") as span:
+    span.set_data("gen_ai.operation.name", "execute_tool")
+    span.set_data("gen_ai.tool.name", "get_weather")
+    span.set_data("gen_ai.tool.call.arguments", json.dumps({"location": "Paris"}))
+
+    result = get_weather(location="Paris")
+
+    span.set_data("gen_ai.tool.call.result", json.dumps(result))
+```
+
+<Expandable title="Execute Tool span attributes">
+  <Include name="tracing/ai-agents-module/execute-tool-span" />
+</Expandable>
+
+<Include name="tracing/ai-agents-module/token-cost-gotchas" />

--- a/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
@@ -80,7 +80,7 @@ with sentry_sdk.start_span(
         )
 ```
 
-Keep system prompts in `gen_ai.system_instructions`, not inside `gen_ai.input.messages`, so they do not pollute conversation titles.
+Keep system prompts in `gen_ai.system_instructions`, not inside `gen_ai.input.messages`. [Conversation titles](/product/agents/conversations/#conversation-titles) are derived from the first user message in the input messages.
 
 <Expandable title="AI Request span attributes">
   <Include name="tracing/ai-agents-module/ai-client-span" />
@@ -93,6 +93,8 @@ Messages use `{role, parts}` where each part has a `type`. Common types:
 - `text` — user-visible content
 - `reasoning` — internal thinking (not shown in the user-facing Conversations view)
 - `tool_call` / `tool_call_response` — tool invocations linked by a shared `id`
+
+Unknown part types are not shown prominently in the Conversations UI. They remain available only in the raw span attribute values.
 
 #### Thinking / reasoning
 

--- a/docs/platforms/python/integrations/anthropic/index.mdx
+++ b/docs/platforms/python/integrations/anthropic/index.mdx
@@ -54,7 +54,7 @@ def my_llm_stuff():
 
 After running this script, the resulting data should show up in the `AI Spans` tab on the `Explore > Traces > Trace` page on Sentry.io.
 
-If you manually created an <PlatformLink to="/agent-tracing/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
+If you manually created an <PlatformLink to="/agent-tracing/manual-instrumentation/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
 
 It may take a couple of moments for the data to appear in [sentry.io](https://sentry.io).
 

--- a/docs/platforms/python/integrations/google-genai/index.mdx
+++ b/docs/platforms/python/integrations/google-genai/index.mdx
@@ -67,7 +67,7 @@ def my_llm_stuff():
 
 After running this script, the resulting data should show up in the `"AI Spans"` tab on the `"Explore" > "Traces"` page on Sentry.io.
 
-If you manually created an <PlatformLink to="/agent-tracing/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
+If you manually created an <PlatformLink to="/agent-tracing/manual-instrumentation/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
 
 It may take a couple of moments for the data to appear in [sentry.io](https://sentry.io).
 

--- a/docs/platforms/python/integrations/litellm/index.mdx
+++ b/docs/platforms/python/integrations/litellm/index.mdx
@@ -71,7 +71,7 @@ print(response.choices[0].message.content)
 
 After running this script, the resulting data should show up in the `"AI Spans"` tab on the `"Explore" > "Traces"` page on Sentry.io.
 
-If you manually created an <PlatformLink to="/agent-tracing/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
+If you manually created an <PlatformLink to="/agent-tracing/manual-instrumentation/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
 
 It may take a couple of moments for the data to appear in [sentry.io](https://sentry.io).
 

--- a/docs/platforms/python/integrations/openai/index.mdx
+++ b/docs/platforms/python/integrations/openai/index.mdx
@@ -63,7 +63,7 @@ def my_llm_stuff():
 
 After running this script, the resulting data should show up in the `"AI Spans"` tab on the `"Explore" > "Traces"` page on Sentry.io.
 
-If you manually created an <PlatformLink to="/agent-tracing/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
+If you manually created an <PlatformLink to="/agent-tracing/manual-instrumentation/#invoke-agent-span">Invoke Agent Span</PlatformLink> (not done in the example above) the data will also show up in the [AI Agents Dashboard](/product/agents).
 
 It may take a couple of moments for the data to appear in [sentry.io](https://sentry.io).
 

--- a/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
+++ b/docs/platforms/python/tracing/instrumentation/custom-instrumentation/index.mdx
@@ -225,7 +225,7 @@ gantt
 
 ### Span Templates
 
-In the `@sentry_sdk.trace` decorator you can also specify a `template`. This helps create spans that follow a certain template. Currently this is only available for spans that are created for the [AI Agents instrumentation](/platforms/python/agent-tracing/#spans) of Sentry.
+In the `@sentry_sdk.trace` decorator you can also specify a `template`. This helps create spans that follow a certain template. Currently this is only available for spans that are created for the [AI Agents instrumentation](/platforms/python/agent-tracing/manual-instrumentation/) of Sentry.
 
 Available templates are `AI_AGENT`, `AI_TOOL`, and `AI_CHAT`.
 
@@ -245,7 +245,7 @@ Available templates are `AI_AGENT`, `AI_TOOL`, and `AI_CHAT`.
  root_function()
 ```
 
-This will treat `my_function` as an AI agent and will create the following span tree that is compatible with the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) and the Sentry conventions for [AI Agents instrumentation](/platforms/python/agent-tracing/#spans). Depending on the template, there will also be a couple of attributes set by default, but those are omitted in the graph below for readability reasons:
+This will treat `my_function` as an AI agent and will create the following span tree that is compatible with the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) and the Sentry conventions for [AI Agents instrumentation](/platforms/python/agent-tracing/manual-instrumentation/). Depending on the template, there will also be a couple of attributes set by default, but those are omitted in the graph below for readability reasons:
 
 ```mermaid
 gantt
@@ -260,9 +260,9 @@ gantt
 
 For the span attributes that are set for the different available templates, see the AI Agents instrumentation documentation:
 
-- `SPANTEMPLATE.AI_AGENT` -> [Invoke Agent Span](/platforms/python/agent-tracing/#invoke-agent-span)
-- `SPANTEMPLATE.AI_CHAT` -> [AI Request span](/platforms/python/agent-tracing/#ai-client-span)
-- `SPANTEMPLATE.AI_TOOL` -> [Execute Tool Span](/platforms/python/agent-tracing/#execute-tool-span)
+- `SPANTEMPLATE.AI_AGENT` -> [Invoke Agent Span](/platforms/python/agent-tracing/manual-instrumentation/#invoke-agent-span)
+- `SPANTEMPLATE.AI_CHAT` -> [AI Request span](/platforms/python/agent-tracing/manual-instrumentation/#ai-request-span)
+- `SPANTEMPLATE.AI_TOOL` -> [Execute Tool Span](/platforms/python/agent-tracing/manual-instrumentation/#execute-tool-span)
 
 Currently it is not possible to define custom span templates.
 

--- a/docs/product/agents/costs.mdx
+++ b/docs/product/agents/costs.mdx
@@ -66,6 +66,6 @@ Cost estimates only account for **token-based pricing**. The following are **not
 
 If you're using manual instrumentation and your costs look unexpected (for example, negative costs), the most common cause is incorrectly set token attributes. See the "Token Usage and Cost Gotchas" section on the manual instrumentation page for your platform:
 
-- [Python](/platforms/python/agent-tracing/#token-usage-and-cost-gotchas)
+- [Python](/platforms/python/agent-tracing/manual-instrumentation/#token-usage-and-cost-gotchas)
 - [JavaScript](/platforms/javascript/guides/node/agent-tracing/manual-instrumentation/#token-usage-and-cost-gotchas)
 - [Ruby](/platforms/ruby/tracing/instrumentation/custom-instrumentation/ai-agents-module/#token-usage-and-cost-gotchas)

--- a/docs/product/agents/getting-started.mdx
+++ b/docs/product/agents/getting-started.mdx
@@ -40,6 +40,6 @@ After setting up, [name your agents](/product/agents/naming/) so they appear as 
 
 <Alert title="Don't see your runtime?">
 
-You can also instrument AI agents manually by following our [manual instrumentation guides](/platforms/python/agent-tracing).
+You can also instrument AI agents manually by following our [manual instrumentation guides](/platforms/python/agent-tracing/manual-instrumentation/).
 
 </Alert>

--- a/docs/product/agents/naming.mdx
+++ b/docs/product/agents/naming.mdx
@@ -260,7 +260,7 @@ with sentry_sdk.start_span(
     span.set_data("gen_ai.usage.output_tokens", result.usage.output_tokens)
 ```
 
-See [Python manual instrumentation](/platforms/python/agent-tracing/#invoke-agent-span) for full span attributes.
+See [Python manual instrumentation](/platforms/python/agent-tracing/manual-instrumentation/#invoke-agent-span) for full span attributes.
 
 ### JavaScript
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Python Agent Tracing setup matches the lean Node/Cloudflare hub: bootstrap, stack links, conversations, privacy/streaming options, then a link out for manual work. Manual instrumentation lives on its own page with start-time common attributes, fuller chat/agent/tool recipes (system instructions, tool definitions, response IDs, cache tokens, tool errors), message part types for reasoning and tool calls, streaming guidance without a consume-the-stream sample, and a note that Sentry derives cost from model + usage.

Product and integration links that pointed at the old in-hub span anchors now target the manual page.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)