### PR TITLE
docs(js): add guidance for filtering errors from injected inline scripts

### DIFF
--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -111,6 +111,55 @@ This is the case because the Sentry Loader Script and CDN Bundles are detected a
 
 </Alert>
 
+### Filtering Errors From Injected Scripts
+
+Scripts that third parties inject directly into your page as inline `<script>` elements — a common pattern for tag managers such as Google Tag Manager, ad providers, or A/B testing tools — pose a special filtering challenge.
+When such a script throws, the browser attributes the error to the document URL ("global code") rather than to a script file.
+As a result:
+
+- `allowUrls` and `denyUrls` won't match, because the stack frames don't reference the third-party script's URL.
+- `thirdPartyErrorFilterIntegration` can't classify the frames, because inline scripts are not processed by your bundler and therefore carry no application key.
+
+These errors typically surface via the global `onerror` handler with a stack trace consisting of a single frame pointing at your own page URL, often with a minified message (for example, `Error: pa`) that changes between builds of the third-party script.
+
+If your application never executes code from inline scripts — for example, because all of your code is served from bundled files under a known path — you can filter these errors with a <PlatformIdentifier name="before-send" /> hook that inspects the stack frames:
+
+```javascript
+Sentry.init({
+  beforeSend(event) {
+    const frames =
+      event.exception?.values?.flatMap(
+        (value) => value.stacktrace?.frames ?? []
+      ) ?? [];
+
+    // Adjust this check to match where your bundled application code is served from
+    const isApplicationFrame = (frame) => frame.filename?.includes("/assets/");
+    const isDocumentFrame = (frame) =>
+      frame.filename?.startsWith(`${window.location.origin}/`) &&
+      !isApplicationFrame(frame);
+
+    // Drop errors that contain no application frames and at least one frame
+    // attributed to the document itself (i.e. an inline or injected script)
+    if (
+      frames.length > 0 &&
+      !frames.some(isApplicationFrame) &&
+      frames.some(isDocumentFrame)
+    ) {
+      return null;
+    }
+
+    return event;
+  },
+});
+```
+
+<Alert>
+
+Because the browser reports inline first-party scripts and injected third-party scripts identically, this filter will also drop errors thrown by inline scripts you ship yourself.
+Only use this approach if your own inline scripts are trivial, or narrow the check accordingly.
+
+</Alert>
+
 ## Filtering Transaction Events
 
 <Alert>

--- a/docs/platforms/javascript/common/configuration/filtering.mdx
+++ b/docs/platforms/javascript/common/configuration/filtering.mdx
@@ -127,6 +127,11 @@ If your application never executes code from inline scripts — for example, bec
 ```javascript
 Sentry.init({
   beforeSend(event) {
+    // This heuristic only applies to errors captured in the browser
+    if (typeof window === "undefined") {
+      return event;
+    }
+
     const frames =
       event.exception?.values?.flatMap(
         (value) => value.stacktrace?.frames ?? []


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a new subsection **"Filtering Errors From Injected Scripts"** to the JavaScript filtering docs, between the `thirdPartyErrorFilterIntegration` section and "Filtering Transaction Events".

Scripts injected as inline `<script>` elements (Google Tag Manager, ad providers, A/B testing tools) throw errors that browsers attribute to the document URL ("global code") instead of a script file. This means:

- `allowUrls` / `denyUrls` never match — the frames don't reference the third-party script URL
- `thirdPartyErrorFilterIntegration` can't classify the frames — inline scripts carry no application key

This is a long-standing gap: getsentry/sentry-javascript#9110 was closed without a resolution, but the `beforeSend` frame-inspection workaround suggested there by @mydea works well in practice. We recently hit exactly this (minified `Error: pa` / `Error: La` / `Error: ia` from gtag.js, single stack frame pointing at our own page URL, unmatchable by any existing filter) and resolved it with this approach.

Since the recommended workaround currently only lives in a closed GitHub issue thread, this PR documents it, including an alert about the trade-off (first-party inline script errors are indistinguishable and get dropped too).

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.