### PR TITLE
docs(alerts): move alert creation to its own page

### DIFF
--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -28,7 +28,7 @@ The **Source** determines where issues that can trigger an Alert come from:
 - **Alert on specific monitors**: Connect individual [Monitors](/product/monitors-and-alerts/monitors/) so the Alert only evaluates issues those Monitors create. Click **Connect Monitors** to search all Monitors, filter by project, and select the ones you want. Use **Edit Monitors** to change your selection later, or **Create New Monitor** to set up a new one.
 - **Alert on all issues in all projects**: The Alert evaluates every issue in the organization. See [Alert on All Projects](#alert-on-all-projects) below.
 
-Pick selected projects when you want coverage for a single service, specific Monitors when the Alert only makes sense for a particular set of Monitors such as a single cron job or set of uptime checks, and all projects when the Alert should apply organization-wide.
+Want coverage for an entire single service? Alert on a project. Want to Alert on a particular set of Monitors such as a single cron job or set of uptime checks? Select a subset of monitors. Want an Alert to apply organization-wide? Select all projects.
 
 ### Alert on All Projects
 

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -40,7 +40,7 @@ This is the best choice for teams with simple alerting needs like feed channels 
 
 Select the <PlatformLink to="/configuration/environments/">environment</PlatformLink> the Alert evaluates. This filters on the `environment` tag in your events, so you can send production alerts somewhere different from staging or QA alerts.
 
-The dropdown defaults to All Environments, which applies no environment filter. Otherwise you can select an environment from the list of distinct environment tags across your projects. It's possible also possible to filter environment tag values in the IF section of the Alert Builder, consider this option for complex routing configurations.
+The dropdown defaults to All Environments. You can select a specific environment from the list of environment tags across your projects. It's also possible to filter environment tag values in the IF section of the Alert Builder. Consider this option for complex routing configurations.
 
 ## Step 3: Build the Alert
 

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -1,0 +1,169 @@
+---
+title: Creating an Alert
+sidebar_order: 10
+description: >-
+  Learn about every option available when you create an Alert, including
+  sources, environments, triggers, filters, actions, and throttling.
+---
+
+Alerts let you configure how you want to learn about issue activity like creation, resolution, or when Seer completes tasks. This page walks through each step of the **New Alert** form and the options available in each one.
+
+<Arcade src="https://demo.arcade.software/yXRDN2qTVqtedkfpQIbB?embed" />
+
+To get started, go to **Monitors > [Alerts](https://sentry.io/monitors/alerts)** and click **Create Alert**.
+
+## Permissions
+
+Alerts are an organization-level feature. Owners, Managers, Admins (and Team Admins) can always create and edit Alerts. Members and Team Contributors can too, as long as **Let Members Create and Edit Monitors and Alerts** is enabled in your [organization settings](https://sentry.io/settings/organization/), which it is by default. Learn more about [roles and permissions](/organization/membership/).
+
+<Alert level="warning">
+  Alerts scoped to [all projects](#alert-on-all-projects) can only be managed by Owners and Managers.
+</Alert>
+
+## Step 1: Select a Source
+
+The **Source** determines where issues that can trigger an Alert come from:
+
+- **Alert on all issues in selected projects**: Pick one or more projects. The Alert evaluates every issue in those projects, no matter which Monitor created it.
+- **Alert on specific monitors**: Connect individual [Monitors](/product/monitors-and-alerts/monitors/) so the Alert only evaluates issues those Monitors create. Click **Connect Monitors** to search all Monitors, filter by project, and select the ones you want. Use **Edit Monitors** to change your selection later, or **Create New Monitor** to set up a new one.
+- **Alert on all issues in all projects**: The Alert evaluates every issue in the organization. See [Alert on All Projects](#alert-on-all-projects) below.
+
+Pick selected projects when you want coverage for a single service, specific Monitors when the Alert only makes sense for a particular set of Monitors such as a single cron job or set of uptime checks, and all projects when the Alert should apply organization-wide.
+
+### Alert on All Projects
+
+Selecting **Alert on all issues in all projects** scopes the Alert to your whole organization instead of a set of projects. Sentry evaluates it against every issue in the organization and issues from projects created after you save the Alert are covered automatically.
+
+This is the best choice for teams with simple alerting needs like feed channels in Slack or high level monitoring of newly detected issues.
+
+## Step 2: Filter Issues by Environment
+
+Select the <PlatformLink to="/configuration/environments/">environment</PlatformLink> the Alert evaluates. This filters on the `environment` tag in your events, so you can send production alerts somewhere different from staging or QA alerts.
+
+The dropdown defaults to All Environments, which applies no environment filter. Otherwise you can select an environment from the list of distinct environment tags across your projects. It's possible also possible to filter environment tag values in the IF section of the Alert Builder, consider this option for complex routing configurations.
+
+## Step 3: Build the Alert
+
+The **Alert Builder** has three sections: **When** (triggers), **If** (filters), and **Then** (actions).
+
+### When: Triggers
+
+Triggers are the issue events that start an Alert evaluation. Triggers use `ANY` logic — the Alert evaluates as soon as one of them happens — and each trigger can only be added once.
+
+| Trigger                                            | Runs when                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **A new issue is created**                         | An issue is created.                                                    |
+| **An issue escalates**                             | An event on an issue caused it to move from a lower priority to a higher one, or causes it to be [flagged as escalating](/product/issues/states-triage/escalating-issues). |
+| **A resolved issue regresses**                     | An resolved issue regresses when it's seen again (cannot be triggered by manually unresolving).                                               |
+| **An issue is resolved**                           | An issue is marked as resolved.                             |
+| **An event is captured**                           | Any event is captured for an issue, including events on existing issues.                          |
+| **Seer runs on an issue and reaches the stage...** | [Seer](/product/ai-in-sentry/seer/) finishes one of the stages you select.                        |
+
+For the Seer trigger, select one or more stages: **Root cause analysis completed**, **Planning completed**, **Coding completed**, or **Pull request created**.
+
+Learn more about issue lifecycle in [Issue States and Triage](/product/issues/states-triage/) and the [Seer Autofix process](/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works).
+
+### If: Filters
+
+Filters decide which actions will run when issue triggers occur. 
+
+An Alert can have many **If** blocks and each **If** block evaluates filters matching with `all`, `any`, or `none` logic:
+
+- **all**: every filter must match.
+- **any**: at least one filter must match.
+- **none**: no filter may match.
+
+If you don't add any filters, every issue trigger matches (the block reads **Any event**). 
+
+#### Filter by Issue Attributes
+
+<Alert>
+
+Event attribute, release, and frequency filters only apply to occurrence-based monitors (errors, N+1, and replay), and only to the **A new issue is created** and **An event is captured** triggers. The builder marks these filters with a warning icon.
+
+</Alert>
+
+| Filter               | Options                                                                                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Issue age**        | The issue is **older than** or **newer than** a value in **minutes**, **hours**, **days**, or **weeks**.                                                   |
+| **Issue assignment** | The issue is assigned to **No One**, a **Team**, or a organization **Member**.                                                                                          |
+| **Issue frequency**  | The issue has happened at least a set number of times.                                                                                                     |
+| **Issue category**   | The issue category is **equal to** or **not equal to** one of `error`, `feedback`, `outage`, `metric`, `db_query`, `http_client`, `frontend`, or `mobile`. |
+| **Issue type**       | The issue type is **equal to** or **not equal to** a specific issue type, which is even more granular than category.                                            |
+| **Issue priority**   | The current [issue priority](/product/issues/issue-priority/) is greater than or equal to **high**, **medium**, or **low**.                                |
+| **De-escalation**    | The issue priority de-escalates (ex. high -> medium, or medium -> low).                                                                                   |
+
+#### Filter by Frequency
+
+Frequency filters compare how often sometvhing happens. Each one supports two comparison modes:
+
+- **more than...**: an absolute count in an interval — **in 5 minutes**, **in 15 minutes**, **in one hour**, **in one day**, **in one week**, or **in 30 days**.
+- **relatively higher than...**: a percentage increase over a past interval — **5 minutes ago**, **15 minutes ago**, **one hour ago**, **one day ago**, **one week ago**, or **30 days ago**.
+
+| Filter                              | Description                                                                                                                                                                    |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Number of events**                | How many events the issue has received.                                                                                                                                        |
+| **Number of users affected**        | How many unique users the issue has affected.                                                                                                                                  |
+| **Percentage of sessions affected** | Compares the issue's event count against an estimate of project [sessions](/product/releases/health/#sessions) in the selected interval. Intervals are limited to **5 minutes**, **10 minutes**, **30 minutes**, and **one hour**. |
+
+Frequency filters also accept **sub-filters**, which scope the count to a subset of events. Add one or more sub-filters in the form `[Attribute or Tag] [is / is not] [value]`. Multiple sub-filters are combined with `and`.
+
+#### Filter by Event Attributes
+
+| Filter              | Options                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Event attribute** | The event's [attribute](/concepts/search/searchable-properties/) matches a value. Attributes include `message`, `platform`, `environment`, `type`, `error.handled`, `error.unhandled`, `error.main_thread`, `exception.type`, `exception.value`, `user.id`, `user.email`, `user.username`, `user.ip_address`, `http.method`, `http.url`, `http.status_code`, `sdk.name`, `stacktrace.code`, `stacktrace.module`, `stacktrace.filename`, `stacktrace.abs_path`, `stacktrace.package`, `unreal.crash_type`, `app.in_foreground`, `os.distribution_name`, and `os.distribution_version`. |
+| **Tagged event**    | The event's <PlatformLink to="/enriching-events/tags/">tag</PlatformLink> matches a value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **Event level**     | The event's level **equals**, is **greater than or equal**, or is **less than or equal** to `fatal`, `error`, `warning`, `info`, `debug`, or `sampling`.                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **Latest release**  | The issue is in the latest [release](/product/releases/). This filter has no additional options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **Release age**     | The **oldest** or **newest** adopted release associated with the event's issue is **older than** or **newer than** the latest adopted release in a given environment.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+
+Event attribute and tag filters support these match types: **contains**, **equals**, **starts with**, **ends with**, **does not contain**, **does not equal**, **does not start with**, **does not end with**, **is set**, **is not set**, **is one of**, and **is not one of**.
+
+### Then: Actions
+
+Actions are what Sentry does when the triggers and filters match. Available actions depend on the [integrations](/integrations/) installed in your organization.
+
+#### Notifications
+
+- **Notify on preferred channel**: Notify **Suggested Assignees**, a **Team**, or a **Member**, and Sentry delivers via each recipient's [notification settings](/product/notifications/notification-settings/). Suggested Assignees include current assignees, issue owners from [ownership rules](/product/issues/ownership-rules/), and authors of [suspect commits](/product/issues/suspect-commits/). When no suggested assignee is found, choose a fallback: **Recently Active Members** (default), **All Project Members**, or **No One**.
+- **[Slack](/integrations/notification-incidents/slack/)**: Select the workspace and channel. You can also add a channel or user ID to avoid [rate limiting](/integrations/notification-incidents/slack/#rate-limiting-error), and optionally show **tags** (for example, `environment,my_tag`) and **notes** (for example, `@jane, @on-call-team`) in the message.
+- **[Discord](/integrations/notification-incidents/discord/)**: Select the server and enter a channel ID or URL — a channel name won't work. You can optionally show **tags** in the message.
+- **[MS Teams](/integrations/notification-incidents/msteams/)**: Select the team and channel.
+- **[PagerDuty](/integrations/notification-incidents/pagerduty/)**: Select the service and the **severity** to send.
+- **[Opsgenie](/integrations/notification-incidents/opsgenie/)**: Select the team and the **priority** to send.
+- **Send a notification via an integration**: Take action via a [third party integration](/integrations/third-party-integrations/) that supports Alert actions or trigger a custom webhook.
+
+#### Ticket Creation
+
+Create a work item in an issue tracker, and use **these settings** on the action to configure fields such as project, issue type, assignee, and labels:
+
+- **[Jira](/integrations/issue-tracking/jira/)** and **Jira Server**
+- **[GitHub](/integrations/source-code-mgmt/github/)** and **GitHub Enterprise**
+- **[Azure DevOps](/integrations/source-code-mgmt/azure-devops/)**
+
+#### Other Integrations
+
+Take action via a [third party integration](/integrations/third-party-integrations/) that supports Alert actions or to legacy integrations (plugins) configured on the project.
+
+<Alert>
+
+Click **Send Test Notification** on an **If/Then** block to send a test event through that block's actions. This verifies that your integrations are wired up correctly before you save but event based triggers may behave differently.
+
+</Alert>
+
+### Add Multiple If/Then Blocks
+
+Click **+ If/Then Block** to add another set of filters and actions to the same Alert. Every block evaluates against the same triggers, so you can route different event shapes to different places from a single Alert — for example, create a Jira ticket or Slack notification for every new issue, but only page on-call when the issue is high priority.
+
+## Step 4: Set Throttling
+
+**Throttling** (previously called the action interval) controls how often the Alert can run its actions for a given issue. If events in an issue match triggers repeatedly within the throttle window, the actions won't run again until the throttle period has elapsed.
+
+Options are **Get notified on every trigger** (the default), **5 minutes**, **10 minutes**, **30 minutes**, **60 minutes**, **3 hours**, **12 hours**, **24 hours**, **1 week**, and **30 days**.
+
+## Step 5: Name and Save
+
+Sentry generates a name from your configuration as you build. To change it, click the name in the header at the top of the page and enter a descriptive one, such as "Frontend high priority to #frontend-oncall".
+
+Click **Create Alert** to save. Sentry takes you to the Alert's details page, where you can review its history, edit it, or turn it off. Learn more in [Managing Alerts](/product/monitors-and-alerts/alerts/#managing-alerts).

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -126,6 +126,8 @@ Event attribute and tag filters support these match types: **contains**, **equal
 
 Actions are what Sentry does when the triggers and filters match. Available actions depend on the [integrations](/integrations/) installed in your organization.
 
+Read more about [Notifications](#notifications), [Ticket Creation](#ticket-creation), and [Other Integrations](#other-integrations). 
+
 #### Notifications
 
 - **Notify on preferred channel**: Notify **Suggested Assignees**, a **Team**, or a **Member**, and Sentry delivers via each recipient's [notification settings](/product/notifications/notification-settings/). Suggested Assignees include current assignees, issue owners from [ownership rules](/product/issues/ownership-rules/), and authors of [suspect commits](/product/issues/suspect-commits/). When no suggested assignee is found, choose a fallback: **Recently Active Members** (default), **All Project Members**, or **No One**.

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -46,6 +46,8 @@ The dropdown defaults to All Environments. You can select a specific environment
 
 The **Alert Builder** has three sections: **When** (triggers), **If** (filters), and **Then** (actions).
 
+For example: **When** _an issue is escalated_, **If** _issue category is outage_, **Then** _send a message to the team-platform slack channel_
+
 ### When: Triggers
 
 Triggers are the issue events that start an Alert evaluation. Triggers use `ANY` logic — the Alert evaluates as soon as one of them happens — and each trigger can only be added once.

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -50,7 +50,7 @@ For example: **When** _an issue is escalated_, **If** _issue category is outage_
 
 ### When: Triggers
 
-Triggers are the issue events that start an Alert evaluation. Triggers use `ANY` logic — the Alert evaluates as soon as one of them happens — and each trigger can only be added once.
+Triggers are the issue events that start an Alert evaluation. Triggers use `ANY` logic — the Alert evaluates as soon as one of the events happens — and each trigger can only be added once.
 
 | Trigger                                            | Runs when                                                                                         |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -73,7 +73,7 @@ An Alert can have many **If** blocks and each **If** block evaluates filters mat
 - **any**: at least one filter must match.
 - **none**: no filter may match.
 
-If you don't add any filters, every issue trigger matches (the block reads **Any event**). 
+If you don't add any filters, your Alert will fire on every Issue matching just the selected qualifying trigger event(s) - created, escalated, etc. 
 
 #### Filter by Issue Attributes
 

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -14,7 +14,7 @@ To get started, go to **Monitors > [Alerts](https://sentry.io/monitors/alerts)**
 
 ## Permissions
 
-Alerts are an organization-level feature. Owners, Managers, Admins (and Team Admins) can always create and edit Alerts. Members and Team Contributors can too, as long as **Let Members Create and Edit Monitors and Alerts** is enabled in your [organization settings](https://sentry.io/settings/organization/), which it is by default. Learn more about [roles and permissions](/organization/membership/).
+Alerts are an organization-level feature. Owners, Managers, Admins (and Team Admins) can always create and edit Alerts. By default, Members and Team Contributors can too, under **Let Members Create and Edit Monitors and Alerts**, which is enabled in your [organization settings](https://sentry.io/settings/organization/). Learn more about [roles and permissions](/organization/membership/).
 
 <Alert level="warning">
   Alerts scoped to [all projects](#alert-on-all-projects) can only be managed by Owners and Managers.

--- a/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
+++ b/docs/product/monitors-and-alerts/alerts/create-alerts.mdx
@@ -154,7 +154,7 @@ Click **Send Test Notification** on an **If/Then** block to send a test event th
 
 ### Add Multiple If/Then Blocks
 
-Click **+ If/Then Block** to add another set of filters and actions to the same Alert. Every block evaluates against the same triggers, so you can route different event shapes to different places from a single Alert — for example, create a Jira ticket or Slack notification for every new issue, but only page on-call when the issue is high priority.
+Click **+ If/Then Block** to add another set of filters and actions to the same Alert. Every block evaluates separately against the same triggers, so you can route different event shapes to different places from a single Alert — for example, create a Jira ticket or Slack notification for every new issue, but only page on-call when the issue is high priority.
 
 ## Step 4: Set Throttling
 

--- a/docs/product/monitors-and-alerts/alerts/index.mdx
+++ b/docs/product/monitors-and-alerts/alerts/index.mdx
@@ -5,7 +5,7 @@ sidebar_order: 60
 og_image: /og-images/product-alerts.png
 ---
 
-Sentry's **Alerts** take action when issues in your organization match pre-defined rules. An alert can send notifications, create tickets, call webhooks, or use other [integrations](/integrations/)—for issues coming from projects or [Monitors](/product/monitors-and-alerts/monitors/).
+Sentry's **Alerts** take action when issues in your organization match pre-defined rules. An alert can send notifications, create tickets, call webhooks, or use other [integrations](/integrations/) for issues coming from projects or [Monitors](/product/monitors-and-alerts/monitors/).
 
 ### Some examples of when you could use an Alert
 

--- a/docs/product/monitors-and-alerts/alerts/index.mdx
+++ b/docs/product/monitors-and-alerts/alerts/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Alerts
-description: Use Alerts to notify or take action on important issues. 
+description: Use Alerts to notify or take action on important issues.
 sidebar_order: 60
 og_image: /og-images/product-alerts.png
 ---
@@ -15,29 +15,19 @@ Sentry's **Alerts** take action when issues in your organization match pre-defin
 
 ![alert-config =800x](./img/alert-details.png)
 
-## Creating an Alert
+## Creating Alerts
 
-<Arcade src="https://demo.arcade.software/yXRDN2qTVqtedkfpQIbB?embed" />
+You can create an Alert from **Monitors > [Alerts](https://sentry.io/monitors/alerts)**. When creating an Alert, you'll configure the issue sources, event triggers, filters, actions, and Alert throttling.
 
-To create an Alert, go to the [Alerts](https://sentry.io/monitors/alerts) page in Sentry and click **Create Alert**.
+For an in-depth walkthrough of each setting, see [Creating an Alert](/product/monitors-and-alerts/alerts/create-alerts/).
 
-### Select Sources and Environments
+<Alert>
 
-The source of an Alert can be one or more Projects, or one or more Monitors. After you choose sources, pick which **environment(s)** the alert evaluates. By default, alerts run across all environments.
+Alerts are an Organization-level feature. Org Owners, Org Managers, Org Admins, and Team Admins can always create and edit Alerts. Org Members and Team Contributors can too, as long as **Let Members Create and Edit Monitors and Alerts** is enabled (the default) in your [organization settings](https://sentry.io/settings/organization/). Alerts scoped to all projects are restricted to Org Owners and Org Managers.
 
-### Set Triggers
+</Alert>
 
-A trigger is an action that must occur for the Alert to run. All trigger actions are issue state based. For example, you may want to send a notification to your team's Slack channel _when an issue is created_. You can select multiple triggers in a single Alert. They will run under an `ANY` condition, meaning that if any one of the triggers happen, the Alert will run.
-
-### Set Filters
-
-Filters are conditions that must be met for the Alert to run. For example, you may want to create a ticket _only for issues that are assigned to a specific team_ and _at a certain severity_. You can create multiple filters in a single Alert, and group them under either `ANY` or `ALL` conditions. For `ANY` conditions, if any one of the filters are true, the Alert will run. For `ALL` conditions, only if all of the filters are true, the Alert will run.
-
-### Add Actions
-
-Actions run when triggers and filters match. Depending on your integrations, actions can include chat notifications (Slack, Microsoft Teams, Discord), email, on-call tools (PagerDuty, Opsgenie), issue trackers (Jira, Azure DevOps, Linear), webhooks, and [integrations](/integrations/integration-platform/).
-
-**Note:** Some integrations are only available for certain sources or issue types. Check [Integrations](/integrations/) for your workspace.
+Available actions depend on the [integrations](/integrations/) installed in your organization, and some integrations are only available for certain sources or issue types.
 
 ### When to Notify the Team
 
@@ -51,12 +41,6 @@ Using Alerts with custom filters allows you to notify the team about critical is
 
 You can see a list of all your Alerts on the [Alerts](https://sentry.io/monitors/alerts) page. By default, Alerts are filtered down to your projects.
 
-<Alert>
-
-Alerts are an Organization-level feature. By default, all team members can create and edit Alerts. You can update this setting in [Organization Membership settings](https://sentry.io/settings/organization/).
-
-</Alert>
-
 By clicking on an Alert, you can view the details, edit the Alert, or turn it on or off.
 
 The details page will show a high level chart of how often the Alert has run, a list of the most recent runs, the configuration, and connected monitors.
@@ -66,10 +50,15 @@ The details page will show a high level chart of how often the Alert has run, a 
 The main goal is to create Alerts that are valuable and not too noisy.
 
 Here are some quick tips:
+
 - Use filters to narrow down the issues that are critical for to your team to be notified about.
 - Select only the triggers that matter for Alerting actions. For example, you may want to create a Jira ticket any time an issue is created, but only be notified in Slack when an issue is a certain severity.
-- Consider how your team works in terms of triaging. For example, do you want individual alerts routing to specific project, or service channels, or one alert to catch them all in a team channel? 
+- Consider how your team works in terms of triaging. For example, do you want individual alerts routing to specific project, or service channels, or one alert to catch them all in a team channel?
 
 ## Sentry Notifications
 
 Besides Alerts, Sentry sends you notifications about various things like [issue state changes](/product/issues/states-triage/), [release deploys](/product/releases/), and [quota usage](/pricing/quotas/). You can fine-tune these notifications, as well as your personal alert settings, in **User Settings > Notifications**. Learn more about notifications and adjusting their associated settings in [the full documentation](/product/notifications/).
+
+## Learn More
+
+<PageGrid />

--- a/docs/product/monitors-and-alerts/index.mdx
+++ b/docs/product/monitors-and-alerts/index.mdx
@@ -14,7 +14,7 @@ Sentry separates **what you detect** from **what you do about it**:
 
 Using both Monitors and Alerts gives you a path from signal → triageable issue → team workflow, without wiring every integration by hand for every edge case.
 
-For a concise **Issues-centric** explanation (how this shows up in your triage flow), see [Monitors and Alerts](/product/issues/monitors-and-alerts/). For **hands-on setup**, see [Creating an Alert](/product/monitors-and-alerts/alerts/#creating-an-alert).
+For a concise **Issues-centric** explanation (how this shows up in your triage flow), see [Monitors and Alerts](/product/issues/monitors-and-alerts/). For **hands-on setup**, see [Creating an Alert](/product/monitors-and-alerts/alerts/create-alerts/).
 
 ## End-to-End Flow
 

--- a/docs/product/monitors-and-alerts/monitors/crons/job-monitoring.mdx
+++ b/docs/product/monitors-and-alerts/monitors/crons/job-monitoring.mdx
@@ -32,7 +32,7 @@ To monitor the same job in different environments, use a shared schedule to send
 
 ### Alerting on Specific Environments
 
-To only receive failing or missed monitor notifications for a specific environment or set of environments, scope your **[Alert](/product/monitors-and-alerts/alerts/)** sources and **environments** to match the check-in you care about, and use filters (for example on tags such as `monitor.slug`) where needed. See [Select Sources and Environments](/product/monitors-and-alerts/alerts/#select-sources-and-environments). For how the check-in `environment` is sent, see your SDK [environment configuration](/platform-redirect/?next=/configuration/environments/).
+To only receive failing or missed monitor notifications for a specific environment or set of environments, scope your **[Alert](/product/monitors-and-alerts/alerts/)** sources and **environments** to match the check-in you care about, and use filters (for example on tags such as `monitor.slug`) where needed. See [Select a Source](/product/monitors-and-alerts/alerts/create-alerts/#step-1-select-a-source). For how the check-in `environment` is sent, see your SDK [environment configuration](/platform-redirect/?next=/configuration/environments/).
 
 ### Existing Limitations:
 

--- a/docs/product/monitors-and-alerts/monitors/uptime-monitoring/index.mdx
+++ b/docs/product/monitors-and-alerts/monitors/uptime-monitoring/index.mdx
@@ -95,7 +95,7 @@ Uptime checks include spans called _uptime request spans_ that Sentry automatica
 
 ## Notifications
 
-To start getting notifications for a new downtime issue, [configure an Alert](/product/monitors-and-alerts/alerts/#creating-an-alert) that matches outage / downtime issues and add actions for email, Slack, on-call tools, or other integrations.
+To start getting notifications for a new downtime issue, [configure an Alert](/product/monitors-and-alerts/alerts/create-alerts/) that matches outage / downtime issues and add actions for email, Slack, on-call tools, or other integrations.
 
 ![Uptime alert configuration](./img/uptime-alert.png)
 

--- a/docs/product/monitors-and-alerts/monitors/uptime-monitoring/troubleshooting.mdx
+++ b/docs/product/monitors-and-alerts/monitors/uptime-monitoring/troubleshooting.mdx
@@ -24,4 +24,4 @@ See [IP Ranges](/security-legal-pii/security/ip-ranges/#uptime-monitoring) for a
 
 ## Verify That Alerts Match Downtime Issues
 
-Uptime monitors create downtime issues. If you're not receiving notifications when downtimes are detected, make sure you've [configured an Alert](/product/monitors-and-alerts/alerts/#creating-an-alert) whose sources and filters match those issues, with actions for the channels you expect.
+Uptime monitors create downtime issues. If you're not receiving notifications when downtimes are detected, make sure you've [configured an Alert](/product/monitors-and-alerts/alerts/create-alerts/) whose sources and filters match those issues, with actions for the channels you expect.

--- a/redirects.js
+++ b/redirects.js
@@ -2994,11 +2994,11 @@ const userDocsRedirects = [
   },
   {
     source: '/product/alerts/create-alerts/',
-    destination: '/product/monitors-and-alerts/alerts/',
+    destination: '/product/monitors-and-alerts/alerts/create-alerts/',
   },
   {
     source: '/product/alerts/create-alerts/issue-alert-config/',
-    destination: '/product/monitors-and-alerts/alerts/',
+    destination: '/product/monitors-and-alerts/alerts/create-alerts/',
   },
   {
     source: '/product/alerts/create-alerts/metric-alert-config/',
@@ -3006,7 +3006,7 @@ const userDocsRedirects = [
   },
   {
     source: '/product/alerts/create-alerts/routing-alerts/',
-    destination: '/product/monitors-and-alerts/alerts/',
+    destination: '/product/monitors-and-alerts/alerts/create-alerts/',
   },
   {
     source: '/product/alerts/create-alerts/uptime-alert-config/',


### PR DESCRIPTION
Split the per-option detail out of the Alerts index into a dedicated Creating an Alert page, and document the new "alert on all issues in all projects" source option.

- Add docs/product/monitors-and-alerts/alerts/create-alerts.mdx covering sources, environment, triggers, filters, actions, and throttling
- Trim the Alerts index to a high-level summary plus permissions
- Point legacy /product/alerts/create-alerts/ redirects at the new page
- Update inbound links from the Monitors and uptime pages

<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
*Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically.*

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
