### PR TITLE
ref(python): Move AI library pages under agent-tracing

### DIFF
--- a/docs/platforms/python/agent-tracing/anthropic/index.mdx
+++ b/docs/platforms/python/agent-tracing/anthropic/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Anthropic
 description: "Learn about using Sentry for Anthropic."
+sidebar_order: 20
 ---
 
 This integration connects Sentry with the [Anthropic Python SDK](https://github.com/anthropics/anthropic-sdk-python).

--- a/docs/platforms/python/agent-tracing/google-genai/index.mdx
+++ b/docs/platforms/python/agent-tracing/google-genai/index.mdx
@@ -1,13 +1,16 @@
 ---
-title: LiteLLM
-description: "Learn about using Sentry for LiteLLM."
+title: Google Gen AI
+description: "Learn about using Sentry for Google Gen AI."
+sidebar_order: 21
 ---
 
-This integration connects Sentry with the [LiteLLM Python SDK](https://github.com/BerriAI/litellm).
+This integration connects Sentry with the [Google Gen AI Python SDK](https://github.com/googleapis/python-genai).
 
 Once you've installed this SDK, you can use the Sentry Agents Tracing, a Sentry dashboard that helps you understand what's going on with your AI requests.
 
 Sentry AI Observability will automatically collect information about prompts, tools, tokens, and models. Learn more about the [Agents Dashboard](/product/agents/dashboards/).
+
+<Include name="python-stream-mode-general-callout.mdx" />
 
 ## Install
 
@@ -23,11 +26,11 @@ uv add sentry-sdk
 
 ## Configure
 
-Add `LiteLLMIntegration()` to your `integrations` list:
+Add `GoogleGenAIIntegration()` to your `integrations` list:
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.litellm import LiteLLMIntegration
+from sentry_sdk.integrations.google_genai import GoogleGenAIIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
@@ -38,35 +41,32 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
     integrations=[
-        LiteLLMIntegration(),
+        GoogleGenAIIntegration(),
     ],
 )
 ```
 
 ## Verify
 
-Verify that the integration works by making a chat completion request to LiteLLM.
+Verify that the integration works by making a chat request to Google Gen AI.
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.litellm import LiteLLMIntegration
-import litellm
+from sentry_sdk.integrations.google_genai import GoogleGenAIIntegration
+from google.genai import Client
 
-sentry_sdk.init(
-    dsn="___PUBLIC_DSN___",
-    traces_sample_rate=1.0,
-    send_default_pii=True,
-    integrations=[
-        LiteLLMIntegration(),
-    ],
-)
+sentry_sdk.init(...)  # same as above
 
-response = litellm.completion(
-    model="gpt-3.5-turbo",
-    messages=[{"role": "user", "content": "say hello"}],
-    max_tokens=100
-)
-print(response.choices[0].message.content)
+client = Client(api_key="(your Google API key)")
+
+def my_llm_stuff():
+    # or sentry_sdk.traces.start_span(name="The result of the AI inference", parent_span=None) in stream mode
+    with sentry_sdk.start_transaction(name="The result of the AI inference"):
+        response = client.models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents="say hello"
+        )
+        print(response.text)
 ```
 
 After running this script, the resulting data should show up in the `"AI Spans"` tab on the `"Explore" > "Traces"` page on Sentry.io.
@@ -77,19 +77,19 @@ It may take a couple of moments for the data to appear in [sentry.io](https://se
 
 ## Behavior
 
-- The LiteLLM integration will connect Sentry with the supported LiteLLM methods automatically.
+- The Google Gen AI integration will connect Sentry with the supported Google Gen AI methods automatically.
 
-- The supported functions are currently `completion` and `embedding` (both sync and async).
+- The supported function is currently `models.generate_content` (both sync and async).
 
 - Sentry considers LLM inputs/outputs as PII (Personally identifiable information) and doesn't include PII data by default. If you want to include the data, set `send_default_pii=True` in the `sentry_sdk.init()` call. To explicitly exclude prompts and outputs despite `send_default_pii=True`, configure the integration with `include_prompts=False` as shown in the [Options section](#options) below.
 
 ## Options
 
-By adding `LiteLLMIntegration` to your `sentry_sdk.init()` call explicitly, you can set options for `LiteLLMIntegration` to change its behavior:
+You can set options for `GoogleGenAIIntegration` to change its behavior:
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.litellm import LiteLLMIntegration
+from sentry_sdk.integrations.google_genai import GoogleGenAIIntegration
 
 sentry_sdk.init(
     # ...
@@ -97,14 +97,14 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
     integrations=[
-        LiteLLMIntegration(
+        GoogleGenAIIntegration(
             include_prompts=False,  # LLM inputs/outputs will be not sent to Sentry, despite send_default_pii=True
         ),
     ],
 )
 ```
 
-You can pass the following keyword arguments to `LiteLLMIntegration()`:
+You can pass the following keyword arguments to `GoogleGenAIIntegration()`:
 
 - `include_prompts`:
 
@@ -114,5 +114,5 @@ You can pass the following keyword arguments to `LiteLLMIntegration()`:
 
 ## Supported Versions
 
-- LiteLLM: 1.77.5+
-- Python: 3.8+
+- google-genai: 1.29.0+
+- Python: 3.9+

--- a/docs/platforms/python/agent-tracing/huggingface_hub/index.mdx
+++ b/docs/platforms/python/agent-tracing/huggingface_hub/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hugging Face Hub
 description: "Learn about using Sentry for Hugging Face Hub."
+sidebar_order: 28
 ---
 
 This integration connects Sentry with [Hugging Face Hub](https://github.com/huggingface/huggingface_hub) in Python.

--- a/docs/platforms/python/agent-tracing/index.mdx
+++ b/docs/platforms/python/agent-tracing/index.mdx
@@ -29,15 +29,15 @@ sentry_sdk.init(
 
 Pick your AI stack. Each page has install and verify details.
 
-- <PlatformLink to="/integrations/anthropic/">Anthropic</PlatformLink>
-- <PlatformLink to="/integrations/google-genai/">Google Gen AI</PlatformLink>
-- <PlatformLink to="/integrations/openai/">OpenAI</PlatformLink>
-- <PlatformLink to="/integrations/openai-agents/">OpenAI Agents SDK</PlatformLink>
-- <PlatformLink to="/integrations/langchain/">LangChain</PlatformLink>
-- <PlatformLink to="/integrations/langgraph/">LangGraph</PlatformLink>
-- <PlatformLink to="/integrations/litellm/">LiteLLM</PlatformLink>
-- <PlatformLink to="/integrations/pydantic-ai/">Pydantic AI</PlatformLink>
-- <PlatformLink to="/integrations/huggingface_hub/">Hugging Face Hub</PlatformLink>
+- <PlatformLink to="/agent-tracing/anthropic/">Anthropic</PlatformLink>
+- <PlatformLink to="/agent-tracing/google-genai/">Google Gen AI</PlatformLink>
+- <PlatformLink to="/agent-tracing/openai/">OpenAI</PlatformLink>
+- <PlatformLink to="/agent-tracing/openai-agents/">OpenAI Agents SDK</PlatformLink>
+- <PlatformLink to="/agent-tracing/langchain/">LangChain</PlatformLink>
+- <PlatformLink to="/agent-tracing/langgraph/">LangGraph</PlatformLink>
+- <PlatformLink to="/agent-tracing/litellm/">LiteLLM</PlatformLink>
+- <PlatformLink to="/agent-tracing/pydantic-ai/">Pydantic AI</PlatformLink>
+- <PlatformLink to="/agent-tracing/huggingface_hub/">Hugging Face Hub</PlatformLink>
 
 ## Tracking Conversations
 

--- a/docs/platforms/python/agent-tracing/langchain/index.mdx
+++ b/docs/platforms/python/agent-tracing/langchain/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: LangChain
 description: "Learn about using Sentry for LangChain."
+sidebar_order: 24
 ---
 
 This integration connects Sentry with [LangChain](https://github.com/langchain-ai/langchain) in Python.

--- a/docs/platforms/python/agent-tracing/langgraph/index.mdx
+++ b/docs/platforms/python/agent-tracing/langgraph/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: LangGraph
 description: "Learn about using Sentry for LangGraph."
+sidebar_order: 25
 ---
 
 This integration connects Sentry with [LangGraph](https://github.com/langchain-ai/langgraph) in Python.

--- a/docs/platforms/python/agent-tracing/litellm/index.mdx
+++ b/docs/platforms/python/agent-tracing/litellm/index.mdx
@@ -1,15 +1,14 @@
 ---
-title: Google Gen AI
-description: "Learn about using Sentry for Google Gen AI."
+title: LiteLLM
+description: "Learn about using Sentry for LiteLLM."
+sidebar_order: 26
 ---
 
-This integration connects Sentry with the [Google Gen AI Python SDK](https://github.com/googleapis/python-genai).
+This integration connects Sentry with the [LiteLLM Python SDK](https://github.com/BerriAI/litellm).
 
 Once you've installed this SDK, you can use the Sentry Agents Tracing, a Sentry dashboard that helps you understand what's going on with your AI requests.
 
 Sentry AI Observability will automatically collect information about prompts, tools, tokens, and models. Learn more about the [Agents Dashboard](/product/agents/dashboards/).
-
-<Include name="python-stream-mode-general-callout.mdx" />
 
 ## Install
 
@@ -25,11 +24,11 @@ uv add sentry-sdk
 
 ## Configure
 
-Add `GoogleGenAIIntegration()` to your `integrations` list:
+Add `LiteLLMIntegration()` to your `integrations` list:
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.google_genai import GoogleGenAIIntegration
+from sentry_sdk.integrations.litellm import LiteLLMIntegration
 
 sentry_sdk.init(
     dsn="___PUBLIC_DSN___",
@@ -40,32 +39,35 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
     integrations=[
-        GoogleGenAIIntegration(),
+        LiteLLMIntegration(),
     ],
 )
 ```
 
 ## Verify
 
-Verify that the integration works by making a chat request to Google Gen AI.
+Verify that the integration works by making a chat completion request to LiteLLM.
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.google_genai import GoogleGenAIIntegration
-from google.genai import Client
+from sentry_sdk.integrations.litellm import LiteLLMIntegration
+import litellm
 
-sentry_sdk.init(...)  # same as above
+sentry_sdk.init(
+    dsn="___PUBLIC_DSN___",
+    traces_sample_rate=1.0,
+    send_default_pii=True,
+    integrations=[
+        LiteLLMIntegration(),
+    ],
+)
 
-client = Client(api_key="(your Google API key)")
-
-def my_llm_stuff():
-    # or sentry_sdk.traces.start_span(name="The result of the AI inference", parent_span=None) in stream mode
-    with sentry_sdk.start_transaction(name="The result of the AI inference"):
-        response = client.models.generate_content(
-            model="gemini-2.0-flash-exp",
-            contents="say hello"
-        )
-        print(response.text)
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "say hello"}],
+    max_tokens=100
+)
+print(response.choices[0].message.content)
 ```
 
 After running this script, the resulting data should show up in the `"AI Spans"` tab on the `"Explore" > "Traces"` page on Sentry.io.
@@ -76,19 +78,19 @@ It may take a couple of moments for the data to appear in [sentry.io](https://se
 
 ## Behavior
 
-- The Google Gen AI integration will connect Sentry with the supported Google Gen AI methods automatically.
+- The LiteLLM integration will connect Sentry with the supported LiteLLM methods automatically.
 
-- The supported function is currently `models.generate_content` (both sync and async).
+- The supported functions are currently `completion` and `embedding` (both sync and async).
 
 - Sentry considers LLM inputs/outputs as PII (Personally identifiable information) and doesn't include PII data by default. If you want to include the data, set `send_default_pii=True` in the `sentry_sdk.init()` call. To explicitly exclude prompts and outputs despite `send_default_pii=True`, configure the integration with `include_prompts=False` as shown in the [Options section](#options) below.
 
 ## Options
 
-You can set options for `GoogleGenAIIntegration` to change its behavior:
+By adding `LiteLLMIntegration` to your `sentry_sdk.init()` call explicitly, you can set options for `LiteLLMIntegration` to change its behavior:
 
 ```python
 import sentry_sdk
-from sentry_sdk.integrations.google_genai import GoogleGenAIIntegration
+from sentry_sdk.integrations.litellm import LiteLLMIntegration
 
 sentry_sdk.init(
     # ...
@@ -96,14 +98,14 @@ sentry_sdk.init(
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
     integrations=[
-        GoogleGenAIIntegration(
+        LiteLLMIntegration(
             include_prompts=False,  # LLM inputs/outputs will be not sent to Sentry, despite send_default_pii=True
         ),
     ],
 )
 ```
 
-You can pass the following keyword arguments to `GoogleGenAIIntegration()`:
+You can pass the following keyword arguments to `LiteLLMIntegration()`:
 
 - `include_prompts`:
 
@@ -113,5 +115,5 @@ You can pass the following keyword arguments to `GoogleGenAIIntegration()`:
 
 ## Supported Versions
 
-- google-genai: 1.29.0+
-- Python: 3.9+
+- LiteLLM: 1.77.5+
+- Python: 3.8+

--- a/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/python/agent-tracing/manual-instrumentation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Manual Instrumentation
 sidebar_title: Manual Instrumentation
-sidebar_order: 10
+sidebar_order: 90
 description: "Learn how to manually instrument your agents to capture spans, token usage, and tool execution."
 ---
 

--- a/docs/platforms/python/agent-tracing/openai-agents/index.mdx
+++ b/docs/platforms/python/agent-tracing/openai-agents/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: OpenAI Agents
 description: "Learn about using Sentry for OpenAI Agents SDK."
+sidebar_order: 23
 ---
 
 <Alert title="Beta">

--- a/docs/platforms/python/agent-tracing/openai/index.mdx
+++ b/docs/platforms/python/agent-tracing/openai/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: OpenAI
 description: "Learn about using Sentry for OpenAI."
+sidebar_order: 22
 ---
 
 This integration connects Sentry with the [OpenAI Python SDK](https://github.com/openai/openai-python).

--- a/docs/platforms/python/agent-tracing/pydantic-ai/index.mdx
+++ b/docs/platforms/python/agent-tracing/pydantic-ai/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Pydantic AI
 description: "Learn about using Sentry for Pydantic AI."
+sidebar_order: 27
 ---
 
 <Alert title="Beta">

--- a/docs/platforms/python/integrations/index.mdx
+++ b/docs/platforms/python/integrations/index.mdx
@@ -42,15 +42,15 @@ The Sentry SDK uses integrations to hook into the functionality of popular libra
 
 |                                                                                                                                   | **Auto-enabled** |
 | --------------------------------------------------------------------------------------------------------------------------------- | :--------------: |
-| <LinkWithPlatformIcon platform="anthropic"       label="Anthropic" url="/platforms/python/integrations/anthropic" />              |        ✓         |
-| <LinkWithPlatformIcon platform="google-genai"    label="Google Gen AI" url="/platforms/python/integrations/google-genai" />       |        ✓         |
-| <LinkWithPlatformIcon platform="huggingface_hub" label="Hugging Face Hub" url="/platforms/python/integrations/huggingface_hub" /> |        ✓         |
-| <LinkWithPlatformIcon platform="openai"          label="OpenAI" url="/platforms/python/integrations/openai" />                    |        ✓         |
-| <LinkWithPlatformIcon platform="openai-agents"   label="OpenAI Agents SDK" url="/platforms/python/integrations/openai-agents" />  |        ✓         |
-| <LinkWithPlatformIcon platform="langchain"       label="LangChain" url="/platforms/python/integrations/langchain" />              |        ✓         |
-| <LinkWithPlatformIcon platform="langgraph"       label="LangGraph" url="/platforms/python/integrations/langgraph" />              |        ✓         |
-| <LinkWithPlatformIcon platform="litellm"         label="LiteLLM" url="/platforms/python/integrations/litellm" />                  |                  |
-| <LinkWithPlatformIcon platform="pydantic-ai"     label="Pydantic AI" url="/platforms/python/integrations/pydantic-ai" />          |        ✓         |
+| <LinkWithPlatformIcon platform="anthropic"       label="Anthropic" url="/platforms/python/agent-tracing/anthropic" />              |        ✓         |
+| <LinkWithPlatformIcon platform="google-genai"    label="Google Gen AI" url="/platforms/python/agent-tracing/google-genai" />       |        ✓         |
+| <LinkWithPlatformIcon platform="huggingface_hub" label="Hugging Face Hub" url="/platforms/python/agent-tracing/huggingface_hub" /> |        ✓         |
+| <LinkWithPlatformIcon platform="openai"          label="OpenAI" url="/platforms/python/agent-tracing/openai" />                    |        ✓         |
+| <LinkWithPlatformIcon platform="openai-agents"   label="OpenAI Agents SDK" url="/platforms/python/agent-tracing/openai-agents" />  |        ✓         |
+| <LinkWithPlatformIcon platform="langchain"       label="LangChain" url="/platforms/python/agent-tracing/langchain" />              |        ✓         |
+| <LinkWithPlatformIcon platform="langgraph"       label="LangGraph" url="/platforms/python/agent-tracing/langgraph" />              |        ✓         |
+| <LinkWithPlatformIcon platform="litellm"         label="LiteLLM" url="/platforms/python/agent-tracing/litellm" />                  |                  |
+| <LinkWithPlatformIcon platform="pydantic-ai"     label="Pydantic AI" url="/platforms/python/agent-tracing/pydantic-ai" />          |        ✓         |
 | <LinkWithPlatformIcon platform="mcp"             label="MCP (Model Context Protocol)" url="/platforms/python/integrations/mcp" /> |        ✓         |
 
 

--- a/redirects.js
+++ b/redirects.js
@@ -2320,6 +2320,79 @@ const userDocsRedirects = [
       '/platforms/javascript/guides/:guide/agent-tracing/mastra/:path*',
   },
   // Agent Tracing moved to top-level feature
+  // Python AI library pages moved from integrations to agent-tracing
+  {
+    source: '/platforms/python/integrations/anthropic.md',
+    destination: '/platforms/python/agent-tracing/anthropic.md',
+  },
+  {
+    source: '/platforms/python/integrations/anthropic/:path*',
+    destination: '/platforms/python/agent-tracing/anthropic/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/google-genai.md',
+    destination: '/platforms/python/agent-tracing/google-genai.md',
+  },
+  {
+    source: '/platforms/python/integrations/google-genai/:path*',
+    destination: '/platforms/python/agent-tracing/google-genai/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/huggingface_hub.md',
+    destination: '/platforms/python/agent-tracing/huggingface_hub.md',
+  },
+  {
+    source: '/platforms/python/integrations/huggingface_hub/:path*',
+    destination: '/platforms/python/agent-tracing/huggingface_hub/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/langchain.md',
+    destination: '/platforms/python/agent-tracing/langchain.md',
+  },
+  {
+    source: '/platforms/python/integrations/langchain/:path*',
+    destination: '/platforms/python/agent-tracing/langchain/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/langgraph.md',
+    destination: '/platforms/python/agent-tracing/langgraph.md',
+  },
+  {
+    source: '/platforms/python/integrations/langgraph/:path*',
+    destination: '/platforms/python/agent-tracing/langgraph/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/litellm.md',
+    destination: '/platforms/python/agent-tracing/litellm.md',
+  },
+  {
+    source: '/platforms/python/integrations/litellm/:path*',
+    destination: '/platforms/python/agent-tracing/litellm/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/openai.md',
+    destination: '/platforms/python/agent-tracing/openai.md',
+  },
+  {
+    source: '/platforms/python/integrations/openai/:path*',
+    destination: '/platforms/python/agent-tracing/openai/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/openai-agents.md',
+    destination: '/platforms/python/agent-tracing/openai-agents.md',
+  },
+  {
+    source: '/platforms/python/integrations/openai-agents/:path*',
+    destination: '/platforms/python/agent-tracing/openai-agents/:path*',
+  },
+  {
+    source: '/platforms/python/integrations/pydantic-ai.md',
+    destination: '/platforms/python/agent-tracing/pydantic-ai.md',
+  },
+  {
+    source: '/platforms/python/integrations/pydantic-ai/:path*',
+    destination: '/platforms/python/agent-tracing/pydantic-ai/:path*',
+  },
   // AI library setup pages moved from configuration/integrations to agent-tracing
   {
     source: '/platforms/javascript/configuration/integrations/vercelai/',

--- a/src/components/sidebar/platformSidebar.tsx
+++ b/src/components/sidebar/platformSidebar.tsx
@@ -4,16 +4,18 @@ import {DynamicNav, toTree} from './dynamicNav';
 import {PlatformSidebarProps} from './types';
 import {getNavNodes} from './utils';
 
-// AI library pages that live under agent-tracing but are also integrations.
-const AI_INTEGRATION_SLUGS = [
-  'anthropic',
-  'google-genai',
-  'langchain',
-  'langgraph',
-  'mastra',
-  'openai',
-  'vercelai',
-];
+/**
+ * Platforms whose AI library pages live under agent-tracing, mapped to where that
+ * platform keeps its integrations list. The library pages are mirrored into that
+ * list so they stay discoverable from both places.
+ */
+const INTEGRATIONS_PATH_BY_PLATFORM: Record<string, string> = {
+  javascript: 'configuration/integrations',
+  python: 'integrations',
+};
+
+/** Pages under agent-tracing that document the feature rather than a library. */
+const NON_LIBRARY_AGENT_TRACING_PAGES = new Set(['manual-instrumentation']);
 
 export function PlatformSidebar({
   rootNode,
@@ -60,25 +62,33 @@ export function PlatformSidebar({
 
   // The AI library pages live under agent-tracing, but they're also integrations,
   // so mirror them into the integrations list. These are link-only entries: they
-  // sit under configuration/integrations but point at the real agent-tracing page.
-  const aiIntegrationAliases = AI_INTEGRATION_SLUGS.map(slug => {
-    const target = nodeForPath(rootNode, [...pathRoot.split('/'), 'agent-tracing', slug]);
-    // Not every library is supported on every platform - skip where there's no page.
-    if (!target || target.missing || target.frontmatter.draft) {
-      return undefined;
-    }
-    return {
-      context: {
-        platform: {platformName},
-        title: target.frontmatter.title,
-        sidebar_title: target.frontmatter.sidebar_title,
-        // Deliberately no sidebar_order: these sort alphabetically among the
-        // other integrations rather than carrying their agent-tracing ordering.
-        href: '/' + target.path + '/',
-      },
-      path: `/${pathRoot}/configuration/integrations/${slug}/`,
-    };
-  }).filter(n => n !== undefined);
+  // sit under the integrations path but point at the real agent-tracing page.
+  // The list is derived from whatever pages exist under agent-tracing for this
+  // platform or guide, so it needs no maintenance as libraries come and go.
+  const integrationsPath = INTEGRATIONS_PATH_BY_PLATFORM[platformName];
+  const agentTracingNode =
+    integrationsPath && nodeForPath(rootNode, [...pathRoot.split('/'), 'agent-tracing']);
+
+  const aiIntegrationAliases = !agentTracingNode
+    ? []
+    : agentTracingNode.children
+        .filter(
+          child =>
+            !child.missing &&
+            !child.frontmatter.draft &&
+            !NON_LIBRARY_AGENT_TRACING_PAGES.has(child.slug)
+        )
+        .map(child => ({
+          context: {
+            platform: {platformName},
+            title: child.frontmatter.title,
+            sidebar_title: child.frontmatter.sidebar_title,
+            // Deliberately no sidebar_order: these sort alphabetically among the
+            // other integrations rather than carrying their agent-tracing ordering.
+            href: '/' + child.path + '/',
+          },
+          path: `/${pathRoot}/${integrationsPath}/${child.slug}/`,
+        }));
 
   const tree = toTree([...nodes, ...aiIntegrationAliases].filter(n => !!n.context));
 


### PR DESCRIPTION
Same restructure as #19152 did for JavaScript, applied to Python.