### PR TITLE
docs(python): document experimental data_collection option

### DIFF
--- a/docs/platforms/python/configuration/options.mdx
+++ b/docs/platforms/python/configuration/options.mdx
@@ -101,6 +101,13 @@ If this flag is enabled, [certain personally identifiable information (PII)](/pl
 
 If you enable this option, be sure to manually remove what you don't want to send using our features for managing [_Sensitive Data_](../../data-management/sensitive-data/).
 
+<Alert>
+  We plan to eventually deprecate `send_default_pii` in favor of the experimental [`data_collection`](#data_collection) option, but that won't happen until a future major version. Until then, `send_default_pii` remains fully supported.
+
+If you set both, `send_default_pii` is ignored entirely and the SDK emits a `DeprecationWarning`.
+
+</Alert>
+
 </SdkOption>
 
 <SdkOption name="event_scrubber" type='sentry_sdk.scrubber.EventScrubber' defaultValue='None'>
@@ -642,5 +649,109 @@ For automatic capture of logs from the standard library `logging` module and fro
 In SDK versions prior to `2.68.0`, this option had to be set to `True` to use the `sentry_sdk.logger` API, and it also enabled automatic capture of logs from the standard library `logging` module and from Loguru. In version `2.68.0` only, the option had no effect at all. Upgrade to `2.68.1` or later if you rely on it.
 
 Deprecated in version `2.68.1`. New in SDK version `2.35.0`. Prior to `2.35.0`, this option was experimental.
+
+</SdkOption>
+
+## Experimental Options
+
+<Alert level="warning">
+  Experimental options are passed through the `_experiments` dictionary. They
+  may change or be removed in any release without a major version bump, so pin
+  your SDK version if you rely on them.
+</Alert>
+
+<SdkOption name="data_collection" type='dict' defaultValue='None'>
+
+Controls which categories of data the SDK collects automatically, replacing the single `send_default_pii` boolean with a per-category configuration. All keys are optional.
+
+Because it's experimental, `data_collection` goes inside `_experiments`, not at the top level of `sentry_sdk.init()`:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "user_info": False,
+            "gen_ai": {"inputs": False, "outputs": False},
+        },
+    },
+)
+```
+
+Passing a `data_collection` dictionary opts you into its defaults, which are more permissive than `send_default_pii=False`. Any key you don't set falls back to the default in the table below, so the SDK collects rich debugging context (user identity, request bodies, generative AI content) and scrubs values whose keys match the built-in sensitive denylist (`auth`, `token`, `password`, and similar).
+
+If you set both `data_collection` and `send_default_pii`, `send_default_pii` is ignored entirely and the SDK emits a `DeprecationWarning`.
+
+For more on what data Sentry collects and how to control it, see <PlatformLink to="/data-management/data-collected/">Data Collected</PlatformLink>.
+
+### Keys
+
+| Key                     | Type                                    | Default                                                    | Description                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------- | --------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user_info`             | `bool`                                  | `True`                                                     | Populate `user.*` fields (`id`, `email`, `username`, `ip_address`) from instrumentation.                                                                                                                                                                                                                                                             |
+| `cookies`               | key-value behavior                      | `{"mode": "denylist"}`                                     | Collect cookies.                                                                                                                                                                                                                                                                                                                                     |
+| `http_headers`          | `{"request": key-value behavior}`       | `{"request": {"mode": "denylist"}}`                        | Collect HTTP request headers. The Python SDK currently doesn't capture response headers.                                                                                                                                                                                                                                                             |
+| `http_bodies`           | `list[str]`                             | `["incoming_request", "outgoing_request"]`                 | Body types to collect. Set to `[]` to disable. The Python SDK currently doesn't capture response bodies.                                                                                                                                                                                                                                             |
+| `url_query_params`      | key-value behavior                      | `{"mode": "denylist"}`                                     | Collect URL query parameters.                                                                                                                                                                                                                                                                                                                        |
+| `graphql`               | `{"document": bool, "variables": bool}` | both `True`                                                | Collect the GraphQL query document and its variables.                                                                                                                                                                                                                                                                                                |
+| `gen_ai`                | `{"inputs": bool, "outputs": bool}`     | both `True`                                                | Collect generative AI input and output content. Metadata such as the model ID and token counts is always collected.                                                                                                                                                                                                                                  |
+| `database_query_data`   | `bool`                                  | `True`                                                     | Collect database query data. Query parameter values are never sent; queries are parameterized first.                                                                                                                                                                                                                                                 |
+| `queues`                | `bool`                                  | `True`                                                     | Collect message body data for queue and task-queue integrations.                                                                                                                                                                                                                                                                                     |
+| `stack_frame_variables` | `bool` or key-value behavior            | `True`  | Include local variable values captured within stack frames. Accepts a boolean (`True` collects all variables, `False` collects none) or a key-value behavior to filter which variables are sent by name (see [Filtering Stack Frame Variables](https://develop.sentry.dev/sdk/foundations/client/data-collection/#filtering-stack-frame-variables)). |
+| `frame_context_lines`   | `int` or `bool`                         | `5`                                                        | Source code lines captured above and below each stack frame. `True` means the default of `5`, `False` means `0`.                                                                                                                                                                                                                                     |
+
+### Key-Value Collection Behavior
+
+The `cookies`, `http_headers["request"]`, and `url_query_params` categories take a dictionary with a `mode` and an optional list of `terms`:
+
+```python
+{"mode": "denylist", "terms": ["forwarded", "-ip", "remote-", "via", "-user"]}
+```
+
+| `mode`        | Behavior                                                                                                              |
+| ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `"denylist"`  | Collect everything, replacing the value of any key matching `terms` (in addition to the built-in sensitive denylist). |
+| `"allowlist"` | Only keys matching `terms` send their real value. Every other key is kept, but its value is replaced.                 |
+| `"off"`       | Collect nothing in this category.                                                                                     |
+
+`terms` match partially and case-insensitively, so `"-ip"` matches `X-Real-IP`. Filtered values are replaced with `[Filtered]`; the key itself is always preserved. The built-in sensitive denylist (`auth`, `token`, `secret`, `password`, `key`, `session`, and similar) always applies, even in `"allowlist"` mode.
+
+### Preserving `send_default_pii=False` Behavior
+
+To keep the conservative collection you get from `send_default_pii=False` while using `data_collection`, opt out of each category explicitly:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "user_info": False,
+            "gen_ai": {"inputs": False, "outputs": False},
+            "graphql": {"document": False, "variables": False},
+            "database_query_data": False,
+            "queues": False,
+            "http_bodies": [],
+            "cookies": {
+                "mode": "denylist",
+                "terms": ["forwarded", "-ip", "remote-", "via", "-user"],
+            },
+            "http_headers": {
+                "request": {
+                    "mode": "denylist",
+                    "terms": ["forwarded", "-ip", "remote-", "via", "-user"],
+                },
+            },
+            "url_query_params": {
+                "mode": "denylist",
+                "terms": ["forwarded", "-ip", "remote-", "via", "-user"],
+            },
+        },
+    },
+)
+```
 
 </SdkOption>

--- a/docs/platforms/python/data-management/data-collected.mdx
+++ b/docs/platforms/python/data-management/data-collected.mdx
@@ -6,13 +6,51 @@ sidebar_order: 1
 
 Sentry takes data privacy very seriously and has default settings in place that prioritize data safety, especially when it comes to personally identifiable information (PII) data. When you add the Sentry SDK to your application, you allow it to collect data and send it to Sentry during the runtime of your application.
 
-The category types and amount of data collected vary, depending on the integrations you've enabled in the Sentry SDK. Here's a list of data categories the Sentry Python SDK collects:
+The category types and amount of data collected vary, depending on the integrations you've enabled in the Sentry SDK. This page lists data categories that the Sentry Python SDK collects.
+
+<Expandable title="Options to control data collection">
+
+You can control many of the categories listed here with the <PlatformLink to="/configuration/options/#data_collection">experimental `data_collection` option</PlatformLink>, which lets you opt in or out of each data category individually. Because it's experimental, it goes inside the `_experiments` dictionary in your `sentry_sdk.init()` call.
+
+The <PlatformLink to="/configuration/options/#send_default_pii">`send_default_pii` option</PlatformLink> is still fully supported. We plan to eventually deprecate it in favor of `data_collection`, but that won't happen until a future major version.
+
+How much data the SDK collects by default depends on which option you use. Without `data_collection` (and with `send_default_pii` unset or `False`), the SDK collects conservatively, and the defaults described on this page apply.
+
+As soon as you pass a `data_collection` dictionary, the categories you don't set explicitly fall back to their `data_collection` defaults, which are more permissive. For example, cookies, query parameters (with sensitive values scrubbed), and AI message content are then collected unless you opt out. Setting `send_default_pii=True` is roughly equivalent to enabling all `data_collection` categories.
+
+If you set both, `send_default_pii` is ignored entirely and the SDK emits a `DeprecationWarning`.
+
+Regardless of these options, you can always scrub any data before it's sent to Sentry. See <PlatformLink to="/data-management/sensitive-data/">Scrubbing Sensitive Data</PlatformLink> for details.
+
+</Expandable>
 
 ## HTTP Headers
 
-By default, the Sentry SDK sends HTTP headers to Sentry but filters out any headers that contain sensitive data. (See the [list of headers](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/_wsgi_common.py#L28-L35) that are filtered).
+By default, the Sentry SDK sends HTTP request headers to Sentry but filters out any headers that contain sensitive data. (See the [list of headers](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/_wsgi_common.py#L28-L35) that are filtered). The Python SDK doesn't capture response headers.
 
 To send all HTTP headers, set `send_default_pii=True` in the `sentry_sdk.init()` call.
+
+When using `data_collection`, request headers are collected with sensitive values scrubbed. Use `http_headers` to control this:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            # Collect nothing:
+            "http_headers": {"request": {"mode": "off"}},
+            # Or only send real values for the listed headers:
+            # "http_headers": {"request": {"mode": "allowlist", "terms": ["content-type"]}},
+            # Or collect everything, filtering additional terms:
+            # "http_headers": {"request": {"mode": "denylist", "terms": ["-ip"]}},
+        },
+    },
+)
+```
+
+Values whose keys match Sentry's built-in sensitive denylist (such as `auth`, `token`, or `password`) are always scrubbed, while the keys are kept. See <PlatformLink to="/configuration/options/#data_collection">the `data_collection` reference</PlatformLink> for details on `mode` and `terms`.
 
 Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) removes sensitive data from headers (and a lot of other fields) right before sending data to Sentry.
 
@@ -22,6 +60,21 @@ By default, the Sentry SDK doesn't send cookies. Sentry tries to remove any cook
 
 If you want to send cookies, set `send_default_pii=True` in the `sentry_sdk.init()` call.
 
+When using `data_collection`, cookies are collected by default with sensitive values scrubbed. Opt out with `{"mode": "off"}`, or restrict which values are sent using `"allowlist"` or `"denylist"` mode:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "cookies": {"mode": "off"},
+        },
+    },
+)
+```
+
 Additionally a [data scrubber](/platforms/python/data-management/sensitive-data/) removes sensitive data from cookies (and a lot of other fields) right before sending data to Sentry.
 
 ## Information About Logged-in User
@@ -30,11 +83,56 @@ By default, the Sentry SDK doesn't send any information about the logged-in user
 
 To start sending logged-in user information, set `send_default_pii=True` in the `sentry_sdk.init()` call.
 
+When using `data_collection`, the SDK populates user identity fields (`user.id`, `user.email`, `user.username`) from instrumentation by default. To disable this, set `user_info` to `False`:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "user_info": False,
+        },
+    },
+)
+```
+
 ## Users' IP Address
 
 By default, the Sentry SDK doesn't send the user's IP address. Even if enabled, whether you're able to send the user's IP address or not, will depend on the integrations you enable in Sentry's SDK. Most integrations won't set the user's IP address at all.
 
 To enable sending the user's IP address, set `send_default_pii=True` in the `sentry_sdk.init()` call.
+
+When using `data_collection`, the user's IP address is sent by default. Disable it by setting `user_info` to `False`.
+
+Even when this is disabled, IP addresses can still reach Sentry through collected HTTP headers, cookies, or query parameters (for example, the `X-Forwarded-For` header). If you use `data_collection`, add these terms to the deny lists for those categories so their values are filtered:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "http_headers": {
+                "request": {
+                    "mode": "denylist",
+                    "terms": ["forwarded", "-ip", "remote-", "via", "-user"],
+                },
+            },
+            "cookies": {
+                "mode": "denylist",
+                "terms": ["forwarded", "-ip", "remote-", "via", "-user"],
+            },
+            "url_query_params": {
+                "mode": "denylist",
+                "terms": ["forwarded", "-ip", "remote-", "via", "-user"],
+            },
+        },
+    },
+)
+```
 
 ## Request URL
 
@@ -42,7 +140,24 @@ The full request URL of outgoing and incoming HTTP requests is **always sent to 
 
 ## Request Query String
 
-The full request query string of outgoing and incoming HTTP requests is **always sent to Sentry**. Depending on your application, this could contain PII data.
+By default, the full request query string of outgoing and incoming HTTP requests is sent to Sentry. Depending on your application, this could contain PII data. For example, a query string like `?user_id=1234`, where `1234` is a user id (which may be considered PII).
+
+When using `data_collection`, use `url_query_params` to control this. Set it to `{"mode": "off"}` to disable collection entirely, or use `"allowlist"` / `"denylist"` mode to filter which values are sent. Values whose keys match the built-in sensitive denylist (terms like `auth`, `token`, `password`, and `secret`) are scrubbed automatically.
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "url_query_params": {"mode": "off"},
+        },
+    },
+)
+```
+
+Sentry also has some additional [server-side data scrubbing](/security-legal-pii/scrubbing/server-side-scrubbing/) in place to remove sensitive data from the query string.
 
 ## Request Body
 
@@ -56,11 +171,46 @@ The request body of incoming HTTP requests can be sent to Sentry. Whether it's s
 
 If you want to prevent bodies from being sent to Sentry altogether, set `max_request_body_size` to `"never"`.
 
+When using `data_collection`, incoming and outgoing request bodies are collected by default. To disable body collection, set `http_bodies` to an empty list, or provide only the body types you want:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        # Collect only incoming request bodies:
+        "data_collection": {
+            "http_bodies": ["incoming_request"],
+        },
+    },
+)
+```
+
+The valid body types are `"incoming_request"` and `"outgoing_request"`. The Python SDK doesn't capture response bodies, so there are no response body types.
+
+`max_request_body_size` still applies on top of `http_bodies`.
+
 ## Source Context
 
 When an unhandled exception is sent to Sentry, a snapshot of the source code surrounding the line where the error originates is sent with it.
 
 To opt out of sending this source context to Sentry, set `include_source_context` to `False`.
+
+When using `data_collection`, use `frame_context_lines` to control how many lines above and below each stack frame are captured. It defaults to `5`. Set it to `0` (or `False`) to opt out:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "frame_context_lines": 0,
+        },
+    },
+)
+```
 
 ## Local Variables In Stack Trace
 
@@ -68,12 +218,99 @@ When unhandled errors and exceptions are sent to Sentry, the names and values of
 
 You can stop sending local variables to Sentry by setting `include_local_variables=False` in the `sentry_sdk.init()` call.
 
+When using `data_collection`, `stack_frame_variables` controls this. Unlike the other categories, it has no `data_collection` default of its own. If you don't set it, it falls back to whatever `include_local_variables` is, which is `True` unless you've changed it. This means passing a `data_collection` dictionary doesn't turn local variables on or off by itself.
+
+To opt out explicitly, set `stack_frame_variables` to `False`:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "stack_frame_variables": False,
+        },
+    },
+)
+```
+
 ## SQL Queries
 
 While SQL queries are sent to Sentry, neither the full SQL query (`UPDATE app_user SET password='supersecret' WHERE id=1;`), nor the values of its parameters will ever be sent. A parameterized version of the query (`UPDATE app_user SET password='%s' WHERE id=%s;`) is sent instead.
+
+When using `data_collection`, set `database_query_data` to `False` to stop collecting database query data:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "database_query_data": False,
+        },
+    },
+)
+```
+
+## GraphQL Documents And Variables
+
+When using `data_collection`, the GraphQL query document and its variables are collected by default. Both can be disabled independently:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "graphql": {"document": False, "variables": False},
+        },
+    },
+)
+```
+
+Without `data_collection` (and with `send_default_pii` unset or `False`), GraphQL documents and variables aren't collected.
+
+## Queue And Task Message Data
+
+When using `data_collection`, message body data for queue and task-queue integrations is collected by default. Set `queues` to `False` to opt out:
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "queues": False,
+        },
+    },
+)
+```
+
+Without `data_collection` (and with `send_default_pii` unset or `False`), this data isn't collected.
 
 ## LLM Inputs And Responses
 
 When using Sentry in your AI apps, the SDK by default won't add data like LLM inputs and responses to spans. To start recording these, add `send_default_pii=True` to your `sentry_sdk.init()` call.
 
 Most AI integrations have an additional parameter to control whether prompts should be included called `include_prompts`. See the <PlatformLink to="/integrations/#ai">documentation for the specific AI framework</PlatformLink> for more information.
+
+When using `data_collection`, the `gen_ai` category records both inputs and outputs unless you opt out. Metadata like the model ID and token counts is always collected.
+
+```python
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    _experiments={
+        "data_collection": {
+            "gen_ai": {"inputs": False, "outputs": False},
+        },
+    },
+)
+```
+
+`gen_ai` supersedes the per-integration `include_prompts` parameter. When `data_collection` is set, `gen_ai` determines whether prompt content is recorded, regardless of what an individual integration's `include_prompts` is set to.

--- a/docs/platforms/python/data-management/data-collected.mdx
+++ b/docs/platforms/python/data-management/data-collected.mdx
@@ -218,7 +218,7 @@ When unhandled errors and exceptions are sent to Sentry, the names and values of
 
 You can stop sending local variables to Sentry by setting `include_local_variables=False` in the `sentry_sdk.init()` call.
 
-When using `data_collection`, `stack_frame_variables` controls this. Unlike the other categories, it has no `data_collection` default of its own. If you don't set it, it falls back to whatever `include_local_variables` is, which is `True` unless you've changed it. This means passing a `data_collection` dictionary doesn't turn local variables on or off by itself.
+When using `data_collection`, `stack_frame_variables` controls this and defaults to `True`.
 
 To opt out explicitly, set `stack_frame_variables` to `False`:
 


### PR DESCRIPTION
Adds the `data_collection` experimental option to the Python SDK options reference and expands the Data Collected page with per-category defaults and examples (cookies, headers, query params, user info, GraphQL, queues, gen_ai, stack frame variables, source context). Notes that it will eventually replace `send_default_pii`, but `send_default_pii` remains fully supported until a future major version.

Fixes PY-2590
Fixes #6750

<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

_Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically._

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
