### PR TITLE
fix(security): override fast-uri to ^3.1.5 to resolve host confusion vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,8 @@
       "shell-quote": "^1.8.4",
       "launch-editor": "^2.14.1",
       "form-data": "^4.0.6",
-      "vite": "^7.3.5"
+      "vite": "^7.3.5",
+      "fast-uri": "^3.1.5"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   launch-editor: ^2.14.1
   form-data: ^4.0.6
   vite: ^7.3.5
+  fast-uri: ^3.1.5
 
 patchedDependencies:
   remark-mdx-images@3.0.0:
@@ -4797,8 +4798,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -11540,7 +11541,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12823,7 +12824,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.2.0:
     dependencies:


### PR DESCRIPTION
fast-uri < 3.1.5 is vulnerable to host confusion via backslash authority introducer (GHSA 387). Applications using fast-uri to enforce host-based policy can be steered to unintended destinations when the same URL is later parsed by Node's WHATWG URL.

Since fast-uri is a deep transitive dep (via ajv -> schema-utils -> webpack), Dependabot cannot update it automatically. Adding a pnpm override to force resolution to the patched version.

Closes issue (https://github.com/getsentry/sentry-docs/security/dependabot/387)

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [x] Urgent deadline (GA date, etc.): ASAP
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
