### PR TITLE
docs(sourcemaps): Document token exclusion when Allowed Domains is *

### DIFF
--- a/docs/platforms/javascript/common/sourcemaps/uploading/hosting-publicly.mdx
+++ b/docs/platforms/javascript/common/sourcemaps/uploading/hosting-publicly.mdx
@@ -67,7 +67,7 @@ While the recommended solution is to upload your source artifacts to Sentry, som
 
 If you want to keep your source maps secret and choose not to upload your source maps directly to Sentry, you can enable the “Security Token” option in your project settings.
 
-This will cause outbound requests from Sentry’s servers to URLs originating from your “Allowed Domains” to have the HTTP header `X-Sentry-Token` header append:
+With “Security Token” enabled and “Allowed Domains” not set to `*`, outbound requests from Sentry’s servers to URLs matching “Allowed Domains” will include the HTTP header `X-Sentry-Token`:
 
 ```bash
 GET /assets/bundle.min.js


### PR DESCRIPTION
## DESCRIBE YOUR PR

After [https://github.com/getsentry/sentry/pull/120182](<https://github.com/getsentry/sentry/pull/120182>), sentry no longer sends the user-provided security token to symbolicator - which uses it for sourcemap scraping - if `Allowed Domains` is set to `*`. Unfortunately, this has broken stack traces for customers without them understanding why. This change is one step towards preventing this.

Ref: [INGEST-1111](https://linear.app/getsentry/issue/INGEST-1111/sourcemap-scraping-403s)

## IS YOUR CHANGE URGENT?

- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](<https://github.com/orgs/getsentry/teams/docs>)