### PR TITLE
docs(native): update note on `decref` for event hooks

### DIFF
--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -98,7 +98,7 @@ These options can be used to hook the SDK in various ways to customize the repor
 
 <SdkOption name="before_send" type="function">
 
-This function is called with an SDK-specific message or error event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. This can be used, for instance, for manual PII stripping before sending.
+This function is called with an SDK-specific message or error event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. To drop it, you **must** call `sentry_value_decref(event)` before returning. This hook can be used, for instance, for manual PII stripping before sending.
 
 By the time <PlatformIdentifier name="before_send" /> is executed, all scope data has already been applied to the event. Further modification of the scope won't have any effect.
 
@@ -106,13 +106,13 @@ By the time <PlatformIdentifier name="before_send" /> is executed, all scope dat
 
 <SdkOption name="on_crash" type="function">
 
-This function is called with a backend-specific event object, and can return a modified event object or nothing to skip reporting the event. In contrast to `before_send`, it is only called when a crash occurred. You can find detailed information concerning its usage in [Filtering](/platforms/native/configuration/filtering/#using-on_crash).
+This function is called with a backend-specific event object, and can return a modified event object or nothing to skip reporting the event. To drop it, you **must** call `sentry_value_decref(event)` before returning. In contrast to `before_send`, it is only called when a crash occurred. You can find detailed information concerning its usage in [Filtering](/platforms/native/configuration/filtering/#using-on_crash).
 
 </SdkOption>
 
 <SdkOption name="before_transaction" type="function">
 
-This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `sentry_value_new_null()` to skip reporting the event. One way this might be used is for manual PII stripping before sending.
+This function is called with an SDK-specific transaction event object, and can return a modified transaction event object, or `sentry_value_new_null()` to skip reporting the event. To drop it, you **must** call `sentry_value_decref(tx)` before returning. One way this might be used is for manual PII stripping before sending.
 
 </SdkOption>
 
@@ -148,7 +148,7 @@ This option enables the [logging integration](/platforms/native/logs), which all
 
 <SdkOption name="before_send_log" type="function">
 
-This function is called with an SDK-specific log object, and can return a modified log object, or `sentry_value_new_null()` to drop the log.
+This function is called with an SDK-specific log object, and can return a modified log object, or `sentry_value_new_null()` to drop the log. In that case, you **must** call `sentry_value_decref(log)` before returning.
 
 </SdkOption>
 

--- a/docs/platforms/native/common/configuration/options.mdx
+++ b/docs/platforms/native/common/configuration/options.mdx
@@ -106,7 +106,7 @@ By the time <PlatformIdentifier name="before_send" /> is executed, all scope dat
 
 <SdkOption name="on_crash" type="function">
 
-This function is called with a backend-specific event object, and can return a modified event object or nothing to skip reporting the event. To drop it, you **must** call `sentry_value_decref(event)` before returning. In contrast to `before_send`, it is only called when a crash occurred. You can find detailed information concerning its usage in [Filtering](/platforms/native/configuration/filtering/#using-on_crash).
+This function is called with a backend-specific event object, and can return a modified event object, or `sentry_value_new_null()` to skip reporting the event. To drop it, you **must** call `sentry_value_decref(event)` before returning. In contrast to `before_send`, it is only called when a crash occurred. You can find detailed information concerning its usage in [Filtering](/platforms/native/configuration/filtering/#using-on_crash).
 
 </SdkOption>
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
Noticed in https://github.com/getsentry/sentry-docs/pull/18982 that we don't specify `decref` as a necessity for native event hooks discarding events. Adding it to our options docs with this PR.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+
