### PR TITLE
docs(self-hosted): Clarify Kubernetes support boundary

### DIFF
--- a/develop-docs/self-hosted/support.mdx
+++ b/develop-docs/self-hosted/support.mdx
@@ -11,6 +11,12 @@ how various components fit together. Folks needing larger setups can expand from
 Please see our <Link to="/self-hosted/troubleshooting/">troubleshooting section</Link> before posting on the forum or filing an issue.
 </Alert>
 
+## Kubernetes and Helm
+
+The self-hosted project maintains only the Docker Compose deployment. Sentry does not publish Kubernetes manifests or Helm charts for self-hosted installations and does not provide support for those deployment methods.
+
+A [community-maintained Helm chart](https://github.com/sentry-kubernetes/charts) is available, but it is not affiliated with Sentry and falls outside the self-hosted project's support scope. Direct questions and bug reports about that chart to its [issue tracker](https://github.com/sentry-kubernetes/charts/issues).
+
 Our principles for the support of self-hosted Sentry are:
 
 1. We **DO NOT** provide dedicated support for self-hosted.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Clarifies that the maintained self-hosted deployment uses Docker Compose and that Sentry does not publish or support Kubernetes manifests or Helm charts. The page now directs questions about the unaffiliated community Helm chart to that project's issue tracker.

This keeps the documentation aligned with maintainer responses in getsentry/self-hosted#2607, getsentry/self-hosted#3280, getsentry/self-hosted#4006, and getsentry/self-hosted#4212 without presenting the third-party chart as an official deployment method.

## IS YOUR CHANGE URGENT?

- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
