### PR TITLE
feat(apple): add enableUIViewControllerInitSwizzling option

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -1139,14 +1139,6 @@ This feature is currently experimental and disabled by default. Learn more in th
 
 </SdkOption>
 
-<SdkOption name="enableUIViewControllerInitSwizzling" type="bool" defaultValue="false" availableSince="9.26.0">
-
-When enabled, the SDK swizzles each `UIViewController` subclass the first time an instance of it is created, instead of scanning your app's binary images for `UIViewController` subclasses at startup. This fixes crashes that can occur during the startup scan.
-
-This feature is currently experimental and disabled by default.
-
-</SdkOption>
-
 ## App Hang Options
 
 <SdkOption name="enableAppHangTracking" type="bool" defaultValue="true">
@@ -1308,6 +1300,12 @@ Learn more in the <PlatformLink to="/session-replay/configuration/#network-detai
 When enabled, the SDK sends app start data as a standalone `app.start` transaction instead of attaching it as spans to the first UIViewController transaction. This makes app starts easier to find, sample, and analyze independently.
 
 Learn more in the <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#standalone-app-start-tracing">Standalone App Start Tracing</PlatformLink> documentation.
+
+</SdkOption>
+
+<SdkOption name="experimental.enableUIViewControllerInitSwizzling" type="bool" defaultValue="false" availableSince="9.26.0">
+
+When enabled, the SDK swizzles each `UIViewController` subclass the first time an instance of it is created, instead of scanning your app's binary images for `UIViewController` subclasses at startup. This fixes crashes that can occur during the startup scan.
 
 </SdkOption>
 

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -1139,11 +1139,11 @@ This feature is currently experimental and disabled by default. Learn more in th
 
 </SdkOption>
 
-<SdkOption name="experimental.enableUIViewControllerInitSwizzling" type="bool" defaultValue="false" availableSince="9.26.0">
+<SdkOption name="enableUIViewControllerInitSwizzling" type="bool" defaultValue="false" availableSince="9.26.0">
 
 When enabled, the SDK swizzles each `UIViewController` subclass the first time an instance of it is created, instead of scanning your app's binary images for `UIViewController` subclasses at startup. This fixes crashes that can occur during the startup scan.
 
-This feature is currently experimental and disabled by default. Learn more in the <PlatformLink to="/configuration/swizzling/">Swizzling</PlatformLink> documentation.
+This feature is currently experimental and disabled by default.
 
 </SdkOption>
 

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -1141,7 +1141,7 @@ This feature is currently experimental and disabled by default. Learn more in th
 
 <SdkOption name="experimental.enableUIViewControllerInitSwizzling" type="bool" defaultValue="false" availableSince="9.26.0">
 
-When enabled, the SDK swizzles each `UIViewController` subclass the first time an instance of it is created, instead of scanning your app's binary images for `UIViewController` subclasses at startup. This can avoid crashes that may occur during the startup scan.
+When enabled, the SDK swizzles each `UIViewController` subclass the first time an instance of it is created, instead of scanning your app's binary images for `UIViewController` subclasses at startup. This fixes crashes that can occur during the startup scan.
 
 This feature is currently experimental and disabled by default. Learn more in the <PlatformLink to="/configuration/swizzling/">Swizzling</PlatformLink> documentation.
 

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -1139,6 +1139,14 @@ This feature is currently experimental and disabled by default. Learn more in th
 
 </SdkOption>
 
+<SdkOption name="experimental.enableUIViewControllerInitSwizzling" type="bool" defaultValue="false" availableSince="9.26.0">
+
+When enabled, the SDK swizzles each `UIViewController` subclass the first time an instance of it is created, instead of scanning your app's binary images for `UIViewController` subclasses at startup. This can avoid crashes that may occur during the startup scan.
+
+This feature is currently experimental and disabled by default. Learn more in the <PlatformLink to="/configuration/swizzling/">Swizzling</PlatformLink> documentation.
+
+</SdkOption>
+
 ## App Hang Options
 
 <SdkOption name="enableAppHangTracking" type="bool" defaultValue="true">

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -105,6 +105,26 @@ SentrySDK.start { options in
 }];
 ```
 
+As of Sentry Cocoa SDK version `9.26.0`, there's also an experimental option you can enable that may avoid this crash without needing to exclude specific classes:
+
+```swift
+SentrySDK.start { options in
+    options.experimental.enableUIViewControllerInitSwizzling = true
+}
+```
+
+```objc {tabTitle:Objective-C}
+[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+     options.experimental.enableUIViewControllerInitSwizzling = YES;
+}];
+```
+
+```objc {tabTitle:Objective-C (SentryObjC)}
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+     options.experimental.enableUIViewControllerInitSwizzling = YES;
+}];
+```
+
 If you can't upgrade the Sentry Cocoa SDK to version `8.23.0`, you can also disable swizzling, as shown below.
 However, this would also disable some useful features, such as automatic tracing and network breadcrumbs.
 

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -119,6 +119,8 @@ SentrySDK.start { options in
 }];
 ```
 
+If enabling this option doesn't fix the crash for you, please add a comment to [this GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/8684).
+
 If you can't upgrade the Sentry Cocoa SDK to version `8.23.0`, you can also disable swizzling, as shown below.
 However, this would also disable some useful features, such as automatic tracing and network breadcrumbs.
 

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -119,6 +119,12 @@ SentrySDK.start { options in
 }];
 ```
 
+```objc {tabTitle:Objective-C (SentryObjC)}
+[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+     options.experimental.enableUIViewControllerInitSwizzling = YES;
+}];
+```
+
 If enabling this option doesn't fix the crash for you, please add a comment to [this GitHub issue](https://github.com/getsentry/sentry-cocoa/issues/8684).
 
 If you can't upgrade the Sentry Cocoa SDK to version `8.23.0`, you can also disable swizzling, as shown below.

--- a/docs/platforms/apple/common/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/troubleshooting/index.mdx
@@ -105,7 +105,7 @@ SentrySDK.start { options in
 }];
 ```
 
-As of Sentry Cocoa SDK version `9.26.0`, there's also an experimental option you can enable that may avoid this crash without needing to exclude specific classes:
+As of Sentry Cocoa SDK version `9.26.0`, there's also an experimental option you can enable that should fix this crash without needing to exclude specific classes:
 
 ```swift
 SentrySDK.start { options in
@@ -115,12 +115,6 @@ SentrySDK.start { options in
 
 ```objc {tabTitle:Objective-C}
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-     options.experimental.enableUIViewControllerInitSwizzling = YES;
-}];
-```
-
-```objc {tabTitle:Objective-C (SentryObjC)}
-[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
      options.experimental.enableUIViewControllerInitSwizzling = YES;
 }];
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

⚠️ **Do not merge until sentry-cocoa 9.26.0 (or whichever version ships [getsentry/sentry-cocoa#8687](https://github.com/getsentry/sentry-cocoa/pull/8687)) is released.** 

Documents the new experimental `enableUIViewControllerInitSwizzling` option being introduced in sentry-cocoa#8687. This option swizzles each `UIViewController` subclass on first init instead of scanning binary images at startup, which can avoid the `SentrySubClassFinder actOnSubclassesOfViewControllerInImage` crash.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] sentry-cocoa 9.26.0 (or the release containing #8687) has shipped
- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)