### PR TITLE
docs(unreal): remove mention of Enable Structured Logging/Metrics options

### DIFF
--- a/docs/platforms/unreal/metrics/index.mdx
+++ b/docs/platforms/unreal/metrics/index.mdx
@@ -23,7 +23,7 @@ With Sentry's [Application Metrics](/product/metrics/), you can send counters, g
 
 ## Automatic Metrics
 
-The SDK can automatically collect performance metrics from the engine without any manual instrumentation. All automatic metrics are configured under **Project Settings > Plugins > Sentry > Metrics > Performance** and require **Enable Metrics** to be checked.
+The SDK can automatically collect performance metrics from the engine without any manual instrumentation. All automatic metrics are configured under **Project Settings > Plugins > Sentry > Metrics > Performance**.
 
 All automatic metrics include the following attributes for filtering and grouping in Sentry dashboards:
 
@@ -54,7 +54,6 @@ To avoid flooding the metrics pipeline, the SDK throttles emission to at most on
 ```cpp
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableMetrics = true;
     Settings->EnableAutoFrameTimeMetrics = true;
     Settings->FrameTimeSampleInterval = 1.0f; // Sample at most once per second (default)
 }));
@@ -77,7 +76,6 @@ GC pauses are a common source of hitches in Unreal Engine games — a single GC 
 ```cpp
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableMetrics = true;
     Settings->EnableAutoGCMetrics = true;
 }));
 ```
@@ -100,7 +98,6 @@ The **Game stats sample interval** setting controls how often game stats are col
 ```cpp
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableMetrics = true;
     Settings->EnableAutoGameStatsMetrics = true;
     Settings->GameStatsSampleIntervalSeconds = 60; // Sample every 60 seconds (default)
 }));
@@ -145,7 +142,6 @@ The **Network metrics sample interval** setting controls how often network stats
 ```cpp
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableMetrics = true;
     Settings->EnableAutoNetworkMetrics = true;
     Settings->NetworkMetricsSampleInterval = 10; // Poll every 10 seconds (default)
 }));

--- a/platform-includes/logs/options/unreal.mdx
+++ b/platform-includes/logs/options/unreal.mdx
@@ -2,7 +2,6 @@ The following configuration options are available for Sentry Logs in Unreal Engi
 
 | Option | Description | Default |
 |--------|-------------|------------|
-| **Enable Structured Logging** | Master toggle for the structured logging feature | `true` |
 | **Enable Debug Logs** | Forward Debug level UE_LOG calls to Sentry | `false` |
 | **Enable Info Logs** | Forward Info level UE_LOG calls to Sentry | `false` |
 | **Enable Warning Logs** | Forward Warning level UE_LOG calls to Sentry | `false` |

--- a/platform-includes/logs/setup/unreal.mdx
+++ b/platform-includes/logs/setup/unreal.mdx
@@ -1,28 +1,4 @@
-To enable logging in your Unreal Engine project, you need to configure the Sentry SDK with structured logging enabled.
-
-### Project Settings Configuration
-
-1. Open your project settings: **Project Settings > Plugins > Sentry**
-2. Check the **Enable Structured Logging** option
-
-### Programmatic Configuration
-
-Alternatively, you can enable logging programmatically when initializing the SDK:
-
-```cpp
-#include "SentrySubsystem.h"
-
-void ConfigureSentryWithLogs()
-{
-    USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
-
-    // Create settings with logging enabled
-    SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
-    {
-        Settings->EnableStructuredLogging = true;
-    }));
-}
-```
+Structured logging is enabled by default, so no setup is required to start capturing logs. This page covers the advanced options available for configuring how logs are captured and forwarded.
 
 ### Advanced Configuration Options
 
@@ -38,8 +14,6 @@ USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem
 // Configure automatic log forwarding programmatically
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableStructuredLogging = true;
-
     // Enable specific severity levels for UE_LOG forwarding
     Settings->StructuredLoggingLevels.bOnDebugLog = false;
     Settings->StructuredLoggingLevels.bOnInfoLog = true;
@@ -59,11 +33,8 @@ You can filter which log categories are sent to Sentry:
 // Configure category filtering
 USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
 
-// Create settings with logging enabled
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableStructuredLogging = true;
-
     // Only forward logs from specific categories
     TArray<FString> AllowedCategories;
     AllowedCategories.Add(TEXT("LogGameFlow"));
@@ -121,9 +92,6 @@ SettingsDelegate.BindDynamic(this, &USomeClass::HandleSettingsDelegate);
 
 void USomeClass::HandleSettingsDelegate(USentrySettings* Settings)
 {
-    // Enable structured logging
-    Settings->EnableStructuredLogging = true;
-
     // Configure individual severity levels
     Settings->StructuredLoggingLevels.bOnDebugLog = false;
     Settings->StructuredLoggingLevels.bOnInfoLog = true;

--- a/platform-includes/metrics/options/unreal.mdx
+++ b/platform-includes/metrics/options/unreal.mdx
@@ -2,7 +2,6 @@ The following configuration options are available for Sentry's [Application Metr
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| **Enable Metrics** | Master toggle for the metrics feature | `true` |
 | **Collect frame time metrics** | Automatically emit frame time and per-thread performance metrics. | `false` |
 | **Frame time sample interval (seconds)** | How often to sample frame time metrics. | `1.0` |
 | **Collect GC pause metrics** | Emit a metric for each garbage collection pause duration. | `false` |
@@ -41,7 +40,6 @@ Configure the handler in project settings under **Hooks > Custom `beforeMetric` 
 ```cpp
 SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
 {
-    Settings->EnableMetrics = true;
     Settings->BeforeMetricHandler = UCustomMetricFilter::StaticClass();
 }));
 ```

--- a/platform-includes/metrics/setup/unreal.mdx
+++ b/platform-includes/metrics/setup/unreal.mdx
@@ -1,24 +1,3 @@
-To enable metrics in your Unreal Engine project, you need to configure the Sentry SDK with metrics enabled.
+Metrics are enabled by default in your Unreal Engine project, so no setup is required to start capturing them.
 
-### Project Settings Configuration
-
-1. Open your project settings: **Project Settings > Plugins > Sentry**
-2. Check the **Enable Metrics** option
-
-### Programmatic Configuration
-
-Alternatively, you can enable metrics programmatically when initializing the SDK:
-
-```cpp
-#include "SentrySubsystem.h"
-
-void ConfigureSentryWithMetrics()
-{
-    USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
-
-    SentrySubsystem->InitializeWithSettings(FConfigureSettingsNativeDelegate::CreateLambda([=](USentrySettings* Settings)
-    {
-        Settings->EnableMetrics = true;
-    }));
-}
-```
+To automatically collect performance metrics from the engine (frame time, GC pauses, game stats, and network), enable the corresponding options under **Project Settings > Plugins > Sentry > Metrics > Performance**.


### PR DESCRIPTION
This PR removes documentation references to the `Enable Structured Logging` and `Enable Metrics` options in the Unreal Engine SDK. Both features are now always enabled, and the corresponding plugin settings are deprecated no-ops.

## Key Changes

- Reframe the logs and metrics **Setup** includes to state the features are enabled by default (drop the "check the option" / "set it programmatically" steps)
- Remove the **Enable Structured Logging** and **Enable Metrics** master-toggle rows from the options tables
- Drop the redundant `Settings->EnableStructuredLogging = true;` / `Settings->EnableMetrics = true;` assignments from the code samples

## Related items

- getsentry/sentry-unreal#1538