### PR TITLE
fix(python): Update `max_value_length` default

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -180,7 +180,7 @@ Please note that the Sentry server [limits HTTP request body size](https://devel
 
 <SdkOption name="max_value_length" type='Optional[int]' defaultValue='None'>
 
-The number of characters after which the values containing text in the event payload will be truncated. If set to `None` (default), no truncation will be done.
+The number of characters after which the values containing text in the event payload will be truncated. If set to `None` (default), no truncation will be performed.
 
 In SDK versions prior to `2.61`, the default was `100_000`. In SDK versions prior to `2.34.0`, the default was `1024`.
 

--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -178,11 +178,11 @@ Please note that the Sentry server [limits HTTP request body size](https://devel
 
 </SdkOption>
 
-<SdkOption name="max_value_length" type='int' defaultValue='100 000'>
+<SdkOption name="max_value_length" type='Optional[int]' defaultValue='None'>
 
-The number of characters after which the values containing text in the event payload will be truncated.
+The number of characters after which the values containing text in the event payload will be truncated. If set to `None` (default), no truncation will be done.
 
-In SDK versions prior to `2.34.0`, the default was `1024`.
+In SDK versions prior to `2.61`, the default was `100_000`. In SDK versions prior to `2.34.0`, the default was `1024`.
 
 </SdkOption>
 


### PR DESCRIPTION
We changed the default of this SDK option some time ago, but forgot to update the docs.

Closes https://github.com/getsentry/sentry-docs/issues/18902

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
