### PR TITLE
docs(js): make logs enabled by default, drop required enableLogs flag

### DIFF
--- a/docs/platforms/javascript/common/best-practices/sentry-testkit.mdx
+++ b/docs/platforms/javascript/common/best-practices/sentry-testkit.mdx
@@ -78,7 +78,7 @@ Beyond errors and performance transactions, the testkit captures a range of Sent
 
 - **Errors** — `testkit.reports()` returns all captured error reports. Each report also exposes any evaluated feature flags via `report.flags`.
 - **Transactions** — `testkit.transactions()` returns all captured performance transactions.
-- **Structured logs** — `testkit.logs()` returns captured logs (requires `enableLogs: true` in your Sentry configuration).
+- **Structured logs** — `testkit.logs()` returns captured logs (on SDK versions below `10.71.0`, requires `enableLogs: true` in your Sentry configuration).
 - **User feedback** — `testkit.feedback()` returns submitted user feedback.
 - **Cron check-ins** — `testkit.checkIns()` returns cron monitor check-ins with their status.
 

--- a/docs/platforms/javascript/common/configuration/integrations/pino.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/pino.mdx
@@ -36,9 +36,12 @@ _Import name: `Sentry.pinoIntegration`_
 
 The `pinoIntegration` adds instrumentation for the `pino` library so that calls to the pino logger are captured as logs. Optionally, you can capture calls to the pino logger as errors.
 
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
+
 ```JavaScript
 Sentry.init({
-  enableLogs: true,
   integrations: [Sentry.pinoIntegration()],
 });
 ```
@@ -72,7 +75,7 @@ Configure how pino logs are captured as Sentry logs.
 - Type: `Array<'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'>`
 - Default: `["trace", "debug", "info", "warn", "error", "fatal"]`
 
-Levels that trigger capturing of logs. Logs are only captured if `enableLogs` is enabled in your Sentry configuration.
+Levels that trigger capturing of logs.
 
 ## Supported Versions
 
@@ -84,7 +87,6 @@ Levels that trigger capturing of logs. Logs are only captured if `enableLogs` is
 
 ```js
 Sentry.init({
-  enableLogs: true,
   integrations: [
     Sentry.pinoIntegration({ log: { levels: ["info", "warn", "error"] } }),
   ],
@@ -95,7 +97,6 @@ Sentry.init({
 
 ```js
 Sentry.init({
-  enableLogs: true,
   integrations: [
     Sentry.pinoIntegration({ error: { levels: ["warn", "error"] } }),
   ],

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -752,9 +752,13 @@ Instead, <PlatformLink to="/tracing/streamed-spans">enable stream mode</Platform
   are set.
 </PlatformSection>
 
-<SdkOption name="enableLogs" type='boolean' defaultValue='false'>
+<SdkOption name="enableLogs" type='boolean' defaultValue='true'>
 
-Set this option to `true` to enable log capturing in Sentry. Only when this is enabled will the `logger` APIs actually send logs to Sentry.
+Controls whether the `logger` APIs send logs to Sentry. Logs are captured by default. Set this option to `false` to disable log capturing.
+
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
 
 </SdkOption>
 

--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -56,7 +56,6 @@ Select which Sentry features you'd like to install in addition to Error Monitori
         "performance",
         "session-replay",
         "user-feedback",
-        "logs",
       ]}
     />
   </PlatformSection>
@@ -73,7 +72,7 @@ Select which Sentry features you'd like to install in addition to Error Monitori
 <PlatformCategorySection notSupported={["browser"]}>
   <PlatformSection notSupported={["javascript.bun"]}>
     <OnboardingOptionButtons
-      options={["error-monitoring", "performance", "profiling", "logs"]}
+      options={["error-monitoring", "performance", "profiling"]}
     />
   </PlatformSection>
 
@@ -82,7 +81,7 @@ In addition to capturing errors, you can monitor interactions between multiple s
 Select which Sentry features you'd like to install in addition to Error Monitoring to get the corresponding installation and configuration instructions below.
 
   <PlatformSection supported={["javascript.bun"]}>
-    <OnboardingOptionButtons options={["error-monitoring", "performance", "logs"]} />
+    <OnboardingOptionButtons options={["error-monitoring", "performance"]} />
   </PlatformSection>
 </PlatformCategorySection>
 

--- a/docs/platforms/javascript/common/logs/index.mdx
+++ b/docs/platforms/javascript/common/logs/index.mdx
@@ -23,7 +23,7 @@ Sentry Logs are **high-cardinality** — you can pass any attributes you want an
 
 ## Setup
 
-Enable logging by adding `enableLogs: true` to your Sentry configuration.
+Logs are enabled by default. Just initialize the SDK and use `Sentry.logger` to send logs.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -31,7 +31,6 @@ Enable logging by adding `enableLogs: true` to your Sentry configuration.
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```
 
@@ -184,7 +183,6 @@ The log object includes: `level`, `message`, `timestamp`, and `attributes`.
 ```javascript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
   beforeSendLog: (log) => {
     // Drop debug logs in production
     if (log.level === "debug") {

--- a/docs/platforms/javascript/guides/angular/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/angular/manual-setup.mdx
@@ -87,7 +87,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -164,11 +163,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
@@ -232,11 +226,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 platformBrowserDynamic()

--- a/docs/platforms/javascript/guides/astro/index.mdx
+++ b/docs/platforms/javascript/guides/astro/index.mdx
@@ -41,7 +41,6 @@ Choose the features you want to configure, and this guide will show you how:
     "profiling",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 

--- a/docs/platforms/javascript/guides/azure-functions/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/index.mdx
@@ -18,7 +18,7 @@ categories:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
+  options={["error-monitoring", "performance", "profiling"]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -86,11 +86,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 // your function code

--- a/docs/platforms/javascript/guides/bun/index.mdx
+++ b/docs/platforms/javascript/guides/bun/index.mdx
@@ -18,7 +18,7 @@ categories:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "logs"]}
+  options={["error-monitoring", "performance" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -78,11 +78,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/docs/platforms/javascript/guides/capacitor/index.mdx
+++ b/docs/platforms/javascript/guides/capacitor/index.mdx
@@ -67,7 +67,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
@@ -135,7 +135,6 @@ export const onRequest = [
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
@@ -28,7 +28,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -111,11 +110,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -173,11 +167,6 @@ Sentry.init({
     // userInfo: false,
     // httpBodies: [],
   },
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -227,9 +216,6 @@ export default {
           // ___PRODUCT_OPTION_START___ performance
           tracesSampleRate: 1.0,
           // ___PRODUCT_OPTION_END___ performance
-          // ___PRODUCT_OPTION_START___ logs
-          enableLogs: true,
-          // ___PRODUCT_OPTION_END___ logs
           dataCollection: {
             // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
             // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/remix.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/remix.mdx
@@ -20,7 +20,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/tanstack-start.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/tanstack-start.mdx
@@ -22,8 +22,7 @@ Choose the features you want to configure, and this guide will show you how:
     "error-monitoring",
     "performance",
     "session-replay",
-    "user-feedback",
-    "logs",
+    "user-feedback"
   ]}
 />
 
@@ -91,11 +90,6 @@ export default Sentry.withSentry(
       // userInfo: false,
       // httpBodies: [],
     },
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
@@ -177,11 +171,6 @@ export const getRouter = () => {
 +       }),
 +       // ___PRODUCT_OPTION_END___ user-feedback
 +     ],
-+     // ___PRODUCT_OPTION_START___ logs
-+
-+     // Enable logs to be sent to Sentry
-+     enableLogs: true,
-+     // ___PRODUCT_OPTION_END___ logs
 +     // ___PRODUCT_OPTION_START___ performance
 +
 +     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -36,7 +36,7 @@ Use this guide for general instructions on using the Sentry SDK with Cloudflare.
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "logs"]}
+  options={["error-monitoring", "performance" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -135,11 +135,6 @@ export default Sentry.withSentry(
       // httpBodies: [],
       // genAI: { inputs: false, outputs: false },
     },
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
@@ -193,11 +188,6 @@ export const onRequest = [
       // httpBodies: [],
       // genAI: { inputs: false, outputs: false },
     },
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.

--- a/docs/platforms/javascript/guides/deno/index.mdx
+++ b/docs/platforms/javascript/guides/deno/index.mdx
@@ -24,7 +24,7 @@ This SDK is currently in **beta**. Beta features are still in progress and may h
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "logs"]}
+  options={["error-monitoring", "performance" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -84,11 +84,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/docs/platforms/javascript/guides/effect/index.mdx
+++ b/docs/platforms/javascript/guides/effect/index.mdx
@@ -97,11 +97,6 @@ const SentryLive = Layer.mergeAll(
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   }),
   // ___PRODUCT_OPTION_START___ performance
 
@@ -145,11 +140,6 @@ const SentryLive = Layer.mergeAll(
     tracesSampleRate: 1.0,
     integrations: [Sentry.browserTracingIntegration()],
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   }),
   // ___PRODUCT_OPTION_START___ performance
 
@@ -205,11 +195,6 @@ const SentryLive = Layer.mergeAll(
     // We recommend adjusting this value in production.
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   }),
   // ___PRODUCT_OPTION_START___ performance
 
@@ -254,11 +239,6 @@ const SentryLive = Layer.mergeAll(
     tracesSampleRate: 1.0,
     integrations: [Sentry.browserTracingIntegration()],
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   }),
   // ___PRODUCT_OPTION_START___ performance
 

--- a/docs/platforms/javascript/guides/elysia/index.mdx
+++ b/docs/platforms/javascript/guides/elysia/index.mdx
@@ -31,7 +31,7 @@ You need:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "logs"]}
+  options={["error-monitoring", "performance" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -100,11 +100,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#tracesSampleRate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 // withElysia returns the app instance, so you can chain routes directly
@@ -135,11 +130,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#tracesSampleRate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 // withElysia returns the app instance, so you can chain routes directly

--- a/docs/platforms/javascript/guides/ember/index.mdx
+++ b/docs/platforms/javascript/guides/ember/index.mdx
@@ -40,7 +40,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -86,11 +85,6 @@ Sentry.init({
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/firebase/index.mdx
+++ b/docs/platforms/javascript/guides/firebase/index.mdx
@@ -32,7 +32,7 @@ This integration is enabled by default, so you get automatic performance monitor
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
+  options={["error-monitoring", "performance", "profiling"]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -122,10 +122,6 @@ Sentry.init({
   // This is relative to tracesSampleRate
   profilesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/docs/platforms/javascript/guides/gatsby/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/index.mdx
@@ -96,7 +96,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -140,11 +139,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/gcp-functions/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/index.mdx
@@ -30,7 +30,7 @@ categories:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
+  options={["error-monitoring", "performance", "profiling"]}
 />
 
 <Include name="quick-start-features-expandable" />

--- a/docs/platforms/javascript/guides/hono/index.mdx
+++ b/docs/platforms/javascript/guides/hono/index.mdx
@@ -30,7 +30,7 @@ The community middleware `@hono/sentry` has been deprecated in favor of `@sentry
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
+  options={["error-monitoring", "performance", "profiling"]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -200,11 +200,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -270,11 +265,6 @@ app.use(
     // of spans for tracing.
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   })
 );
 
@@ -319,11 +309,6 @@ app.use(
     // of spans for tracing.
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   })
 );
 
@@ -354,11 +339,6 @@ app.use(
     // of spans for tracing.
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   })
 );
 

--- a/docs/platforms/javascript/guides/nestjs/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/index.mdx
@@ -20,7 +20,7 @@ categories:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
+  options={["error-monitoring", "performance", "profiling"]}
 />
 
 <Include name="quick-start-features-expandable" />

--- a/docs/platforms/javascript/guides/nextjs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/index.mdx
@@ -30,7 +30,6 @@ The wizard will prompt you to select features. Choose the ones you want to enabl
     "error-monitoring",
     { id: "performance", checked: true },
     "session-replay",
-    { id: "logs", checked: true },
   ]}
 />
 
@@ -75,9 +74,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   integrations: [
     // ___PRODUCT_OPTION_START___ session-replay
     Sentry.replayIntegration(),
@@ -101,9 +97,6 @@ Sentry.init({
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -122,9 +115,6 @@ Sentry.init({
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/docs/platforms/javascript/guides/nextjs/logs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/logs/index.mdx
@@ -18,13 +18,17 @@ Sentry Logs let you send structured log data from your Next.js application. Unli
 
 ### Enable Logging
 
-Add `enableLogs: true` to your Sentry configuration in all three runtime files.
+Logs are enabled by default across all three runtime files. Initialize the SDK as usual, then use `Sentry.logger` to send logs.
 
 Logs work across all Next.js runtimes:
 
 - **Client** — Browser-side logging
 - **Server** — Node.js server-side logging
 - **Edge** — Edge runtime logging
+
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` in all three runtime files to send them.
+</Alert>
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -34,7 +38,6 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```
 
@@ -43,7 +46,6 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```
 
@@ -52,7 +54,6 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```
 
@@ -189,7 +190,6 @@ The integration parses multiple arguments as searchable attributes.
 ```typescript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
   integrations: [
     Sentry.consoleLoggingIntegration({
       levels: ["log", "warn", "error"],
@@ -221,7 +221,6 @@ Requires SDK version `10.18.0` or higher.
 ```typescript
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
   integrations: [Sentry.pinoIntegration()],
 });
 ```
@@ -238,7 +237,7 @@ See <PlatformLink to="/configuration/integrations/pino">Pino integration docs</P
 
 Send logs from the [Consola](https://github.com/unjs/consola) logging library to Sentry.
 
-Requires SDK version `10.12.0` or higher and `enableLogs: true` in your `Sentry.init` call.
+Requires SDK version `10.12.0` or higher.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -263,7 +262,7 @@ consola.addReporter(sentryReporter);
 
 Send logs from the [Winston](https://github.com/winstonjs/winston) logging library to Sentry.
 
-Requires SDK version `9.13.0` or higher and `enableLogs: true` in your `Sentry.init` call.
+Requires SDK version `9.13.0` or higher.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -314,7 +313,6 @@ Use this to:
 ```typescript {filename:instrumentation-client.ts}
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 
   beforeSendLog(log) {
     // Drop debug logs in production
@@ -388,7 +386,7 @@ Any attributes set via `Sentry.setAttribute()` / `Sentry.setAttributes()` (or di
 
 ### Logs not appearing
 
-Make sure `enableLogs: true` is set in **all** Sentry config files:
+On SDK versions below `10.71.0`, logs are opt-in. Make sure `enableLogs: true` is set in **all** Sentry config files:
 
 - `instrumentation-client.ts` (client)
 - `sentry.server.config.ts` (server)

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
@@ -30,7 +30,6 @@ Choose the features you want to configure:
     { id: "performance", checked: true },
     "session-replay",
     "user-feedback",
-    { id: "logs", checked: true },
   ]}
 />
 
@@ -161,11 +160,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 // ___PRODUCT_OPTION_START___ performance
@@ -192,11 +186,6 @@ Sentry.init({
   // Adjust based on your traffic volume
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -218,11 +207,6 @@ Sentry.init({
   // Adjust based on your traffic volume
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -522,7 +506,7 @@ const result = await Sentry.startSpan(
 
 ### Logs <FeatureBadge type="new" size="small" />
 
-Logs are enabled with `enableLogs: true` in your SDK config. Use the Sentry logger to send structured logs from anywhere in your application.
+Logs are enabled by default. Use the Sentry logger to send structured logs from anywhere in your application.
 
 Connect popular logging libraries via [Integrations](/platforms/javascript/guides/nextjs/logs/#integrations).
 

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/pages-router.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/pages-router.mdx
@@ -23,7 +23,6 @@ Choose the features you want to configure:
     "error-monitoring",
     { id: "performance", checked: true },
     "session-replay",
-    { id: "logs", checked: true },
   ]}
 />
 
@@ -180,11 +179,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -206,11 +200,6 @@ Sentry.init({
   // Adjust based on your traffic volume
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -232,11 +221,6 @@ Sentry.init({
   // Adjust based on your traffic volume
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -420,7 +404,7 @@ Sentry.init({
 
 ### Logs <FeatureBadge type="new" size="small" />
 
-Logs are enabled with `enableLogs: true` in your SDK config. Use the Sentry logger to send structured logs.
+Logs are enabled by default. Use the Sentry logger to send structured logs.
 
 **Verify:** Add a log statement, trigger it, then check [**Logs**](https://sentry.io/orgredirect/organizations/:orgslug/explore/logs/) in Sentry.
 

--- a/docs/platforms/javascript/guides/nitro/index.mdx
+++ b/docs/platforms/javascript/guides/nitro/index.mdx
@@ -30,7 +30,7 @@ You need:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "logs"]}
+  options={["error-monitoring", "performance" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -156,11 +156,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/nitro/configuration/options/#tracesSampleRate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -55,7 +55,6 @@ Select which Sentry features you'd like to install in addition to Error Monitori
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
     {
       id: "profiling",
       checked: false,
@@ -113,11 +112,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -181,11 +175,6 @@ Sentry.init({
     // userInfo: false,
     // httpBodies: [],
   },
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ profiling
 
   // Add our Profiling integration

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -27,11 +27,10 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
     {
       id: "profiling",
       checked: false,
-    },
+    }
   ]}
 />
 
@@ -152,11 +151,6 @@ The `sentryOnError` handler integrates with React Router's [`onError` hook](http
 +    }),
 +    // ___PRODUCT_OPTION_END___ user-feedback
 +  ],
-+  // ___PRODUCT_OPTION_START___ logs
-+
-+  // Enable logs to be sent to Sentry
-+  enableLogs: true,
-+  // ___PRODUCT_OPTION_END___ logs
 +  // ___PRODUCT_OPTION_START___ performance
 +
 +  // Set tracesSampleRate to 1.0 to capture 100%
@@ -233,11 +227,6 @@ Sentry.init({
     // userInfo: false,
     // httpBodies: [],
   },
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ profiling
 
   // Add our Profiling integration

--- a/docs/platforms/javascript/guides/react/index.mdx
+++ b/docs/platforms/javascript/guides/react/index.mdx
@@ -51,7 +51,6 @@ Choose the features you want to configure:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -101,11 +100,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/remix/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/remix/manual-setup.mdx
@@ -27,7 +27,6 @@ Choose the features you want to configure, and this guide will show you how:
     "profiling",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 

--- a/docs/platforms/javascript/guides/solid/index.mdx
+++ b/docs/platforms/javascript/guides/solid/index.mdx
@@ -54,7 +54,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -106,11 +105,6 @@ if (!DEV) {
       }),
       // ___PRODUCT_OPTION_END___ user-feedback
     ],
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
 
     // ___PRODUCT_OPTION_START___ performance
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -32,7 +32,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -141,11 +140,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 mount(() => <StartClient />, document.getElementById("app"));
@@ -186,11 +180,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/docs/platforms/javascript/guides/svelte/index.mdx
+++ b/docs/platforms/javascript/guides/svelte/index.mdx
@@ -52,7 +52,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -99,11 +98,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -157,11 +151,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/sveltekit/manual-setup__v10.7.0.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/manual-setup__v10.7.0.mdx
@@ -45,7 +45,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -115,11 +114,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 const myErrorHandler = ({ error, event }) => {
@@ -154,11 +148,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 const myErrorHandler = ({ error, event }) => {

--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -42,7 +42,6 @@ The wizard will have prompted you to select which features to enable. Select the
     "performance",
     "session-replay",
     "user-feedback",
-    { id: "logs", checked: true },
   ]}
 />
 

--- a/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
@@ -36,7 +36,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -106,11 +105,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -221,11 +215,6 @@ Sentry.init({
     // userInfo: false,
     // httpBodies: [],
   },
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/vue/index.mdx
+++ b/docs/platforms/javascript/guides/vue/index.mdx
@@ -48,7 +48,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -106,11 +105,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -166,11 +160,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%

--- a/docs/platforms/javascript/guides/wasm/index.mdx
+++ b/docs/platforms/javascript/guides/wasm/index.mdx
@@ -24,7 +24,7 @@ categories:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "logs"]}
+  options={["error-monitoring", "performance" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -96,11 +96,6 @@ Sentry.init({
   // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
   tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/includes/logs/default-attributes/integration-filter-example/javascript.mdx
+++ b/includes/logs/default-attributes/integration-filter-example/javascript.mdx
@@ -3,7 +3,6 @@ To filter out all SDK-generated logs and keep only your application logs, use th
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
   beforeSendLog: (log) => {
     if (log.attributes?.["sentry.origin"] !== undefined) {
       return null;

--- a/includes/logs/javascript-consola-integration.mdx
+++ b/includes/logs/javascript-consola-integration.mdx
@@ -1,6 +1,10 @@
 ### Consola Integration
 
-In `10.12.0` and above of the JavaScript SDKs, we've added support to send logs via the [consola](https://github.com/unjs/consola) logging library. Requires `enableLogs: true` in your `Sentry.init` call.
+In `10.12.0` and above of the JavaScript SDKs, we've added support to send logs via the [consola](https://github.com/unjs/consola) logging library.
+
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
 
 ```js
 import { consola } from "consola";

--- a/includes/logs/javascript-console-logging-integration.mdx
+++ b/includes/logs/javascript-console-logging-integration.mdx
@@ -2,10 +2,13 @@
 
 You can also configure the SDK to send logs via the JavaScript console object, using the SDK's `consoleLoggingIntegration`.
 
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
+
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
   integrations: [
     // send console.log, console.warn, and console.error calls as logs to Sentry
     Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),

--- a/includes/logs/javascript-pino-integration.mdx
+++ b/includes/logs/javascript-pino-integration.mdx
@@ -2,9 +2,12 @@
 
 In `10.18.0` and above of the JavaScript SDKs, we've added support to send logs via the pino logging library. To add the pino integration, you need to add the `pinoIntegration` to your Sentry initialization.
 
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
+
 ```js
 Sentry.init({
-  enableLogs: true,
   integrations: [Sentry.pinoIntegration()],
 });
 ```

--- a/includes/logs/javascript-winston-integration.mdx
+++ b/includes/logs/javascript-winston-integration.mdx
@@ -1,6 +1,10 @@
 ### Winston Integration
 
-In `9.13.0` and above of the JavaScript SDKs, we've added support to send logs via the winston logging library. Requires `enableLogs: true` in your `Sentry.init` call.
+In `9.13.0` and above of the JavaScript SDKs, we've added support to send logs via the winston logging library.
+
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
 
 ```js
 const winston = require("winston");

--- a/platform-includes/configuration/console-logs-vs-breadcrumbs/_default.mdx
+++ b/platform-includes/configuration/console-logs-vs-breadcrumbs/_default.mdx
@@ -5,9 +5,8 @@
 
 <Alert level="warning" title="Did you mean logs instead?">
 
-This integration captures console logs as breadcrumbs (great for error context!). But if you need to search and query your logs across your entire application, use <PlatformLink to="/logs/">Sentry Logs</PlatformLink> instead. Set `enableLogs: true`, and add the <PlatformLink to="/logs/#integrations">Sentry console logging integration</PlatformLink> in your SDK config.
+This integration captures console logs as breadcrumbs (great for error context!). But if you need to search and query your logs across your entire application, use <PlatformLink to="/logs/">Sentry Logs</PlatformLink> instead, and add the <PlatformLink to="/logs/#integrations">Sentry console logging integration</PlatformLink> in your SDK config.
 
 </Alert>
 
 </PlatformSection>
-

--- a/platform-includes/getting-started-complete/javascript.astro.mdx
+++ b/platform-includes/getting-started-complete/javascript.astro.mdx
@@ -142,10 +142,6 @@ export default Sentry.withSentry(
     // or use tracesSampler for greater control.
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   }),
   handler
 );
@@ -264,11 +260,6 @@ Sentry.init({
   // sessions when an error occurs.
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -360,11 +351,6 @@ Sentry.init({
   // Define how many user sessions have profiling enabled.
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/platform-includes/getting-started-complete/javascript.mdx
+++ b/platform-includes/getting-started-complete/javascript.mdx
@@ -7,7 +7,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 <Include name="quick-start-features-expandable" />

--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -15,7 +15,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -138,11 +137,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -204,11 +198,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 

--- a/platform-includes/getting-started-complete/javascript.remix.mdx
+++ b/platform-includes/getting-started-complete/javascript.remix.mdx
@@ -66,11 +66,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -203,11 +198,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 
   // Optionally capture action formData attributes with errors.
   // This requires `sendDefaultPii` set to true as well.
@@ -304,11 +294,6 @@ export const onRequest = [
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
 
     // Optionally capture action formData attributes with errors.
     // This requires `sendDefaultPii` set to true as well.

--- a/platform-includes/getting-started-complete/javascript.sveltekit.mdx
+++ b/platform-includes/getting-started-complete/javascript.sveltekit.mdx
@@ -63,7 +63,6 @@ Choose the features you want to configure, and this guide will show you how:
     "performance",
     "session-replay",
     "user-feedback",
-    "logs",
   ]}
 />
 
@@ -165,11 +164,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 
 const myErrorHandler = ({ error, event }) => {
@@ -272,11 +266,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -358,11 +347,6 @@ export const handle = sequence(
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
   }),
   sentryHandle()
 );

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -17,10 +17,6 @@ Sentry.init(
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
     dist: "<dist>",
-    // ___PRODUCT_OPTION_START___ logs
-    // Logs requires @sentry/capacitor 2.0.0 or newer.
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     integrations: [
       // ___PRODUCT_OPTION_START___ performance
       // Registers and configures the Tracing integration,
@@ -109,9 +105,6 @@ Sentry.init(
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
     dist: "<dist>",
-    // ___PRODUCT_OPTION_START___ logs
-    // Logs requires Angular 14 or newer.
-    // ___PRODUCT_OPTION_END___ logs
     integrations: [
       // ___PRODUCT_OPTION_START___ performance
       // Registers and configures the Tracing integration,
@@ -197,10 +190,6 @@ Sentry.init(
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
     dist: "<dist>",
-    // ___PRODUCT_OPTION_START___ logs
-    // Logs requires @sentry/capacitor 2.0.0 or newer.
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     integrations: [
       // ___PRODUCT_OPTION_START___ performance
       // Registers and configures the Tracing integration,
@@ -278,10 +267,6 @@ Sentry.init(
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
     dist: "<dist>",
-    // ___PRODUCT_OPTION_START___ logs
-    // Logs requires @sentry/capacitor 2.0.0 or newer.
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     integrations: [
       // ___PRODUCT_OPTION_START___ performance
       // Registers and configures the Tracing integration,
@@ -347,10 +332,6 @@ Sentry.init(
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
     dist: "<dist>",
-    // ___PRODUCT_OPTION_START___ logs
-    // Logs requires @sentry/capacitor 2.0.0 or newer.
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     integrations: [
       // ___PRODUCT_OPTION_START___ performance
       // Registers and configures the Tracing integration,
@@ -418,10 +399,6 @@ Sentry.init({
   release: "my-project-name@<release-name>",
   // Set your dist version, such as "1"
   dist: "<dist>",
-  // ___PRODUCT_OPTION_START___ logs
-  // Logs requires @sentry/capacitor 2.0.0 or newer.
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     // Registers and configures the Tracing integration,

--- a/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
@@ -26,11 +26,6 @@ export default Sentry.withSentry(
       // userInfo: false,
       // httpBodies: [],
     },
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.

--- a/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
@@ -20,11 +20,6 @@ export default Sentry.withSentry(
       // userInfo: false,
       // httpBodies: [],
     },
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.

--- a/platform-includes/getting-started-config/javascript.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.hono.mdx
@@ -37,11 +37,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -84,10 +79,5 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```

--- a/platform-includes/getting-started-config/javascript.mdx
+++ b/platform-includes/getting-started-config/javascript.mdx
@@ -40,11 +40,6 @@ Sentry.init({
     }),
     // ___PRODUCT_OPTION_END___ user-feedback
   ],
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -104,11 +99,6 @@ Sentry.init({
         }),
         // ___PRODUCT_OPTION_END___ user-feedback
       ],
-      // ___PRODUCT_OPTION_START___ logs
-
-      // Enable logs to be sent to Sentry
-      enableLogs: true,
-      // ___PRODUCT_OPTION_END___ logs
       // ___PRODUCT_OPTION_START___ performance
 
       // Set tracesSampleRate to 1.0 to capture 100%
@@ -170,11 +160,6 @@ Sentry.init({
       }),
       // ___PRODUCT_OPTION_END___ user-feedback
     ],
-    // ___PRODUCT_OPTION_START___ logs
-
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    // ___PRODUCT_OPTION_END___ logs
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/getting-started-config/javascript.nestjs.mdx
+++ b/platform-includes/getting-started-config/javascript.nestjs.mdx
@@ -29,10 +29,5 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```

--- a/platform-includes/getting-started-config/javascript.node.mdx
+++ b/platform-includes/getting-started-config/javascript.node.mdx
@@ -37,11 +37,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -84,10 +79,5 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/configuration/options/#profileSessionSampleRate
   profileSessionSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ profiling
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```

--- a/platform-includes/getting-started-node/javascript.mdx
+++ b/platform-includes/getting-started-node/javascript.mdx
@@ -7,7 +7,7 @@
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance", "profiling", "logs"]}
+  options={["error-monitoring", "performance", "profiling"]}
 />
 
 <Include name="quick-start-features-expandable" />

--- a/platform-includes/logs/options/javascript.mdx
+++ b/platform-includes/logs/options/javascript.mdx
@@ -5,7 +5,6 @@ To filter logs, or update them before they are sent to Sentry, you can use the `
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
   beforeSendLog: (log) => {
     if (log.level === "info") {
       // Filter out all info logs

--- a/platform-includes/logs/requirements/javascript.mdx
+++ b/platform-includes/logs/requirements/javascript.mdx
@@ -1,4 +1,8 @@
-Logs for JavaScript are supported in Sentry JavaScript SDK version `9.41.0` and above.
+Logs for JavaScript are supported in Sentry JavaScript SDK version `9.41.0` and above, and are enabled by default in version `10.71.0` and above.
+
+<Alert>
+  On SDK versions below `10.71.0`, logs are opt-in. Set `enableLogs: true` in your `Sentry.init` to send them.
+</Alert>
 
 <PlatformSection supported={["javascript"]}>
 

--- a/platform-includes/logs/setup/javascript.cloudflare.mdx
+++ b/platform-includes/logs/setup/javascript.cloudflare.mdx
@@ -1,4 +1,4 @@
-To enable logging, you need to initialize the SDK with the `enableLogs` option set to `true`.
+Logs are enabled by default. Initialize the SDK as usual, then use `Sentry.logger` to send logs.
 
 ```typescript
 import * as Sentry from "@sentry/cloudflare";
@@ -6,8 +6,6 @@ import * as Sentry from "@sentry/cloudflare";
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
   }),
   {
     async fetch(request, env, ctx) {

--- a/platform-includes/logs/setup/javascript.mdx
+++ b/platform-includes/logs/setup/javascript.mdx
@@ -1,9 +1,7 @@
-To enable logging, you need to initialize the SDK with the `enableLogs` option set to `true`.
+Logs are enabled by default. Initialize the SDK as usual, then use `Sentry.logger` to send logs.
 
 ```js
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 });
 ```

--- a/platform-includes/logs/setup/javascript.nextjs.mdx
+++ b/platform-includes/logs/setup/javascript.nextjs.mdx
@@ -1,11 +1,10 @@
-To enable logging in Next.js, add `enableLogs: true` to all your Sentry configuration files:
+Logs are enabled by default across all your Sentry configuration files. Initialize the SDK as usual, then use `Sentry.logger` to send logs.
 
 ```typescript {tabTitle:Client} {mdExpandTabs} {filename:instrumentation-client.ts}
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```
 
@@ -14,7 +13,6 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```
 
@@ -23,6 +21,5 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  enableLogs: true,
 });
 ```


### PR DESCRIPTION
`10.71.0` changed the `enableLogs` default in the JS SDK to true. This updates the docs accordingly. 

This PR excludes the electron SDK, which hasn't yet released this change. This will be handled separately in https://github.com/getsentry/sentry-docs/pull/19175.