### PR TITLE
docs(cocoa): Add sentry-apple-binaries repo and v10 pre-compiled warning

### DIFF
--- a/docs/platforms/apple/common/install/swift-package-manager.mdx
+++ b/docs/platforms/apple/common/install/swift-package-manager.mdx
@@ -46,6 +46,10 @@ Then depend on the `SentrySPM` product:
 
 ### Pre-Compiled
 
+<Alert level="warning">
+  Starting with SDK version 10, the `sentry-cocoa` repository will no longer include pre-built binary products. Use the [sentry-apple-binaries](https://github.com/getsentry/sentry-apple-binaries) repository instead for pre-compiled frameworks via SPM.
+</Alert>
+
 These products use pre-built binary frameworks. They don't add to your project's compile time, but they do not support compile-time configuration such as package traits, and you cannot step through SDK code while debugging.
 
 - **`Sentry`** — Static pre-built framework. Provides the fastest app start time among the pre-compiled options.
@@ -65,6 +69,21 @@ When your project uses a `Package.swift` file, add the dependency and select the
     name: "MyApp",
     dependencies: [
         .product(name: "Sentry", package: "sentry-cocoa"),
+    ]
+)
+```
+
+Alternatively, you can use the [sentry-apple-binaries](https://github.com/getsentry/sentry-apple-binaries) repository, a dedicated SPM package that only contains pre-built binary frameworks. This avoids downloading the SDK source code and provides `Sentry-Static` and `SentryObjC-Static`:
+
+```swift {tabTitle:Swift}
+.package(url: "https://github.com/getsentry/sentry-apple-binaries", from: "{{@inject packages.version('sentry.cocoa') }}"),
+```
+
+```swift {tabTitle:Swift}
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "Sentry-Static", package: "sentry-apple-binaries"),
     ]
 )
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the [sentry-apple-binaries](https://github.com/getsentry/sentry-apple-binaries) SPM package as an alternative for pre-built binary frameworks in the Apple SPM installation docs.

- Add `sentry-apple-binaries` repo with `Package.swift` snippets for `Sentry-Static` and `SentryObjC-Static`
- Add warning that `sentry-cocoa` will no longer include pre-built binary products starting with SDK v10

Related: https://github.com/getsentry/sentry-cocoa/pull/8662

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)