### PR TITLE
feat(rails): add Active Job section

### DIFF
--- a/docs/platforms/ruby/common/configuration/integration_options.mdx
+++ b/docs/platforms/ruby/common/configuration/integration_options.mdx
@@ -14,15 +14,31 @@ Rails catches exceptions in the `ActionDispatch::ShowExceptions` or `ActionDispa
 You can disable this by setting it to `false`:
 
 ```ruby
-config.rails.report_rescued_exceptions
+config.rails.report_rescued_exceptions = false
 ```
 
 `rails.skippable_job_adapters`
 
-If you don't want to report events from a certain ActiveJob adapter, or you already have a better setup for it, you can use this option to skip ActiveJob reporting on that adapter.
+Use this option to disable Active Job error reporting, tracing, and context propagation for an adapter. Queue-specific integrations for Sidekiq, Delayed Job, and Resque add their adapters automatically to prevent duplicate instrumentation.
 
 ```ruby
 config.rails.skippable_job_adapters = ["ActiveJob::QueueAdapters::MyAdapter"]
+```
+
+`rails.active_job_propagate_traces`
+
+Controls whether Sentry connects Active Job execution to the trace that enqueued it. The default is `true`. Disabling this option still records enqueue spans and job execution transactions, but they won't be connected.
+
+```ruby
+config.rails.active_job_propagate_traces = false
+```
+
+`rails.active_job_report_on_retry_error`
+
+By default, Sentry reports an Active Job failure after all `retry_on` attempts are exhausted. Set this option to `true` to report every failed attempt.
+
+```ruby
+config.rails.active_job_report_on_retry_error = true
 ```
 
 `rails.tracing_subscribers`

--- a/docs/platforms/ruby/common/data-management/data-collected.mdx
+++ b/docs/platforms/ruby/common/data-management/data-collected.mdx
@@ -40,6 +40,12 @@ The request body of incoming HTTP requests is sent to Sentry only if `send_defau
 
 We try to decode JSON and form data bodies in UTF-8 encoding. Raw byte payloads will not be sent to Sentry.
 
+## Active Job Data
+
+The Rails integration stores trace propagation headers in serialized Active Job payloads. You can disable this with `config.rails.active_job_propagate_traces = false`.
+
+When `send_default_pii = true`, the payload also includes the current user's `id`, `email`, and `username`. Failed-job events include serialized job arguments and, on Rails 7 or later, context set with `Rails.error.set_context` when `send_default_pii` is enabled.
+
 ## Source Context
 
 When an unhandled exception is sent to Sentry, a snapshot of the source code surrounding the line where the error originates is sent with it.

--- a/docs/platforms/ruby/common/integrations/index.mdx
+++ b/docs/platforms/ruby/common/integrations/index.mdx
@@ -15,14 +15,14 @@ The following table lists all integrations available as gems.
 
 Simply add the relevant gems to your Gemfile and run `bundle install` to install them.
 
-|                     Integration                                                                                                               | `Gemfile`                    |
-| ---------------------------------------------------------------------------------------------------------------------                         | :--------------:             |
-| <LinkWithPlatformIcon platform="ruby.rails"            label="Rails"          url="/platforms/ruby/guides/rails" />                           | `gem "sentry-rails"`         |
-| <LinkWithPlatformIcon platform="ruby.sidekiq"          label="Sidekiq"        url="/platforms/ruby/guides/sidekiq" />                         | `gem "sentry-sidekiq"`       |
-| <LinkWithPlatformIcon platform="ruby.delayed_job"      label="Delayed Job"    url="/platforms/ruby/guides/delayed_job/" />                    | `gem "sentry-delayed_job"`   |
-| <LinkWithPlatformIcon platform="ruby.resque"           label="Resque"         url="/platforms/ruby/guides/resque" />                          | `gem "sentry-resque"`        |
-| <LinkWithPlatformIcon platform="ruby.opentelemetry"    label="OpenTelemetry"  url="/platforms/ruby/tracing/instrumentation/opentelemetry" />  | `gem "sentry-opentelemetry"` |
-| <LinkWithPlatformIcon platform="ruby"                  label="Yabeda"         url="/platforms/ruby/integrations/yabeda" />                    | `gem "sentry-yabeda"`        |
+| Integration                                                                                                                                  |          `Gemfile`           |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------: |
+| <LinkWithPlatformIcon platform="ruby.rails"            label="Rails"          url="/platforms/ruby/guides/rails" />                          |     `gem "sentry-rails"`     |
+| <LinkWithPlatformIcon platform="ruby.sidekiq"          label="Sidekiq"        url="/platforms/ruby/guides/sidekiq" />                        |    `gem "sentry-sidekiq"`    |
+| <LinkWithPlatformIcon platform="ruby.delayed_job"      label="Delayed Job"    url="/platforms/ruby/guides/delayed_job/" />                   |  `gem "sentry-delayed_job"`  |
+| <LinkWithPlatformIcon platform="ruby.resque"           label="Resque"         url="/platforms/ruby/guides/resque" />                         |    `gem "sentry-resque"`     |
+| <LinkWithPlatformIcon platform="ruby.opentelemetry"    label="OpenTelemetry"  url="/platforms/ruby/tracing/instrumentation/opentelemetry" /> | `gem "sentry-opentelemetry"` |
+| <LinkWithPlatformIcon platform="ruby"                  label="Yabeda"         url="/platforms/ruby/integrations/yabeda" />                   |    `gem "sentry-yabeda"`     |
 
 ## Patches
 
@@ -38,13 +38,13 @@ config.enabled_patches << :faraday
 config.enabled_patches.delete(:puma)
 ```
 
-|                     Patch   | **Auto-enabled** |
-| ----------------------------|:----------------:|
-| `:http`                     |       ✓          |
-| `:redis`                    |       ✓          |
-| `:puma`                     |       ✓          |
-| `:faraday`                  |                  |
-| `:graphql`                  |                  |
+| Patch      | **Auto-enabled** |
+| ---------- | :--------------: |
+| `:http`    |        ✓         |
+| `:redis`   |        ✓         |
+| `:puma`    |        ✓         |
+| `:faraday` |                  |
+| `:graphql` |                  |
 
 ## Features
 
@@ -52,17 +52,17 @@ config.enabled_patches.delete(:puma)
 
 The Rails integration is a feature rich integration that:
 
-* captures Errors anywhere in your Rails application
-* creates Transactions for incoming HTTP Requests
-* records Spans in those Transactions for various important operations like:
-  * database queries (performed with `activerecord`)
-  * view renders
+- captures Errors anywhere in your Rails application
+- creates Transactions for incoming HTTP Requests
+- records Spans in those Transactions for various important operations like:
+  - database queries (performed with `activerecord`)
+  - view renders
 
 ### Queues
 
 The various Queue integrations for Sidekiq, Delayed Job and Resque create distributed traces connecting tasks that are performed in the background asynchronously.
 
-The Rails integration also includes this functionality for `ActiveJob`.
+The Rails integration also traces [Active Job](/platforms/ruby/guides/rails/integrations/active-job/) enqueueing and execution, including Solid Queue jobs.
 
 ### OpenTelemetry
 

--- a/docs/platforms/ruby/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/ruby/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -7,9 +7,10 @@ supported:
 description: "Learn what instrumentation automatically captures transactions."
 ---
 
-Many integrations for popular frameworks automatically capture transactions. If you use have any of the following frameworks set up for Sentry error reporting and use the relevant Sentry gem, you will start to see traces immediately:
+Many integrations for popular frameworks automatically capture transactions. If you have any of the following frameworks set up for Sentry error reporting and use the relevant Sentry gem, you'll start to see traces immediately:
 
 - Ruby on Rails (`sentry-rails`)
+- Active Job (`sentry-rails`)
 - Sidekiq (`sentry-sidekiq`)
 - Delayed Job (`sentry-delayed_job`)
 - Resque (`sentry-resque`)
@@ -20,7 +21,10 @@ Spans are instrumented for the following operations within a transaction:
   - includes common database systems such as Postgres and MySQL
 - Outgoing HTTP requests made with `Net::HTTP`
 - Redis operations
+- Active Job enqueueing (`queue.publish`)
+
+Active Job execution creates a `queue.process` transaction and continues the trace from the enqueue operation. Learn more in the [Active Job integration guide](/platforms/ruby/guides/rails/integrations/active-job/).
 
 The SDK also captures **queue time** as transaction data (not a child span) when a `X-Request-Start` header is present from your reverse proxy (Nginx, HAProxy, or Heroku). See <PlatformLink to="/tracing/instrumentation/performance-metrics/#automatic-queue-time-capture">Automatic Queue Time Capture</PlatformLink> for setup instructions.
 
-Spans are only created within an existing transaction. If you're not using any of the supported frameworks, you'll need to <PlatformLink to="/tracing/instrumentation/custom-instrumentation/">create transactions manually</PlatformLink>.
+Child spans are only created within an existing transaction. If you're not using any of the supported frameworks, you'll need to <PlatformLink to="/tracing/instrumentation/custom-instrumentation/">create transactions manually</PlatformLink>.

--- a/docs/platforms/ruby/guides/rails/integrations/active-job.mdx
+++ b/docs/platforms/ruby/guides/rails/integrations/active-job.mdx
@@ -1,0 +1,125 @@
+---
+title: Active Job
+description: "Learn how Sentry traces Active Job enqueueing and execution and reports job failures."
+sidebar_order: 10
+---
+
+The Rails integration instruments Active Job automatically, so you can follow work from enqueueing through execution and connect job failures to the rest of a trace. Install `sentry-rails` and <PlatformLink to="/tracing/">enable tracing</PlatformLink>.
+
+## Trace Jobs
+
+When `perform_later` runs inside an active transaction, Sentry creates a `queue.publish` child span. The SDK adds trace headers to the serialized job payload and continues the trace with a `queue.process` transaction when the job runs.
+
+The execution transaction is named after the job class and includes the queue adapter, queue name, job ID, retry count, and queue latency. Spans created while the job runs, such as database or HTTP spans, become children of this transaction.
+
+If no span is active when the job is enqueued, Sentry doesn't create a `queue.publish` span. When the job runs, Sentry still instruments it with a `queue.process` transaction, subject to your tracing sampling configuration.
+
+### Control Trace Propagation
+
+Trace propagation is enabled by default. To keep the enqueue and execution telemetry but start a separate trace for the job, disable it:
+
+```ruby {filename:config/initializers/sentry.rb}
+Sentry.init do |config|
+  config.rails.active_job_propagate_traces = false
+end
+```
+
+When `send_default_pii` is enabled, Sentry also propagates the current user's `id`, `email`, and `username` to the job execution.
+
+## Report Job Failures
+
+If a job raises an exception that Active Job doesn't handle, Sentry reports the failure and links it to the `queue.process` transaction. Retry and exception handlers can make a failure handled, which changes whether and when Sentry reports it.
+
+These examples use Solid Queue through Active Job:
+
+```ruby {filename:config/application.rb}
+config.active_job.queue_adapter = :solid_queue
+```
+
+### Report Failures After Retries Are Exhausted
+
+By default, Sentry follows Active Job's retry handling. When `retry_on` catches an exception and schedules another attempt, Sentry doesn't report that attempt because Active Job handled it.
+
+<Alert level="warning" title="Only the Final Failure Is Reported by Default">
+
+With `retry_on`, Sentry reports an error only if every attempt fails and the final exception escapes the job. If a later attempt succeeds, Sentry reports no error event.
+
+</Alert>
+
+This job allows up to three total attempts:
+
+```ruby {filename:app/jobs/process_order_job.rb}
+class ProcessOrderJob < ApplicationJob
+  queue_as :default
+  retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
+
+  def perform(order_id)
+    OrderProcessor.call(order_id)
+  end
+end
+```
+
+With the default Sentry behavior:
+
+- If the job succeeds on any attempt, Sentry reports no error event.
+- If all three attempts fail, Sentry reports one error event for the final unhandled failure.
+
+### Report Every Failed Attempt
+
+To investigate intermittent failures even when a retry succeeds, enable `active_job_report_on_retry_error`:
+
+```ruby {filename:config/initializers/sentry.rb}
+Sentry.init do |config|
+  config.rails.active_job_report_on_retry_error = true
+end
+```
+
+<Alert level="warning" title="Every Failed Attempt Is Reported When Enabled">
+
+Sentry reports each failed attempt, even if a later attempt succeeds. Jobs with multiple failed attempts can therefore create multiple error events.
+
+</Alert>
+
+This job allows up to five total attempts:
+
+```ruby {filename:app/jobs/sync_inventory_job.rb}
+class SyncInventoryJob < ApplicationJob
+  queue_as :low_priority
+  retry_on Net::ReadTimeout, wait: 30.seconds, attempts: 5
+
+  def perform(product_id)
+    InventorySync.call(product_id)
+  end
+end
+```
+
+With per-attempt reporting enabled:
+
+- If the first attempt succeeds, Sentry reports no error event.
+- If two attempts fail and the third succeeds, Sentry reports two error events.
+- If all five attempts fail, Sentry reports five error events.
+
+### Discarded and Rescued Failures
+
+Exceptions suppressed by `discard_on` or `rescue_from` are handled by Active Job, so Sentry doesn't report them automatically. If a `rescue_from` handler raises another exception, Sentry reports the new unhandled exception along with the original exception chain.
+
+## Supported Queue Adapters
+
+The Ruby SDK runs its Active Job integration test suite against these adapters:
+
+- Delayed Job (`:delayed_job`)
+- Resque (`:resque`)
+- Sidekiq (`:sidekiq`)
+- Solid Queue (`:solid_queue`)
+
+Other Active Job adapters may work, but aren't officially supported.
+
+<Alert level="info" title="Queue-Specific Integrations Take Precedence">
+
+If you install `sentry-sidekiq`, `sentry-delayed_job`, or `sentry-resque`, the queue-specific integration takes over. Sentry skips the generic Active Job instrumentation for that adapter to avoid duplicate events.
+
+</Alert>
+
+You can also skip a custom adapter with <PlatformLink to="/configuration/integration_options/">`rails.skippable_job_adapters`</PlatformLink>.
+
+For scheduled jobs, see <PlatformLink to="/crons/">Cron Monitoring</PlatformLink>. To capture Active Job logs, see <PlatformLink to="/logs/">Logs</PlatformLink>.

--- a/platform-includes/crons/setup/ruby.mdx
+++ b/platform-includes/crons/setup/ruby.mdx
@@ -12,9 +12,9 @@ Sentry.init do |config|
 end
 ```
 
-More generally, popular job frameworks such as `ActiveJob` and `Sidekiq` with
-a `perform` method can use the `Sentry::Cron::MonitorCheckIns` mixin module
-to automatically capture check-ins.
+More generally, popular job frameworks such as [Active Job](/platforms/ruby/guides/rails/integrations/active-job/)
+and `Sidekiq` with a `perform` method can use the
+`Sentry::Cron::MonitorCheckIns` mixin module to automatically capture check-ins.
 
 ```rb {tabTitle: ActiveJob} {mdExpandTabs}
 class ExampleJob < ApplicationJob

--- a/platform-includes/logs/default-attributes/ruby.rails.mdx
+++ b/platform-includes/logs/default-attributes/ruby.rails.mdx
@@ -15,6 +15,7 @@ The Rails SDK automatically sets several default attributes on all log entries t
 When using structured logging with Log Subscribers, additional Rails-specific attributes are automatically included:
 
 #### ActiveRecord Logs
+
 - `sql` - The SQL query executed
 - `duration_ms` - Query execution time in milliseconds
 - `cached` - Whether the query result was cached
@@ -27,6 +28,7 @@ When using structured logging with Log Subscribers, additional Rails-specific at
 - `server_socket_address` - Database socket path (when available)
 
 #### ActionController Logs
+
 - `controller` - Controller class name
 - `action` - Action method name
 - `duration_ms` - Request processing time in milliseconds
@@ -38,9 +40,12 @@ When using structured logging with Log Subscribers, additional Rails-specific at
 - `db_runtime_ms` - Database query time in milliseconds (when available)
 - `params` - Filtered request parameters (only when `send_default_pii` is enabled)
 
-#### ActiveJob Logs (when enabled)
+#### Active Job Logs (when enabled)
 
-**Common attributes for all ActiveJob events:**
+For error and trace instrumentation, see the <PlatformLink to="/integrations/active-job/">Active Job integration</PlatformLink>.
+
+**Common attributes for all Active Job events:**
+
 - `job_class` - Job class name
 - `job_id` - Unique job identifier
 - `queue_name` - Queue name where job is processed
@@ -48,6 +53,7 @@ When using structured logging with Log Subscribers, additional Rails-specific at
 - `priority` - Job priority
 
 **For `perform` events:**
+
 - `duration_ms` - Job execution time in milliseconds
 - `adapter` - Queue adapter class name
 - `scheduled_at` - When job was scheduled in ISO8601 format (for delayed jobs)
@@ -55,17 +61,20 @@ When using structured logging with Log Subscribers, additional Rails-specific at
 - `arguments` - Job arguments (only when `send_default_pii` is enabled, filtered for sensitive data)
 
 **For `enqueue` events:**
+
 - `adapter` - Queue adapter class name (when available)
 - `scheduled_at` - When job was scheduled in ISO8601 format (for delayed jobs)
 - `delay_seconds` - Delay between current time and scheduled time in seconds (for delayed jobs)
 
 **For `retry_stopped` and `discard` events:**
+
 - `error_class` - Error class name (when error is present)
 - `error_message` - Error message (when error is present)
 
 #### ActionMailer Logs (when enabled)
 
 **For `deliver` events:**
+
 - `mailer` - Mailer class name
 - `duration_ms` - Email delivery time in milliseconds
 - `perform_deliveries` - Whether deliveries are enabled
@@ -74,6 +83,7 @@ When using structured logging with Log Subscribers, additional Rails-specific at
 - `message_id` - Email message ID (only when `send_default_pii` is enabled)
 
 **For `process` events:**
+
 - `mailer` - Mailer class name
 - `action` - Mailer action method name
 - `duration_ms` - Email processing time in milliseconds


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Adds `Active Job` sub-section under `Integrations` in Rails docs. The high-light of this feature is that we now officially support Solid Queue, and run consolidated Active Job spec suite against a bunch of adapters as part of CI.

There's no dedicated Solid Queue section though, since there's nothing SQ-specific in our integration that we could show, but maybe we want it anyway? I added some code examples that do use `:solid_queue` adapter, FWIW.

The retry logic is one of the tricky bits, hence the alert callouts explaining different behaviors.

## Considerations

- I thought about making it a top-level section too - it's a big feature after all, so maybe having it "buried" under "Configuration / Integrations" is not a good idea?

## Preview

This is the new section added under Rails/Integrations. I wanted to add the `NEW` badge but seems like you can't do it when a sub-section is not expanded by default:

https://sentry-docs-git-feat-ruby-activejob-doc-updates.sentry.dev/platforms/ruby/guides/rails/integrations/active-job/

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
