### PR TITLE
docs(unreal): Add user feedback filtering callback

### DIFF
--- a/docs/platforms/unreal/configuration/filtering.mdx
+++ b/docs/platforms/unreal/configuration/filtering.mdx
@@ -21,3 +21,13 @@ All Sentry SDKs support the <PlatformIdentifier name="before-send" /> callback m
 <PlatformContent includePath="configuration/before-send/" />
 
 Note also that breadcrumbs can be filtered, as discussed in [our Breadcrumbs documentation](/product/issues/issue-details/breadcrumbs/).
+
+## Filtering User Feedback
+
+Configure your SDK to filter user feedback by using the `beforeSendFeedback` callback method.
+
+### Using `beforeSendFeedback`
+
+The `beforeSendFeedback` callback is called immediately before user feedback is sent to Sentry. It receives the feedback object as a parameter, which you can use to either modify the feedback's data or drop it completely by returning `null`, based on custom logic and the data available on the feedback.
+
+<PlatformContent includePath="configuration/before-send-feedback/" />

--- a/docs/platforms/unreal/configuration/filtering.mdx
+++ b/docs/platforms/unreal/configuration/filtering.mdx
@@ -28,6 +28,12 @@ Configure your SDK to filter user feedback by using the `beforeSendFeedback` cal
 
 ### Using `beforeSendFeedback`
 
-The `beforeSendFeedback` callback is called immediately before user feedback is sent to Sentry. It receives the feedback object as a parameter, which you can use to either modify the feedback's data or drop it completely by returning `null`, based on custom logic and the data available on the feedback.
+The `beforeSendFeedback` callback is called immediately before user feedback is sent to Sentry. It receives the feedback event as a parameter, which you can use to modify or enrich the event (for example, adjusting the feedback message, tags, or contexts, or scrubbing sensitive data), or drop it completely by returning `null`.
+
+<Alert>
+
+`beforeSendFeedback` is currently not supported on macOS and iOS.
+
+</Alert>
 
 <PlatformContent includePath="configuration/before-send-feedback/" />

--- a/platform-includes/configuration/before-send-feedback/unreal.mdx
+++ b/platform-includes/configuration/before-send-feedback/unreal.mdx
@@ -1,0 +1,30 @@
+```cpp
+UCLASS()
+class USomeBeforeSendFeedbackHandler : public USentryBeforeSendFeedbackHandler
+{
+	GENERATED_BODY()
+
+public:
+	virtual USentryFeedback* HandleBeforeSendFeedback_Implementation(USentryFeedback* Feedback, USentryHint* Hint) override
+    {
+        UE_LOG(LogTemp, Log, TEXT("Hello from CPP beforeSendFeedback handler"));
+	    return Super::HandleBeforeSendFeedback_Implementation(Feedback, Hint);
+    }
+};
+
+...
+
+FConfigureSettingsDelegate SettingsDelegate;
+SettingsDelegate.BindDynamic(this, &USomeClass::HandleSettingsDelegate);
+
+void USomeClass::HandleSettingsDelegate(USentrySettings* Settings)
+{
+    Settings->BeforeSendFeedbackHandler = USomeBeforeSendFeedbackHandler::StaticClass();
+}
+
+...
+
+USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
+
+SentrySubsystem->InitializeWithSettings(SettingsDelegate);
+```

--- a/platform-includes/configuration/before-send-feedback/unreal.mdx
+++ b/platform-includes/configuration/before-send-feedback/unreal.mdx
@@ -5,10 +5,10 @@ class USomeBeforeSendFeedbackHandler : public USentryBeforeSendFeedbackHandler
 	GENERATED_BODY()
 
 public:
-	virtual USentryFeedback* HandleBeforeSendFeedback_Implementation(USentryFeedback* Feedback, USentryHint* Hint) override
+	virtual USentryEvent* HandleBeforeSendFeedback_Implementation(USentryEvent* Event, USentryHint* Hint) override
     {
         UE_LOG(LogTemp, Log, TEXT("Hello from CPP beforeSendFeedback handler"));
-	    return Super::HandleBeforeSendFeedback_Implementation(Feedback, Hint);
+	    return Super::HandleBeforeSendFeedback_Implementation(Event, Hint);
     }
 };
 

--- a/platform-includes/configuration/before-send-feedback/unreal.mdx
+++ b/platform-includes/configuration/before-send-feedback/unreal.mdx
@@ -7,7 +7,13 @@ class USomeBeforeSendFeedbackHandler : public USentryBeforeSendFeedbackHandler
 public:
 	virtual USentryEvent* HandleBeforeSendFeedback_Implementation(USentryEvent* Event, USentryHint* Hint) override
     {
-        UE_LOG(LogTemp, Log, TEXT("Hello from CPP beforeSendFeedback handler"));
+        // The feedback fields are available through the event
+        if (USentryFeedback* Feedback = Event->GetFeedback())
+        {
+            // Scrub or modify the feedback before it's sent
+            Feedback->SetContactEmail(TEXT("redacted@example.com"));
+        }
+
 	    return Super::HandleBeforeSendFeedback_Implementation(Event, Hint);
     }
 };


### PR DESCRIPTION
This PR documents the new `beforeSendFeedback` hook in the Unreal SDK.

## Key Changes

- Adds a "Filtering User Feedback" section to the Unreal filtering guide.
- Adds a `configuration/before-send-feedback` platform-include showing how to subclass `USentryBeforeSendFeedbackHandler` and register it via the settings delegate.

## Related Items

- getsentry/sentry-unreal#1528
