### PR TITLE
fix(docs): show script in ngrok split silo section

### DIFF
--- a/develop-docs/development-infrastructure/ngrok.mdx
+++ b/develop-docs/development-infrastructure/ngrok.mdx
@@ -100,15 +100,16 @@ ngrok start --all --config region.yml
 ### Step 4: Start Devserver
 In two separate terminal windows, start the devserver for the control and region silos:
 
+```shell
+getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=region
+getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=control
+```
+
 First, start the taskbroker:
 ```shell
 devservices up --mode=taskbroker
 ```
 
-```shell
-getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=region
-getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=control
-```
 
 This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production.
 

--- a/develop-docs/development-infrastructure/ngrok.mdx
+++ b/develop-docs/development-infrastructure/ngrok.mdx
@@ -98,18 +98,17 @@ ngrok start --all --config region.yml
 ```
 
 ### Step 4: Start Devserver
+First, start the taskbroker:
+```shell
+devservices up --mode=taskbroker
+```
+
 In two separate terminal windows, start the devserver for the control and region silos:
 
 ```shell
 getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=region
 getsentry devserver --ngrok <yourname>.ngrok.io --workers --celery-beat --silo=control
 ```
-
-First, start the taskbroker:
-```shell
-devservices up --mode=taskbroker
-```
-
 
 This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production.
 


### PR DESCRIPTION
<!-- Use this checklist to make sure your PR is ready for merge. You may delete any sections you don't need. -->

## DESCRIBE YOUR PR
the shell script doesn't show for the `getsentry` section, and the order of the paragraphs should be the other way around

<img width="1085" height="370" alt="image" src="https://github.com/user-attachments/assets/9abf4745-0416-4056-81b0-0c19d6bc1010" />

## IS YOUR CHANGE URGENT?  

Help us prioritize incoming PRs by letting us know when the change needs to go live.
- [ ] Urgent deadline (GA date, etc.): <!-- ENTER DATE HERE -->
- [ ] Other deadline: <!-- ENTER DATE HERE -->
- [x] None: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've added an urgent due date to it.
Thanks in advance for your help!

## PRE-MERGE CHECKLIST

*Make sure you've checked the following before merging your changes:*

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
