### PR TITLE
feat(home): surface MCP, CLI, and Sentry for AI on the homepage

### DIFF
--- a/src/components/home.module.scss
+++ b/src/components/home.module.scss
@@ -100,13 +100,17 @@
   .setupDesc {
     margin-bottom: 0;
     flex: unset;
+
+    & + .setupDesc {
+      margin-top: 6px;
+    }
   }
 
   .commandPill {
     margin-top: 0;
     margin-left: auto;
     flex-shrink: 0;
-    align-self: center;
+    align-self: flex-start;
   }
 }
 

--- a/src/components/home.module.scss
+++ b/src/components/home.module.scss
@@ -78,23 +78,37 @@
 }
 
 .setupRowCopy {
-  flex: 1;
   min-width: 0;
 }
 
 .agentHeader {
-  display: flex;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  column-gap: 16px;
+  row-gap: 16px;
 
   .setupIcon {
+    grid-column: 1;
+    grid-row: 1;
     margin-bottom: 0;
-    flex-shrink: 0;
   }
 
   .setupTitle {
-    margin-bottom: 4px;
+    grid-column: 2;
+    grid-row: 1;
+    margin-bottom: 0;
+  }
+
+  .commandPill {
+    grid-column: 3;
+    grid-row: 1;
+    margin-top: 0;
+    margin-left: 0;
+  }
+
+  .setupRowCopy {
+    grid-column: 1 / -1;
   }
 
   .setupDesc {
@@ -105,20 +119,14 @@
       margin-top: 6px;
     }
   }
-
-  .commandPill {
-    margin-top: 0;
-    margin-left: auto;
-    flex-shrink: 0;
-    align-self: flex-start;
-  }
 }
 
 @media (max-width: 767px) {
   .agentHeader {
+    grid-template-columns: auto 1fr;
+
     .commandPill {
-      margin-left: 0;
-      flex-basis: 100%;
+      grid-column: 1 / -1;
     }
   }
 }

--- a/src/components/home.module.scss
+++ b/src/components/home.module.scss
@@ -127,6 +127,11 @@
 
     .commandPill {
       grid-column: 1 / -1;
+      grid-row: 2;
+    }
+
+    .setupRowCopy {
+      grid-row: 3;
     }
   }
 }

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -180,9 +180,9 @@ export async function Home() {
             />
             <QuickLink href="/api/" title="API" desc="Access Sentry programmatically." />
             <QuickLink
-              href="/cli/"
-              title="CLI"
-              desc="Use sentry-cli on the command line."
+              href="/ai/"
+              title="Sentry for AI"
+              desc="See all the ways Sentry plugs into your agents and workflows."
             />
           </div>
         </section>

--- a/src/components/homeAiSetupCard.tsx
+++ b/src/components/homeAiSetupCard.tsx
@@ -60,6 +60,18 @@ export function HomeAiSetupCard() {
           <Link href="/ai/agent-plugin/" className={styles.seeAllLink}>
             Read about the agent plugin
           </Link>
+          .
+        </p>
+        <p className={styles.setupDesc}>
+          Use Sentry without leaving your agent conversations by setting up the{' '}
+          <Link href="https://mcp.sentry.dev/" className={styles.seeAllLink}>
+            Sentry MCP server
+          </Link>{' '}
+          and{' '}
+          <Link href="https://cli.sentry.dev/" className={styles.seeAllLink}>
+            Sentry CLI
+          </Link>
+          .
         </p>
       </div>
       <button

--- a/src/components/homeAiSetupCard.tsx
+++ b/src/components/homeAiSetupCard.tsx
@@ -52,8 +52,24 @@ export function HomeAiSetupCard() {
           <path d="M18.5 13.5l.95 2.3 2.3.95-2.3.95-.95 2.3-.95-2.3-2.3-.95 2.3-.95.95-2.3z" />
         </svg>
       </div>
+      <h2 className={styles.setupTitle}>Set up with a coding agent</h2>
+      <button
+        type="button"
+        className={styles.commandPill}
+        onClick={copyCommand}
+        aria-label={`Copy "${INSTALL_COMMAND}" to the clipboard`}
+      >
+        <span className={styles.agentIcons} aria-hidden>
+          <Claude width={15} height={15} />
+          <Codex width={15} height={15} />
+          <Cursor width={14} height={14} />
+        </span>
+        <code className={styles.commandText}>{INSTALL_COMMAND}</code>
+        <span className={styles.commandAction}>
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </span>
+      </button>
       <div className={styles.setupRowCopy}>
-        <h2 className={styles.setupTitle}>Set up with a coding agent</h2>
         <p className={styles.setupDesc}>
           One command teaches Claude Code, Cursor, Codex, and Grok how to install and
           configure Sentry for you.{' '}
@@ -74,22 +90,6 @@ export function HomeAiSetupCard() {
           .
         </p>
       </div>
-      <button
-        type="button"
-        className={styles.commandPill}
-        onClick={copyCommand}
-        aria-label={`Copy "${INSTALL_COMMAND}" to the clipboard`}
-      >
-        <span className={styles.agentIcons} aria-hidden>
-          <Claude width={15} height={15} />
-          <Codex width={15} height={15} />
-          <Cursor width={14} height={14} />
-        </span>
-        <code className={styles.commandText}>{INSTALL_COMMAND}</code>
-        <span className={styles.commandAction}>
-          {copied ? <Check size={14} /> : <Copy size={14} />}
-        </span>
-      </button>
     </div>
   );
 }

--- a/src/components/homeAiSetupCard.tsx
+++ b/src/components/homeAiSetupCard.tsx
@@ -10,6 +10,7 @@ import Codex from 'sentry-docs/icons/codex';
 import Cursor from 'sentry-docs/icons/cursor';
 import {DocMetrics} from 'sentry-docs/metrics';
 
+import {ExternalLink} from './externalLink';
 import styles from './home.module.scss';
 
 /** Keep in sync with /ai/agent-plugin/. */
@@ -80,13 +81,13 @@ export function HomeAiSetupCard() {
         </p>
         <p className={styles.setupDesc}>
           Use Sentry without leaving your agent conversations by setting up the{' '}
-          <Link href="https://mcp.sentry.dev/" className={styles.seeAllLink}>
+          <ExternalLink href="https://mcp.sentry.dev/" className={styles.seeAllLink}>
             Sentry MCP server
-          </Link>{' '}
+          </ExternalLink>{' '}
           and{' '}
-          <Link href="https://cli.sentry.dev/" className={styles.seeAllLink}>
+          <ExternalLink href="https://cli.sentry.dev/" className={styles.seeAllLink}>
             Sentry CLI
-          </Link>
+          </ExternalLink>
           .
         </p>
       </div>


### PR DESCRIPTION
## DESCRIBE YOUR PR

The docs homepage now points people to agent tooling instead of burying it. The coding-agent setup card links the [Sentry MCP server](https://mcp.sentry.dev/) and [Sentry CLI](https://cli.sentry.dev/) after the agent plugin intro, and the Learn More CLI card is replaced with **Sentry for AI**, linking to `/ai/`.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)

Made with [Cursor](https://cursor.com)