### PR TITLE
docs(python): Update Boto3 and HTTPX quick start guides

### DIFF
--- a/docs/platforms/python/integrations/boto3/index.mdx
+++ b/docs/platforms/python/integrations/boto3/index.mdx
@@ -12,8 +12,8 @@ The Boto3 integration instruments requests made to Amazon Web Services done with
 You need:
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - Your application up and running
-- botocore: `1.12+`
-- Python: `3.6+`
+- botocore `1.12+`
+- Python `3.6+`
 
 <StepConnector selector="h2" showNumbers={true}>
 
@@ -55,6 +55,10 @@ main()
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+## Next Steps
+
+<PlatformContent includePath="getting-started-next-steps" />
 
 <Expandable permalink={false} title="Are you having problems setting up the SDK or integration?">
 - Find various topics in <PlatformLink to="/troubleshooting/">Troubleshooting</PlatformLink>

--- a/docs/platforms/python/integrations/boto3/index.mdx
+++ b/docs/platforms/python/integrations/boto3/index.mdx
@@ -35,6 +35,7 @@ To verify that Sentry captures your Boto3 requests to Amazon Web Services, add t
 <SplitSectionCode>
 
 ```python
+import sentry_sdk
 import boto3
 
 def main():

--- a/docs/platforms/python/integrations/boto3/index.mdx
+++ b/docs/platforms/python/integrations/boto3/index.mdx
@@ -1,30 +1,64 @@
 ---
 title: Boto3
-description: "Learn about the Boto3 integration and how it adds support for the Boto3 and botocore libraries."
+description: "Learn how to set up Sentry's Boto3 integration and how to capture requests as spans."
 ---
 
-The Boto3 integration instruments requests made to Amazon Web Services done with [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) (or the low level [botocore](https://github.com/boto/botocore) library that Boto3 uses under the hood). It creates a span for every request.
+The Boto3 integration instruments requests made to Amazon Web Services done with [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) (or the low level [botocore](https://github.com/boto/botocore) library that Boto3 uses under the hood).
 
-## Install
+<Include name="python-stream-mode-general-callout.mdx" />
 
-Install `sentry-sdk` from PyPI:
+## Prerequisites
 
-```bash {tabTitle:pip}
-pip install "sentry-sdk"
+You need:
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running
+- botocore: `1.12+`
+- Python: `3.6+`
+
+<StepConnector selector="h2" showNumbers={true}>
+
+## Install & Configure
+
+Follow our <PlatformLink to="/">quick start guide</PlatformLink> to set up Sentry in your Python application (make sure to enable tracing).
+Sentry's Boto3 integration is enabled automatically if you have the `boto3` package in your dependencies.
+
+
+## Verify Your Setup
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+To verify that Sentry captures your Boto3 requests to Amazon Web Services, add this code to your app, which will create a transaction called `testing_sentry` in the [Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/) section:
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```python
+import boto3
+
+def main():
+    # same as in the Python quick start guide (https://docs.sentry.io/platforms/python)
+    sentry_sdk.init(...)
+
+    s3 = boto3.resource('s3')
+
+    # or sentry_sdk.traces.start_span(name="testing_sentry", parent_span=None) in stream mode
+    with sentry_sdk.start_transaction(name="testing_sentry"):
+        # make a request to the service and print out bucket names
+        for bucket in s3.buckets.all():
+            print(bucket.name)
+
+main()
 ```
-```bash {tabTitle:uv}
-uv add "sentry-sdk"
-```
 
-## Configure
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-If you have the `boto3` package in your dependencies, the Boto3 integration will be enabled automatically when you initialize the Sentry SDK.
+<Expandable permalink={false} title="Are you having problems setting up the SDK or integration?">
+- Find various topics in <PlatformLink to="/troubleshooting/">Troubleshooting</PlatformLink>
+- [Get support](https://www.sentry.help/en/)
+</Expandable>
 
-<PlatformContent includePath="getting-started-config" />
-
-## Supported Versions
-
-- botocore: 1.12+
-- Python: 3.6+
-
-<Include name="python-use-older-sdk-for-legacy-support.mdx" />
+</StepConnector>

--- a/docs/platforms/python/integrations/httpx/index.mdx
+++ b/docs/platforms/python/integrations/httpx/index.mdx
@@ -1,40 +1,46 @@
 ---
 title: HTTPX
-description: "Learn about the HTTPX integration and how it adds support for the HTTPX HTTP client."
+description: "Learn how to set up Sentry's HTTPX integration and how to capture outgoing HTTP requests as spans."
 ---
 
-The [HTTPX](https://www.python-httpx.org/) integration instruments outgoing HTTP requests using either the sync or the async HTTPX clients.
-
-Use this integration to create spans for outgoing requests and ensure traces are properly propagated to downstream services.
+Sentry's [HTTPX](https://www.python-httpx.org/) integration instruments outgoing HTTP requests using either the sync or the async HTTPX clients.
 
 <Include name="python-stream-mode-general-callout.mdx" />
 
-## Install
+## Prerequisites
 
-Install `sentry-sdk` from PyPI:
+You need:
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running
+- HTTPX `0.16+`
+- Python `3.6+`
 
-```bash {tabTitle:pip}
-pip install sentry-sdk
-```
+<StepConnector selector="h2" showNumbers={true}>
 
-```bash {tabTitle:uv}
-uv add sentry-sdk
-```
+## Install & Configure
 
-## Configure
+Follow our <PlatformLink to="/">quick start guide</PlatformLink> to set up Sentry in your Python application (make sure to enable tracing).
+Sentry's HTTPX integration is enabled automatically if you have the `httpx` package installed.
 
-The HTTPX integration is enabled automatically if you have the `httpx` package installed.
+## Verify Your Setup
 
-<PlatformContent includePath="getting-started-config" />
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
 
-## Verify
+To verify that Sentry captures your HTTPX requests, add this code to your app, which will create a transaction called `testing_sentry` in the [Traces](https://sentry.io/orgredirect/organizations/:orgslug/explore/traces/) section and create spans for the outgoing HTTP requests:
+
+</SplitSectionText>
+<SplitSectionCode>
 
 ```python
 import httpx
 
 def main():
-    sentry_init(...)  # same as above
-    # or sentry_sdk.traces.start_span(name="your_span_name", parent_span=None) in stream mode
+    # same as in the Python quick start guide (https://docs.sentry.io/platforms/python)
+    sentry_init(...)
+
+    # or sentry_sdk.traces.start_span(name="testing_sentry", parent_span=None) in stream mode
     with sentry_sdk.start_transaction(name="testing_sentry"):
         r1 = httpx.get("https://sentry.io/")
         r2 = httpx.post("http://httpbin.org/post")
@@ -42,11 +48,17 @@ def main():
 main()
 ```
 
-This will create a transaction called `testing_sentry` in the Performance section of [sentry.io](https://sentry.io), and create spans for the outgoing HTTP requests.
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
 
-It takes a couple of moments for the data to appear in [sentry.io](https://sentry.io).
+## Next Steps
 
-## Supported Versions
+<PlatformContent includePath="getting-started-next-steps" />
 
-- HTTPX: 0.16+
-- Python: 3.6+
+<Expandable permalink={false} title="Are you having problems setting up the SDK or integration?">
+- Find various topics in <PlatformLink to="/troubleshooting/">Troubleshooting</PlatformLink>
+- [Get support](https://www.sentry.help/en/)
+</Expandable>
+
+</StepConnector>

--- a/docs/platforms/python/integrations/httpx/index.mdx
+++ b/docs/platforms/python/integrations/httpx/index.mdx
@@ -34,11 +34,12 @@ To verify that Sentry captures your HTTPX requests, add this code to your app, w
 <SplitSectionCode>
 
 ```python
+import sentry_sdk
 import httpx
 
 def main():
     # same as in the Python quick start guide (https://docs.sentry.io/platforms/python)
-    sentry_init(...)
+    sentry_sdk.init(...)
 
     # or sentry_sdk.traces.start_span(name="testing_sentry", parent_span=None) in stream mode
     with sentry_sdk.start_transaction(name="testing_sentry"):


### PR DESCRIPTION
<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

Updates the Boto3 and HTTPX guides to follow our quick start guide template.

- removed the installation and configuration instructions and linked to the quick start guide instead. 
- added a verification section for Boto3

Closes: #19145

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
