### PR TITLE
Remove accidental re-inclusion of Event PII Fields Event.exceptions.value

### DIFF
--- a/src/data/relay_event_pii.json
+++ b/src/data/relay_event_pii.json
@@ -44,10 +44,6 @@
     "additional_properties": false
   },
   {
-    "path": "Event.exceptions.value",
-    "additional_properties": false
-  },
-  {
     "path": "Event.expectct",
     "additional_properties": false
   },


### PR DESCRIPTION

## DESCRIBE YOUR PR
Reverting #13555 which shouldn't have been merged. This field was intentionally removed from Event PII Fields and called out in our changelog explicitly in Apr 2025 https://sentry.io/changelog/default-event-pii-fields-scrubbed/ 

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.

- [X] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
