### PR TITLE
docs(native): Document scope attributes and scoped logs and metrics

### DIFF
--- a/docs/platforms/native/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/native/common/enriching-events/attributes/index.mdx
@@ -22,7 +22,7 @@ Attributes can currently be used to enrich the following:
 
 ## Setting Attributes on a Scope
 
-Passing the same attributes to every call gets repetitive once a group of logs or metrics shares context. Set them on a scope instead, and everything captured against that scope inherits them.
+Passing the same attributes to every call gets repetitive once a group of logs or metrics shares context. Set them on a scope instead, and everything captured with that scope inherits them.
 
 `sentry_set_attribute` writes to the global scope, so every log and metric the SDK sends carries the attribute:
 

--- a/docs/platforms/native/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/native/common/enriching-events/attributes/index.mdx
@@ -47,6 +47,6 @@ sentry_scope_free(scope);
 
 Both setters have an `_n` variant that takes an explicit key length, and `sentry_remove_attribute` / `sentry_scope_remove_attribute` remove an attribute again.
 
-The SDK resolves attributes most-specific-first: **per-call attributes** > **passed scope** > **global scope**. Each source contributes the attributes only it defines, so a scope attribute and a global attribute with different names both end up on the log or metric. When the same attribute is set in more than one place, the most specific one wins as a whole.
+Attribute precedence is resolved from most to least specific: **per-call attributes** > **passed scope** > **global scope**. Attributes are merged from every source, so differently named attributes from all three are included on the resulting log or metric. When the same attribute is set in more than one source, the most specific one is used.
 
 See [Scopes](/platforms/native/enriching-events/scopes/) for how scopes are created and freed.

--- a/docs/platforms/native/common/enriching-events/attributes/index.mdx
+++ b/docs/platforms/native/common/enriching-events/attributes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attributes
-description: "Learn how to construct custom attributes to enrich logs."
+description: "Learn how to construct custom attributes to enrich logs and metrics."
 ---
 
 Attributes are a specific kind of `sentry_value_t` object which contains items with a `value`, `type` and optional `unit` field. The type is inferred from the given `sentry_value_t` value, which can be `bool`, `int32`, `int64`, `uint64`, `double` or `string`.
@@ -16,4 +16,37 @@ sentry_value_set_by_key(attributes, "number.second", attr_3);
 ```
 
 Attributes can currently be used to enrich the following:
+
 - [Structured logs](/platforms/native/logs/#additional-attributes)
+- [Metrics](/platforms/native/metrics/#custom-attributes)
+
+## Setting Attributes on a Scope
+
+Passing the same attributes to every call gets repetitive once a group of logs or metrics shares context. Set them on a scope instead, and everything captured against that scope inherits them.
+
+`sentry_set_attribute` writes to the global scope, so every log and metric the SDK sends carries the attribute:
+
+```c
+sentry_set_attribute("cache.backend",
+    sentry_value_new_attribute(sentry_value_new_string("redis"), NULL));
+```
+
+When the context belongs to one unit of work rather than the whole program, set the attribute on a scope you create and capture with it:
+
+```c
+sentry_scope_t *scope = sentry_scope_new();
+sentry_scope_set_attribute(scope, "cache.backend",
+    sentry_value_new_attribute(sentry_value_new_string("redis"), NULL));
+
+sentry_scope_capture_log(scope, SENTRY_LEVEL_INFO, "Cache miss", sentry_value_new_null());
+sentry_scope_capture_metric(scope, SENTRY_METRIC_COUNT, "cache.miss",
+    sentry_value_new_int64(1), NULL, sentry_value_new_null());
+
+sentry_scope_free(scope);
+```
+
+Both setters have an `_n` variant that takes an explicit key length, and `sentry_remove_attribute` / `sentry_scope_remove_attribute` remove an attribute again.
+
+The SDK resolves attributes most-specific-first: **per-call attributes** > **passed scope** > **global scope**. Each source contributes the attributes only it defines, so a scope attribute and a global attribute with different names both end up on the log or metric. When the same attribute is set in more than one place, the most specific one wins as a whole.
+
+See [Scopes](/platforms/native/enriching-events/scopes/) for how scopes are created and freed.

--- a/docs/platforms/native/common/enriching-events/scopes/index.mdx
+++ b/docs/platforms/native/common/enriching-events/scopes/index.mdx
@@ -92,7 +92,7 @@ sentry_scope_capture_metric(
 
 When you capture with a scope, the SDK combines that scope with the global scope. Data set in only one place is still included, so events captured with their own scope continue to carry global values such as release, environment, and user. When the same key is set in more than one place, the most specific one wins: **event data** > **passed scope** > **global scope**. Data you set directly on the event value therefore survives whatever the scopes carry.
 
-Logs and metrics resolve attributes and the trace from the call site as well, which is the most specific source of the three: **per-call attributes** > **passed scope** > **global scope**. See [Attributes](/platforms/native/enriching-events/attributes/) for how to build them.
+Logs and metrics resolve attributes from the call site as well, which is the most specific source of the three: **per-call attributes** > **passed scope** > **global scope**. See [Attributes](/platforms/native/enriching-events/attributes/) for how to build them.
 
 ## Clearing and Copying Scopes
 

--- a/platform-includes/logs/usage/native.mdx
+++ b/platform-includes/logs/usage/native.mdx
@@ -61,7 +61,7 @@ sentry_log(SENTRY_LEVEL_INFO, user_query, attributes);
 
 ### Logging With a Scope
 
-Tagging a group of logs with shared context means either repeating the attributes at every call or writing them to the global scope, which every thread sees. `sentry_scope_capture_log()` is the third option: it behaves like `sentry_log()`, but the log also carries the attributes and trace of the scope you pass it.
+Tagging a group of logs with shared context means either repeating the attributes at every call or writing them to the global scope, which every thread sees. `sentry_scope_capture_log()` is the third option: it behaves like `sentry_log()`, but the log also carries the attributes of the scope you pass it.
 
 ```c
 sentry_scope_t *scope = sentry_scope_new();

--- a/platform-includes/logs/usage/native.mdx
+++ b/platform-includes/logs/usage/native.mdx
@@ -5,7 +5,7 @@ sentry_log_info("A simple log message");
 sentry_log_error("A %s log message", "formatted");
 ```
 
-### Additional attributes
+### Additional Attributes
 
 In case you want to provide additional attributes directly to the logging functions, you must enable the `logs_with_attributes` option. Any `sentry_log_X()` calls will expect a `sentry_value_t` object of attributes as the first `varg` after the log message.
 
@@ -44,3 +44,27 @@ sentry_value_set_by_key(param_attributes, "sentry.sdk.name", param_attr_2);
 // will only have "custom-sdk-name" as an attribute value, but not "custom parameter" which gets overwritten by "and format-string"
 sentry_log_fatal("logging with a custom parameter %s attributes", param_attributes, "and format-string");
 ```
+
+### Logging User-Provided Text
+
+The `sentry_log_X()` functions treat the message as a printf format string, so text you didn't write yourself can be misread as format specifiers. Use `sentry_log()` for that: it stores the body as-is and takes its attributes as an explicit argument, independent of the `logs_with_attributes` option.
+
+```c
+sentry_log(SENTRY_LEVEL_WARNING, user_supplied_text, sentry_value_new_null());
+```
+
+### Logging Against a Scope
+
+Tagging a group of logs with shared context means either repeating the attributes at every call or writing them to the global scope, which every thread sees. `sentry_scope_capture_log()` is the third option: it behaves like `sentry_log()`, but the log also carries the attributes and trace of the scope you pass it.
+
+```c
+sentry_scope_t *scope = sentry_scope_new();
+sentry_scope_set_attribute(scope, "worker.id",
+    sentry_value_new_attribute(sentry_value_new_string("asset-loader"), NULL));
+
+sentry_scope_capture_log(scope, SENTRY_LEVEL_INFO, "Cache warmed", sentry_value_new_null());
+
+sentry_scope_free(scope);
+```
+
+Pass `NULL` as the scope to apply the global scope alone. Which constructor you used decides who frees the scope, as described in <PlatformLink to="/enriching-events/scopes/#creating-a-scope">Scopes</PlatformLink>; see <PlatformLink to="/enriching-events/attributes/#setting-attributes-on-a-scope">Attributes</PlatformLink> for how per-call, scope, and global attributes resolve.

--- a/platform-includes/logs/usage/native.mdx
+++ b/platform-includes/logs/usage/native.mdx
@@ -59,7 +59,7 @@ sentry_log(SENTRY_LEVEL_INFO, user_query, attributes);
 
 `sentry_log()` takes ownership of the attributes you pass, so don't free them yourself. To send the same attributes with more than one log, call `sentry_value_incref` before each additional call.
 
-### Logging Against a Scope
+### Logging With a Scope
 
 Tagging a group of logs with shared context means either repeating the attributes at every call or writing them to the global scope, which every thread sees. `sentry_scope_capture_log()` is the third option: it behaves like `sentry_log()`, but the log also carries the attributes and trace of the scope you pass it.
 

--- a/platform-includes/logs/usage/native.mdx
+++ b/platform-includes/logs/usage/native.mdx
@@ -47,11 +47,17 @@ sentry_log_fatal("logging with a custom parameter %s attributes", param_attribut
 
 ### Logging User-Provided Text
 
-The `sentry_log_X()` functions treat the message as a printf format string, so text you didn't write yourself can be misread as format specifiers. Use `sentry_log()` for that: it stores the body as-is and takes its attributes as an explicit argument, independent of the `logs_with_attributes` option.
+The `sentry_log_X()` functions treat the message as a printf format string, so user-provided text may be interpreted as format specifiers. To log user-provided text safely, use `sentry_log()` instead. It stores the message body as-is and accepts attributes as an explicit argument.
 
 ```c
-sentry_log(SENTRY_LEVEL_WARNING, user_supplied_text, sentry_value_new_null());
+sentry_value_t attributes = sentry_value_new_object();
+sentry_value_set_by_key(attributes, "search.source",
+    sentry_value_new_attribute(sentry_value_new_string("command-palette"), NULL));
+
+sentry_log(SENTRY_LEVEL_INFO, user_query, attributes);
 ```
+
+`sentry_log()` takes ownership of the attributes you pass, so don't free them yourself. To send the same attributes with more than one log, call `sentry_value_incref` before each additional call.
 
 ### Logging Against a Scope
 

--- a/platform-includes/logs/usage/native.mdx
+++ b/platform-includes/logs/usage/native.mdx
@@ -73,4 +73,4 @@ sentry_scope_capture_log(scope, SENTRY_LEVEL_INFO, "Cache warmed", sentry_value_
 sentry_scope_free(scope);
 ```
 
-Pass `NULL` as the scope to apply the global scope alone. Which constructor you used decides who frees the scope, as described in <PlatformLink to="/enriching-events/scopes/#creating-a-scope">Scopes</PlatformLink>; see <PlatformLink to="/enriching-events/attributes/#setting-attributes-on-a-scope">Attributes</PlatformLink> for how per-call, scope, and global attributes resolve.
+The scope constructor determines who frees the scope; see <PlatformLink to="/enriching-events/scopes/#creating-a-scope">Scopes</PlatformLink>. For how per-call, scope, and global attributes are applied, see <PlatformLink to="/enriching-events/attributes/#setting-attributes-on-a-scope">Attributes</PlatformLink>.

--- a/platform-includes/metrics/usage/native.mdx
+++ b/platform-includes/metrics/usage/native.mdx
@@ -66,7 +66,7 @@ sentry_metrics_gauge("memory.usage", 1024, SENTRY_UNIT_BYTE, sentry_value_new_nu
 sentry_metrics_distribution("latency", 42.5, SENTRY_UNIT_MILLISECOND, sentry_value_new_null());
 ```
 
-### Recording Against a Scope
+### Recording With a Scope
 
 When a group of metrics shares the same attributes, put them on a scope once instead of repeating them at every call site. `sentry_scope_capture_metric()` records a metric of any of the three types, carrying the scope's attributes and trace:
 

--- a/platform-includes/metrics/usage/native.mdx
+++ b/platform-includes/metrics/usage/native.mdx
@@ -68,7 +68,7 @@ sentry_metrics_distribution("latency", 42.5, SENTRY_UNIT_MILLISECOND, sentry_val
 
 ### Recording With a Scope
 
-When a group of metrics shares the same attributes, put them on a scope once instead of repeating them at every call site. `sentry_scope_capture_metric()` records a metric of any of the three types, carrying the scope's attributes and trace:
+When a group of metrics shares the same attributes, put them on a scope once instead of repeating them at every call site. `sentry_scope_capture_metric()` records a metric of any of the three types, carrying the scope's attributes:
 
 ```c
 sentry_scope_t *scope = sentry_scope_new();

--- a/platform-includes/metrics/usage/native.mdx
+++ b/platform-includes/metrics/usage/native.mdx
@@ -81,4 +81,4 @@ sentry_scope_capture_metric(scope, SENTRY_METRIC_COUNT, "api.calls",
 sentry_scope_free(scope);
 ```
 
-Pass `NULL` as the scope to apply the global scope alone. Which constructor you used decides who frees the scope, as described in <PlatformLink to="/enriching-events/scopes/#creating-a-scope">Scopes</PlatformLink>; see <PlatformLink to="/enriching-events/attributes/#setting-attributes-on-a-scope">Attributes</PlatformLink> for how per-call, scope, and global attributes resolve.
+The scope constructor determines who frees the scope; see <PlatformLink to="/enriching-events/scopes/#creating-a-scope">Scopes</PlatformLink>. For how per-call, scope, and global attributes are applied, see <PlatformLink to="/enriching-events/attributes/#setting-attributes-on-a-scope">Attributes</PlatformLink>.

--- a/platform-includes/metrics/usage/native.mdx
+++ b/platform-includes/metrics/usage/native.mdx
@@ -65,3 +65,20 @@ For `gauge` and `distribution` metrics, specify a unit to help Sentry display va
 sentry_metrics_gauge("memory.usage", 1024, SENTRY_UNIT_BYTE, sentry_value_new_null());
 sentry_metrics_distribution("latency", 42.5, SENTRY_UNIT_MILLISECOND, sentry_value_new_null());
 ```
+
+### Recording Against a Scope
+
+When a group of metrics shares the same attributes, put them on a scope once instead of repeating them at every call site. `sentry_scope_capture_metric()` records a metric of any of the three types, carrying the scope's attributes and trace:
+
+```c
+sentry_scope_t *scope = sentry_scope_new();
+sentry_scope_set_attribute(scope, "region",
+    sentry_value_new_attribute(sentry_value_new_string("us-west"), NULL));
+
+sentry_scope_capture_metric(scope, SENTRY_METRIC_COUNT, "api.calls",
+    sentry_value_new_int64(1), NULL, sentry_value_new_null());
+
+sentry_scope_free(scope);
+```
+
+Pass `NULL` as the scope to apply the global scope alone. Which constructor you used decides who frees the scope, as described in <PlatformLink to="/enriching-events/scopes/#creating-a-scope">Scopes</PlatformLink>; see <PlatformLink to="/enriching-events/attributes/#setting-attributes-on-a-scope">Attributes</PlatformLink> for how per-call, scope, and global attributes resolve.


### PR DESCRIPTION
Documents scope attributes for the Native SDK: setting them on the global scope or on a scope you create, how per-call, scope, and global attributes are applied, and the scoped capture functions for logs and metrics. Also corrects the Scopes page, which claimed logs and metrics resolve a trace from the call site — a scope you create carries no trace of its own.

- Refs https://github.com/getsentry/sentry-native/pull/1861
- Refs https://github.com/getsentry/sentry-native/pull/1879

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
