### PR TITLE
docs(python): Document `enable_logs` as deprecated, not a no-op

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -626,10 +626,21 @@ Self-hosted Sentry users should set this option to `False`, as standalone `gen_a
 
 <SdkOption name="enable_logs" type='bool' defaultValue='False'>
 
-Starting from `2.68.0`, this option has no effect. The `sentry_sdk.logger` API works standalone. Automatic capture of logs by integrations is off by default and can be toggled on the integration level with the `capture_sentry_logs` integration option. See the [Logs documentation](/platforms/python/logs#other-logging-integrations) for more details.
+**Deprecated:** This option will be removed in the next major version. Use the `capture_sentry_logs` option on the [`logging`](/platforms/python/integrations/logging/#options) and [Loguru](/platforms/python/integrations/loguru/#options) integrations instead.
 
-In older SDK versions (prior to `2.68`), this option had to be set to `True` to be able to use the `sentry_sdk.logger` API. It also enabled automatic capture of logs from the standard library `logging` module as well as from Loguru.
+The `sentry_sdk.logger` API works standalone and is not affected by this option.
 
-Made no-op in version `2.68.0`. New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
+For automatic capture of logs from the standard library `logging` module and from Loguru, this option acts as a fallback. If an integration leaves `capture_sentry_logs` unset, `enable_logs=True` turns automatic capture on for that integration. Setting `capture_sentry_logs` on the integration always wins.
+
+| `enable_logs`     | `capture_sentry_logs` | Automatic capture |
+| ----------------- | --------------------- | ----------------- |
+| not set / `False` | not set               | off               |
+| `True`            | not set               | on                |
+| any               | `True`                | on                |
+| any               | `False`               | off               |
+
+In SDK versions prior to `2.68.0`, this option had to be set to `True` to use the `sentry_sdk.logger` API, and it also enabled automatic capture of logs from the standard library `logging` module and from Loguru. In version `2.68.0` only, the option had no effect at all. Upgrade to `2.68.1` or later if you rely on it.
+
+Deprecated in version `2.68.1`. New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
 
 </SdkOption>

--- a/docs/platforms/python/integrations/logging/index.mdx
+++ b/docs/platforms/python/integrations/logging/index.mdx
@@ -59,7 +59,7 @@ This will capture both logs and send them to Sentry Logs. Additionally, an error
 
 ## Behavior
 
-When `capture_sentry_logs` is `True`, logs with a level of `INFO` and higher will be captured as Sentry logs if the log level set in the `logging` module is `INFO` or below. The threshold can be configured via the [`sentry_logs_level` option](#options).
+When the integration is capturing Sentry logs, logs with a level of `INFO` and higher will be captured as Sentry logs if the log level set in the `logging` module is `INFO` or below. The threshold can be configured via the [`sentry_logs_level` option](#options).
 
 Additionally, the logging integration will create an error event from all `ERROR`-level logs. This feature is configurable via the [`event_level` integration option](#options).
 
@@ -156,9 +156,9 @@ sentry_sdk.init(
 
 You can pass the following keyword arguments to `LoggingIntegration()`:
 
-- `capture_sentry_logs` (default `False`): Set to `True` to capture log records as [Sentry structured logs](/platforms/python/logs/).
+- `capture_sentry_logs` (default: unset, which behaves as `False`): Set to `True` to capture log records as [Sentry structured logs](/platforms/python/logs/). If you leave this unset and have the deprecated [`enable_logs`](/platforms/python/configuration/options/#enable_logs) set to `True`, the SDK captures records as Sentry logs. Setting this option explicitly always wins over `enable_logs`.
 
-- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/) as long as `capture_sentry_logs` is `True`.
+- `sentry_logs_level` (default `INFO`): The Sentry Python SDK will capture records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/), as long as the integration is capturing Sentry logs.
 
 - `level` (default `INFO`): The Sentry Python SDK will record log records with a level higher than or equal to `level` as breadcrumbs. Inversely, the SDK completely ignores any log record with a level lower than this one. If a value of `None` occurs, the SDK won't send log records as breadcrumbs.
 
@@ -202,7 +202,7 @@ See the [API documentation](https://getsentry.github.io/sentry-python/integratio
 
 <Expandable title="Logs not appearing in Sentry">
 
-  First, make sure you're on the latest version of the SDK. If you're using the `sentry_sdk.logger` API directly (e.g., `sentry_sdk.logger.info(...)`), logs are sent automatically. If you're using Python's `logging` module and want those log records captured as Sentry logs, make sure you have `capture_sentry_logs=True` set on your `LoggingIntegration`.
+  First, make sure you're on the latest version of the SDK. If you're using the `sentry_sdk.logger` API directly (e.g., `sentry_sdk.logger.info(...)`), logs are sent automatically. If you're using Python's `logging` module and want those log records captured as Sentry logs, make sure you have `capture_sentry_logs=True` set on your `LoggingIntegration`. Setting the deprecated `enable_logs=True` also works, but only if `capture_sentry_logs` is left unset on the integration.
 
   The SDK will honor the configured level of each logger (set with `logger.setLevel(level)` or `logging.basicConfig(level=level)`). That means that you will not see any `INFO` or `DEBUG` events from a logger with the level set to `WARNING`, regardless of how you configure the integration. If not set explicitly, the logging level defaults to `WARNING`.
 

--- a/docs/platforms/python/integrations/loguru/index.mdx
+++ b/docs/platforms/python/integrations/loguru/index.mdx
@@ -63,7 +63,7 @@ This will capture both logs and send them to Sentry Logs. Additionally, an error
 
 ## Behavior
 
-Logs with a level of `INFO` and higher will be captured as Sentry logs as long as `capture_sentry_logs` is `True` and the log level set in the `logging` module is `INFO` or below. The threshold can be configured via the [`sentry_logs_level` option](#options).
+Logs with a level of `INFO` and higher will be captured as Sentry logs as long as the integration is capturing Sentry logs and the log level set in the `logging` module is `INFO` or below. The threshold can be configured via the [`sentry_logs_level` option](#options).
 
 Additionally, the Loguru integration will create an error event from all `ERROR`-level logs. This feature is configurable via the [`event_level` integration option](#options).
 
@@ -156,13 +156,13 @@ sentry_sdk.init(
 
 - `capture_sentry_logs`
 
-  Set to `True` to capture Loguru log records as [Sentry structured logs](/platforms/python/logs/).
+  Set to `True` to capture Loguru log records as [Sentry structured logs](/platforms/python/logs/). If you leave this unset and have the deprecated [`enable_logs`](/platforms/python/configuration/options/#enable_logs) set to `True`, the SDK captures records as Sentry logs. Setting this option explicitly always wins over `enable_logs`.
 
-  Default: `False`
+  Default: unset, which behaves as `False`
 
 - `sentry_logs_level`
 
-  The Sentry Python SDK will capture log records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/). If set to `None`, the SDK won't send records as logs. Only applies when `capture_sentry_logs` is `True`.
+  The Sentry Python SDK will capture log records with a level higher than or equal to `sentry_logs_level` as [Sentry structured logs](/platforms/python/logs/). If set to `None`, the SDK won't send records as logs. Only applies when the integration is capturing Sentry logs.
 
   Default: `INFO`
 
@@ -182,7 +182,7 @@ sentry_sdk.init(
 
 <Expandable title="Logs not appearing in Sentry">
 
-  First, make sure you're on the latest version of the SDK. If you're using the `sentry_sdk.logger` API directly (e.g., `sentry_sdk.logger.info(...)`), logs are sent automatically. If you're using Loguru and want those log records captured as Sentry logs, make sure you have `capture_sentry_logs=True` set on your `LoguruIntegration`.
+  First, make sure you're on the latest version of the SDK. If you're using the `sentry_sdk.logger` API directly (e.g., `sentry_sdk.logger.info(...)`), logs are sent automatically. If you're using Loguru and want those log records captured as Sentry logs, make sure you have `capture_sentry_logs=True` set on your `LoguruIntegration`. Setting the deprecated `enable_logs=True` also works, but only if `capture_sentry_logs` is left unset on the integration.
 
   Your logs could be missing because of the logging level of the logger. The SDK will honor the configured level of each logger. That means that you won't see any `INFO` or `DEBUG` data in Sentry from a logger with the level set to `WARNING`, regardless of how you configure the integration.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Python SDK [2.68.1](https://github.com/getsentry/sentry-python/releases/tag/2.68.1) restored `enable_logs` as a deprecated compatibility layer ([sentry-python#7237](https://github.com/getsentry/sentry-python/pull/7237)), walking back part of the removal documented in #19029. Our docs still describe the option as a no-op.

Concretely, in 2.68.1 the `capture_sentry_logs` default changed from `False` to an internal sentinel, and the "`enable_logs` has no effect" warning was removed from `client.py`. So when an integration leaves `capture_sentry_logs` unset, `enable_logs=True` turns automatic log capture back on for the `logging` and Loguru integrations, while an explicit `capture_sentry_logs` always wins:

| `enable_logs`     | `capture_sentry_logs` | Automatic capture |
| ----------------- | --------------------- | ----------------- |
| not set / `False` | not set               | off               |
| `True`            | not set               | on                |
| any               | `True`                | on                |
| any               | `False`               | off               |

Two user-facing consequences of the stale docs: users on `enable_logs=True` are told their config has no effect when it does, and users debugging missing logs are pointed only at the new option.

- Rewrite the `enable_logs` entry in the Python options reference as **deprecated** rather than a no-op, with the precedence table above
- Note that `2.68.0` alone had no effect, so anyone relying on the option upgrades to `2.68.1`+
- Correct the `capture_sentry_logs` default on both the `logging` and Loguru integration pages from `False` to unset, and explain the `enable_logs` fallback
- Mention the deprecated path in both "Logs not appearing in Sentry" troubleshooting entries
- Reword the level-threshold sentences that were conditioned on `capture_sentry_logs is True`

Not included: `DjangoIntegration(failed_request_status_codes=...)` shipped in the same release ([sentry-python#7140](https://github.com/getsentry/sentry-python/pull/7140)) and is undocumented, but it's an unrelated option — worth a separate PR.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
