### PR TITLE
docs(nuxt): Remove mentions of `instrument.server.mjs`

### DIFF
--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -4,7 +4,7 @@ However, it's important to note that not all integrations are compatible with al
 Depending on whether an integration enhances the functionality of a particular runtime, such as the `BrowserTracing` integration for the browser runtime or the `RequestData` integration for the Node.js runtime, you can only include these integrations in their respective configuration files:
 
 - For the browser runtime integrations, add integrations to `Sentry.init` in `sentry.client.config.(js|ts)`
-- For the Node.js runtime integrations, add integrations to `Sentry.init` in `public/instrument.server.mjs`
+- For the Node.js runtime integrations, add integrations to `Sentry.init` in `sentry.server.config.(js|ts)`
 
 ### Common Integrations
 

--- a/platform-includes/performance/configure-sample-rate/javascript.nuxt.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.nuxt.mdx
@@ -1,4 +1,4 @@
-Set `tracesSampleRate` in your config files, `sentry.client.config.(js|ts)` and `instrument.server.mjs`:
+Set `tracesSampleRate` in your config files, `sentry.client.config.(js|ts)` and `sentry.server.config.(js|ts)`:
 
 
 ```javascript


### PR DESCRIPTION
part of https://github.com/getsentry/sentry-javascript/issues/23645

We don't need this file anymore - the setup docs also just mention `sentry.server.config.ts`