### PR TITLE
docs(python): Document `failed_request_status_codes` option for Django

### DIFF
--- a/docs/platforms/python/integrations/django/index.mdx
+++ b/docs/platforms/python/integrations/django/index.mdx
@@ -249,6 +249,24 @@ Note that `OPTIONS` and `HEAD` are excluded by default.
 
 </SdkOption>
 
+<SdkOption name='failed_request_status_codes' type='set[int]' defaultValue='{*range(500, 600)}'>
+
+A set of integers that will determine which status codes should be reported to Sentry.
+
+The `failed_request_status_codes` option determines whether exceptions handled within Django should be
+  reported to Sentry. Unhandled exceptions that don't have a `status_code` attribute will always be reported to Sentry.
+
+Examples of valid `failed_request_status_codes`:
+  - `{500}` will only send events on HTTP 500.
+  - `{400, *range(500, 600)}` will send events on HTTP 400 as well as the 5xx range.
+  - `{500, 503}` will send events on HTTP 500 and 503.
+  - `set()` (the empty set) will not send events for any HTTP status code.
+
+The default is `{*range(500, 600)}`, meaning that all 5xx status codes are reported to Sentry.
+
+</SdkOption>
+
+
 ## Next Steps
 
 <PlatformContent includePath="getting-started-next-steps" />


### PR DESCRIPTION
<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

Add an `<SdkOption>` entry for `failed_request_status_codes` to the Django integration page, matching the existing docs for this option in the FastAPI, Starlette, aiohttp, litestar, and bottle integrations.

Related to changes introduced in https://github.com/getsentry/sentry-python/pull/7140/

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
