### PR TITLE
docs(native): Fix documented APIs that don't exist

### DIFF
--- a/docs/platforms/native/common/configuration/filtering.mdx
+++ b/docs/platforms/native/common/configuration/filtering.mdx
@@ -24,7 +24,7 @@ Note also that breadcrumbs can be filtered, as discussed in [our Breadcrumbs doc
 
 ## Filtering Transaction Events
 
-To prevent certain transactions from being reported to Sentry, use the <PlatformIdentifier name="traces-sampler" /> or <PlatformIdentifier name="before-send-transaction" /> configuration option, which allows you to provide a function to evaluate the current transaction and drop it if it's not one you want.
+To prevent certain transactions from being reported to Sentry, use the <PlatformIdentifier name="traces-sampler" /> or <PlatformIdentifier name="before-transaction" /> configuration option, which allows you to provide a function to evaluate the current transaction and drop it if it's not one you want.
 
 ### Using <PlatformIdentifier name="traces-sampler" />
 
@@ -43,9 +43,9 @@ If the transaction currently being processed has a parent transaction (from an u
 
 Learn more about <PlatformLink to="/configuration/sampling/">configuring the sample rate</PlatformLink>.
 
-### Using <PlatformIdentifier name="before-send-transaction" />
+### Using <PlatformIdentifier name="before-transaction" />
 <Alert>
-When discarding a transaction in a `before_send_transaction` callback, one must call `sentry_value_decref(tx)` and return a `sentry_value_new_null()`.
+When discarding a transaction in a `before_transaction` callback, one must call `sentry_value_decref(tx)` and return a `sentry_value_new_null()`.
 </Alert>
 
 <PlatformContent includePath="configuration/before-send-transaction" />

--- a/platform-includes/set-fingerprint/basic/native.mdx
+++ b/platform-includes/set-fingerprint/basic/native.mdx
@@ -5,7 +5,7 @@ You can set a fingerprint to be added to **all future events and errors**:
 sentry_set_fingerprint("myFingerPrint", NULL); // overwrites existing fingerprints
 my_fingerprinted_function(); // events are grouped on "myFingerPrint"
 
-sentry_clear_fingerprint(); // clears all fingerprints
+sentry_remove_fingerprint(); // clears all fingerprints
 ```
 
 For specific, manually captured events, fingerprints can be added to the `fingerprint` key of the event. This will be prioritized over the globally set fingerprint:


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Two snippets referenced C APIs the Native SDK has never shipped:

- `sentry_clear_fingerprint()` appears in no tagged release. The real API is `sentry_remove_fingerprint()`, available since 0.2.0, so the corrected snippet compiles on every supported version.
- The filtering page called the transaction hook `before_send_transaction`, which does not exist in `sentry.h`. The option is `before_transaction`, which the page's own code sample and the options reference already used.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
