### PR TITLE
docs(unreal): Automatic frame time metrics sampling change

### DIFF
--- a/docs/platforms/unreal/metrics/index.mdx
+++ b/docs/platforms/unreal/metrics/index.mdx
@@ -49,14 +49,14 @@ When **Collect frame time metrics** is enabled, the SDK registers a performance 
 | `game.perf.gpu` | Distribution (ms) | GPU frame time |
 | `game.perf.fps` | Gauge | Engine-smoothed average FPS |
 
-To avoid flooding the metrics pipeline, the SDK only emits metrics every Nth frame, controlled by the **Frame time sample interval** setting. The default value of 30 produces approximately 2 samples per second at 60 FPS, which is sufficient for accurate percentile computation while keeping overhead minimal.
+To avoid flooding the metrics pipeline, the SDK throttles emission to at most one sample per **Frame time sample interval**. The default value of 1 second is sufficient for accurate percentile computation while keeping overhead minimal.
 
 ```cpp
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
     Settings->EnableMetrics = true;
     Settings->EnableAutoFrameTimeMetrics = true;
-    Settings->FrameTimeSampleInterval = 30; // Emit every 30th frame (default)
+    Settings->FrameTimeSampleInterval = 1.0f; // Sample at most once per second (default)
 }));
 ```
 
@@ -88,7 +88,7 @@ SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::Create
   Tracking of active UObjects number requires Unreal Engine 5.3 or later.
 </Alert>
 
-When **Collect game stats metrics** is enabled, the SDK periodically samples system-level statistics and emits them as gauge metrics. Unlike frame time metrics which are collected per-frame, game stats are sampled on a fixed time interval to avoid unnecessary overhead — these values change slowly and don't need per-frame resolution.
+When **Collect game stats metrics** is enabled, the SDK periodically samples system-level statistics and emits them as gauge metrics. Game stats are sampled on a fixed time interval to avoid unnecessary overhead — these values change slowly and don't need frame-level resolution.
 
 | Metric | Type | Description |
 |--------|------|-------------|

--- a/platform-includes/metrics/options/unreal.mdx
+++ b/platform-includes/metrics/options/unreal.mdx
@@ -4,7 +4,7 @@ The following configuration options are available for Sentry's [Application Metr
 |--------|-------------|---------|
 | **Enable Metrics** | Master toggle for the metrics feature | `true` |
 | **Collect frame time metrics** | Automatically emit frame time and per-thread performance metrics. | `false` |
-| **Frame time sample interval (frames)** | Emit performance metrics every Nth frame. | `30` |
+| **Frame time sample interval (seconds)** | How often to sample frame time metrics. | `1.0` |
 | **Collect GC pause metrics** | Emit a metric for each garbage collection pause duration. | `false` |
 | **Collect game stats metrics** | Periodically collect game stats such as process memory usage and active UObject count. | `false` |
 | **Game stats sample interval (seconds)** | How often to sample game stats metrics. | `60` |


### PR DESCRIPTION
Updates the Unreal Engine metrics docs to reflect that automatic frame time metrics are now sampled on a wall-clock interval. `FrameTimeSampleInterval` is documented as seconds (default `1.0`) in the settings table, code sample, and Frame Time section.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1522