### PR TITLE
docs(js): Clarify browser AI support in v11

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing-browser/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing-browser/index.mdx
@@ -50,10 +50,6 @@ With <Link to="/product/agents/dashboards/">Sentry Agent Tracing</Link>, you can
 
 Before setting up Agent Tracing, ensure you have <PlatformLink to="/tracing/">tracing enabled</PlatformLink> in your Sentry configuration.
 
-<Alert level="info">
-
-**Browser applications require manual instrumentation.** Unlike Node.js applications, the JavaScript SDK does not provide automatic instrumentation for AI libraries in the browser.
-
-</Alert>
+Starting with JavaScript SDK v11, browser SDKs no longer export AI integrations or instrumentation helpers. Use [manual span creation](#manual-span-creation) instead. Browser SDK v10 and earlier can still use integration helpers, and server SDK support is unchanged.
 
 <Include name="agent-tracing/manual-instrumentation" />


### PR DESCRIPTION
## DESCRIBE YOUR PR

Browser Agent Tracing page now tells v11 and later users that browser SDKs no longer export AI integrations or instrumentation helpers. It directs these users to manual span creation and clarifies that server SDK support remains unchanged.

Fixes [TET-2747](https://linear.app/getsentry/issue/TET-2747/in-v11-version-there-are-no-ai-exports-in-javascript-sdk).

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
