### PR TITLE
Add logs config option to Electron integrations

### DIFF
--- a/docs/platforms/javascript/guides/electron/configuration/integrations/childprocess.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/integrations/childprocess.mdx
@@ -22,6 +22,12 @@ interface ChildProcessOptions {
   breadcrumbs: ExitReason[];
   /** Child process events that generate Sentry events */
   events: ExitReason[];
+  /**
+   * Whether to also capture Sentry logs for child process events
+   *
+   * default: false
+   */
+  logs: boolean;
 }
 ```
 

--- a/docs/platforms/javascript/guides/electron/configuration/integrations/electronbreadcrumbs.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/integrations/electronbreadcrumbs.mdx
@@ -40,6 +40,7 @@ Sentry.init({
       screen: true,
       powerMonitor: true,
       captureWindowTitles: false,
+      logs: false,
     }),
   ],
 });

--- a/docs/platforms/javascript/guides/electron/configuration/integrations/net.mdx
+++ b/docs/platforms/javascript/guides/electron/configuration/integrations/net.mdx
@@ -23,6 +23,12 @@ interface NetOptions {
    * Defaults to: true
    */
   tracing: boolean | (method: string, url: string) => boolean;
+  /**
+   * Whether to also capture Sentry logs for net requests
+   *
+   * Defaults to: false
+   */
+  logs: boolean;
 }
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Documents the new `logs` config option for the Electron SDK's `childProcess`, `electronBreadcrumbs`, and `electronNet` integrations.

As of [sentry-electron#1416](https://github.com/getsentry/sentry-electron/pull/1416) (js SDK v10.73.0), auto-captured Sentry logs for these integrations are gated behind an explicit `logs` opt-in that defaults to `false`, rather than being driven by the SDK-wide `enableLogs` option.

- Add `logs: boolean` (default `false`) to the `ChildProcessOptions` interface on the ChildProcess page
- Add `logs: false` to the defaults example on the ElectronBreadcrumbs page
- Add `logs: boolean` (default `false`) to the `NetOptions` interface on the ElectronNet page

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHNBydVrhSwmkqkUm8szZq)_