### PR TITLE
docs(self-hosted): Document overriding LAUNCHPAD_RPC_SHARED_SECRET

### DIFF
--- a/develop-docs/self-hosted/configuration/index.mdx
+++ b/develop-docs/self-hosted/configuration/index.mdx
@@ -35,6 +35,14 @@ You can find more about configuring Sentry at [the configuration section of our 
 
 Sentry comes with a cleanup cron job that prunes events older than `90 days` by default. If you want to change that, you can edit the `SENTRY_EVENT_RETENTION_DAYS` environment variable in `.env` or simply override it in your environment.
 
+### Internal RPC Shared Secret
+
+The `taskbroker` and `launchpad` services authenticate internal RPC calls to each other using the `LAUNCHPAD_RPC_SHARED_SECRET` environment variable. This ships with a hardcoded default in `.env` that's fine for local testing but too weak for production.
+
+<Alert title="Warning" level="warning">
+  Override <code>LAUNCHPAD_RPC_SHARED_SECRET</code> in your <code>.env.custom</code> file with a strong, randomly generated value to secure internal communication between the <code>taskbroker</code> and <code>launchpad</code> services.
+</Alert>
+
 ### Installing a specific SHA
 
 If you want to install a specific release of Sentry, use the tags/releases on the self-hosted repository.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents that self-hosted operators should override the `LAUNCHPAD_RPC_SHARED_SECRET` environment variable, which ships with a weak hardcoded default in `.env`. This secret authenticates internal RPC calls between the `taskbroker` and `launchpad` services.

Previously this was only ever called out in release notes — never in our configuration docs. This adds a dedicated section to the self-hosted configuration page telling operators to override it in `.env.custom` with a strong value for production.

- Add `### Internal RPC Shared Secret` section to `develop-docs/self-hosted/configuration/index.mdx`, placed alongside the existing Event Retention env-var guidance

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
