### PR TITLE
docs(unreal): Drop experimental labeling from automatic performance metrics

### DIFF
--- a/docs/platforms/unreal/metrics/index.mdx
+++ b/docs/platforms/unreal/metrics/index.mdx
@@ -23,11 +23,7 @@ With Sentry's [Application Metrics](/product/metrics/), you can send counters, g
 
 ## Automatic Metrics
 
-<Alert level="warning">
-  Automatic metrics are experimental and may change in future releases.
-</Alert>
-
-The SDK can automatically collect performance metrics from the engine without any manual instrumentation. All automatic metrics are configured under **Project Settings > Plugins > Sentry > Metrics > Experimental** and require **Enable Metrics** to be checked.
+The SDK can automatically collect performance metrics from the engine without any manual instrumentation. All automatic metrics are configured under **Project Settings > Plugins > Sentry > Metrics > Performance** and require **Enable Metrics** to be checked.
 
 All automatic metrics include the following attributes for filtering and grouping in Sentry dashboards:
 


### PR DESCRIPTION
Automatic performance metrics in the Unreal SDK have been stable for a while, so this removes the experimental labeling from the docs:

- Removes the "Automatic metrics are experimental and may change in future releases" warning.
- Updates the settings path from **Metrics > Experimental** to **Metrics > Performance** to match the plugin.

### Related Items

- getsentry/sentry-unreal#1515