### PR TITLE
docs(native): Document metrics options

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -162,7 +162,7 @@ Metrics have been enabled by default since `0.13.5`. In earlier versions they we
 
 <SdkOption name="before_send_metric" type="function" availableSince="0.12.6">
 
-This function is called with an SDK-specific metric object, and can return a modified metric object, or `sentry_value_new_null()` to drop the metric. To drop it, call `sentry_value_decref(metric)` first — the SDK doesn't release the metric you were handed, so skipping this leaks it. An example can be found on the [Metrics page](/platforms/native/metrics/#before_send_metric).
+This function is called with an SDK-specific metric object, and can return a modified metric object, or `sentry_value_new_null()` to drop the metric. In that case, you **must** call `sentry_value_decref(metric)` before returning. An example can be found on the [Metrics page](/platforms/native/metrics/#before_send_metric).
 
 </SdkOption>
 

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -98,7 +98,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 <SdkOption name="before_send" type="function">
 
-This function is called with an SDK-specific message or error event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. To skip it, call `sentry_value_decref(event)` first — the SDK doesn't release the event you were handed, so skipping this leaks it. This can be used, for instance, for manual PII stripping before sending.
+This function is called with an SDK-specific message or error event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
 
 By the time <PlatformIdentifier name="before_send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
@@ -112,7 +112,7 @@ This function is called with a backend-specific event object, and can return a m
 
 <SdkOption name="before_transaction" type="function">
 
-This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `sentry_value_new_null()` to skip reporting the event. To skip it, call `sentry_value_decref(transaction)` first — the SDK doesn't release the transaction you were handed, so skipping this leaks it. One way this might be used is for manual PII stripping before sending.
+This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `sentry_value_new_null()` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
 
 </SdkOption>
 

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -150,6 +150,22 @@ Whether calls to `sentry_log_X()` expect an attributes object as the second argu
 
 </SdkOption>
 
+## Metrics Options
+
+<SdkOption name="enable_metrics" type="bool" defaultValue="true" availableSince="0.12.6">
+
+This option enables [Application Metrics](/platforms/native/metrics). When disabled, all calls to `sentry_metrics_*()` are no-ops.
+
+Metrics have been enabled by default since `0.13.5`. In earlier versions they were experimental and had to be turned on explicitly.
+
+</SdkOption>
+
+<SdkOption name="before_send_metric" type="function" availableSince="0.12.6">
+
+This function is called with an SDK-specific metric object, and can return a modified metric object, or `sentry_value_new_null()` to drop the metric. An example can be found on the [Metrics page](/platforms/native/metrics/#before_send_metric).
+
+</SdkOption>
+
 ## App Hang Options
 
 These options control in-process app-hang detection. See the [App Hangs page](/platforms/native/app-hangs/) for a full explanation and usage example.

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -98,7 +98,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 <SdkOption name="before_send" type="function">
 
-This function is called with an SDK-specific message or error event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
+This function is called with an SDK-specific message or error event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. To skip it, call `sentry_value_decref(event)` first — the SDK doesn't release the event you were handed, so skipping this leaks it. This can be used, for instance, for manual PII stripping before sending.
 
 By the time <PlatformIdentifier name="before_send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
@@ -112,7 +112,7 @@ This function is called with a backend-specific event object, and can return a m
 
 <SdkOption name="before_transaction" type="function">
 
-This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `sentry_value_new_null()` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
+This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `sentry_value_new_null()` to skip reporting the event. To skip it, call `sentry_value_decref(transaction)` first — the SDK doesn't release the transaction you were handed, so skipping this leaks it. One way this might be used is for manual PII stripping before sending.
 
 </SdkOption>
 
@@ -162,7 +162,7 @@ Metrics have been enabled by default since `0.13.5`. In earlier versions they we
 
 <SdkOption name="before_send_metric" type="function" availableSince="0.12.6">
 
-This function is called with an SDK-specific metric object, and can return a modified metric object, or `sentry_value_new_null()` to drop the metric. An example can be found on the [Metrics page](/platforms/native/metrics/#before_send_metric).
+This function is called with an SDK-specific metric object, and can return a modified metric object, or `sentry_value_new_null()` to drop the metric. To drop it, call `sentry_value_decref(metric)` first — the SDK doesn't release the metric you were handed, so skipping this leaks it. An example can be found on the [Metrics page](/platforms/native/metrics/#before_send_metric).
 
 </SdkOption>
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the two Native SDK metrics options, which the options page didn't cover: `enable_metrics` and `before_send_metric`. Both have existed since 0.12.6, and the default for `enable_metrics` flipped to enabled in 0.13.5, so the page now states when metrics turn themselves on and how to opt out or filter them.

- Metrics support, `enable_metrics` and `before_send_metric` https://github.com/getsentry/sentry-native/pull/1498
- Metrics enabled by default https://github.com/getsentry/sentry-native/pull/1609

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
