### PR TITLE
docs(rust): Undocument soon-deprecated `enable_logs`

### DIFF
--- a/docs/platforms/rust/common/configuration/options.mdx
+++ b/docs/platforms/rust/common/configuration/options.mdx
@@ -198,14 +198,6 @@ By default, the SDK uses a transport based on the `reqwest` crate running on a b
 
 ## Logging Options
 
-<SdkOption name="enable_logs" type='bool' defaultValue='true'>
-
-Determines whether captured structured logs should be sent to Sentry.
-
-Sending logs requires Sentry to be compiled with the `logs` feature. As the `logs` feature is included in the default feature set, you only explicitly need to enable `logs` when compiling without default features.
-
-</SdkOption>
-
 <SdkOption name="before_send_log" type='Fn'>
 
 Callback that is executed for each Log being captured. When `None` is returned from the function, the log record is dropped. To pass the log record through, return the log record itself.


### PR DESCRIPTION
https://github.com/getsentry/sentry-rust/pull/1299 deprecates the Rust SDK's `enable_logs` option.

This change removes the last-remaining reference to `enable_logs` in the Rust SDK's docs.

Relates to https://github.com/getsentry/sentry-rust/issues/1297
Relates to [RUST-274](https://linear.app/getsentry/issue/RUST-274/deprecate-and-no-op-ify-enable-logs)
