### PR TITLE
docs(develop-docs): add redis TTL guidance page

### DIFF
--- a/develop-docs/backend/application-domains/redis.mdx
+++ b/develop-docs/backend/application-domains/redis.mdx
@@ -1,0 +1,46 @@
+---
+title: Redis
+description: Every new Redis key sets a TTL or is registered as accepted durable data. What that means in practice, and which commands silently drop a TTL.
+sidebar_order: 65
+---
+
+<Alert>
+  This document uses key words such as "MUST", "SHOULD", and "MAY" as defined in
+  [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) to indicate requirement
+  levels.
+</Alert>
+
+Sentry uses Redis for caches, counters, buffers, and other short-lived state. Redis holds everything in memory, and our capacity planning and cluster migrations assume that keys expire. A key that lives forever quietly turns a cache into a datastore: memory grows without bound, and the cluster can no longer be drained, resharded, or failed over without losing data nobody agreed to lose.
+
+## Every New Key Gets a TTL
+
+Every new Redis key **MUST** have a TTL.
+
+If the data genuinely cannot expire, you **MUST** instead register the key with Infrastructure Engineering as accepted durable data: what the key holds, why it cannot expire, and how to rebuild it if the cluster loses it. Infrastructure Engineering maintains the list of accepted durable keys.
+
+There is no third option. A TTL-less key that is not on the list is a leak, even if the data it holds is useful.
+
+## A Sliding TTL Is Not a Bound
+
+Calling `EXPIRE` every time you write to a key does not bound its lifetime. It resets the clock: as long as writes keep arriving, the key never expires, and neither does the data it already holds. A set you refresh on every append still holds its very first member years later.
+
+If a continuously-written key needs a real bound, bound the data instead. Shard by time window (`mykey:2026-08-27`) and give each shard a fixed TTL, so old shards age out on their own while new writes go to new shards.
+
+## Keeping a TTL Is Its Own Job
+
+Some write commands silently discard the TTL a key already has:
+
+- `SET` and `GETSET` replace the value and drop the TTL. Pass `KEEPTTL` to `SET` if you mean to keep it.
+- `SETEX` throws away the existing TTL and installs the one you pass.
+
+Others leave the TTL alone: `SADD`, `ZADD`, `HSET`, `HINCRBY`, and `INCR` modify the value without touching the expiry.
+
+None of them ever adds a TTL either. A key created through one of these commands has no expiry at all until something calls `EXPIRE` on it.
+
+This distinction is where real leaks come from: code that sets the TTL correctly in one place, then loses it through a later write to the same key. Reviewing a change by asking "does this write set an expiry?" will not catch that. The question that catches it is "does any write to this key drop one?"
+
+## Snuba, Relay, Seer, and the Uptime Checker
+
+These services live outside the `sentry` codebase and each build their own Redis client, in their own language, with no shared helper in between. Nothing there can enforce these rules mechanically.
+
+For them the rules are advisory: a TTL-less write will not fail. The expectations don't change, though, and their keys **SHOULD** carry a TTL or a registration like everyone else's.

--- a/develop-docs/backend/application-domains/redis.mdx
+++ b/develop-docs/backend/application-domains/redis.mdx
@@ -10,15 +10,13 @@ sidebar_order: 65
   levels.
 </Alert>
 
-Sentry uses Redis for caches, counters, buffers, and other short-lived state. Redis holds everything in memory, and our capacity planning and cluster migrations assume that keys expire. A key that lives forever quietly turns a cache into a datastore: memory grows without bound, and the cluster can no longer be drained, resharded, or failed over without losing data nobody agreed to lose.
+Sentry uses Redis for caches, counters, buffers, and other short-lived state. Redis holds everything in memory, and our capacity planning and cluster migrations assume that keys expire. A key that lives forever quietly turns a cache into a datastore: memory grows without bound, and the cluster can no longer be drained, resharded, or failed over without data loss, or more complex migration operations.
 
 ## Every New Key Gets a TTL
 
 Every new Redis key **MUST** have a TTL.
 
 If the data genuinely cannot expire, you **MUST** instead register the key with Infrastructure Engineering as accepted durable data: what the key holds, why it cannot expire, and how to rebuild it if the cluster loses it. Infrastructure Engineering maintains the list of accepted durable keys.
-
-There is no third option. A TTL-less key that is not on the list is a leak, even if the data it holds is useful.
 
 ## A Sliding TTL Is Not a Bound
 
@@ -37,10 +35,4 @@ Others leave the TTL alone: `SADD`, `ZADD`, `HSET`, `HINCRBY`, and `INCR` modify
 
 None of them ever adds a TTL either. A key created through one of these commands has no expiry at all until something calls `EXPIRE` on it.
 
-This distinction is where real leaks come from: code that sets the TTL correctly in one place, then loses it through a later write to the same key. Reviewing a change by asking "does this write set an expiry?" will not catch that. The question that catches it is "does any write to this key drop one?"
-
-## Snuba, Relay, Seer, and the Uptime Checker
-
-These services live outside the `sentry` codebase and each build their own Redis client, in their own language, with no shared helper in between. Nothing there can enforce these rules mechanically.
-
-For them the rules are advisory: a TTL-less write will not fail. The expectations don't change, though, and their keys **SHOULD** carry a TTL or a registration like everyone else's.
+This distinction is where leaks come from: code that sets the TTL correctly in one place, then loses it through a later write to the same key. Reviewing a change by asking "does this write set an expiry?" will not catch that. The question that catches it is "does any write to this key drop one?"


### PR DESCRIPTION
## DESCRIBE YOUR PR

This adds a Redis page to the develop docs stating the TTL rules for new keys:
set a TTL or register the key as accepted durable data, a sliding `EXPIRE` is
not a bound, and some commands silently drop an existing TTL. The rules are
advisory for Snuba, Relay, Seer and the uptime checker, which have no shared
client to enforce through.

The page does not link the accepted-durable-keys list yet: that list has no
published home until [INFRENG-455](https://linear.app/getsentry/issue/INFRENG-455/determine-durable-key-list)
lands, and that ticket includes adding the link here.

INFRENG-508

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a de

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)