### PR TITLE
fix(llms-txt): replace dead skills.sentry.dev entry points in llms.txt + SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -19,9 +19,9 @@ The plugin provides current skills for SDK setup, debugging workflows, and featu
 
 If the plugin is not available, fetch skills directly:
 - **Full skill index**: https://skills.sentry.dev
-- **SDK setup** (detect platform and install): https://skills.sentry.dev/sdks
-- **Debugging workflows** (fix issues, review code): https://skills.sentry.dev/workflows
-- **Feature setup** (AI monitoring, alerts, OTel): https://skills.sentry.dev/features
+- **SDK setup** (detect platform and install): https://skills.sentry.dev/instrument
+- **Debugging workflows** (fix issues, review code): https://skills.sentry.dev/sentry-debug-issue/SKILL.md
+- **Feature setup** (AI monitoring, alerts, OTel): https://skills.sentry.dev/sentry-create-alert/SKILL.md
 
 Source repo: https://github.com/getsentry/sentry-for-ai
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,7 +21,8 @@ If the plugin is not available, fetch skills directly:
 - **Full skill index**: https://skills.sentry.dev
 - **SDK setup** (detect platform and install): https://skills.sentry.dev/instrument
 - **Debugging workflows** (fix issues, review code): https://skills.sentry.dev/sentry-debug-issue/SKILL.md
-- **Feature setup** (AI monitoring, alerts, OTel): https://skills.sentry.dev/sentry-create-alert/SKILL.md
+- **Feature setup** (AI monitoring, alerts): https://skills.sentry.dev/sentry-create-alert/SKILL.md
+- **OTel setup** (OpenTelemetry Collector + Sentry Exporter): https://skills.sentry.dev/sentry-otel-exporter-setup/SKILL.md
 
 Source repo: https://github.com/getsentry/sentry-for-ai
 

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -189,8 +189,9 @@ on the machine and sets up the plugin in each.
 Browse the skill library:
 - [All Skills](https://skills.sentry.dev/): Full skill index with SDK setup, workflows, and feature configuration
 - [SDK Setup](https://skills.sentry.dev/instrument): Detect your platform and install Sentry with the right features
-- [Workflows](https://skills.sentry.dev/workflows): Debug production issues, review code, upgrade SDKs
-- [Features](https://skills.sentry.dev/features): AI monitoring, alerts, OpenTelemetry setup
+- [Debug Issues](https://skills.sentry.dev/sentry-debug-issue/SKILL.md): Debug production issues, review code
+- [Create Alerts](https://skills.sentry.dev/sentry-create-alert/SKILL.md): Workflow-engine alerts and automations
+- [OTel Setup](https://skills.sentry.dev/sentry-otel-exporter-setup/SKILL.md): OpenTelemetry Collector + Sentry Exporter
 
 Source: https://github.com/getsentry/sentry-for-ai`;
 


### PR DESCRIPTION
## Summary

Fixes #19182.

`docs.sentry.io/llms.txt` (L183–186) and the repo-root `SKILL.md` (L22–24) direct AI agents to browse the Sentry skill library — but two of the four advertised entry points are dead:

| Advertised URL | Status |
|---|---|
| `https://skills.sentry.dev/` | 200 |
| `https://skills.sentry.dev/instrument` | 200 |
| `https://skills.sentry.dev/workflows` | **404** |
| `https://skills.sentry.dev/features` | **404** |

The served skill tree no longer contains `workflows`/`features` as top-level routes — the current skills are the flat `sentry-*` set. When a coding agent follows the published "Workflows" / "Features" entry points and hits a bare 404 from Vercel, it either dead-ends or improvises — the exact failure mode llms.txt exists to prevent.

This PR replaces both dead links (plus the `/sdks` → `/instrument` redirect in SKILL.md) with canonical paths that exist today.

## Changes

- `scripts/generate-llms-txt.mjs` — `AGENT_SKILLS` block: `[Workflows]`/`[Features]` → `[Debug Issues]` / `[Create Alerts]` / `[OTel Setup]`, all pointing at real `sentry-*/SKILL.md` routes
- `SKILL.md` — same three-line replacement, additionally fixing `/sdks` → `/instrument`

## Verification

- 404s confirmed deterministic (3 passes, browser + curl UAs, `x-vercel-cache: MISS` from origin)
- All replacement URLs verified 200 live at PR time:
  - `https://skills.sentry.dev/`
  - `https://skills.sentry.dev/instrument`
  - `https://skills.sentry.dev/sentry-debug-issue/SKILL.md`
  - `https://skills.sentry.dev/sentry-create-alert/SKILL.md`
  - `https://skills.sentry.dev/sentry-otel-exporter-setup/SKILL.md`
- `AGENT_SKILLS` injection into both outputs (`public/llms.txt` + `public/md-exports/index.md`) verified in generator source (assembly at L251/L281)
- Diff is identical to the one offered in #19182

## Context

I audit AI-agent tooling and documentation drift. Recent related work: [cloudflare/cloudflare-docs#32985](https://github.com/cloudflare/cloudflare-docs/pull/32985) (merged: llms.txt hub link generation fix) and the Codex TOML fix in [upstash/context7#3060](https://github.com/upstash/context7/issues/3060) (shipped by the maintainer in #3075).


## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+
