### PR TITLE
docs: State the source map size limit

### DIFF
--- a/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -63,7 +63,7 @@ If your source code does not contain this snippet and you're using a Sentry plug
 
 If you're using the Sentry CLI, verify that you're running the `inject` command **before** you upload to Sentry and **before** you deploy your files.
 
-## Verify Your SDK is Up-to-Date
+### Verify Your SDK is Up-to-Date
 
 When inspecting the event payload JSON data in Sentry, verify that the events have a `debug_meta` property. If this property is missing and you already made sure your source files contain debug ID injection snippets, this likely means that you're using an outdated SDK.
 
@@ -168,6 +168,9 @@ The Sentry Node.js SDK generally works well with the [source-map-support](https:
 
 If you are uploading source maps to Sentry or if you are using a Sentry SDK in the browser, your code cannot use the `source-map-support` package.
 `source-map-support` overwrites the captured stack trace in a way that prevents our source map processors from correctly parsing it.
+
+### Verify the source map does not exceed 190 MiB
+If a source map exceeds 190 MiB, it will not be used. 
 
 ### Third-Party Integrations
 

--- a/platform-includes/sourcemaps/troubleshooting/javascript.mdx
+++ b/platform-includes/sourcemaps/troubleshooting/javascript.mdx
@@ -169,7 +169,7 @@ The Sentry Node.js SDK generally works well with the [source-map-support](https:
 If you are uploading source maps to Sentry or if you are using a Sentry SDK in the browser, your code cannot use the `source-map-support` package.
 `source-map-support` overwrites the captured stack trace in a way that prevents our source map processors from correctly parsing it.
 
-### Verify the source map does not exceed 190 MiB
+### Verify Source Map Does Not Exceed 190 MiB
 If a source map exceeds 190 MiB, it will not be used. 
 
 ### Third-Party Integrations


### PR DESCRIPTION
## DESCRIBE YOUR PR
State the source map size limit in the troubleshooting docs to help customers whose stack traces don't get unminified. 

Ref https://linear.app/getsentry/issue/INGEST-1112

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [X] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)