### PR TITLE
docs(issues): Update issue categories to match sidebar taxonomy

### DIFF
--- a/docs/product/issues/index.mdx
+++ b/docs/product/issues/index.mdx
@@ -41,7 +41,13 @@ When you click on an issue on the main **Issues** page, the **Issue Details** pa
 
 ## Issue Categories
 
-There are two categories of issues: [_error issues_](/product/issues/issue-details/error-issues/) and [_performance issues_](/product/issues/issue-details/performance-issues/). An error issue is a grouping of error events; a performance issue is a grouping of poorly-performing transactions. To learn more about each issue category and what kind of information is captured in their detailed view, check out our full [Error Issues](/product/issues/issue-details/error-issues/) and [Performance Issues](/product/issues/issue-details/performance-issues/) documentation.
+Sentry creates issues for more than just errors. The **Issues** page sidebar groups them by the kind of problem they represent:
+
+- **Errors & Outages** — Things that break functionality: [runtime errors and exceptions](/product/issues/issue-details/error-issues/), [failed cron jobs](/product/monitors-and-alerts/monitors/crons/), and [uptime outages](/product/issues/issue-details/uptime-issues/).
+- **Breached Metrics** — Degraded behavior over time, such as [endpoint latency regressions](/product/issues/issue-details/performance-issues/endpoint-regressions/) or a metric crossing a threshold you've set.
+- **Warnings** — Code that works but inefficiently, like [N+1 queries, render-blocking assets, or file I/O on the main thread](/product/issues/issue-details/performance-issues/). These degrade performance and user experience.
+- **Configuration** (beta) — SDK or tooling setup problems that make your data harder to debug, such as [low-value spans](/product/issues/issue-details/low-value-span-issues/).
+- **User Feedback** — Reports your users submit directly through [User Feedback](/product/user-feedback/).
 
 ## Issue Triage
 


### PR DESCRIPTION
The overview described only two categories, error and performance. Sentry now creates issues across many categories, and the performance category has been split into db_query, http_client, frontend, and mobile.

Reframe the section around the four groups the Issues sidebar actually shows, plus User Feedback, rather than enumerating raw category slugs. Users navigate by these groups and rarely search by category directly.