### PR TITLE
docs(python): Update FastAPI quick start guide

### DIFF
--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -242,7 +242,7 @@ The default is `{*range(500, 600)}`, meaning that all 5xx status codes are repor
 
 <SdkOption name='middleware_spans' type='bool' defaultValue='False'>
 
-Create spans and track performance of all middleware layers in your Django project. Set to `True` to enable.
+Create spans and track performance of all middleware layers in your FastAPI project. Set to `True` to enable.
 The default is `False`.
 
 </SdkOption>

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -134,12 +134,23 @@ async def trigger_error():
 
 </OnboardingOption>
 
+### View Captured Data in Sentry
+
+Now, head over to your project on [Sentry.io](https://sentry.io) to view the collected data (it takes a couple of moments for the data to appear).
+
+<Include name="quick-start-locate-data-expandable" />
+
 ## Options
 
 <Include name="python-stream-mode-integration-option-callout.mdx" />
 
-By adding `FastApiIntegration` to your `sentry_sdk.init()` call explicitly, you can set options for `FastApiIntegration` to change its behavior.
+Add `FastApiIntegration` to your `sentry_sdk.init()` call to set options for `FastApiIntegration` to change its behavior.
+
+<Alert level="warning">
+
 Because FastAPI is based on the Starlette framework, both integrations, `StarletteIntegration` and `FastApiIntegration`, must be instantiated.
+
+</Alert>
 
 ```python
 from sentry_sdk.integrations.starlette import StarletteIntegration
@@ -164,11 +175,24 @@ sentry_sdk.init(
 
 You can pass the following keyword arguments to `StarletteIntegration()` and `FastApiIntegration()`:
 
-- `transaction_style`:
+<SdkOption name='transaction_style' type='string' defaultValue='"url"'>
 
-  This option lets you influence how the transactions are named in Sentry. For example:
+How to name transactions that show up in Sentry tracing.
+The default is `"url"`.
 
-  ```python
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+In the code example, the transaction name will be:
+
+- `"/catalog/product/{product_id}"` if you set `transaction_style="url"`
+- `"product_detail"` if you set `transaction_style="endpoint"`
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```python
   import sentry_sdk
   from sentry_sdk.integrations.starlette import StarletteIntegration
   from sentry_sdk.integrations.fastapi import FastApiIntegration
@@ -190,43 +214,56 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
   @app.get("/catalog/product/{product_id}")
   async def product_detail(product_id):
       return {...}
-  ```
+```
 
-  In the above code, the transaction name will be:
-  - `"/catalog/product/{product_id}"` if you set `transaction_style="url"`
-  - `"product_detail"` if you set `transaction_style="endpoint"`
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-  The default is `"url"`.
+</SdkOption>
 
-- `failed_request_status_codes`:
+<SdkOption name='failed_request_status_codes' type='set[int]' defaultValue='{*range(500, 600)}'>
 
-  A `set` of integers that will determine which status codes should be reported to Sentry.
+A `set` of integers that determine which status codes should be reported to Sentry.
 
-  The `failed_request_status_codes` option determines whether [`HTTPException`](https://fastapi.tiangolo.com/reference/exceptions/?h=httpexception) exceptions should be
-  reported to Sentry. Unhandled exceptions that don't have a `status_code` attribute will always be reported to Sentry.
+The `failed_request_status_codes` option determines whether [`HTTPException`](https://fastapi.tiangolo.com/reference/exceptions/?h=httpexception) exceptions should be
+reported to Sentry. Unhandled exceptions that don't have a `status_code` attribute will always be reported to Sentry.
 
-  Examples of valid `failed_request_status_codes`:
-  - `{500}` will only send events on HTTP 500.
-  - `{400, *range(500, 600)}` will send events on HTTP 400 as well as the 5xx range.
-  - `{500, 503}` will send events on HTTP 500 and 503.
-  - `set()` (the empty set) will not send events for any HTTP status code.
+Examples of valid `failed_request_status_codes`:
 
-  The default is `{*range(500, 600)}`, meaning that all 5xx status codes are reported to Sentry.
+- `{500}` will only send events on HTTP 500.
+- `{400, *range(500, 600)}` will send events on HTTP 400 as well as the 5xx range.
+- `{500, 503}` will send events on HTTP 500 and 503.
+- `set()` (the empty set) will not send events for any HTTP status code.
 
-- `middleware_spans`:
+The default is `{*range(500, 600)}`, meaning that all 5xx status codes are reported to Sentry.
 
-  Create spans and track performance of all middleware layers in your FastAPI project. Set to `True` to enable.
+</SdkOption>
 
-  The default is `False`.
+<SdkOption name='middleware_spans' type='bool' defaultValue='False'>
 
-- `http_methods_to_capture`:
+Create spans and track performance of all middleware layers in your Django project. Set to `True` to enable.
+The default is `False`.
 
-  A tuple containing all the HTTP methods that should create a transaction in Sentry.
+</SdkOption>
 
-  The default is `("CONNECT", "DELETE", "GET", "PATCH", "POST", "PUT", "TRACE",)`.
+<SdkOption name='http_methods_to_capture' type='Tuple[str, ...]' defaultValue='("CONNECT", "DELETE", "GET", "PATCH", "POST", "PUT", "TRACE",)' availableSince='2.15.0'>
 
-  (Note that `OPTIONS` and `HEAD` are missing by default.)
+A tuple containing all the HTTP methods (as uppercase strings) that should create a transaction in Sentry.
+The default is `("CONNECT", "DELETE", "GET", "PATCH", "POST", "PUT", "TRACE",)`.
 
-  <Alert title="Added in 2.15.0">The `http_methods_to_capture` option.</Alert>
+Note that `OPTIONS` and `HEAD` are excluded by default.
 
+</SdkOption>
+
+## Next Steps
+
+<PlatformContent includePath="getting-started-next-steps" />
+
+<Expandable permalink={false} title="Are you having problems setting up the SDK?">
+
+- Find various topics in <PlatformLink to="/troubleshooting/">Troubleshooting</PlatformLink>
+- [Get support](https://www.sentry.help/en/)
+
+</Expandable>
 </StepConnector>

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -26,7 +26,7 @@ You need:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs", "metrics"]}
+  options={["error-monitoring", "performance", "profiling", "metrics"]}
 />
 
 <Include name="quick-start-features-expandable" />

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -122,11 +122,7 @@ async def trigger_error():
 
 </OnboardingOption>
 
-<OnboardingOption optionId="logs">
-
 <Include name="logs/python-quick-start-verify-logs-splitlayout.mdx" />
-
-</OnboardingOption>
 
 <OnboardingOption optionId="metrics">
 

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -1,32 +1,104 @@
 ---
 title: FastAPI
-description: Learn about using Sentry with FastAPI.
+description: Learn how to set up Sentry in you FastAPI app, capture your first errors and traces, and view them in Sentry.
 og_image: /og-images/platforms-python-integrations-fastapi.png
 ---
 
-The FastAPI integration adds support for the [FastAPI Framework](https://fastapi.tiangolo.com/).
-
 <Include name="python-stream-mode-general-callout.mdx" />
+
+## Prerequisites
+
+You need:
+
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running
+- FastAPI `0.79.0+`
+- Python `3.7+`
+
+<StepConnector selector="h2" showNumbers={true}>
 
 ## Install
 
-Install `sentry-sdk` from PyPI:
-
-```bash {tabTitle:pip}
-pip install sentry-sdk
-```
-
-```bash {tabTitle:uv}
-uv add sentry-sdk
-```
+<PlatformContent includePath="getting-started-install" />
 
 ## Configure
 
-If you have the `fastapi` package in your dependencies, the FastAPI integration will be enabled automatically when you initialize the Sentry SDK.
+Choose the features you want to configure, and this guide will show you how:
 
-<PlatformContent includePath="getting-started-config" />
+<OnboardingOptionButtons
+  options={["error-monitoring", "performance", "profiling", "logs", "metrics"]}
+/>
 
-## Verify
+<Include name="quick-start-features-expandable" />
+
+### Initialize the Sentry SDK
+
+Configuration should happen as **early as possible** in your application's lifecycle.
+
+<Alert>
+
+If you have the `fastapi` package in your dependencies, the Sentry FastAPI integration will be enabled automatically when you initialize the Sentry SDK.
+
+</Alert>
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+Import and initialize the SDK in your app's entry point:
+
+</SplitSectionText>
+<SplitSectionCode>
+
+<PlatformContent
+  includePath="getting-started-config"
+  platform="python.splitlayout"
+/>
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+To further customize your setup, review the [Options section](#options) below.
+
+### Capturing Errors
+
+Sentry automatically captures errors and reports issues for you.
+You can also expect the following for your FastAPI project:
+
+- By default, all exceptions leading to an Internal Server Error are captured and reported. The HTTP status codes to report on are configurable via the `failed_request_status_codes` [option](#options).
+- Request data will be attached to all events: HTTP method, URL, headers, form data, JSON payloads. Sentry excludes raw bodies and multipart file uploads.
+- Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+
+To learn how to manually report issues, see <PlatformLink to="/usage/">Capturing Errors</PlatformLink>.
+
+<OnboardingOption optionId="performance">
+
+The Sentry SDK automatically monitors the following parts of your FastAPI project:
+
+- Middleware stack
+- Middleware `send` and `receive` callbacks
+- Database queries
+- Redis commands
+
+You can also manually capture performance data – see <PlatformLink to="/tracing/instrumentation/custom-instrumentation/">Custom Instrumentation</PlatformLink> to learn more.
+
+</OnboardingOption>
+
+## Verify Your Setup
+
+Let's test your setup and confirm that data reaches your Sentry project.
+
+### Issues
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+To verify that Sentry captures errors and creates issues in your Sentry project, add this intentional error to your application:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```python
 from fastapi import FastAPI
@@ -40,35 +112,27 @@ async def trigger_error():
     division_by_zero = 1 / 0
 ```
 
-When you point your browser to [http://localhost:8000/sentry-debug](http://localhost:8000/sentry-debug) a transaction will be created in the Performance section of [sentry.io](https://sentry.io). Additionally, an error event will be sent to [sentry.io](https://sentry.io) and will be connected to the transaction.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+<OnboardingOption optionId="performance">
 
-## Behaviour
+<Include name="tracing/python-quick-start-verify-tracing-splitlayout.mdx" />
 
-### Issue Reporting
+</OnboardingOption>
 
-The following information about your FastAPI project will be available to you on Sentry.io:
+<OnboardingOption optionId="logs">
 
-- By default, all exceptions leading to an Internal Server Error are captured and reported. The HTTP status codes to report on are configurable via the `failed_request_status_codes` [option](#options).
-- Request data such as URL, HTTP method, headers, form data, and JSON payloads is attached to all issues.
-- Sentry excludes raw bodies and multipart file uploads.
-- Sentry also excludes personally identifiable information (such as user ids, usernames, cookies, authorization headers, IP addresses) unless you set `send_default_pii` to `True`.
+<Include name="logs/python-quick-start-verify-logs-splitlayout.mdx" />
 
-### Monitor Performance
+</OnboardingOption>
 
-The following parts of your FastAPI project are monitored:
+<OnboardingOption optionId="metrics">
 
-- Middleware stack
-- Middleware `send` and `receive` callbacks
-- Database queries
-- Redis commands
+<Include name="metrics/python-quick-start-verify-metrics-splitlayout.mdx" />
 
-<Alert>
-
-The parameter [traces_sample_rate](/platforms/python/configuration/options/#traces-sample-rate) needs to be set when initializing the Sentry SDK for performance measurements to be recorded.
-
-</Alert>
+</OnboardingOption>
 
 ## Options
 
@@ -165,7 +229,4 @@ You can pass the following keyword arguments to `StarletteIntegration()` and `Fa
 
   <Alert title="Added in 2.15.0">The `http_methods_to_capture` option.</Alert>
 
-## Supported Versions
-
-- FastAPI: 0.79.0+
-- Python: 3.7+
+</StepConnector>

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: FastAPI
-description: Learn how to set up Sentry in you FastAPI app, capture your first errors and traces, and view them in Sentry.
+description: Learn how to set up Sentry in your FastAPI app, capture your first errors and traces, and view them in Sentry.
 og_image: /og-images/platforms-python-integrations-fastapi.png
 ---
 

--- a/docs/platforms/python/integrations/fastapi/index.mdx
+++ b/docs/platforms/python/integrations/fastapi/index.mdx
@@ -26,7 +26,7 @@ You need:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "metrics"]}
+  options={["error-monitoring", "performance", "profiling", "logs", "metrics"]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -73,6 +73,8 @@ You can also expect the following for your FastAPI project:
 To learn how to manually report issues, see <PlatformLink to="/usage/">Capturing Errors</PlatformLink>.
 
 <OnboardingOption optionId="performance">
+
+### Instrumenting Your App
 
 The Sentry SDK automatically monitors the following parts of your FastAPI project:
 
@@ -122,7 +124,11 @@ async def trigger_error():
 
 </OnboardingOption>
 
+<OnboardingOption optionId="logs">
+
 <Include name="logs/python-quick-start-verify-logs-splitlayout.mdx" />
+
+</OnboardingOption>
 
 <OnboardingOption optionId="metrics">
 

--- a/platform-includes/getting-started-config/python.splitlayout.mdx
+++ b/platform-includes/getting-started-config/python.splitlayout.mdx
@@ -1,0 +1,31 @@
+```python
+import sentry_sdk
+# ___PRODUCT_OPTION_START___ metrics
+from sentry_sdk import metrics
+# ___PRODUCT_OPTION_END___ metrics
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    # Add data like request headers and IP for users, if applicable;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    # ___PRODUCT_OPTION_START___ performance
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for tracing.
+    traces_sample_rate=1.0,
+    # ___PRODUCT_OPTION_END___ performance
+    # ___PRODUCT_OPTION_START___ profiling
+    # To collect profiles for all profile sessions,
+    # set `profile_session_sample_rate` to 1.0.
+    profile_session_sample_rate=1.0,
+    # Profiles will be automatically collected while
+    # there is an active span.
+    profile_lifecycle="trace",
+    # ___PRODUCT_OPTION_END___ profiling
+    # ___PRODUCT_OPTION_START___ logs
+
+    # Enable logs to be sent to Sentry
+    enable_logs=True,
+    # ___PRODUCT_OPTION_END___ logs
+)
+```

--- a/platform-includes/getting-started-config/python.splitlayout.mdx
+++ b/platform-includes/getting-started-config/python.splitlayout.mdx
@@ -22,10 +22,5 @@ sentry_sdk.init(
     # there is an active span.
     profile_lifecycle="trace",
     # ___PRODUCT_OPTION_END___ profiling
-    # ___PRODUCT_OPTION_START___ logs
-
-    # Enable logs to be sent to Sentry
-    enable_logs=True,
-    # ___PRODUCT_OPTION_END___ logs
 )
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updated the FastAPI quick start guide to follow our quick start guide template.

* adds some more includes for shared content within the guides
* split layout
* follows general structure of quick start guide
* adds "metrics" to onboarding options
* adds more Verify examples
* uses SdkOption for a clean options list
* removes "enable_logs"

Closes: getsentry/sentry-docs#19008

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.

- [ ] Urgent deadline (GA date, etc.):
- [ ] Other deadline:
- [X] None: Not urgent, can wait up to 1 week+

## SLA

* Teamwork makes the dream work, so please add a reviewer to your PRs.
* Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.  <br>Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](<https://github.com/orgs/getsentry/teams/docs>)

## EXTRA RESOURCES

* [Sentry Docs contributor guide](<https://docs.sentry.io/contributing/>)