### PR TITLE
feat(elixir): document new oban check-in config

### DIFF
--- a/docs/platforms/elixir/integrations/oban/index.mdx
+++ b/docs/platforms/elixir/integrations/oban/index.mdx
@@ -80,3 +80,32 @@ end
 ```
 
 This is available since v10.9.0 of the SDK.
+
+### Suppressing Failed Check-Ins While Retries Remain
+
+By default, every failed attempt of a cron job sends an `error` check-in, so a job that fails once and succeeds on retry still marks the monitor as failed. If your cron workers rely on Oban's retries, use `:should_report_error_check_in_callback` to hold off until the retries are exhausted:
+
+```elixir {filename:config/config.exs}
+config :sentry,
+  # ...,
+  integrations: [
+    oban: [
+      cron: [
+        enabled: true,
+        should_report_error_check_in_callback: fn _worker, job ->
+          job.attempt >= job.max_attempts
+        end
+      ]
+    ]
+  ]
+```
+
+The callback receives the worker module and the [`Oban.Job` struct](https://hexdocs.pm/oban/Oban.Job.html), and returns `true` to send the failed check-in or `false` to skip it. When it returns `false`, the check-in is left open instead of being closed as failed, so the retry that eventually succeeds closes that same check-in.
+
+Keep in mind:
+
+  * The callback only gates `error` check-ins. The `in_progress` check-in at the start of a job and the `ok` check-in on success always go out.
+  * If the callback raises, the SDK logs a warning and reports the failed check-in anyway, so a broken callback never hides a failure.
+  * Snoozed jobs also keep their check-in open, since Oban reschedules a snoozed job rather than finishing it.
+
+This is available since v13.5.0 of the SDK.


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

Adds documentation for the new `should_report_error_check_in_callback` oban config option added in 13.5.0.

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [ ] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
