### PR TITLE
fix(dev): Update installation command for @sentry/conventions

### DIFF
--- a/develop-docs/engineering-practices/sentry-conventions.mdx
+++ b/develop-docs/engineering-practices/sentry-conventions.mdx
@@ -168,7 +168,7 @@ Sentry uses the `@sentry/conventions` package in the frontend, which just needs 
 
 1. Bump the package version:
    ```bash
-   pnpm install @sentry/conventions@^<version>
+   pnpm install -w @sentry/conventions@^<version>
    ```
 2. Commit, open a PR, and merge it once you got approval.
 


### PR DESCRIPTION
The `-w` flag is required. Otherwise, the update fails with this message:

>  ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.