### PR TITLE
docs(electron): make logs enabled by default, drop required enableLogs flag

### DIFF
--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -49,8 +49,7 @@ Choose the features you want to configure, and this guide will show you how:
     "error-monitoring",
     "performance",
     "session-replay",
-    "user-feedback",
-    "logs",
+    "user-feedback"
   ]}
 />
 
@@ -84,11 +83,6 @@ Sentry.init({
   tracesSampleRate: 1.0,
   integrations: [Sentry.startupTracingIntegration()],
   // ___PRODUCT_OPTION_END___ performance
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -146,11 +140,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   // ___PRODUCT_OPTION_END___ session-replay
-  // ___PRODUCT_OPTION_START___ logs
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
 });
 ```
 
@@ -172,12 +161,7 @@ If your app uses utility processes, initialize Sentry in each one.
 ```javascript
 import * as Sentry from "@sentry/electron/utility";
 
-Sentry.init({
-  // ___PRODUCT_OPTION_START___ logs
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-  // ___PRODUCT_OPTION_END___ logs
-});
+Sentry.init();
 ```
 
 </SplitSectionCode>

--- a/platform-includes/logs/setup/javascript.electron.mdx
+++ b/platform-includes/logs/setup/javascript.electron.mdx
@@ -1,4 +1,4 @@
-To enable logging, you need to initialize the SDK in the renderer and main processes with the `_experiments.enableLogs` option set to `true`.
+Logs are enabled by default. Initialize the SDK in both the main and renderer processes, then use `Sentry.logger` to send logs.
 
 First update the main process file.
 
@@ -7,8 +7,6 @@ import * as Sentry from "@sentry/electron/main";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 });
 ```
 
@@ -19,7 +17,5 @@ import * as Sentry from "@sentry/electron/renderer";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 });
 ```


### PR DESCRIPTION
This removes `enableLogs` from the electron SDK docs. For the remaining JS SDKs this is done in https://github.com/getsentry/sentry-docs/pull/19080.