### PR TITLE
docs: Fix duplicate word in organization setup guide

### DIFF
--- a/docs/organization/getting-started/index.mdx
+++ b/docs/organization/getting-started/index.mdx
@@ -80,7 +80,7 @@ If you're using a different SCM provider or don't want Sentry to connect to your
 
 Enabling an integration with your issue tracking solution allows you to create a new issue from within the **Issue Details** page in [sentry.io](https://sentry.io), or link to an existing one. GitHub, GitLab, and Bitbucket issues are associated with their respective SCM integrations. Sentry also integrates with [Azure DevOps](/integrations/source-code-mgmt/azure-devops/), [Shortcut](/integrations/issue-tracking/shortcut/), [Jira](/integrations/issue-tracking/jira/), and others.
 
-For a list of all supported integrations, check out out our [full Integrations documentation](/integrations/).
+For a list of all supported integrations, check out our [full Integrations documentation](/integrations/).
 
 You can set up automated issue management when you create alerts that route to [Azure DevOps](/integrations/source-code-mgmt/azure-devops/#automatically) and [Jira](/integrations/issue-tracking/jira/#automatically). External issues will be created for new Sentry issues on your behalf, and these issues will use the configured fields in your Azure DevOps or Jira workspace. For other issue tracking solutions, you can manually link Sentry issues.
 


### PR DESCRIPTION
Removes the duplicated word "out" from the integrations link in the organization setup guide.

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
