### PR TITLE
docs(cloudflare): Document min compatibility_date and ai v7 requirements

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/vercelai.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/vercelai.mdx
@@ -64,11 +64,12 @@ Cloudflare Workers can't load OpenTelemetry instrumentation. On both entrypoints
 
 Your entrypoint decides the rest:
 
-|                            | `@sentry/cloudflare` | `@sentry/cloudflare/nodejs_compat` |
-| -------------------------- | -------------------- | ---------------------------------- |
-| Record inputs and outputs  | Per call only        | Integration or per call            |
-| AI SDK v7                  | Not supported        | Supported                          |
-| Minimum Sentry SDK         | `10.6.0`             | `10.64.0`                          |
+|                              | `@sentry/cloudflare` | `@sentry/cloudflare/nodejs_compat` |
+| ---------------------------- | -------------------- | ---------------------------------- |
+| Record inputs and outputs    | Per call only        | Integration or per call            |
+| AI SDK v7                    | Not supported        | Supported                          |
+| Minimum Sentry SDK           | `10.6.0`             | `10.64.0`                          |
+| Minimum `compatibility_date` | `2024-09-23`         | `2026-02-19`                       |
 
 </PlatformSection>
 
@@ -163,9 +164,16 @@ export default Sentry.withSentry(
 
 ```jsonc {filename:wrangler.jsonc}
 {
-  "compatibility_flags": ["nodejs_compat"]
+  "compatibility_date": "2026-02-19",
+  "compatibility_flags": ["nodejs_compat"],
 }
 ```
+
+<Alert level="warning">
+
+AI SDK v7 only emits telemetry when `compatibility_date` is `2026-02-19` or later, and Wrangler is `4.67.0` or later. With an earlier date you get no AI spans and no error message.
+
+</Alert>
 
 ### AI SDK v6 and Below
 

--- a/docs/platforms/javascript/guides/cloudflare/features/nodejs-compat.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/nodejs-compat.mdx
@@ -42,3 +42,9 @@ To use the entrypoint, your Worker must set the `nodejs_compat` compatibility fl
 ```toml {tabTitle:Toml} {filename:wrangler.toml}
 compatibility_flags = ["nodejs_compat"]
 ```
+
+<Alert>
+
+We recommend that you also keep `compatibility_date` and Wrangler up to date. Some instrumentation depends on Node.js APIs that Cloudflare only exposes from a given compatibility date on, and an older date can turn that instrumentation off without an error message. The <PlatformLink to="/agent-tracing/vercelai">Vercel AI integration</PlatformLink>, for example, needs `2026-02-19` or later.
+
+</Alert>

--- a/platform-includes/getting-started-config/javascript.cloudflare.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.mdx
@@ -2,7 +2,7 @@
 <SplitSection>
 <SplitSectionText>
 
-Since the SDK needs access to the `AsyncLocalStorage` API, you need to set the `nodejs_compat` compatibility flag in your `wrangler.(jsonc|toml)` configuration file:
+Since the SDK needs access to the `AsyncLocalStorage` API, you need to set the `nodejs_compat` compatibility flag and a `compatibility_date` of `2024-09-23` or later in your `wrangler.(jsonc|toml)` configuration file. We recommend the latest compatibility date, as some integrations depend on newer Cloudflare runtime features:
 
 </SplitSectionText>
 
@@ -10,11 +10,13 @@ Since the SDK needs access to the `AsyncLocalStorage` API, you need to set the `
 
 ```jsonc {tabTitle:JSON} {filename:wrangler.jsonc}
 {
+  "compatibility_date": "2024-09-23",
   "compatibility_flags": ["nodejs_compat"],
 }
 ```
 
 ```toml {tabTitle:Toml} {filename:wrangler.toml}
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 ```
 


### PR DESCRIPTION
closes JS-3477

<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

The compatibility date seems to be very important for Vercel AI v7 and needs to be set to `2026-02-19` or later to work. I also mentioned the minimum compatibility date for normal usage

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
