### PR TITLE
docs(go): Remove retired telemetry kill switches

### DIFF
--- a/docs/platforms/go/common/configuration/options.mdx
+++ b/docs/platforms/go/common/configuration/options.mdx
@@ -209,22 +209,6 @@ In practice, reporting very long chains usually provides little value when debug
 
 </SdkOption>
 
-## Logging Options
-
-<SdkOption name="DisableLogs" type="bool" defaultValue="false">
-
-When set to `true`, the SDK does not capture or send log messages to Sentry. By default, logs are enabled.
-
-</SdkOption>
-
-## Metrics Options
-
-<SdkOption name="DisableMetrics" type="bool" defaultValue="false">
-
-When set to `true`, the SDK does not emit metrics. By default, metrics are enabled.
-
-</SdkOption>
-
 ## Client Reports Options
 
 <SdkOption name="DisableClientReports" type="bool" defaultValue="false">

--- a/docs/platforms/go/common/logs/zerolog.mdx
+++ b/docs/platforms/go/common/logs/zerolog.mdx
@@ -74,7 +74,6 @@ func main() {
 	// Initialize Sentry
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
-		// Note: Structured Logs are enabled by default.
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("sentry initialization failed")

--- a/docs/platforms/go/common/logs/zerolog.mdx
+++ b/docs/platforms/go/common/logs/zerolog.mdx
@@ -74,7 +74,7 @@ func main() {
 	// Initialize Sentry
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn: "___PUBLIC_DSN___",
-		// Note: Structured Logs are enabled by default. To disable them, set DisableLogs: true.
+		// Note: Structured Logs are enabled by default.
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("sentry initialization failed")

--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -22,7 +22,7 @@ err := sentry.Init(sentry.ClientOptions{
     TracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
     // ___PRODUCT_OPTION_START___ logs
-    // Logs are enabled by default. To disable them, set DisableLogs: true.
+    // Logs are enabled by default.
     // ___PRODUCT_OPTION_END___ logs
 })
 if err != nil {

--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -28,9 +28,4 @@ if err != nil {
 // Flush buffered events before the program terminates.
 // Set the timeout to the maximum duration the program can afford to wait.
 defer sentry.Flush(2 * time.Second)
-
-// ___PRODUCT_OPTION_START___ logs
-logger := sentry.NewLogger(context.Background())
-logger.Info().Emit("User example action completed")
-// ___PRODUCT_OPTION_END___ logs
 ```

--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -21,9 +21,6 @@ err := sentry.Init(sentry.ClientOptions{
     // of transactions for tracing.
     TracesSampleRate: 1.0,
     // ___PRODUCT_OPTION_END___ performance
-    // ___PRODUCT_OPTION_START___ logs
-    // Logs are enabled by default.
-    // ___PRODUCT_OPTION_END___ logs
 })
 if err != nil {
     log.Fatalf("sentry.Init: %s", err)
@@ -31,4 +28,9 @@ if err != nil {
 // Flush buffered events before the program terminates.
 // Set the timeout to the maximum duration the program can afford to wait.
 defer sentry.Flush(2 * time.Second)
+
+// ___PRODUCT_OPTION_START___ logs
+logger := sentry.NewLogger(context.Background())
+logger.Info().Emit("User example action completed")
+// ___PRODUCT_OPTION_END___ logs
 ```

--- a/platform-includes/getting-started-include-logs-config/go.mdx
+++ b/platform-includes/getting-started-include-logs-config/go.mdx
@@ -14,7 +14,6 @@ err := sentry.Init(sentry.ClientOptions{
     // Adds request headers and IP for users,
     // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
     SendDefaultPII: true,
-    // Logs are enabled by default.
     // ___PRODUCT_OPTION_START___ performance
     EnableTracing: true,
     // Set TracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/getting-started-include-logs-config/go.mdx
+++ b/platform-includes/getting-started-include-logs-config/go.mdx
@@ -14,7 +14,7 @@ err := sentry.Init(sentry.ClientOptions{
     // Adds request headers and IP for users,
     // visit: https://docs.sentry.io/platforms/go/data-management/data-collected/ for more info
     SendDefaultPII: true,
-    // Logs are enabled by default. To disable them, set DisableLogs: true.
+    // Logs are enabled by default.
     // ___PRODUCT_OPTION_START___ performance
     EnableTracing: true,
     // Set TracesSampleRate to 1.0 to capture 100%

--- a/platform-includes/logs/setup/go.mdx
+++ b/platform-includes/logs/setup/go.mdx
@@ -20,12 +20,3 @@ func main() {
 	defer sentry.Flush(2 * time.Second)
 }
 ```
-
-To disable logs, set `DisableLogs` to `true`:
-
-```go
-sentry.Init(sentry.ClientOptions{
-	Dsn:         "___PUBLIC_DSN___",
-	DisableLogs: true,
-})
-```

--- a/platform-includes/metrics/options/go.mdx
+++ b/platform-includes/metrics/options/go.mdx
@@ -39,15 +39,3 @@ err := sentry.Init(sentry.ClientOptions{
   },
 })
 ```
-
-### Disabling Metrics
-
-Metrics are enabled by default. If you want to disable metrics collection entirely,
-you can do so by setting `DisableMetrics` to `true`:
-
-```go
-err := sentry.Init(sentry.ClientOptions{
-	Dsn:           "___PUBLIC_DSN___",
-	DisableMetrics: true,
-})
-```


### PR DESCRIPTION
## DESCRIBE YOUR PR

Go onboarding, logging, metrics, and configuration docs now match [sentry-go#1392](https://github.com/getsentry/sentry-go/pull/1392). The removed `DisableLogs` and `DisableMetrics` options are no longer shown, and selecting Logs now adds a concise `sentry.NewLogger` invocation.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.)
- [ ] Other deadline
- [x] None: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs
- [ ] PR was reviewed and approved by a member of the Sentry docs team