### PR TITLE
fix(docs): correct PR triage token permissions

### DIFF
--- a/.github/workflows/codeowner_assignment.yaml
+++ b/.github/workflows/codeowner_assignment.yaml
@@ -43,6 +43,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             sentry-docs
+          permission-members: read
           permission-pull-requests: write
 
       - name: Resolve trusted base commit

--- a/.github/workflows/pr-priority-metadata.yml
+++ b/.github/workflows/pr-priority-metadata.yml
@@ -18,7 +18,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   priority_metadata:

--- a/scripts/assign-pr-reviewers.mjs
+++ b/scripts/assign-pr-reviewers.mjs
@@ -38,6 +38,21 @@ async function getPreviousPriority() {
     : parsePriority(event.changes.body.from);
 }
 
+async function isOrganizationMember(login) {
+  if (!login) {
+    return null;
+  }
+  try {
+    await github(`/orgs/${repositoryOwner}/members/${encodeURIComponent(login)}`);
+    return true;
+  } catch (error) {
+    if (error.status === 404) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 const pullRequestPath = `/repos/${repository}/pulls/${pullRequestNumber}`;
 const [pullRequest, files, requestedReviewers, codeowners, previousPriority] =
   await Promise.all([
@@ -47,12 +62,14 @@ const [pullRequest, files, requestedReviewers, codeowners, previousPriority] =
     readCodeowners(),
     getPreviousPriority(),
   ]);
+const organizationMember = await isOrganizationMember(pullRequest.user?.login);
 
 const triage = evaluateDocsReview({
   body: pullRequest.body,
   files,
   author: pullRequest.user,
   authorAssociation: pullRequest.author_association,
+  isOrganizationMember: organizationMember,
   isDraft: pullRequest.draft,
 });
 const priorityAlertReason = previousPriority

--- a/scripts/codeowner-workflow.test.mjs
+++ b/scripts/codeowner-workflow.test.mjs
@@ -52,6 +52,7 @@ describe('codeowner assignment workflow', () => {
 
     expect(token.with.repositories.trim()).toBe('sentry-docs');
     expect(token.with['permission-contents']).toBeUndefined();
+    expect(token.with['permission-members']).toBe('read');
     expect(token.with['permission-pull-requests']).toBe('write');
   });
 

--- a/scripts/docs-pr-triage.mjs
+++ b/scripts/docs-pr-triage.mjs
@@ -289,7 +289,7 @@ export function calculateReviewableChanges(files) {
   };
 }
 
-export function classifyAuthor(author, authorAssociation) {
+export function classifyAuthor(author, authorAssociation, isOrganizationMember) {
   const login = typeof author === 'string' ? author : author?.login;
   const isBot = Boolean(
     (typeof author === 'object' &&
@@ -299,20 +299,29 @@ export function classifyAuthor(author, authorAssociation) {
     /^dependabot$/i.test(login ?? '')
   );
   const association = String(authorAssociation ?? '').toUpperCase();
+  const membershipKnown = typeof isOrganizationMember === 'boolean';
   return {
     isBot,
     isExternal:
       !isBot &&
       Boolean(login) &&
-      Boolean(association) &&
-      !['MEMBER', 'OWNER'].includes(association),
+      (membershipKnown
+        ? !isOrganizationMember
+        : Boolean(association) && !['MEMBER', 'OWNER'].includes(association)),
   };
 }
 
-export function evaluateDocsReview({body, files, author, authorAssociation, isDraft}) {
+export function evaluateDocsReview({
+  body,
+  files,
+  author,
+  authorAssociation,
+  isOrganizationMember,
+  isDraft,
+}) {
   const priority = parsePriority(body);
   const changes = calculateReviewableChanges(files);
-  const authorStatus = classifyAuthor(author, authorAssociation);
+  const authorStatus = classifyAuthor(author, authorAssociation, isOrganizationMember);
   const reasons = [];
 
   if (

--- a/scripts/docs-pr-triage.test.mjs
+++ b/scripts/docs-pr-triage.test.mjs
@@ -408,6 +408,17 @@ describe('classifyAuthor', () => {
     });
   });
 
+  it('uses explicit organization membership over author association', () => {
+    expect(classifyAuthor({login: 'employee'}, 'CONTRIBUTOR', true)).toEqual({
+      isBot: false,
+      isExternal: false,
+    });
+    expect(classifyAuthor({login: 'former-member'}, 'MEMBER', false)).toEqual({
+      isBot: false,
+      isExternal: true,
+    });
+  });
+
   it.each([
     [{login: 'dependabot[bot]'}, 'NONE'],
     [{login: 'app/sentry'}, 'NONE'],

--- a/scripts/github-api.mjs
+++ b/scripts/github-api.mjs
@@ -35,7 +35,10 @@ export function createGitHubClient({token, apiBase, fetchImplementation = fetch}
     const text = await response.text();
     const data = text ? JSON.parse(text) : null;
     if (!response.ok) {
-      const error = new Error(`GitHub API ${response.status}: ${data?.message ?? text}`);
+      const details = data?.errors ? ` ${JSON.stringify(data.errors)}` : '';
+      const error = new Error(
+        `GitHub API ${response.status}: ${data?.message ?? text}${details}`
+      );
       error.status = response.status;
       throw error;
     }

--- a/scripts/github-api.test.mjs
+++ b/scripts/github-api.test.mjs
@@ -84,4 +84,23 @@ describe('createGitHubClient', () => {
 
     await expect(request('/missing')).rejects.toMatchObject({status: 404});
   });
+
+  it('includes GitHub validation details in API errors', async () => {
+    const {request} = createGitHubClient({
+      token: 'secret',
+      apiBase: 'https://api.github.test',
+      fetchImplementation: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              message: 'Validation Failed',
+              errors: [{resource: 'PullRequest', code: 'unprocessable'}],
+            }),
+            {status: 422}
+          )
+        ),
+    });
+
+    await expect(request('/invalid')).rejects.toThrow('PullRequest');
+  });
 });

--- a/scripts/priority-metadata-workflow.test.mjs
+++ b/scripts/priority-metadata-workflow.test.mjs
@@ -24,7 +24,7 @@ describe('priority metadata workflow', () => {
     expect(workflow.permissions).toEqual({
       contents: 'read',
       issues: 'write',
-      'pull-requests': 'read',
+      'pull-requests': 'write',
     });
   });
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes both PR triage workflow failures observed on #19096.

- Grants the priority metadata workflow `pull-requests: write`, which GitHub requires in this repository to label and comment on PRs.
- Restores the Codeowner App token's organization Members read permission so it can resolve private teams such as `getsentry/docs`.
- Checks organization membership directly instead of relying on token-dependent `author_association`, preventing private Sentry members from being classified as external.
- Includes GitHub validation details in API errors to make future 422 failures diagnosable.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## TEST PLAN

- `pnpm exec vitest run scripts/github-api.test.mjs scripts/docs-pr-triage.test.mjs scripts/pr-reviewer-assignment.test.mjs scripts/pr-priority-metadata.test.mjs scripts/codeowner-workflow.test.mjs scripts/priority-metadata-workflow.test.mjs` (116 tests)
- `pnpm test:ci` (348 tests)
- Reviewer dry run on #19096 confirms the author is internal and no Docs request is planned for the two-line change.
- Reviewer dry run on #19075 confirms a non-member still gets the external-author reason and Docs request.
- Metadata dry run on #19096 still plans `Priority: Normal`.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)