### PR TITLE
fix(scrubbing): Clarify safe-field path selector logic

### DIFF
--- a/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx
+++ b/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx
@@ -90,6 +90,7 @@ Safe Fields are used to exclude fields and data from scrubbing. For example, tak
 
 When scrubbing is enabled and `id` added as a sensitive field, the `password` string in `extra.'sys.argv'`,
 both `id` fields (`user.id` and `extra.id`), as well as the entire `credentials` object will be scrubbed.
+Note the quotes around `'sys.argv'` which is needed since the key itself contains a dot. Without the quotes `extra.sys.argv` would match the `argv` field inside the `sys` object, the same way that `extra.'sys.argv'` matches the `'sys.argv`' field inside the `extra` object.
 
 To accommodate more fine-grained filtering, the Safe Fields support the same syntax as the
 [Advanced Datascrubbing Sources](/security-legal-pii/scrubbing//advanced-datascrubbing/#sources).

--- a/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx
+++ b/docs/security-legal-pii/scrubbing/server-side-scrubbing/index.mdx
@@ -90,7 +90,7 @@ Safe Fields are used to exclude fields and data from scrubbing. For example, tak
 
 When scrubbing is enabled and `id` added as a sensitive field, the `password` string in `extra.'sys.argv'`,
 both `id` fields (`user.id` and `extra.id`), as well as the entire `credentials` object will be scrubbed.
-Note the quotes around `'sys.argv'` which is needed since the key itself contains a dot. Without the quotes `extra.sys.argv` would match the `argv` field inside the `sys` object, the same way that `extra.'sys.argv'` matches the `'sys.argv`' field inside the `extra` object.
+Note the quotes around `'sys.argv'` which is needed since the key itself contains a dot. Without the quotes `extra.sys.argv` would match the `argv` field inside the `sys` object, the same way that `extra.'sys.argv'` matches the `'sys.argv'` field inside the `extra` object.
 
 To accommodate more fine-grained filtering, the Safe Fields support the same syntax as the
 [Advanced Datascrubbing Sources](/security-legal-pii/scrubbing//advanced-datascrubbing/#sources).


### PR DESCRIPTION
This section already implicitly describes the difference between `foo.bar` and `'foo.bar'`. This now adds the explanation explicitly.