### PR TITLE
feat(md-exports): Improve soft-404 recovery for agent .md requests

### DIFF
--- a/app/md-exports/[...path]/route.test.ts
+++ b/app/md-exports/[...path]/route.test.ts
@@ -16,6 +16,21 @@ vi.mock('@sentry/nextjs', () => ({
   metrics: {count: metricsCount},
 }));
 
+// Hermetic redirect tables: the route unions next.config's redirects.js with the
+// middleware's legacy list, skipping pattern (`:path*`) sources.
+vi.mock('../../../redirects', () => ({
+  userDocsRedirects: [
+    {source: '/old-page/', destination: '/new-page/'},
+    {source: '/product/alerts/:path*', destination: '/product/monitors-and-alerts/'},
+  ],
+  developerDocsRedirects: [],
+}));
+
+vi.mock('../../../middleware', () => ({
+  USER_DOCS_REDIRECTS: [{from: '/product/sentry-mcp/', to: 'https://mcp.sentry.dev'}],
+  DEVELOPER_DOCS_REDIRECTS: [],
+}));
+
 const SAMPLE_DOCTREE = {
   path: '',
   slug: '',
@@ -165,6 +180,7 @@ describe('md-exports 404 catch-all route', () => {
           requested_path: 'platforms/javascript/made/up/page',
           has_suggestions: true,
           agent: 'claude',
+          outcome: 'unknown_path',
         },
       })
     );
@@ -177,5 +193,82 @@ describe('md-exports 404 catch-all route', () => {
       1,
       expect.objectContaining({attributes: expect.objectContaining({agent: 'other'})})
     );
+  });
+
+  describe('redirected paths', () => {
+    it('points internal redirects at the destination .md export', async () => {
+      const res = await callRoute(['old-page.md']);
+      const body = await res.text();
+      expect(body).toContain('# Page Moved');
+      expect(body).toContain('https://docs.sentry.io/new-page.md');
+      expect(body).toContain('title: "Page Moved"');
+    });
+
+    it('links external redirect destinations as-is', async () => {
+      const res = await callRoute(['product', 'sentry-mcp.md']);
+      const body = await res.text();
+      expect(body).toContain('# Page Moved');
+      expect(body).toContain('https://mcp.sentry.dev');
+      expect(body).not.toContain('mcp.sentry.dev.md');
+    });
+
+    it('emits the metric with a redirected outcome', async () => {
+      await callRoute(['old-page.md']);
+      expect(metricsCount).toHaveBeenCalledWith(
+        'docs.md_export.not_found',
+        1,
+        expect.objectContaining({
+          attributes: expect.objectContaining({outcome: 'redirected'}),
+        })
+      );
+    });
+
+    it('ignores pattern redirect sources', async () => {
+      const res = await callRoute(['product', 'alerts', 'foo.md']);
+      const body = await res.text();
+      expect(body).toContain('# Page Not Found');
+      expect(metricsCount).toHaveBeenCalledWith(
+        'docs.md_export.not_found',
+        1,
+        expect.objectContaining({
+          attributes: expect.objectContaining({outcome: 'unknown_path'}),
+        })
+      );
+    });
+  });
+
+  describe('pages that exist but have no export', () => {
+    it('says the export is unavailable and links the HTML page', async () => {
+      const res = await callRoute(['platforms', 'javascript.md']);
+      const body = await res.text();
+      expect(body).toContain('# Markdown Export Unavailable');
+      expect(body).toContain('https://docs.sentry.io/platforms/javascript/');
+    });
+
+    it('lists the page children as suggestions', async () => {
+      const res = await callRoute(['platforms', 'javascript.md']);
+      const body = await res.text();
+      expect(body).toContain('Pages in Browser JavaScript');
+      expect(body).toContain('Installation Methods');
+    });
+
+    it('uses a shorter cache lifetime so a fixed export takes over quickly', async () => {
+      const res = await callRoute(['platforms', 'javascript.md']);
+      expect(res.headers.get('Cache-Control')).toBe('public, max-age=60');
+    });
+
+    it('emits the metric with a page_exists outcome', async () => {
+      await callRoute(['platforms', 'javascript.md']);
+      expect(metricsCount).toHaveBeenCalledWith(
+        'docs.md_export.not_found',
+        1,
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            outcome: 'page_exists',
+            has_suggestions: true,
+          }),
+        })
+      );
+    });
   });
 });

--- a/app/md-exports/[...path]/route.ts
+++ b/app/md-exports/[...path]/route.ts
@@ -3,7 +3,10 @@ import {join} from 'node:path';
 
 import {isDeveloperDocs} from 'sentry-docs/isDeveloperDocs';
 import {AI_AGENT_PATTERN, matchPattern} from 'sentry-docs/lib/trafficClassification';
-import {DocMetrics} from 'sentry-docs/metrics';
+import {DocMetrics, MdExportMissOutcome} from 'sentry-docs/metrics';
+
+import {DEVELOPER_DOCS_REDIRECTS, USER_DOCS_REDIRECTS} from '../../../middleware';
+import {developerDocsRedirects, userDocsRedirects} from '../../../redirects';
 
 interface DocTreeNode {
   path: string;
@@ -66,6 +69,130 @@ function renderSiblingList(siblings: DocTreeNode[], baseUrl: string): string {
     .join('\n');
 }
 
+let cachedRedirectLookup: Map<string, string> | null = null;
+
+/**
+ * Literal-source redirects from both redirect tables (next.config's redirects.js
+ * and the middleware's legacy list), keyed by source path without trailing slash.
+ * Pattern sources (`:path*` etc.) are skipped — the metric will show whether they
+ * matter enough to support.
+ */
+function getRedirectLookup(): Map<string, string> {
+  if (cachedRedirectLookup) {
+    return cachedRedirectLookup;
+  }
+  const lookup = new Map<string, string>();
+  const nextConfigRedirects = isDeveloperDocs
+    ? developerDocsRedirects
+    : userDocsRedirects;
+  const middlewareRedirects = isDeveloperDocs
+    ? DEVELOPER_DOCS_REDIRECTS
+    : USER_DOCS_REDIRECTS;
+  for (const {source, destination} of nextConfigRedirects) {
+    if (!source.includes(':')) {
+      lookup.set(normalizeRedirectPath(source), destination);
+    }
+  }
+  for (const {from, to} of middlewareRedirects) {
+    if (!from.includes(':')) {
+      lookup.set(normalizeRedirectPath(from), to);
+    }
+  }
+  cachedRedirectLookup = lookup;
+  return lookup;
+}
+
+function normalizeRedirectPath(source: string): string {
+  return '/' + source.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * The URL to advertise for a redirect destination. Internal destinations get the
+ * `.md` export URL; destinations with a query string (e.g. `/platform-redirect/?next=…`)
+ * and external ones are linked as-is, since no `.md` variant exists for them.
+ */
+function destinationUrl(destination: string): string {
+  if (/^https?:\/\//.test(destination)) {
+    return destination;
+  }
+  if (destination.includes('?') || destination.includes('#')) {
+    return `${BASE_URL}${destination}`;
+  }
+  return `${BASE_URL}${normalizeRedirectPath(destination)}.md`;
+}
+
+function frontmatterLines(title: string, requestedPath: string): string[] {
+  return ['---', `title: "${title}"`, `url: "${BASE_URL}/${requestedPath}"`, '---', ''];
+}
+
+function findWhatYouNeedLines(): string[] {
+  return [
+    '## Find what you need',
+    '',
+    `- [Site index](${BASE_URL}/llms.txt) — LLM-optimized page listing`,
+    `- [Documentation root](${BASE_URL}/index.md) — full docs overview`,
+    `- [Platforms](${BASE_URL}/platforms.md) — all SDK platforms`,
+    '',
+  ];
+}
+
+function renderMovedBody(requestedPath: string, destination: string): string {
+  return [
+    ...frontmatterLines('Page Moved', requestedPath),
+    '# Page Moved',
+    '',
+    `The page \`/${requestedPath}\` has moved to:`,
+    '',
+    `- [${destination}](${destinationUrl(destination)})`,
+    '',
+    ...findWhatYouNeedLines(),
+  ].join('\n');
+}
+
+function renderExportMissingBody(requestedPath: string, node: DocTreeNode): string {
+  const title = node.frontmatter?.title || node.slug;
+  const lines = [
+    ...frontmatterLines('Markdown Export Unavailable', requestedPath),
+    '# Markdown Export Unavailable',
+    '',
+    `The page \`/${requestedPath}\` ("${title}") exists, but its Markdown export was not available for this request. Retry shortly, or use the HTML page:`,
+    '',
+    `- [${title}](${BASE_URL}/${requestedPath}/)`,
+    '',
+  ];
+  if (node.children?.length) {
+    lines.push(
+      `## Pages in ${title}`,
+      '',
+      renderSiblingList(node.children, BASE_URL),
+      ''
+    );
+  }
+  lines.push(...findWhatYouNeedLines());
+  return lines.join('\n');
+}
+
+function renderNotFoundBody(requestedPath: string, ancestor: DocTreeNode | null): string {
+  const lines = [
+    ...frontmatterLines('Page Not Found', requestedPath),
+    '# Page Not Found',
+    '',
+    `The page \`/${requestedPath}\` does not exist.`,
+    '',
+  ];
+  if (ancestor && ancestor.children?.length) {
+    const ancestorTitle = ancestor.frontmatter?.title || ancestor.slug || 'this section';
+    lines.push(
+      `## Pages in ${ancestorTitle}`,
+      '',
+      renderSiblingList(ancestor.children, BASE_URL),
+      ''
+    );
+  }
+  lines.push(...findWhatYouNeedLines());
+  return lines.join('\n');
+}
+
 export async function GET(
   request: Request,
   {params}: {params: Promise<{path: string[]}>}
@@ -75,59 +202,31 @@ export async function GET(
 
   let body: string;
   let hasSuggestions = false;
+  let outcome: MdExportMissOutcome = 'unknown_path';
 
-  try {
-    const tree = await getDocTree();
-    const ancestor = findClosestAncestor(tree, requestedPath.split('/'));
+  const redirectDestination = getRedirectLookup().get(`/${requestedPath}`);
 
-    const lines: string[] = [
-      '---',
-      `title: "Page Not Found"`,
-      `url: "${BASE_URL}/${requestedPath}"`,
-      '---',
-      '',
-      '# Page Not Found',
-      '',
-      `The page \`/${requestedPath}\` does not exist.`,
-      '',
-    ];
+  if (redirectDestination) {
+    outcome = 'redirected';
+    body = renderMovedBody(requestedPath, redirectDestination);
+  } else {
+    try {
+      const tree = await getDocTree();
+      const ancestor = findClosestAncestor(tree, requestedPath.split('/'));
 
-    if (ancestor && ancestor.children?.length) {
-      hasSuggestions = true;
-      const ancestorTitle =
-        ancestor.frontmatter?.title || ancestor.slug || 'this section';
-      lines.push(`## Pages in ${ancestorTitle}`);
-      lines.push('');
-      lines.push(renderSiblingList(ancestor.children, BASE_URL));
-      lines.push('');
+      if (ancestor && ancestor.path === requestedPath) {
+        // The page is real — the static export is what's missing (deploy window,
+        // export-pipeline gap). Very different signal from an invented URL.
+        outcome = 'page_exists';
+        hasSuggestions = !!ancestor.children?.length;
+        body = renderExportMissingBody(requestedPath, ancestor);
+      } else {
+        hasSuggestions = !!(ancestor && ancestor.children?.length);
+        body = renderNotFoundBody(requestedPath, ancestor);
+      }
+    } catch {
+      body = renderNotFoundBody(requestedPath, null);
     }
-
-    lines.push('## Find what you need');
-    lines.push('');
-    lines.push(`- [Site index](${BASE_URL}/llms.txt) — LLM-optimized page listing`);
-    lines.push(`- [Documentation root](${BASE_URL}/index.md) — full docs overview`);
-    lines.push(`- [Platforms](${BASE_URL}/platforms.md) — all SDK platforms`);
-    lines.push('');
-
-    body = lines.join('\n');
-  } catch {
-    body = [
-      '---',
-      `title: "Page Not Found"`,
-      `url: "${BASE_URL}/${requestedPath}"`,
-      '---',
-      '',
-      '# Page Not Found',
-      '',
-      `The page \`/${requestedPath}\` does not exist.`,
-      '',
-      '## Find what you need',
-      '',
-      `- [Site index](${BASE_URL}/llms.txt) — LLM-optimized page listing`,
-      `- [Documentation root](${BASE_URL}/index.md) — full docs overview`,
-      `- [Platforms](${BASE_URL}/platforms.md) — all SDK platforms`,
-      '',
-    ].join('\n');
   }
 
   // Normalize the agent to a low-cardinality name (e.g. "claude", "gptbot") rather
@@ -137,7 +236,7 @@ export async function GET(
 
   // Track the full invented URL by agent so we can see which agents make up which
   // pages most (and whether the soft-404 had suggestions to offer them).
-  DocMetrics.mdExportNotFound(requestedPath.split('/'), hasSuggestions, agent);
+  DocMetrics.mdExportNotFound(requestedPath.split('/'), hasSuggestions, agent, outcome);
 
   // Return 200 (not 404) on purpose. This route serves a Markdown "page not found"
   // helper that links to real nearby pages so AI agents can self-correct. Many agent
@@ -151,7 +250,10 @@ export async function GET(
     status: 200,
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=300',
+      // page_exists misses are usually transient (deploy windows), so let a fixed
+      // export replace the helper quickly.
+      'Cache-Control':
+        outcome === 'page_exists' ? 'public, max-age=60' : 'public, max-age=300',
       'X-Robots-Tag': 'noindex',
       'X-Sentry-Docs-Not-Found': '1',
     },

--- a/md-overrides/platform-redirect.mdx
+++ b/md-overrides/platform-redirect.mdx
@@ -1,0 +1,29 @@
+---
+title: "Choose Your Platform"
+description: "The platform-redirect page forwards visitors to a page under their selected platform's documentation. Build the platform URL directly instead."
+append_sections: false
+---
+
+On the docs website, `/platform-redirect/` is an interactive platform chooser: it takes a `next` query parameter and forwards the visitor to that page under the platform they select. It has no content of its own.
+
+To reach the same content directly, put the platform into the URL:
+
+```
+https://docs.sentry.io/platforms/<platform>/<page>.md
+```
+
+For example, `/platform-redirect/?next=/configuration/options/` with Python selected resolves to:
+
+```
+https://docs.sentry.io/platforms/python/configuration/options.md
+```
+
+For framework-specific documentation, use the guide path instead, for example `https://docs.sentry.io/platforms/javascript/guides/nextjs/<page>.md`.
+
+## Platforms
+
+<PlatformList />
+
+## Frameworks
+
+<FrameworkGroups />

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,11 @@ const BASE_URL = isDeveloperDocs
 // Production domains whose content should be indexable by search engines.
 // All other hostnames (Vercel preview/deployment URLs, old production deployments)
 // get X-Robots-Tag: noindex to prevent search engines from indexing stale content.
-const INDEXABLE_HOSTNAMES = new Set(['docs.sentry.io', 'develop.sentry.dev', 'localhost']);
+const INDEXABLE_HOSTNAMES = new Set([
+  'docs.sentry.io',
+  'develop.sentry.dev',
+  'localhost',
+]);
 
 export const config = {
   // learn more: https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher
@@ -417,14 +421,14 @@ const handleRedirects = (request: NextRequest) => {
   return undefined;
 };
 
-type Redirect = {
+export type Redirect = {
   /** a string with a leading and a trailing slash */
   from: `/${string}/` | '/';
   to: string;
 };
 
 /** Note: if you want to set redirects for developer docs, set them below in `DEVELOPER_DOCS_REDIRECTS` */
-const USER_DOCS_REDIRECTS: Redirect[] = [
+export const USER_DOCS_REDIRECTS: Redirect[] = [
   {
     from: '/platforms/python/http_errors/',
     to: '/platforms/python/integrations/django/http_errors/',
@@ -3926,7 +3930,7 @@ const USER_DOCS_REDIRECTS: Redirect[] = [
   },
 ];
 
-const DEVELOPER_DOCS_REDIRECTS: Redirect[] = [
+export const DEVELOPER_DOCS_REDIRECTS: Redirect[] = [
   {
     from: '/',
     to: '/getting-started/',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -92,13 +92,22 @@ export const DocMetrics = {
    * @param path - Full requested path segments (the invented URL is the signal)
    * @param hasSuggestions - Whether sibling/section suggestions were returned
    * @param agent - Normalized agent name (e.g. "claude", "gptbot"), or "other"
+   * @param outcome - Why the export was missing: "redirected" (path has a redirect,
+   *   we pointed at the destination), "page_exists" (page is in the doctree, so the
+   *   static export pipeline had a gap), or "unknown_path" (agent invented the URL)
    */
-  mdExportNotFound: (path: string[], hasSuggestions: boolean, agent: string) => {
+  mdExportNotFound: (
+    path: string[],
+    hasSuggestions: boolean,
+    agent: string,
+    outcome: MdExportMissOutcome
+  ) => {
     Sentry.metrics.count('docs.md_export.not_found', 1, {
       attributes: {
         requested_path: path.join('/'),
         has_suggestions: hasSuggestions,
         agent,
+        outcome,
       },
     });
   },
@@ -184,6 +193,12 @@ export const DocMetrics = {
     });
   },
 };
+
+/**
+ * Why a Markdown export request missed the static files.
+ * Distinguishes "the agent invented a URL" from "our export pipeline has a gap".
+ */
+export type MdExportMissOutcome = 'redirected' | 'page_exists' | 'unknown_path';
 
 /**
  * Page type represents the main documentation section


### PR DESCRIPTION
## DESCRIBE YOUR PR

Agent-facing `.md` soft-404s (the `docs.md_export.not_found` metric, ~6.9k hits since July 20) fall into three classes that today all get the same generic "Page Not Found" markdown. This PR gives each class a response the agent can actually act on:

- **`platform-redirect` (top missed path, ~330 hits/month):** new `md-overrides/platform-redirect.mdx` explains that the page is a platform chooser with no content of its own and shows how to build `/platforms/<platform>/<page>.md` URLs directly, with platform and framework link lists rendered from the doctree.
- **Redirected pages (e.g. `/product/sentry-mcp.md`):** the md-exports catch-all route now consults both redirect tables (`redirects.js` and the middleware legacy list) and serves a "Page Moved" body pointing at the destination — the `.md` URL for internal targets, the URL as-is for external ones like mcp.sentry.dev. Pattern (`:path*`) sources are skipped for now; the new metric attribute will show whether they matter.
- **Pages that exist but whose static export was missing (transient deploy-window gaps, e.g. the `product.md` burst on July 30):** the route detects doctree hits and serves "Markdown Export Unavailable" with the HTML link and child pages, cached for 60s so a restored export takes over quickly.

The metric gains an `outcome` attribute (`redirected` | `page_exists` | `unknown_path`) so dashboards can separate agent-invented URLs from export-pipeline gaps. The metric name and existing attributes are unchanged.

Review notes: the `middleware.ts` diff is only `export` keywords on the two redirect arrays and the `Redirect` type — `route.ts` is the substantive change. Verified with 232 passing vitest tests (8 new covering redirect, external-destination, pattern-skip, and page-exists paths), clean `tsc`/ESLint/Prettier, and the override rendered through a mirror of the `generate-md-exports` MDX pipeline against the real doctree. On the Vercel preview, check `/platform-redirect.md` and `/product/sentry-mcp.md`.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
