### PR TITLE
docs(js): Enrich Agent Tracing manual instrumentation

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
@@ -113,6 +113,7 @@ await Sentry.startSpan(
         result.usage.cachedInputTokens
       );
     }
+    return result;
   }
 );
 ```
@@ -265,6 +266,7 @@ await Sentry.startSpan(
     );
     span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
     span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+    return result;
   }
 );
 ```
@@ -295,6 +297,7 @@ await Sentry.startSpan(
     try {
       const result = await getWeather({ location: "Paris" });
       span.setAttribute("gen_ai.tool.call.result", JSON.stringify(result));
+      return result;
     } catch (error) {
       span.setStatus({ code: 2, message: "internal_error" });
       span.setAttribute(

--- a/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
@@ -30,6 +30,8 @@ supported:
 
 If your AI library does not have automatic instrumentation, create spans manually. Spans need well-defined names and data attributes so agent data shows up correctly.
 
+For conversations and privacy (`setConversationId`, `setUser`, `dataCollection`), see the <PlatformLink to="/agent-tracing/">Agent Tracing hub</PlatformLink>.
+
 ## Span Hierarchy
 
 When instrumenting an agent loop, spans nest like this:
@@ -44,27 +46,29 @@ When instrumenting an agent loop, spans nest like this:
 
 `gen_ai.invoke_agent` is the container. `gen_ai.chat` and `gen_ai.execute_tool` spans are its children (siblings of each other). A `gen_ai.chat` span can also appear without an agent parent for standalone LLM calls.
 
+## Common Attributes
+
+Set these **when the span starts** (before the model or tool call), so head-based sampling can see them:
+
+- `gen_ai.operation.name` — required; classifies the span (`chat`, `invoke_agent`, `execute_tool`, …)
+- `gen_ai.provider.name` — e.g. `openai`, `anthropic`
+- `gen_ai.request.model` — requested model (pass the **raw** provider string)
+- `gen_ai.agent.name` / `gen_ai.tool.name` — when applicable
+
+Complex values (messages, tool definitions, arrays) must be **JSON strings** — span attributes only accept primitives.
+
+For manual spans, prompt/response/tool content is whatever you set on the span. Omit those attributes (or gate them yourself) when you do not want content captured. `dataCollection.genAI` and per-integration `recordInputs` / `recordOutputs` apply to automatic instrumentation — see <PlatformLink to="/agent-tracing/#privacy-controls">Privacy Controls</PlatformLink>.
+
 ## AI Request Span
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
 This span represents a request to an LLM model or service that generates a response based on the input prompt.
-
-**Key attributes:**
-- `gen_ai.operation.name` — Required. Set to `"chat"` for chat completions
-- `gen_ai.request.model` — The model name (required)
-- `gen_ai.input.messages` — The prompts sent to the LLM
-- `gen_ai.output.messages` — The model's response
-- `gen_ai.usage.input_tokens` / `output_tokens` — Token counts
-
-</SplitSectionText>
-<SplitSectionCode>
 
 ```javascript
 const messages = [
   { role: "user", parts: [{ type: "text", content: "Tell me a joke" }] },
+];
+const tools = [
+  { name: "get_weather", description: "Get weather for a city" },
 ];
 
 await Sentry.startSpan(
@@ -75,49 +79,145 @@ await Sentry.startSpan(
       "gen_ai.operation.name": "chat",
       "gen_ai.request.model": "o3-mini",
       "gen_ai.provider.name": "openai",
+      "gen_ai.agent.name": "Weather Agent", // when this call is under an agent
+      "gen_ai.system_instructions": "You are a helpful assistant.",
+      "gen_ai.tool.definitions": JSON.stringify(tools),
       "gen_ai.input.messages": JSON.stringify(messages),
     },
   },
   async (span) => {
-    const result = await client.chat.completions.create({
-      model: "o3-mini",
-      messages,
-    });
+    // Call your model provider; map its response into span attributes below
+    const result = await yourLLMClient.chat({ model: "o3-mini", messages });
 
     span.setAttribute("gen_ai.response.model", result.model);
+    span.setAttribute("gen_ai.response.id", result.id);
     span.setAttribute(
       "gen_ai.output.messages",
       JSON.stringify([
         {
           role: "assistant",
-          parts: [
-            { type: "text", content: result.choices[0].message.content },
-          ],
+          parts: [{ type: "text", content: result.text }],
         },
       ])
     );
     span.setAttribute(
       "gen_ai.response.finish_reasons",
-      JSON.stringify([result.choices[0].finish_reason])
+      JSON.stringify([result.finishReason])
     );
-    span.setAttribute("gen_ai.usage.input_tokens", result.usage.prompt_tokens);
-    span.setAttribute(
-      "gen_ai.usage.output_tokens",
-      result.usage.completion_tokens
-    );
+    span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
+    span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+    // If the provider reports cached tokens, record them as a subset of input tokens
+    if (result.usage.cachedInputTokens != null) {
+      span.setAttribute(
+        "gen_ai.usage.cache_read.input_tokens",
+        result.usage.cachedInputTokens
+      );
+    }
   }
 );
 ```
 
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
+Keep system prompts in `gen_ai.system_instructions`, not inside `gen_ai.input.messages`. [Conversation titles](/product/agents/conversations/#conversation-titles) are derived from the first user message in the input messages.
 
 <Expandable title="AI Request span attributes">
   <Include name="tracing/ai-agents-module/ai-client-span" />
 </Expandable>
 
+### Message parts
+
+Messages use `{role, parts}` where each part has a `type`. Common types:
+
+- `text` — user-visible content
+- `reasoning` — internal thinking (not shown in the user-facing Conversations view)
+- `tool_call` / `tool_call_response` — tool invocations linked by a shared `id`
+
+Unknown part types are not shown prominently in the Conversations UI. They remain available only in the raw span attribute values.
+
+#### Thinking / reasoning
+
+Models with extended thinking (such as Anthropic's `thinking` blocks, Gemini's `thought`, or DeepSeek's `reasoning_content`) produce internal reasoning that isn't part of the user-visible reply. Represent this as a `reasoning` part alongside the user-facing `text` part — don't fold thinking into `text`.
+
+```javascript
+span.setAttribute(
+  "gen_ai.output.messages",
+  JSON.stringify([
+    {
+      role: "assistant",
+      parts: [
+        { type: "reasoning", content: "6 times 7 is 42." },
+        { type: "text", content: "The answer is 42." },
+      ],
+    },
+  ])
+);
+span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+// Reasoning tokens are a subset of output tokens
+span.setAttribute(
+  "gen_ai.usage.reasoning.output_tokens",
+  result.usage.reasoningTokens
+);
+```
+
+When previous thinking is fed back into a multi-turn request, include the same `reasoning` parts in assistant messages within `gen_ai.input.messages`.
+
+#### Tool calls in messages
+
+Link a tool request to its result with the same `id`:
+
+```javascript
+// Model asked to call a tool
+span.setAttribute(
+  "gen_ai.output.messages",
+  JSON.stringify([
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "tool_call",
+          id: "call_abc",
+          name: "get_weather",
+          arguments: { location: "Paris" },
+        },
+      ],
+    },
+  ])
+);
+
+// Later chat span: tool result fed back to the model
+const inputWithTool = [
+  {
+    role: "user",
+    parts: [{ type: "text", content: "Weather in Paris?" }],
+  },
+  {
+    role: "assistant",
+    parts: [
+      {
+        type: "tool_call",
+        id: "call_abc",
+        name: "get_weather",
+        arguments: { location: "Paris" },
+      },
+    ],
+  },
+  {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: "call_abc",
+        name: "get_weather",
+        content: '{"temp_c": 18}',
+      },
+    ],
+  },
+];
+span.setAttribute("gen_ai.input.messages", JSON.stringify(inputWithTool));
+```
+
 ## Invoke Agent Span
+
+This span represents the execution of an AI agent, capturing the full lifecycle from receiving a task to producing a final response.
 
 <Alert>
 
@@ -125,34 +225,33 @@ For a complete guide on naming agents across all supported frameworks, see [Nami
 
 </Alert>
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
-This span represents the execution of an AI agent, capturing the full lifecycle from receiving a task to producing a final response.
-
-**Key attributes:**
-- `gen_ai.operation.name` — Required. Set to `"invoke_agent"`
-- `gen_ai.agent.name` — The agent's name (e.g., "Weather Agent")
-- `gen_ai.request.model` — The underlying model used
-- `gen_ai.output.messages` — The agent's final output
-- `gen_ai.usage.input_tokens` / `output_tokens` — Total token counts
-
-</SplitSectionText>
-<SplitSectionCode>
-
 ```javascript
+const messages = [
+  {
+    role: "user",
+    parts: [{ type: "text", content: "What's the weather in Paris?" }],
+  },
+];
+const tools = [
+  { name: "get_weather", description: "Get weather for a city" },
+];
+
 await Sentry.startSpan(
   {
     op: "gen_ai.invoke_agent",
     name: "invoke_agent Weather Agent",
     attributes: {
       "gen_ai.operation.name": "invoke_agent",
-      "gen_ai.request.model": "o3-mini",
       "gen_ai.agent.name": "Weather Agent",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "o3-mini",
+      "gen_ai.system_instructions": "You are a weather assistant.",
+      "gen_ai.tool.definitions": JSON.stringify(tools),
+      "gen_ai.input.messages": JSON.stringify(messages),
     },
   },
   async (span) => {
+    // myAgent is your agent runner; expect { output, usage: { inputTokens, outputTokens } }
     const result = await myAgent.run();
 
     span.setAttribute(
@@ -160,7 +259,7 @@ await Sentry.startSpan(
       JSON.stringify([
         {
           role: "assistant",
-          parts: [{ type: "text", content: result.output }],
+          parts: [{ type: "text", content: String(result.output) }],
         },
       ])
     );
@@ -170,9 +269,7 @@ await Sentry.startSpan(
 );
 ```
 
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
+Child `gen_ai.chat` spans should also set `gen_ai.agent.name` so model usage can be attributed per agent.
 
 <Expandable title="Invoke Agent span attributes">
   <Include name="tracing/ai-agents-module/invoke-agent-span" />
@@ -180,20 +277,7 @@ await Sentry.startSpan(
 
 ## Execute Tool Span
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
 This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.
-
-**Key attributes:**
-- `gen_ai.operation.name` — Required. Set to `"execute_tool"`
-- `gen_ai.tool.name` — The tool's name (e.g., "get_weather")
-- `gen_ai.tool.call.arguments` — The arguments passed to the tool
-- `gen_ai.tool.call.result` — The tool's return value
-
-</SplitSectionText>
-<SplitSectionCode>
 
 ```javascript
 await Sentry.startSpan(
@@ -203,20 +287,27 @@ await Sentry.startSpan(
     attributes: {
       "gen_ai.operation.name": "execute_tool",
       "gen_ai.tool.name": "get_weather",
+      "gen_ai.tool.description": "Get weather for a city",
       "gen_ai.tool.call.arguments": JSON.stringify({ location: "Paris" }),
     },
   },
   async (span) => {
-    const result = await getWeather({ location: "Paris" });
-
-    span.setAttribute("gen_ai.tool.call.result", JSON.stringify(result));
+    try {
+      const result = await getWeather({ location: "Paris" });
+      span.setAttribute("gen_ai.tool.call.result", JSON.stringify(result));
+    } catch (error) {
+      span.setStatus({ code: 2, message: "internal_error" });
+      span.setAttribute(
+        "error.type",
+        error instanceof Error ? error.constructor.name : "Error"
+      );
+      throw error;
+    }
   }
 );
 ```
 
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
+Marking failed tools with an error status populates the Tool Errors widget.
 
 <Expandable title="Execute Tool span attributes">
   <Include name="tracing/ai-agents-module/execute-tool-span" />
@@ -224,7 +315,14 @@ await Sentry.startSpan(
 
 ## Streaming Responses
 
-When the LLM returns a stream, the span must outlive the initial callback. Use `Sentry.startInactiveSpan` to create the span, then end it when the stream finishes:
+When the model streams tokens, keep the span open until the stream finishes (including when you yield chunks to the client). Set response attributes when you have the final usage and text:
+
+- `gen_ai.response.streaming` — `true`
+- `gen_ai.response.time_to_first_chunk` — seconds until the first chunk
+- `gen_ai.response.tokens_per_second` — output throughput, if you can measure it
+- `gen_ai.output.messages`, token usage, and `gen_ai.response.model` — same as a non-streaming call, once the stream completes
+
+Use `Sentry.startInactiveSpan` so the span outlives the initial call, and `Sentry.withActiveSpan` so child spans nest correctly. End the span when the stream completes or errors:
 
 ```javascript
 async function callLLMStreaming(model, messages) {
@@ -253,10 +351,10 @@ async function callLLMStreaming(model, messages) {
           },
         ])
       );
-      span.setAttribute("gen_ai.usage.input_tokens", finalMessage.usage.input);
+      span.setAttribute("gen_ai.usage.input_tokens", finalMessage.usage.inputTokens);
       span.setAttribute(
         "gen_ai.usage.output_tokens",
-        finalMessage.usage.output
+        finalMessage.usage.outputTokens
       );
       span.setAttribute("gen_ai.response.model", finalMessage.model);
       span.setAttribute("gen_ai.response.streaming", true);
@@ -272,6 +370,6 @@ async function callLLMStreaming(model, messages) {
 }
 ```
 
-`startInactiveSpan` creates a span without automatically ending it. `Sentry.withActiveSpan` propagates context so any child spans nest correctly. Call `span.end()` when the stream completes or errors.
-
 <Include name="tracing/ai-agents-module/token-cost-gotchas" />
+
+Sentry derives [model cost](/product/agents/costs/) from the model name and token counts. You do not need to set `gen_ai.cost.*` attributes. Pass the raw provider model string unchanged so pricing can resolve.

--- a/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
@@ -379,9 +379,21 @@ async function callLLMStreaming(model, messages) {
       span.end();
     });
 
-    stream.on("error", () => span.end());
+    stream.on("error", (error) => {
+      span.setStatus({ code: 2, message: "internal_error" });
+      span.setAttribute(
+        "error.type",
+        error instanceof Error ? error.constructor.name : "Error"
+      );
+      span.end();
+    });
     return stream;
   } catch (error) {
+    span.setStatus({ code: 2, message: "internal_error" });
+    span.setAttribute(
+      "error.type",
+      error instanceof Error ? error.constructor.name : "Error"
+    );
     span.end();
     throw error;
   }

--- a/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
@@ -57,7 +57,7 @@ Set these **when the span starts** (before the model or tool call), so head-base
 
 Complex values (messages, tool definitions, arrays) must be **JSON strings** — span attributes only accept primitives.
 
-For manual spans, prompt/response/tool content is whatever you set on the span. Omit those attributes (or gate them yourself) when you do not want content captured. `dataCollection.genAI` and per-integration `recordInputs` / `recordOutputs` apply to automatic instrumentation — see <PlatformLink to="/agent-tracing/#privacy-controls">Privacy Controls</PlatformLink>.
+For manual spans, prompt, response, and tool content is whatever you set on the span. Omit those attributes, or gate them yourself, when you do not want to capture content.
 
 ## AI Request Span
 
@@ -67,9 +67,7 @@ This span represents a request to an LLM model or service that generates a respo
 const messages = [
   { role: "user", parts: [{ type: "text", content: "Tell me a joke" }] },
 ];
-const tools = [
-  { name: "get_weather", description: "Get weather for a city" },
-];
+const tools = [{ name: "get_weather", description: "Get weather for a city" }];
 
 await Sentry.startSpan(
   {
@@ -89,23 +87,19 @@ await Sentry.startSpan(
     // Call your model provider; map its response into span attributes below
     const result = await yourLLMClient.chat({ model: "o3-mini", messages });
 
-    span.setAttribute("gen_ai.response.model", result.model);
-    span.setAttribute("gen_ai.response.id", result.id);
-    span.setAttribute(
-      "gen_ai.output.messages",
-      JSON.stringify([
+    span.setAttributes({
+      "gen_ai.response.model": result.model,
+      "gen_ai.response.id": result.id,
+      "gen_ai.output.messages": JSON.stringify([
         {
           role: "assistant",
           parts: [{ type: "text", content: result.text }],
         },
-      ])
-    );
-    span.setAttribute(
-      "gen_ai.response.finish_reasons",
-      JSON.stringify([result.finishReason])
-    );
-    span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
-    span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+      ]),
+      "gen_ai.response.finish_reasons": JSON.stringify([result.finishReason]),
+      "gen_ai.usage.input_tokens": result.usage.inputTokens,
+      "gen_ai.usage.output_tokens": result.usage.outputTokens,
+    });
     // If the provider reports cached tokens, record them as a subset of input tokens
     if (result.usage.cachedInputTokens != null) {
       span.setAttribute(
@@ -220,12 +214,6 @@ span.setAttribute("gen_ai.input.messages", JSON.stringify(inputWithTool));
 
 This span represents the execution of an AI agent, capturing the full lifecycle from receiving a task to producing a final response.
 
-<Alert>
-
-For a complete guide on naming agents across all supported frameworks, see [Naming Your Agents](/product/agents/naming/).
-
-</Alert>
-
 ```javascript
 const messages = [
   {
@@ -233,9 +221,7 @@ const messages = [
     parts: [{ type: "text", content: "What's the weather in Paris?" }],
   },
 ];
-const tools = [
-  { name: "get_weather", description: "Get weather for a city" },
-];
+const tools = [{ name: "get_weather", description: "Get weather for a city" }];
 
 await Sentry.startSpan(
   {

--- a/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
@@ -344,22 +344,37 @@ async function callLLMStreaming(model, messages) {
       yourLLMClient.stream({ model, messages })
     );
 
-    stream.on("end", (finalMessage) => {
+    // Accumulate from chunk events — stream "end" has no payload
+    let text = "";
+    let usage = { inputTokens: 0, outputTokens: 0 };
+    let responseModel = model;
+
+    stream.on("data", (chunk) => {
+      // Map chunk fields to your provider's shape
+      if (chunk.text) {
+        text += chunk.text;
+      }
+      if (chunk.usage) {
+        usage = chunk.usage;
+      }
+      if (chunk.model) {
+        responseModel = chunk.model;
+      }
+    });
+
+    stream.on("end", () => {
       span.setAttribute(
         "gen_ai.output.messages",
         JSON.stringify([
           {
             role: "assistant",
-            parts: [{ type: "text", content: finalMessage.text }],
+            parts: [{ type: "text", content: text }],
           },
         ])
       );
-      span.setAttribute("gen_ai.usage.input_tokens", finalMessage.usage.inputTokens);
-      span.setAttribute(
-        "gen_ai.usage.output_tokens",
-        finalMessage.usage.outputTokens
-      );
-      span.setAttribute("gen_ai.response.model", finalMessage.model);
+      span.setAttribute("gen_ai.usage.input_tokens", usage.inputTokens);
+      span.setAttribute("gen_ai.usage.output_tokens", usage.outputTokens);
+      span.setAttribute("gen_ai.response.model", responseModel);
       span.setAttribute("gen_ai.response.streaming", true);
       span.end();
     });

--- a/includes/agent-tracing/manual-instrumentation.mdx
+++ b/includes/agent-tracing/manual-instrumentation.mdx
@@ -372,22 +372,37 @@ async function callLLMStreaming(model, messages) {
       yourLLMClient.stream({ model, messages })
     );
 
-    stream.on("end", (finalMessage) => {
+    // Accumulate from chunk events — stream "end" has no payload
+    let text = "";
+    let usage = { inputTokens: 0, outputTokens: 0 };
+    let responseModel = model;
+
+    stream.on("data", (chunk) => {
+      // Map chunk fields to your provider's shape
+      if (chunk.text) {
+        text += chunk.text;
+      }
+      if (chunk.usage) {
+        usage = chunk.usage;
+      }
+      if (chunk.model) {
+        responseModel = chunk.model;
+      }
+    });
+
+    stream.on("end", () => {
       span.setAttribute(
         "gen_ai.output.messages",
         JSON.stringify([
           {
             role: "assistant",
-            parts: [{ type: "text", content: finalMessage.text }],
+            parts: [{ type: "text", content: text }],
           },
         ])
       );
-      span.setAttribute("gen_ai.usage.input_tokens", finalMessage.usage.inputTokens);
-      span.setAttribute(
-        "gen_ai.usage.output_tokens",
-        finalMessage.usage.outputTokens
-      );
-      span.setAttribute("gen_ai.response.model", finalMessage.model);
+      span.setAttribute("gen_ai.usage.input_tokens", usage.inputTokens);
+      span.setAttribute("gen_ai.usage.output_tokens", usage.outputTokens);
+      span.setAttribute("gen_ai.response.model", responseModel);
       span.setAttribute("gen_ai.response.streaming", true);
       span.end();
     });

--- a/includes/agent-tracing/manual-instrumentation.mdx
+++ b/includes/agent-tracing/manual-instrumentation.mdx
@@ -58,238 +58,347 @@ const response = await client.chat.completions.create({
 
 ## Manual Span Creation
 
-If you're using a library that Sentry doesn't provide helpers for, you can manually create spans. For your data to show up in the [AI Agents Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/?filter=onlyPrebuilt&query=agents&sort=mostPopular), spans must have well-defined names and data attributes.
+If you're using a library that Sentry doesn't provide helpers for, create spans manually. Spans need well-defined names and data attributes so agent data shows up correctly in the [AI Agents Dashboards](https://sentry.io/orgredirect/organizations/:orgslug/dashboards/?filter=onlyPrebuilt&query=agents&sort=mostPopular).
+
+### Span Hierarchy
+
+When instrumenting an agent loop, spans nest like this:
+
+```
+── invoke_agent My Agent          (gen_ai.invoke_agent)
+   ├── chat gpt-4o                (gen_ai.chat)         ← 1st LLM call
+   ├── execute_tool get_weather   (gen_ai.execute_tool)  ← tool run
+   ├── chat gpt-4o                (gen_ai.chat)         ← 2nd LLM call
+   └── ...
+```
+
+`gen_ai.invoke_agent` is the container. `gen_ai.chat` and `gen_ai.execute_tool` spans are its children (siblings of each other). A `gen_ai.chat` span can also appear without an agent parent for standalone LLM calls.
+
+### Common Attributes
+
+Set these **when the span starts** (before the model or tool call), so head-based sampling can see them:
+
+- `gen_ai.operation.name` — required; classifies the span (`chat`, `invoke_agent`, `execute_tool`, …)
+- `gen_ai.provider.name` — e.g. `openai`, `anthropic`
+- `gen_ai.request.model` — requested model (pass the **raw** provider string)
+- `gen_ai.agent.name` / `gen_ai.tool.name` — when applicable
+
+Complex values (messages, tool definitions, arrays) must be **JSON strings** — span attributes only accept primitives.
+
+For manual spans, prompt/response/tool content is whatever you set on the span. Omit those attributes (or gate them yourself) when you do not want content captured. Integration helpers honor `recordInputs` / `recordOutputs` (and related defaults).
+
+### AI Request Span
+
+This span represents a request to an LLM model or service that generates a response based on the input prompt.
+
+```javascript
+const messages = [
+  { role: "user", parts: [{ type: "text", content: "Tell me a joke" }] },
+];
+const tools = [
+  { name: "get_weather", description: "Get weather for a city" },
+];
+
+await Sentry.startSpan(
+  {
+    op: "gen_ai.chat",
+    name: "chat o3-mini",
+    attributes: {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.request.model": "o3-mini",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.agent.name": "Weather Agent", // when this call is under an agent
+      "gen_ai.system_instructions": "You are a helpful assistant.",
+      "gen_ai.tool.definitions": JSON.stringify(tools),
+      "gen_ai.input.messages": JSON.stringify(messages),
+    },
+  },
+  async (span) => {
+    // Call your model provider; map its response into span attributes below
+    const result = await yourLLMClient.chat({ model: "o3-mini", messages });
+
+    span.setAttribute("gen_ai.response.model", result.model);
+    span.setAttribute("gen_ai.response.id", result.id);
+    span.setAttribute(
+      "gen_ai.output.messages",
+      JSON.stringify([
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: result.text }],
+        },
+      ])
+    );
+    span.setAttribute(
+      "gen_ai.response.finish_reasons",
+      JSON.stringify([result.finishReason])
+    );
+    span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
+    span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+    // If the provider reports cached tokens, record them as a subset of input tokens
+    if (result.usage.cachedInputTokens != null) {
+      span.setAttribute(
+        "gen_ai.usage.cache_read.input_tokens",
+        result.usage.cachedInputTokens
+      );
+    }
+  }
+);
+```
+
+Keep system prompts in `gen_ai.system_instructions`, not inside `gen_ai.input.messages`. [Conversation titles](/product/agents/conversations/#conversation-titles) are derived from the first user message in the input messages.
+
+<Expandable title="AI Request span attributes">
+  <Include name="tracing/ai-agents-module/ai-client-span" />
+</Expandable>
+
+#### Message parts
+
+Messages use `{role, parts}` where each part has a `type`. Common types:
+
+- `text` — user-visible content
+- `reasoning` — internal thinking (not shown in the user-facing Conversations view)
+- `tool_call` / `tool_call_response` — tool invocations linked by a shared `id`
+
+Unknown part types are not shown prominently in the Conversations UI. They remain available only in the raw span attribute values.
+
+##### Thinking / reasoning
+
+Models with extended thinking (such as Anthropic's `thinking` blocks, Gemini's `thought`, or DeepSeek's `reasoning_content`) produce internal reasoning that isn't part of the user-visible reply. Represent this as a `reasoning` part alongside the user-facing `text` part — don't fold thinking into `text`.
+
+```javascript
+span.setAttribute(
+  "gen_ai.output.messages",
+  JSON.stringify([
+    {
+      role: "assistant",
+      parts: [
+        { type: "reasoning", content: "6 times 7 is 42." },
+        { type: "text", content: "The answer is 42." },
+      ],
+    },
+  ])
+);
+span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+// Reasoning tokens are a subset of output tokens
+span.setAttribute(
+  "gen_ai.usage.reasoning.output_tokens",
+  result.usage.reasoningTokens
+);
+```
+
+When previous thinking is fed back into a multi-turn request, include the same `reasoning` parts in assistant messages within `gen_ai.input.messages`.
+
+##### Tool calls in messages
+
+Link a tool request to its result with the same `id`:
+
+```javascript
+// Model asked to call a tool
+span.setAttribute(
+  "gen_ai.output.messages",
+  JSON.stringify([
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "tool_call",
+          id: "call_abc",
+          name: "get_weather",
+          arguments: { location: "Paris" },
+        },
+      ],
+    },
+  ])
+);
+
+// Later chat span: tool result fed back to the model
+const inputWithTool = [
+  {
+    role: "user",
+    parts: [{ type: "text", content: "Weather in Paris?" }],
+  },
+  {
+    role: "assistant",
+    parts: [
+      {
+        type: "tool_call",
+        id: "call_abc",
+        name: "get_weather",
+        arguments: { location: "Paris" },
+      },
+    ],
+  },
+  {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: "call_abc",
+        name: "get_weather",
+        content: '{"temp_c": 18}',
+      },
+    ],
+  },
+];
+span.setAttribute("gen_ai.input.messages", JSON.stringify(inputWithTool));
+```
 
 ### Invoke Agent Span
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
 This span represents the execution of an AI agent, capturing the full lifecycle from receiving a task to producing a final response.
 
-**Key attributes:**
-- `gen_ai.agent.name` — The agent's name (e.g., "Weather Agent")
-- `gen_ai.request.model` — The underlying model used
-- `gen_ai.output.messages` — The agent's final output
-- `gen_ai.usage.input_tokens` / `output_tokens` — Total token counts
+<Alert>
 
-</SplitSectionText>
-<SplitSectionCode>
+For a complete guide on naming agents across all supported frameworks, see [Naming Your Agents](/product/agents/naming/).
+
+</Alert>
 
 ```javascript
-// Example agent implementation for demonstration
-const myAgent = {
-  name: "Weather Agent",
-  modelProvider: "openai",
-  model: "gpt-4o-mini",
-  async run() {
-    // Agent implementation
-    return {
-      output: "The weather in Paris is sunny",
-      usage: {
-        inputTokens: 15,
-        outputTokens: 8,
-      },
-    };
+const messages = [
+  {
+    role: "user",
+    parts: [{ type: "text", content: "What's the weather in Paris?" }],
   },
-};
+];
+const tools = [
+  { name: "get_weather", description: "Get weather for a city" },
+];
 
-Sentry.startSpan(
+await Sentry.startSpan(
   {
     op: "gen_ai.invoke_agent",
-    name: `invoke_agent ${myAgent.name}`,
+    name: "invoke_agent Weather Agent",
     attributes: {
       "gen_ai.operation.name": "invoke_agent",
-      "gen_ai.request.model": myAgent.model,
-      "gen_ai.agent.name": myAgent.name,
+      "gen_ai.agent.name": "Weather Agent",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "o3-mini",
+      "gen_ai.system_instructions": "You are a weather assistant.",
+      "gen_ai.tool.definitions": JSON.stringify(tools),
+      "gen_ai.input.messages": JSON.stringify(messages),
     },
   },
   async (span) => {
-    // run the agent
+    // myAgent is your agent runner; expect { output, usage: { inputTokens, outputTokens } }
     const result = await myAgent.run();
 
-    // set agent response
-    span.setAttribute("gen_ai.output.messages", JSON.stringify([
-      { role: "assistant", parts: [{ type: "text", content: result.output }] },
-    ]));
-
-    // set token usage
+    span.setAttribute(
+      "gen_ai.output.messages",
+      JSON.stringify([
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: String(result.output) }],
+        },
+      ])
+    );
     span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
     span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
-
-    return result;
   }
 );
 ```
 
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
+Child `gen_ai.chat` spans should also set `gen_ai.agent.name` so model usage can be attributed per agent.
 
-<Expandable title="All Invoke Agent span attributes">
+<Expandable title="Invoke Agent span attributes">
   <Include name="tracing/ai-agents-module/invoke-agent-span" />
-</Expandable>
-
-### AI Client Span
-
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
-This span represents a chat or completion request to an LLM, capturing the messages, model configuration, and response.
-
-**Key attributes:**
-- `gen_ai.request.model` — The model name (required)
-- `gen_ai.input.messages` — Chat messages sent to the LLM
-- `gen_ai.request.max_tokens` — Token limit for the response
-- `gen_ai.output.messages` — The model's response
-
-</SplitSectionText>
-<SplitSectionCode>
-
-```javascript
-// Example AI implementation for demonstration
-const myAi = {
-  modelProvider: "openai",
-  model: "gpt-4o-mini",
-  modelConfig: {
-    temperature: 0.1,
-    presencePenalty: 0.5,
-  },
-  async createMessage(messages, maxTokens) {
-    // AI implementation
-    return {
-      output: "Here's a joke: Why don't scientists trust atoms? Because they make up everything!",
-      usage: {
-        inputTokens: 12,
-        outputTokens: 24,
-      },
-    };
-  },
-};
-
-Sentry.startSpan(
-  {
-    op: "gen_ai.chat",
-    name: `chat ${myAi.model}`,
-    attributes: {
-      "gen_ai.operation.name": "chat",
-      "gen_ai.request.model": myAi.model,
-    },
-  },
-  async (span) => {
-    // set up messages for LLM
-    const maxTokens = 1024;
-    const messages = [{ role: "user", parts: [{ type: "text", content: "Tell me a joke" }] }];
-
-    // set chat request data
-    span.setAttribute("gen_ai.input.messages", JSON.stringify(messages));
-    span.setAttribute("gen_ai.request.max_tokens", maxTokens);
-    span.setAttribute("gen_ai.request.temperature", myAi.modelConfig.temperature);
-
-    // ask the LLM
-    const result = await myAi.createMessage(messages, maxTokens);
-
-    // set response
-    span.setAttribute("gen_ai.output.messages", JSON.stringify([
-      { role: "assistant", parts: [{ type: "text", content: result.output }] },
-    ]));
-
-    // set token usage
-    span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
-    span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
-
-    return result;
-  }
-);
-```
-
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
-
-<Expandable title="All AI Client span attributes">
-  <Include name="tracing/ai-agents-module/ai-client-span" />
 </Expandable>
 
 ### Execute Tool Span
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
-
 This span represents the execution of a tool or function that was requested by an AI model, including the input arguments and resulting output.
 
-**Key attributes:**
-- `gen_ai.tool.name` — The tool's name (e.g., "random_number")
-- `gen_ai.tool.description` — Description of what the tool does
-- `gen_ai.tool.call.arguments` — The arguments passed to the tool
-- `gen_ai.tool.call.result` — The tool's return value
+```javascript
+await Sentry.startSpan(
+  {
+    op: "gen_ai.execute_tool",
+    name: "execute_tool get_weather",
+    attributes: {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "get_weather",
+      "gen_ai.tool.description": "Get weather for a city",
+      "gen_ai.tool.call.arguments": JSON.stringify({ location: "Paris" }),
+    },
+  },
+  async (span) => {
+    try {
+      const result = await getWeather({ location: "Paris" });
+      span.setAttribute("gen_ai.tool.call.result", JSON.stringify(result));
+    } catch (error) {
+      span.setStatus({ code: 2, message: "internal_error" });
+      span.setAttribute(
+        "error.type",
+        error instanceof Error ? error.constructor.name : "Error"
+      );
+      throw error;
+    }
+  }
+);
+```
 
-</SplitSectionText>
-<SplitSectionCode>
+Marking failed tools with an error status populates the Tool Errors widget.
+
+<Expandable title="Execute Tool span attributes">
+  <Include name="tracing/ai-agents-module/execute-tool-span" />
+</Expandable>
+
+### Streaming Responses
+
+When the model streams tokens, keep the span open until the stream finishes (including when you yield chunks to the client). Set response attributes when you have the final usage and text:
+
+- `gen_ai.response.streaming` — `true`
+- `gen_ai.response.time_to_first_chunk` — seconds until the first chunk
+- `gen_ai.response.tokens_per_second` — output throughput, if you can measure it
+- `gen_ai.output.messages`, token usage, and `gen_ai.response.model` — same as a non-streaming call, once the stream completes
+
+Use `Sentry.startInactiveSpan` so the span outlives the initial call, and `Sentry.withActiveSpan` so child spans nest correctly. End the span when the stream completes or errors:
 
 ```javascript
-// Example AI implementation for demonstration
-const myAi = {
-  modelProvider: "openai",
-  model: "gpt-4o-mini",
-  async createMessage(messages, maxTokens) {
-    // AI implementation that returns tool calls
-    return {
-      toolCalls: [
-        {
-          name: "random_number",
-          description: "Generate a random number",
-          arguments: { max: 10 },
-        },
-      ],
-    };
-  },
-};
-
-const messages = [{ role: "user", content: "Generate a random number between 0 and 10" }];
-
-// First, make the AI call
-const result = await Sentry.startSpan(
-  { op: "gen_ai.chat", name: `chat ${myAi.model}` },
-  () => myAi.createMessage(messages, 1024)
-);
-
-// Check if we should call a tool
-if (result.toolCalls && result.toolCalls.length > 0) {
-  const tool = result.toolCalls[0];
-
-  await Sentry.startSpan(
-    {
-      op: "gen_ai.execute_tool",
-      name: `execute_tool ${tool.name}`,
-      attributes: {
-        "gen_ai.operation.name": "execute_tool",
-        "gen_ai.tool.type": "function",
-        "gen_ai.tool.name": tool.name,
-        "gen_ai.tool.description": tool.description,
-        "gen_ai.tool.call.arguments": JSON.stringify(tool.arguments),
-      },
+async function callLLMStreaming(model, messages) {
+  const span = Sentry.startInactiveSpan({
+    name: `chat ${model}`,
+    op: "gen_ai.chat",
+    attributes: {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.request.model": model,
+      "gen_ai.input.messages": JSON.stringify(messages),
     },
-    async (span) => {
-      // run tool (example implementation)
-      const toolResult = Math.floor(Math.random() * tool.arguments.max);
+  });
 
-      // set tool result
-      span.setAttribute("gen_ai.tool.call.result", String(toolResult));
+  try {
+    const stream = await Sentry.withActiveSpan(span, () =>
+      yourLLMClient.stream({ model, messages })
+    );
 
-      return toolResult;
-    }
-  );
+    stream.on("end", (finalMessage) => {
+      span.setAttribute(
+        "gen_ai.output.messages",
+        JSON.stringify([
+          {
+            role: "assistant",
+            parts: [{ type: "text", content: finalMessage.text }],
+          },
+        ])
+      );
+      span.setAttribute("gen_ai.usage.input_tokens", finalMessage.usage.inputTokens);
+      span.setAttribute(
+        "gen_ai.usage.output_tokens",
+        finalMessage.usage.outputTokens
+      );
+      span.setAttribute("gen_ai.response.model", finalMessage.model);
+      span.setAttribute("gen_ai.response.streaming", true);
+      span.end();
+    });
+
+    stream.on("error", () => span.end());
+    return stream;
+  } catch (error) {
+    span.end();
+    throw error;
+  }
 }
 ```
 
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
 
-<Expandable title="All Execute Tool span attributes">
-  <Include name="tracing/ai-agents-module/execute-tool-span" />
-</Expandable>
+<Include name="tracing/ai-agents-module/token-cost-gotchas" />
+
+Sentry derives [model cost](/product/agents/costs/) from the model name and token counts. You do not need to set `gen_ai.cost.*` attributes. Pass the raw provider model string unchanged so pricing can resolve.

--- a/includes/agent-tracing/manual-instrumentation.mdx
+++ b/includes/agent-tracing/manual-instrumentation.mdx
@@ -407,9 +407,21 @@ async function callLLMStreaming(model, messages) {
       span.end();
     });
 
-    stream.on("error", () => span.end());
+    stream.on("error", (error) => {
+      span.setStatus({ code: 2, message: "internal_error" });
+      span.setAttribute(
+        "error.type",
+        error instanceof Error ? error.constructor.name : "Error"
+      );
+      span.end();
+    });
     return stream;
   } catch (error) {
+    span.setStatus({ code: 2, message: "internal_error" });
+    span.setAttribute(
+      "error.type",
+      error instanceof Error ? error.constructor.name : "Error"
+    );
     span.end();
     throw error;
   }

--- a/includes/agent-tracing/manual-instrumentation.mdx
+++ b/includes/agent-tracing/manual-instrumentation.mdx
@@ -141,6 +141,7 @@ await Sentry.startSpan(
         result.usage.cachedInputTokens
       );
     }
+    return result;
   }
 );
 ```
@@ -293,6 +294,7 @@ await Sentry.startSpan(
     );
     span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
     span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+    return result;
   }
 );
 ```
@@ -323,6 +325,7 @@ await Sentry.startSpan(
     try {
       const result = await getWeather({ location: "Paris" });
       span.setAttribute("gen_ai.tool.call.result", JSON.stringify(result));
+      return result;
     } catch (error) {
       span.setStatus({ code: 2, message: "internal_error" });
       span.setAttribute(


### PR DESCRIPTION
## DESCRIBE YOUR PR

JavaScript Agent Tracing manual instrumentation matches the richer Python guide: start-time common attributes, fuller chat/agent/tool recipes (system instructions, tool definitions, response IDs, cache/reasoning tokens, tool errors), message part types for reasoning and tool calls, a streaming span lifecycle example (`startInactiveSpan` / `withActiveSpan`), and a note that Sentry derives cost from model + usage.

The shared include used by browser and React Native gets the same manual span recipes (integration helpers stay as-is). Examples stay provider-agnostic and use the single `{role, parts}` message shape for span attributes.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)