### PR TITLE
docs(agents): Match Conversations guide to current product

### DIFF
--- a/docs/product/agents/conversations/index.mdx
+++ b/docs/product/agents/conversations/index.mdx
@@ -60,7 +60,7 @@ The reverse is also true: a single trace can contain spans from different conver
 
 ## User Attribution
 
-The Conversations view includes a **User** column that shows which user initiated each conversation. To populate it, call `setUser` (JavaScript) or `set_user` (Python) once per request or session, before any AI calls:
+Each conversation in the list shows the user who initiated it alongside the project and conversation ID. To populate the user value, call `setUser` (JavaScript) or `set_user` (Python) once per request or session, before any AI calls:
 
 ```javascript
 // JavaScript / Node.js
@@ -76,7 +76,7 @@ import sentry_sdk
 sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": "jane"})
 ```
 
-Any of `id`, `email`, or `username` is sufficient. If no user is set, the column displays "Unknown".
+Sentry displays the first available user value in this order: `email`, `username`, `ip_address`, then `id`. If no user data is available, the list shows an em dash. Hover over it for setup guidance.
 
 ## Conversation Titles
 
@@ -96,7 +96,7 @@ If no title has been generated yet, the list shows the first user message text i
    [
      {
        "role": "user",
-       "parts": [{"type": "text", "content": "Help me debug this flaky test"}]
+       "parts": [{ "type": "text", "content": "Help me debug this flaky test" }]
      }
    ]
    ```
@@ -105,7 +105,7 @@ If no title has been generated yet, the list shows the first user message text i
 
 3. **Message content actually sent to Sentry.** If inputs are omitted (for example `sendDefaultPii: false` without an override that captures gen AI inputs), or scrubbed to filtered values, title generation has nothing to work with. See [Data Privacy](/product/agents/privacy/).
 
-SDK integrations that already emit OTEL-shaped `gen_ai.*` spans typically meet these requirements once conversation IDs and input collection are enabled. For manual instrumentation, set the attributes on your agent or AI client spans — see the [span attribute tables](/platforms/javascript/guides/node/agent-tracing/manual-instrumentation/).
+SDK integrations that already emit OTEL-shaped `gen_ai.*` spans typically meet these requirements once conversation IDs and input collection are enabled. For manual instrumentation, set the attributes on your agent or AI client spans — see the [span attribute reference](/platforms/javascript/guides/node/agent-tracing/manual-instrumentation/).
 
 ## Conversations List
 
@@ -113,23 +113,33 @@ The [Conversations](https://sentry.io/orgredirect/organizations/:orgslug/explore
 
 ![Conversations List](./img/agent-conversations.png)
 
-Each row in the list displays:
+Each conversation in the list includes:
 
-- **Title** — generated from the first user message; uses that message text until a title is available, or **Untitled conversation** when there are no user messages
-- **User** — the user who initiated the conversation, populated by `setUser` / `set_user`
-- **Last output** — the most recent assistant response
-- **Cost** — estimated dollar cost and token usage
-- **LLM calls** — number of LLM generation requests
-- **Tool calls** — number of tool executions
+- **Conversation** — the title, project, conversation ID, and user. The title comes from the first user message, uses that message text until a generated title is available, or shows **Untitled conversation** when there are no user messages.
+- **Duration** — the total time spent in model-generation spans.
+- **Messages** — the number of recorded model interactions.
+- **Errors** — the number of spans that ended with an error.
+- **Cost** — the estimated cost of the conversation.
+- **Tools** — the names of tools used during the conversation.
+- **Age** — how long ago the conversation was last active.
 
-Use the filters at the top of the page to narrow results by project, date range, or agent.
+Use the project, environment, date range, and agent filters to narrow the list. Date ranges are limited to 30 days. The span search field accepts span attributes or an exact conversation ID, and **Save Query** saves the current query for later use.
+
+The chart above the list can show conversation count (**Individual Chats**), **Cost**, or **Total Messages** as a line, area, or bar chart. You can also change the time interval or collapse the chart.
+
+If every listed conversation lacks captured inputs and outputs, a banner explains how to enable message capture in your SDK. When the selected project has no conversation data, the page shows an onboarding flow with integration-specific setup steps.
 
 ## Conversation Detail
 
-Click any conversation to open the detail view in a drawer.
+Select a conversation to open its full-page detail view at `/explore/agents/conversations/:id/`.
 
 ![Conversation Detail](./img/transcript-span.png)
 
-The detail view shows a chat-like interface with the full message history: user inputs, assistant responses, and tool calls. Click on any message to see the underlying spans, including individual LLM generations and tool executions, with timing and error information.
+The header summarizes the conversation's project, user, tools, LLM calls, errors, token usage, and cost. It also links to the underlying trace. If the conversation spans multiple traces, the **Traces** link opens Explore with results filtered to that conversation.
 
-This makes it straightforward to trace a conversation from start to finish and pinpoint where things went wrong.
+Use the two tabs to inspect the conversation:
+
+- **Transcript** shows user messages, assistant responses, tool calls, collapsible thinking or reasoning rows, and embedding operations in chronological order. Failed tool calls use error styling so they stand out. Select an assistant response or tool call to inspect its input, output, attributes, duration, and status. Use **Copy Transcript** to copy the conversation as Markdown.
+- **Timeline** shows the AI spans in execution order, including spans that don't have content to display in the transcript. Select a span to open the same input, output, and attribute details.
+
+The error count links to the conversation's failed spans, while **Trace** or **Traces** links connect the conversation to the surrounding distributed trace data.


### PR DESCRIPTION

The Conversations guide now matches the current product experience. It documents the list fields, filters, chart options, message-capture guidance, onboarding flow, and full-page Transcript and Timeline views.

Fixes TET-2746 ([Linear issue](https://linear.app/getsentry/issue/TET-2746/update-conversations-page-in-sentry-docs)).


