### PR TITLE
ssl: Add warning about certificate pinning

### DIFF
--- a/docs/security-legal-pii/security/ssl.mdx
+++ b/docs/security-legal-pii/security/ssl.mdx
@@ -46,6 +46,11 @@ This suite of protocols and cipher suites represents Sentry's official support; 
 
 At the moment, all Sentry TLS certificates use Digicert, Let's Encrypt, or Google Trust Services (pki.goog) as certificate authorities. If this list of roots needs to be changed, we will publish an announcement on [status.sentry.io](https://status.sentry.io/).
 
+<Alert title="Note" level="warning">
+
+Sentry does not recommend pinning certificates in your applications. Certificate pinning inherently includes availability risks that may break event ingestion if Sentry rotates certificates or changes certificate authorities, which can cause your SDK to silently fail to send events. If your organization's security policy requires pinning, use the root CA certificates listed below and monitor status.sentry.io for announcements about certificate changes.
+
+</Alert>
 
 Here are corresponding root CA certificates if you would like to pin them in your applications:
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
We would like to advise customers to avoid pinning TLS certificates. This may cause availability issues for them if Sentry rotates certificate authorities, and goes against general best practice guidelines for SSL/TLS certificates.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
