### PR TITLE
docs(js): Deduplicate Cloudflare agent tracing library list

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -83,20 +83,14 @@ Pick your AI stack. Some libraries auto-instrument; others need a short setup �
 
 <PlatformSection supported={["javascript.cloudflare"]}>
 
-On Cloudflare, setup differs by library—open the guide for your stack:
+On Cloudflare, how much setup you need depends on the library. Enabling tracing alone is not enough for most of them.
 
-- **Workers AI** — works automatically once Sentry wraps your worker.
-- **Vercel AI** — turn the integration on in your Sentry options, then enable telemetry on each AI call (details on that page).
-- **OpenAI, Anthropic, Google GenAI, LangChain, LangGraph** — not auto-instrumented here. Each guide shows how to wrap your client so AI spans show up. Tracing alone is not enough.
-
-- <PlatformLink to="/features/workers-ai/">Workers AI</PlatformLink>
-- <PlatformLink to="/features/agents-sdk/">Agents SDK</PlatformLink>
-- <PlatformLink to="/configuration/integrations/vercelai/">Vercel AI</PlatformLink>
-- <PlatformLink to="/configuration/integrations/openai/">OpenAI</PlatformLink>
-- <PlatformLink to="/configuration/integrations/anthropic/">Anthropic</PlatformLink>
-- <PlatformLink to="/configuration/integrations/google-genai/">Google Gen AI</PlatformLink>
-- <PlatformLink to="/configuration/integrations/langchain/">LangChain</PlatformLink>
-- <PlatformLink to="/configuration/integrations/langgraph/">LangGraph</PlatformLink>
+- <PlatformLink to="/features/workers-ai/">Workers AI</PlatformLink> — works as soon as Sentry wraps your worker. Nothing else to do.
+- <PlatformLink to="/configuration/integrations/vercelai/">Vercel AI</PlatformLink> — add the integration to your Sentry options, then enable telemetry on each AI call.
+- <PlatformLink to="/features/agents-sdk/">Agents SDK</PlatformLink> — wrap your agent classes with `instrumentAgentWithSentry`.
+- <PlatformLink to="/configuration/integrations/openai/">OpenAI</PlatformLink>, <PlatformLink to="/configuration/integrations/anthropic/">Anthropic</PlatformLink>, and <PlatformLink to="/configuration/integrations/google-genai/">Google Gen AI</PlatformLink> — wrap your client instance.
+- <PlatformLink to="/configuration/integrations/langchain/">LangChain</PlatformLink> — attach Sentry's callback handler.
+- <PlatformLink to="/configuration/integrations/langgraph/">LangGraph</PlatformLink> — wrap your graph before you call `.compile()`.
 
 </PlatformSection>
 


### PR DESCRIPTION
The Cloudflare instrumentation list named every library twice: once in a prose block describing its setup, then again as a bare link list. Merge them so each library appears once, as a link carrying its setup step.

Before: 
<img width="934" height="609" alt="Screenshot 2026-08-05 at 15 28 57" src="https://github.com/user-attachments/assets/a5e23be3-f3a2-40c3-ac6d-75eaa240beef" />

After:
<img width="932" height="403" alt="Screenshot 2026-08-05 at 15 28 52" src="https://github.com/user-attachments/assets/384a58af-cbd1-48c8-9e03-1b20b1fbbaf6" />
