### PR TITLE
feat(middleware): redirect production build URLs to canonical host

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -166,7 +166,17 @@ describe('production build-url redirect to canonical (Deployment Protection off)
     expect(res.status).not.toBe(308);
   });
 
-  it('does not redirect non-GET requests', async () => {
+  it('redirects HEAD requests', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const res = middleware(
+      makeHostRequest('https://sentry-docs-abc123.vercel.app/foo/', 'HEAD')
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get('location')).toBe('https://docs.sentry.io/foo/');
+  });
+
+  it('does not redirect non-page requests', async () => {
     const {middleware} = await importMiddleware({});
     vi.stubEnv('VERCEL_ENV', 'production');
     const res = middleware(

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -100,6 +100,82 @@ describe('middleware redirect set selection', () => {
   });
 });
 
+describe('production build-url redirect to canonical (Deployment Protection off)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function makeHostRequest(url: string, method = 'GET'): NextRequest {
+    return new NextRequest(new URL(url), {method});
+  }
+
+  it('redirects a non-canonical production host to the canonical host', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const res = middleware(
+      makeHostRequest('https://sentry-docs-abc123.vercel.app/platforms/javascript/')
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get('location')).toBe(
+      'https://docs.sentry.io/platforms/javascript/'
+    );
+  });
+
+  it('preserves query strings when redirecting', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const res = middleware(
+      makeHostRequest('https://sentry-docs-git-master-getsentry.vercel.app/search/?q=x')
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get('location')).toBe('https://docs.sentry.io/search/?q=x');
+  });
+
+  it('redirects to develop.sentry.dev in developer docs mode', async () => {
+    const {middleware} = await importMiddleware({NEXT_PUBLIC_DEVELOPER_DOCS: '1'});
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const res = middleware(
+      makeHostRequest('https://develop-docs-abc123.vercel.app/getting-started/')
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get('location')).toBe(
+      'https://develop.sentry.dev/getting-started/'
+    );
+  });
+
+  it('does not redirect requests already on the canonical host', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const res = middleware(makeHostRequest('https://docs.sentry.io/platforms/'));
+    expect(res.status).not.toBe(308);
+  });
+
+  it('leaves preview deployments accessible (no redirect)', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    const res = middleware(
+      makeHostRequest('https://sentry-docs-git-my-branch.sentry.dev/getting-started/')
+    );
+    expect(res.status).not.toBe(308);
+  });
+
+  it('does nothing locally (VERCEL_ENV unset)', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', '');
+    const res = middleware(makeHostRequest('https://sentry-docs-abc123.vercel.app/foo/'));
+    expect(res.status).not.toBe(308);
+  });
+
+  it('does not redirect non-GET requests', async () => {
+    const {middleware} = await importMiddleware({});
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const res = middleware(
+      makeHostRequest('https://sentry-docs-abc123.vercel.app/foo/', 'POST')
+    );
+    expect(res.status).not.toBe(308);
+  });
+});
+
 describe('canonical Link header on .md responses', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -145,9 +221,12 @@ describe('canonical Link header on .md responses', () => {
 describe('wantsMarkdownViaAccept: text/plain no longer triggers markdown', () => {
   it('does not serve markdown for Accept: application/json, text/plain, */*', async () => {
     const {middleware} = await importMiddleware({});
-    const req = new NextRequest(new URL('/platforms/apple/cocoa/', 'http://localhost:3000'), {
-      headers: {'Accept': 'application/json, text/plain, */*'},
-    });
+    const req = new NextRequest(
+      new URL('/platforms/apple/cocoa/', 'http://localhost:3000'),
+      {
+        headers: {Accept: 'application/json, text/plain, */*'},
+      }
+    );
     const res = middleware(req);
     // Should not rewrite to .md — Next rewrite changes the URL; a plain next() keeps it
     expect(res.headers.get('x-middleware-rewrite')).toBeNull();
@@ -155,9 +234,12 @@ describe('wantsMarkdownViaAccept: text/plain no longer triggers markdown', () =>
 
   it('still serves markdown for explicit text/markdown Accept header', async () => {
     const {middleware} = await importMiddleware({});
-    const req = new NextRequest(new URL('/platforms/apple/cocoa/', 'http://localhost:3000'), {
-      headers: {'Accept': 'text/markdown'},
-    });
+    const req = new NextRequest(
+      new URL('/platforms/apple/cocoa/', 'http://localhost:3000'),
+      {
+        headers: {Accept: 'text/markdown'},
+      }
+    );
     const res = middleware(req);
     // A rewrite to .md will set x-middleware-rewrite
     expect(res.headers.get('x-middleware-rewrite')).toContain('.md');

--- a/middleware.ts
+++ b/middleware.ts
@@ -81,9 +81,10 @@ export function middleware(request: NextRequest) {
  * - not a GET request (avoid interfering with API/cron/webhook traffic), or
  * - the request is already on the canonical host.
  *
- * VERCEL_ENV is inlined at build time (see next.config.ts `env`) because the
- * edge runtime can't read server env vars at request time; it's constant per
- * deployment, so build-time inlining is correct.
+ * VERCEL_ENV is frozen into the bundle at build time (see next.config.ts
+ * `env`) so this has a stable value; it is constant per deployment, so that is
+ * correct. Requires "Automatically expose System Environment Variables" to be
+ * enabled on the Vercel project (the default).
  */
 function redirectProductionBuildUrlToCanonical(
   request: NextRequest

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,6 +16,11 @@ const BASE_URL = isDeveloperDocs
   ? 'https://develop.sentry.dev'
   : 'https://docs.sentry.io';
 
+// The canonical, publicly-served production hostname for this docs site. On
+// production deployments, any other host is a Vercel-generated build URL
+// (e.g. sentry-docs-<hash>.vercel.app) that we redirect to this host.
+const CANONICAL_HOST = new URL(BASE_URL).hostname;
+
 // Production domains whose content should be indexable by search engines.
 // All other hostnames (Vercel preview/deployment URLs, old production deployments)
 // get X-Robots-Tag: noindex to prevent search engines from indexing stale content.
@@ -35,6 +40,16 @@ export const config = {
 
 // This function can be marked `async` if using `await` inside
 export function middleware(request: NextRequest) {
+  // Lock down Vercel-generated *production* build URLs. Deployment Protection is
+  // off, so generated production URLs (e.g. sentry-docs-<hash>.vercel.app) would
+  // otherwise be publicly accessible and indexable as a separate copy of the
+  // site. Redirect them to the canonical domain. Preview deployments are left
+  // untouched and publicly accessible, so contractors can open PR previews.
+  const buildUrlRedirect = redirectProductionBuildUrlToCanonical(request);
+  if (buildUrlRedirect) {
+    return buildUrlRedirect;
+  }
+
   // Classify once per request and record it as a counter. This metric — not
   // trace sampling — is the source of truth for agent/bot/user traffic: the
   // middleware root span is created by Next.js before any request data reaches
@@ -53,6 +68,37 @@ export function middleware(request: NextRequest) {
   annotateMiddlewareSpan(request, classification, response);
 
   return response;
+}
+
+/**
+ * On production deployments, redirects any request whose host isn't the
+ * canonical domain to the canonical domain (preserving path + query). This
+ * keeps Vercel-generated production build URLs from being crawled, indexed, or
+ * used as a separate copy of the site.
+ *
+ * Returns null (no redirect) when:
+ * - not a production deployment (previews stay publicly accessible),
+ * - not a GET request (avoid interfering with API/cron/webhook traffic), or
+ * - the request is already on the canonical host.
+ *
+ * VERCEL_ENV is inlined at build time (see next.config.ts `env`) because the
+ * edge runtime can't read server env vars at request time; it's constant per
+ * deployment, so build-time inlining is correct.
+ */
+function redirectProductionBuildUrlToCanonical(
+  request: NextRequest
+): NextResponse | null {
+  if (process.env.VERCEL_ENV !== 'production' || request.method !== 'GET') {
+    return null;
+  }
+  if (request.nextUrl.hostname === CANONICAL_HOST) {
+    return null;
+  }
+  const url = request.nextUrl.clone();
+  url.protocol = 'https:';
+  url.host = CANONICAL_HOST;
+  url.port = '';
+  return NextResponse.redirect(url, 308);
 }
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,9 +16,6 @@ const BASE_URL = isDeveloperDocs
   ? 'https://develop.sentry.dev'
   : 'https://docs.sentry.io';
 
-// The canonical, publicly-served production hostname for this docs site. On
-// production deployments, any other host is a Vercel-generated build URL
-// (e.g. sentry-docs-<hash>.vercel.app) that we redirect to this host.
 const CANONICAL_HOST = new URL(BASE_URL).hostname;
 
 // Production domains whose content should be indexable by search engines.
@@ -40,11 +37,6 @@ export const config = {
 
 // This function can be marked `async` if using `await` inside
 export function middleware(request: NextRequest) {
-  // Lock down Vercel-generated *production* build URLs. Deployment Protection is
-  // off, so generated production URLs (e.g. sentry-docs-<hash>.vercel.app) would
-  // otherwise be publicly accessible and indexable as a separate copy of the
-  // site. Redirect them to the canonical domain. Preview deployments are left
-  // untouched and publicly accessible, so contractors can open PR previews.
   const buildUrlRedirect = redirectProductionBuildUrlToCanonical(request);
   if (buildUrlRedirect) {
     return buildUrlRedirect;
@@ -70,26 +62,14 @@ export function middleware(request: NextRequest) {
   return response;
 }
 
-/**
- * On production deployments, redirects any request whose host isn't the
- * canonical domain to the canonical domain (preserving path + query). This
- * keeps Vercel-generated production build URLs from being crawled, indexed, or
- * used as a separate copy of the site.
- *
- * Returns null (no redirect) when:
- * - not a production deployment (previews stay publicly accessible),
- * - not a GET request (avoid interfering with API/cron/webhook traffic), or
- * - the request is already on the canonical host.
- *
- * VERCEL_ENV is frozen into the bundle at build time (see next.config.ts
- * `env`) so this has a stable value; it is constant per deployment, so that is
- * correct. Requires "Automatically expose System Environment Variables" to be
- * enabled on the Vercel project (the default).
- */
+/** Redirects page requests on noncanonical production hosts, leaving previews public. */
 function redirectProductionBuildUrlToCanonical(
   request: NextRequest
 ): NextResponse | null {
-  if (process.env.VERCEL_ENV !== 'production' || request.method !== 'GET') {
+  if (
+    process.env.VERCEL_ENV !== 'production' ||
+    (request.method !== 'GET' && request.method !== 'HEAD')
+  ) {
     return null;
   }
   if (request.nextUrl.hostname === CANONICAL_HOST) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -141,6 +141,10 @@ const nextConfig = {
     // Inline NEXT_PUBLIC_DEVELOPER_DOCS into edge middleware at build time.
     // Edge runtime doesn't have access to server env vars at request time.
     DEVELOPER_DOCS: process.env.NEXT_PUBLIC_DEVELOPER_DOCS,
+    // Inline VERCEL_ENV for the same reason: middleware.ts uses it to decide
+    // whether a deployment is production. It is constant per deployment, so
+    // build-time inlining is correct.
+    VERCEL_ENV: process.env.VERCEL_ENV,
   },
   redirects,
   rewrites: () => [

--- a/next.config.ts
+++ b/next.config.ts
@@ -141,9 +141,13 @@ const nextConfig = {
     // Inline NEXT_PUBLIC_DEVELOPER_DOCS into edge middleware at build time.
     // Edge runtime doesn't have access to server env vars at request time.
     DEVELOPER_DOCS: process.env.NEXT_PUBLIC_DEVELOPER_DOCS,
-    // Inline VERCEL_ENV for the same reason: middleware.ts uses it to decide
-    // whether a deployment is production. It is constant per deployment, so
-    // build-time inlining is correct.
+    // Freeze VERCEL_ENV into the bundle at build time so middleware.ts has a
+    // stable value for detecting production deployments. VERCEL_ENV is constant
+    // per deployment, so build-time freezing is intentional and correct; it
+    // follows the DEVELOPER_DOCS pattern above. (Vercel also exposes VERCEL_ENV
+    // at runtime when "Automatically expose System Environment Variables" is
+    // enabled — the default — so this entry is a deliberate freeze, not a
+    // workaround for missing runtime access.)
     VERCEL_ENV: process.env.VERCEL_ENV,
   },
   redirects,

--- a/next.config.ts
+++ b/next.config.ts
@@ -141,13 +141,7 @@ const nextConfig = {
     // Inline NEXT_PUBLIC_DEVELOPER_DOCS into edge middleware at build time.
     // Edge runtime doesn't have access to server env vars at request time.
     DEVELOPER_DOCS: process.env.NEXT_PUBLIC_DEVELOPER_DOCS,
-    // Freeze VERCEL_ENV into the bundle at build time so middleware.ts has a
-    // stable value for detecting production deployments. VERCEL_ENV is constant
-    // per deployment, so build-time freezing is intentional and correct; it
-    // follows the DEVELOPER_DOCS pattern above. (Vercel also exposes VERCEL_ENV
-    // at runtime when "Automatically expose System Environment Variables" is
-    // enabled — the default — so this entry is a deliberate freeze, not a
-    // workaround for missing runtime access.)
+    // Freeze this per-deployment value for middleware, matching the pattern above.
     VERCEL_ENV: process.env.VERCEL_ENV,
   },
   redirects,


### PR DESCRIPTION
## DESCRIBE YOUR PR

**Problem:** Contractors need to view PR previews, but with Vercel Deployment Protection off, generated **production** build URLs (for example, `sentry-docs-<hash>.vercel.app`) are also publicly accessible and indexable as a duplicate copy of the site.

**Solution:** In the existing `middleware.ts`, on production deployments only, `308`-redirect GET and HEAD page requests whose host is not the canonical domain (`docs.sentry.io` / `develop.sentry.dev`) to that domain, preserving path and query.

- Previews stay publicly accessible, so contractors can open preview links without secrets or share links.
- Other methods and paths excluded by the middleware matcher, including API and static asset paths, are unaffected.
- `VERCEL_ENV` is deliberately frozen into the bundle through `next.config.ts`; it is constant per deployment.
- Complements the existing `X-Robots-Tag: noindex` on non-canonical hosts.

This is an SEO/canonicalization measure, not a security boundary. Existing production deployments will be deleted before protection is disabled because immutable older deployments do not contain this middleware.

**Required:** Turn **off** Vercel Standard Protection after this is deployed and old production deployments are deleted so previews are publicly reachable.

## IS YOUR CHANGE URGENT?

- [x] Urgent: should merge asap

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
