### PR TITLE
docs(javascript): clarify HTTP headers require sendDefaultPii

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -110,7 +110,7 @@ Set to `false` to opt out, for example, when using a custom `tunnel` or when run
   (v11). Use [`dataCollection`](#dataCollection) instead.
 </Alert>
 
-Set this option to `true` to send default PII data to Sentry. Among other things, enabling this will enable automatic IP address collection on events.
+Set this option to `true` to send default PII data to Sentry. Among other things, enabling this will enable automatic IP address collection on events, and it is required to collect HTTP response headers (and most request headers) when you are not using [`dataCollection`](#dataCollection). See <PlatformLink to="/data-management/data-collected/#http-headers">Data Collected: HTTP Headers</PlatformLink> for details.
 
 For backwards compatibility, `sendDefaultPii: true` behaves like enabling all [`dataCollection`](#dataCollection) categories.
 If both options are set, `dataCollection` takes precedence.

--- a/docs/platforms/javascript/common/data-management/data-collected/index.mdx
+++ b/docs/platforms/javascript/common/data-management/data-collected/index.mdx
@@ -22,9 +22,9 @@ Regardless of these options, you can always scrub any data before it's sent to S
 
 ## HTTP Headers
 
-By default, the Sentry SDK sends HTTP request and response headers.
+By default, the Sentry SDK does **not** send HTTP response headers, and most request headers are omitted as well (for example, browser SDKs may only include limited request headers such as `User-Agent`). When using `dataCollection`, however, request and response headers are collected with sensitive values scrubbed. Opt out by setting `dataCollection: { httpHeaders: false }`.
 
-Use the `dataCollection.httpHeaders` option to control this. For example, set `dataCollection: { httpHeaders: false }` to disable it, or use `{ allow: [...] }` or `{ deny: [...] }` to restrict which header values are sent. Values whose keys match Sentry's built-in sensitive denylist (such as `auth`, `token`, or `password`) are automatically scrubbed, while the keys are kept.
+To collect HTTP headers when not using `dataCollection`, set the deprecated `sendDefaultPii: true` in `Sentry.init()`. Response headers in particular require this opt-in (or an explicit `dataCollection.httpHeaders` setting). You can also restrict which header values are sent using `{ allow: [...] }` or `{ deny: [...] }` on `dataCollection.httpHeaders`. Values whose keys match Sentry's built-in sensitive denylist (such as `auth`, `token`, or `password`) are automatically scrubbed, while the keys are kept.
 
 ## Cookies
 


### PR DESCRIPTION
## Summary
- Correct the JavaScript **Data Collected** docs: HTTP response headers (and most request headers) are **not** sent by default.
- Clarify that collecting them requires the deprecated `sendDefaultPii: true`, or an explicit `dataCollection.httpHeaders` setting (aligned with the Cookies section and maintainer comments on the issue).
- Link `sendDefaultPii` option docs to the HTTP Headers section on Data Collected.

Fixes getsentry/sentry-javascript#20706

## Test plan
- [ ] Preview the Data Collected page HTTP Headers section
- [ ] Confirm `sendDefaultPii` option text links to `#http-headers`
- [ ] Cross-check wording against Cookies / `dataCollection` defaults on the same page
