### PR TITLE
fix(go): remove inactive Logs onboarding toggle

### DIFF
--- a/platform-includes/getting-started-config/go.mdx
+++ b/platform-includes/getting-started-config/go.mdx
@@ -2,7 +2,6 @@
     options={[
         'error-monitoring',
         'performance',
-        'logs',
     ]}
 />
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Removes the Logs switch from Go SDK getting-started sections. The related conditional Logs configuration was removed previously, so toggling this control no longer changes the instructions.

This change is scoped to the Go platform include and leaves onboarding controls for other SDKs unchanged.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## TESTS

- `git diff --check`
- Confirmed no remaining `'logs'` option in Go onboarding configuration includes or Go docs pages

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
