### PR TITLE
docs(apple): Remove obsolete logs and metrics options

### DIFF
--- a/docs/guides/logs.mdx
+++ b/docs/guides/logs.mdx
@@ -875,7 +875,6 @@ SentrySDK.start { options in
     options.dsn = "..."
     options.environment = "development"
     options.tracesSampleRate = 1.0  // 100% of traces
-    options.enableLogs = true
 }
 ```
 

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -363,9 +363,9 @@ Learn more in the <PlatformLink to="/configuration/graphql-operation-tracking/">
 
 </SdkOption>
 
-<SdkOption name="enableLogs" type="bool" defaultValue="false">
+<SdkOption name="enableLogs" type="bool" defaultValue="false" removedSince="9.27.0">
 
-When enabled, the SDK sends logs to Sentry. You must explicitly set this option to `true` to enable log capturing.
+**Removed in version 9.27.0** — Logs are enabled by default. To stop sending logs, use the <PlatformIdentifier name="beforeSendLog" /> option to return `nil`. See [sentry-cocoa#8783](https://github.com/getsentry/sentry-cocoa/pull/8783) for details.
 
 Learn more about structured logging in the <PlatformLink to="/logs/">logs documentation</PlatformLink>.
 
@@ -486,7 +486,6 @@ import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableLogs = true
     options.beforeSendLog = { log in
         // Filter out info level logs
         if log.level == .info {
@@ -502,7 +501,6 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableLogs = YES;
     options.beforeSendLog = ^SentryLog * _Nullable(SentryLog * _Nonnull log) {
         // Filter out info level logs
         if (log.level == SentryLogLevelInfo) {
@@ -518,7 +516,6 @@ SentrySDK.start { options in
 
 [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableLogs = YES;
     options.beforeSendLog = ^SentryObjCLog * _Nullable(SentryObjCLog * _Nonnull log) {
         // Filter out info level logs
         if (log.level == SentryObjCLogLevelInfo) {
@@ -1247,9 +1244,9 @@ This option is only used when <PlatformIdentifier name="enableSpotlight" /> is s
 
 ## Metrics Options
 
-<SdkOption name="enableMetrics" type="bool" defaultValue="true" availableSince="9.12.0">
+<SdkOption name="enableMetrics" type="bool" defaultValue="true" availableSince="9.12.0" removedSince="9.27.0">
 
-When enabled, the SDK can send metrics to Sentry. Note that metrics are not collected automatically — you must manually call the `SentrySDK.metrics` API to record counters, gauges, and distributions.
+**Removed in version 9.27.0** — Metrics are enabled by default. To stop sending metrics, use the <PlatformIdentifier name="beforeSendMetric" /> option to return `nil`. Metrics are not collected automatically, so you must call the `SentrySDK.metrics` API to record counters, gauges, and distributions. See [sentry-cocoa#8785](https://github.com/getsentry/sentry-cocoa/pull/8785) for details.
 
 Learn more in the <PlatformLink to="/metrics/">Metrics documentation</PlatformLink>.
 
@@ -1314,17 +1311,5 @@ When enabled, the SDK captures fatal C++ exceptions using a more reliable mechan
 <SdkOption name="experimental.enableWatchdogTerminationsV2" type="bool" defaultValue="false">
 
 When enabled, the SDK uses a more efficient mechanism for detecting watchdog terminations.
-
-</SdkOption>
-
-<SdkOption name="experimental.enableMetrics" type="bool" defaultValue="true" availableSince="9.4.0" removedSince="9.12.0">
-
-**Removed in version 9.12.0** — Metrics has graduated to GA. Use the top-level <PlatformIdentifier name="enableMetrics" /> option instead. See [sentry-cocoa#7842](https://github.com/getsentry/sentry-cocoa/pull/7842).
-
-</SdkOption>
-
-<SdkOption name="experimental.beforeSendMetric" type="function" availableSince="9.4.0" removedSince="9.12.0">
-
-**Removed in version 9.12.0** — Metrics has graduated to GA. Use the top-level <PlatformIdentifier name="beforeSendMetric" /> option instead. See [sentry-cocoa#7842](https://github.com/getsentry/sentry-cocoa/pull/7842).
 
 </SdkOption>

--- a/docs/platforms/apple/common/features/index.mdx
+++ b/docs/platforms/apple/common/features/index.mdx
@@ -77,7 +77,7 @@ All features listed below are **enabled by default** unless otherwise noted. Som
 ## Platform-Specific Features
 
 - <PlatformLink to="/configuration/metric-kit">MetricKit</PlatformLink> integration (only available on iOS 15+ and macOS 12+, requires enabling `enableMetricKit` option)
-- Logs capturing (requires <PlatformLink to="/configuration/options#enableLogs">`enableLogs`</PlatformLink> option, only available on iOS, tvOS, visionOS, and macOS)
+- <PlatformLink to="/logs">Logs</PlatformLink> (enabled by default in version 9.27.0 and later, only available on iOS, tvOS, visionOS, and macOS)
 
 ## Data Management
 

--- a/docs/platforms/apple/common/migration/v8-to-v9.mdx
+++ b/docs/platforms/apple/common/migration/v8-to-v9.mdx
@@ -37,9 +37,9 @@ We now automatically disable app hang tracking for: Widgets, Live Activities, Ac
 
 ## Structured Logging
 
-We moved structured logging out of experimental and made it part of the stable API. The `enableLogs` option moved from `options.experimental.enableLogs` to `options.enableLogs`. We added log APIs to `Hub` and `Client`, and logs now include a `sentry.replay_id` attribute.
+We moved structured logging out of experimental and made it part of the stable API. In version 9.0.0, the `enableLogs` option moved from `options.experimental.enableLogs` to `options.enableLogs`. We added log APIs to `Hub` and `Client`, and logs now include a `sentry.replay_id` attribute.
 
-**Migration required:** Update your code from `options.experimental.enableLogs = true` to `options.enableLogs = true`. Logging is not enabled by default; you must explicitly set this option.
+**Migration required:** For SDK versions 9.0.0 through 9.26.x, update your code from `options.experimental.enableLogs = true` to `options.enableLogs = true`. In version 9.27.0 and later, logs are enabled by default and the `enableLogs` option was removed. Remove the option from your configuration. Use `beforeSendLog` to filter or drop logs.
 
 ### HTTP Client Errors
 
@@ -84,7 +84,7 @@ For more information, see the <PlatformLink to="/profiling/#enable-ui-profiling"
 
 - `enableFileManagerSwizzling` is now a top-level non-experimental option and remains disabled by default.
 - `enableDataSwizzling` is now a top-level option and is enabled by default.
-- `enableLogs` is now a top-level non-experimental option and remains disabled by default (you must set it to `true` to enable logging).
+- In version 9.0.0, `enableLogs` became a top-level non-experimental option. In version 9.27.0, the option was removed and logs became enabled by default. Use `beforeSendLog` to filter or drop logs.
 - We increased the maximum attachment size to 200MB (previously 20MB)
 - We removed the following methods and properties:
   - `inAppExclude` (it had no effect)

--- a/docs/platforms/apple/guides/ios/features/index.mdx
+++ b/docs/platforms/apple/guides/ios/features/index.mdx
@@ -34,7 +34,7 @@ iOS supports comprehensive error detection:
 
 ## Logs
 
-<PlatformLink to="/logs">Logs capturing</PlatformLink> is available and requires the `enableLogs` option to be enabled.
+<PlatformLink to="/logs">Logs</PlatformLink> are enabled by default in version 9.27.0 and later.
 
 ## Performance Features Available on iOS
 

--- a/docs/platforms/apple/guides/macos/features/index.mdx
+++ b/docs/platforms/apple/guides/macos/features/index.mdx
@@ -87,7 +87,7 @@ For macOS apps using UIKit (Mac Catalyst), the following features are also avail
 ## Other Features
 
 - Swift Async/Await support for automatically stitching together stack traces of Swift concurrency code
-- <PlatformLink to="/logs">Logs capturing</PlatformLink> available (requires `enableLogs` option)
+- <PlatformLink to="/logs">Logs</PlatformLink> are enabled by default in version 9.27.0 and later
 - Offline caching when a device is unable to connect; we send a report once we receive another event
 
 ## macOS Limitations

--- a/docs/platforms/apple/guides/tvos/features/index.mdx
+++ b/docs/platforms/apple/guides/tvos/features/index.mdx
@@ -72,7 +72,7 @@ tvOS supports comprehensive error detection:
 - <Link to="/product/releases/health">Release health</Link> tracks crash-free users and sessions
 - Offline caching when a device is unable to connect; we send a report once we receive another event
 - Swift Async/Await support for automatically stitching together stack traces of Swift concurrency code
-- <PlatformLink to="/logs">Logs capturing</PlatformLink> available (requires `enableLogs` option)
+- <PlatformLink to="/logs">Logs</PlatformLink> are enabled by default in version 9.27.0 and later
 - <PlatformLink to="/user-feedback">User Feedback</PlatformLink> via programmatic API (no UI available)
 
 For configuration options and detailed documentation, see the <PlatformLink to="/configuration">Configuration</PlatformLink> section.

--- a/docs/platforms/apple/guides/visionos/features/index.mdx
+++ b/docs/platforms/apple/guides/visionos/features/index.mdx
@@ -66,7 +66,7 @@ visionOS supports comprehensive error detection:
 - <Link to="/product/releases/health">Release health</Link> tracks crash-free users and sessions
 - Offline caching when a device is unable to connect; we send a report once we receive another event
 - Swift Async/Await support for automatically stitching together stack traces of Swift concurrency code
-- <PlatformLink to="/logs">Logs capturing</PlatformLink> available (requires `enableLogs` option)
+- <PlatformLink to="/logs">Logs</PlatformLink> are enabled by default in version 9.27.0 and later
 - <PlatformLink to="/user-feedback">User Feedback</PlatformLink> via programmatic API (no UI available)
 
 For configuration options and detailed documentation, see the <PlatformLink to="/configuration">Configuration</PlatformLink> section.

--- a/docs/pricing/quotas/manage-application-metrics-quota.mdx
+++ b/docs/pricing/quotas/manage-application-metrics-quota.mdx
@@ -92,7 +92,7 @@ sentry_sdk.init(
 
 ### Disabling Metrics
 
-If you want to stop sending Application Metrics from a specific SDK entirely, most SDKs expose an option to disable metrics without removing the rest of your Sentry configuration (for example, `enableMetrics: false` in JavaScript SDKs or `experimental.enableMetrics = false` on Apple platforms). See the [platform-specific metrics docs](/product/metrics/getting-started/) for the option name on your SDK.
+If you want to stop sending Application Metrics from a specific SDK entirely, most SDKs expose an option to disable metrics without removing the rest of your Sentry configuration, for example, `enableMetrics: false` in JavaScript SDKs. In Apple SDK version 9.27.0 and later, use `beforeSendMetric` to return `nil` for metrics you do not want to send. See the [platform-specific metrics docs](/product/metrics/getting-started/) for the option name or filtering callback for your SDK.
 
 ### Application Metrics Filtering
 

--- a/includes/apple-platform-getting-started.mdx
+++ b/includes/apple-platform-getting-started.mdx
@@ -125,11 +125,6 @@ func application(_ application: UIApplication,
         options.sessionReplay.onErrorSampleRate = 1.0
         options.sessionReplay.sessionSampleRate = 0.1
         // ___PRODUCT_OPTION_END___ session-replay
-        // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
-        options.enableLogs = true
-        // ___PRODUCT_OPTION_END___ logs
     }
 
     return true
@@ -167,11 +162,6 @@ func application(_ application: UIApplication,
         options.sessionReplay.onErrorSampleRate = 1.0;
         options.sessionReplay.sessionSampleRate = 0.1;
         // ___PRODUCT_OPTION_END___ session-replay
-        // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
-        options.enableLogs = YES;
-        // ___PRODUCT_OPTION_END___ logs
     }];
 
     return YES;
@@ -209,11 +199,6 @@ struct SwiftUIApp: App {
             options.sessionReplay.onErrorSampleRate = 1.0
             options.sessionReplay.sessionSampleRate = 0.1
             // ___PRODUCT_OPTION_END___ session-replay
-
-            // ___PRODUCT_OPTION_START___ logs
-            // Enable logs to be sent to Sentry
-            options.enableLogs = true
-            // ___PRODUCT_OPTION_END___ logs
         }
     }
 }
@@ -248,11 +233,6 @@ func application(_ application: UIApplication,
             $0.sessionSampleRate = 1
         }
         // ___PRODUCT_OPTION_END___ profiling
-        // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
-        options.enableLogs = true
-        // ___PRODUCT_OPTION_END___ logs
     }
 
     return true
@@ -284,11 +264,6 @@ func application(_ application: UIApplication,
             profiling.sessionSampleRate = 1.f;
         };
         // ___PRODUCT_OPTION_END___ profiling
-        // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
-        options.enableLogs = YES;
-        // ___PRODUCT_OPTION_END___ logs
     }];
 
     return YES;
@@ -321,11 +296,6 @@ struct SwiftUIApp: App {
                 $0.sessionSampleRate = 1
             }
             // ___PRODUCT_OPTION_END___ profiling
-            // ___PRODUCT_OPTION_START___ logs
-
-            // Enable logs to be sent to Sentry
-            options.enableLogs = true
-            // ___PRODUCT_OPTION_END___ logs
         }
     }
 }
@@ -355,11 +325,6 @@ func applicationDidFinishLaunching() {
         // We recommend adjusting this value in production.
         options.tracesSampleRate = 1
         // ___PRODUCT_OPTION_END___ performance
-        // ___PRODUCT_OPTION_START___ logs
-
-        // Enable logs to be sent to Sentry
-        options.enableLogs = true
-        // ___PRODUCT_OPTION_END___ logs
     }
 }
 ```

--- a/platform-includes/logs/options/apple.mdx
+++ b/platform-includes/logs/options/apple.mdx
@@ -1,10 +1,10 @@
 #### beforeSendLog
 
-To filter logs, or update them before they are sent to Sentry, you can use the `beforeSendLog` option.
+To filter or modify logs before they are sent to Sentry, use the `beforeSendLog` option.
 
 <Alert>
 
-Starting with version 9.0.0, structured logging is no longer experimental. The option moved from `options.experimental.enableLogs` to `options.enableLogs`.
+Logs are enabled by default in version 9.27.0 and later. In versions 9.0.0 through 9.26.x, set `options.enableLogs` to `true`. Before version 9.0.0, use `options.experimental.enableLogs`.
 
 </Alert>
 
@@ -13,7 +13,6 @@ import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    options.enableLogs = true
 
     options.beforeSendLog = { log in
         if log.level == .info {
@@ -30,7 +29,6 @@ SentrySDK.start { options in
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableLogs = YES;
 
     options.beforeSendLog = ^SentryLog* (SentryLog *log) {
         if (log.level == SentryLogLevelInfo) {
@@ -47,7 +45,6 @@ SentrySDK.start { options in
 
 [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
     options.dsn = @"___PUBLIC_DSN___";
-    options.enableLogs = YES;
 
     options.beforeSendLog = ^SentryLog* (SentryLog *log) {
         if (log.level == SentryLogLevelInfo) {

--- a/platform-includes/logs/setup/apple.mdx
+++ b/platform-includes/logs/setup/apple.mdx
@@ -1,4 +1,6 @@
-To enable logging, set the `enableLogs` option to `true`.
+Logs are enabled by default in version 9.27.0 and later. No additional setup is required.
+
+In versions 9.0.0 through 9.26.x, set the `enableLogs` option to `true`:
 
 ```swift {tabTitle:Swift}
 import Sentry

--- a/platform-includes/metrics/options/apple.mdx
+++ b/platform-includes/metrics/options/apple.mdx
@@ -1,35 +1,6 @@
 The Sentry Cocoa SDK provides several options to configure how metrics are captured and sent to Sentry.
 
-### Enabling/Disabling Metrics
-
-Metrics are enabled by default, but are not collected automatically. You must manually call the `SentrySDK.metrics` API to record metrics. If you need to disable metrics entirely, set `options.enableMetrics` to `false` when initializing the SDK:
-
-```swift {tabTitle:Swift}
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.enableMetrics = false // Metrics are enabled by default
-}
-```
-
-```objc {tabTitle:Objective-C}
-@import Sentry;
-
-[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"___PUBLIC_DSN___";
-    options.enableMetrics = NO; // Metrics are enabled by default
-}];
-```
-
-```objc {tabTitle:Objective-C (SentryObjC)}
-#import <SentryObjC/SentryObjC.h>
-
-[SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
-    options.dsn = @"___PUBLIC_DSN___";
-    options.enableMetrics = NO; // Metrics are enabled by default
-}];
-```
+Metrics are enabled by default, but are not collected automatically. Call the `SentrySDK.metrics` API to record metrics. Use `beforeSendMetric` to filter or drop metrics before the SDK sends them.
 
 ### Filtering and Modifying Metrics
 
@@ -58,7 +29,6 @@ import Sentry
 
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
-    // Metrics are enabled by default, no need to set enableMetrics = true
     options.beforeSendMetric = { metric in
         // Create a mutable copy (SentryMetric is a struct)
         var metric = metric


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the removal of the Apple SDK `enableLogs` and `enableMetrics` options in Sentry Cocoa 9.27.0.

Logs and metrics are now enabled by default, so current Apple setup, filtering, onboarding, feature, and quota guidance no longer configures the removed options. The docs direct developers to `beforeSendLog` and `beforeSendMetric` when they need to drop outgoing data. Version-specific instructions for older SDK releases remain available.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review this PR unless it has an urgent due date.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
