### PR TITLE
docs(js): Add explicit step for `dataCollection` options

### DIFF
--- a/docs/platforms/javascript/common/index.mdx
+++ b/docs/platforms/javascript/common/index.mdx
@@ -116,6 +116,10 @@ Sentry supports multiple versions of React Router. To learn how to configure the
 
 <PlatformContent includePath="getting-started-sourcemaps" />
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 <PlatformSection supported={["javascript.bun"]}>
 
 ## Use

--- a/docs/platforms/javascript/guides/angular/index.mdx
+++ b/docs/platforms/javascript/guides/angular/index.mdx
@@ -63,6 +63,10 @@ Prefer to set things up yourself? Check out the [Manual Setup](/platforms/javasc
 
 <PlatformContent includePath="getting-started-tunneling" />
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify
 
 If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that the Sentry SDK is sending data to your Sentry project by using the example component created by the installation wizard:

--- a/docs/platforms/javascript/guides/angular/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/angular/manual-setup.mdx
@@ -106,7 +106,7 @@ The main configuration should happen as early as possible in your app's lifecycl
 
 <SplitSectionCode>
 
-```typescript {tabTitle: App Config} {mdExpandTabs} {filename: main.ts} {5-48}
+```typescript {tabTitle: App Config} {mdExpandTabs} {filename: main.ts} {5-41}
 import { bootstrapApplication } from "@angular/platform-browser";
 import { appConfig } from "./app/app.config";
 import { AppComponent } from "./app/app.component";
@@ -115,13 +115,6 @@ import * as Sentry from "@sentry/angular";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -170,7 +163,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 );
 ```
 
-```typescript {tabTitle: NGModule Config} {filename: main.ts} {4-47}
+```typescript {tabTitle: NGModule Config} {filename: main.ts} {4-40}
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 import { AppModule } from "./app/app.module";
 
@@ -178,13 +171,6 @@ import * as Sentry from "@sentry/angular";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -382,6 +368,10 @@ export class AppModule {
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify
 

--- a/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/layer.mdx
@@ -73,12 +73,6 @@ const Sentry = require("@sentry/aws-serverless");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Tracing by setting tracesSampleRate and adding integration
@@ -97,12 +91,6 @@ import * as Sentry from "@sentry/aws-serverless";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Tracing by setting tracesSampleRate and adding integration
@@ -124,3 +112,7 @@ NODE_OPTIONS="--import ./instrument.js"
 ```
 
 That's it — make sure to re-deploy your function and you're all set!
+
+## 3. Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />

--- a/docs/platforms/javascript/guides/aws-lambda/install/npm.mdx
+++ b/docs/platforms/javascript/guides/aws-lambda/install/npm.mdx
@@ -99,12 +99,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
   integrations: [nodeProfilingIntegration()],
 
@@ -137,12 +131,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
   integrations: [nodeProfilingIntegration()],
 
@@ -176,6 +164,10 @@ NODE_OPTIONS="--import ./instrument.js"
 To set environment variables, navigate to your Lambda function, select **Configuration**, then **Environment variables**.
 
 That's it - make sure to re-deploy your function and you're all set!
+
+## 4. Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Using the v7 SDK
 

--- a/docs/platforms/javascript/guides/azure-functions/index.mdx
+++ b/docs/platforms/javascript/guides/azure-functions/index.mdx
@@ -60,12 +60,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/azure-functions/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],
@@ -134,6 +128,10 @@ module.exports = async function (context, req) {
 ### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Step 4: Verify Your Setup
 

--- a/docs/platforms/javascript/guides/bun/index.mdx
+++ b/docs/platforms/javascript/guides/bun/index.mdx
@@ -63,12 +63,6 @@ import * as Sentry from "@sentry/bun";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/bun/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Performance Monitoring by setting tracesSampleRate
@@ -113,6 +107,10 @@ bun --preload ./instrument.js app.js
 ### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/capacitor/index.mdx
+++ b/docs/platforms/javascript/guides/capacitor/index.mdx
@@ -99,6 +99,10 @@ If you're using Angular, React, Vue, or Nuxt, make sure to forward the `init` me
 
 You need to provide debug information to Sentry to make the stack-trace information for native crashes on iOS easier to understand. You can provide debug information by [uploading dSYM files](/platforms/javascript/guides/capacitor/dsym).
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx
@@ -100,12 +100,6 @@ export const onRequest = [
   // Make sure Sentry is the first middleware
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     tracesSampleRate: 1.0,
   })),
   // Add more middlewares here

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/hydrogen-react-router.mdx
@@ -84,13 +84,6 @@ import { hydrateRoot } from "react-dom/client";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     // Registers and configures the Tracing integration,
@@ -161,12 +154,6 @@ import * as Sentry from "@sentry/react-router";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -216,12 +203,6 @@ export default {
           // ___PRODUCT_OPTION_START___ performance
           tracesSampleRate: 1.0,
           // ___PRODUCT_OPTION_END___ performance
-          dataCollection: {
-            // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-            // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-            // userInfo: false,
-            // httpBodies: [],
-          },
         },
         request: request as any,
         context: executionContext,
@@ -370,6 +351,10 @@ sentry-cli sourcemaps upload /path/to/build/dir
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/cloudflare/frameworks/tanstack-start.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/frameworks/tanstack-start.mdx
@@ -84,12 +84,6 @@ export default Sentry.withSentry(
   () => ({
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
@@ -149,13 +143,6 @@ export const getRouter = () => {
 + if (!router.isServer) {
 +   Sentry.init({
 +     dsn: "___PUBLIC_DSN___",
-+
-+     dataCollection: {
-+       // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-+       // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-+       // userInfo: false,
-+       // httpBodies: [],
-+     },
 +
 +     integrations: [
 +       // ___PRODUCT_OPTION_START___ performance
@@ -237,6 +224,10 @@ export const startInstance = createStart(() => {
   includePath="getting-started-sourcemaps-short-version-splitlayout"
   platform="javascript"
 />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/cloudflare/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/index.mdx
@@ -241,6 +241,10 @@ export const handle = ({ event, resolve }) => {
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.

--- a/docs/platforms/javascript/guides/cordova/index.mdx
+++ b/docs/platforms/javascript/guides/cordova/index.mdx
@@ -87,13 +87,6 @@ onDeviceReady: function() {
   var Sentry = cordova.require("sentry-cordova.Sentry");
   Sentry.init({
     dsn: '___PUBLIC_DSN___',
-
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
   });
 }
 ```
@@ -120,6 +113,10 @@ Make sure your app can talk to Sentry by adding this to your `config.xml`:
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/deno/index.mdx
+++ b/docs/platforms/javascript/guides/deno/index.mdx
@@ -69,12 +69,6 @@ import * as Sentry from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/deno/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -132,6 +126,10 @@ deno run --allow-read=./src index.ts
 ### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/effect/index.mdx
+++ b/docs/platforms/javascript/guides/effect/index.mdx
@@ -263,6 +263,10 @@ const MainLive = YourAppLayer.pipe(Layer.provide(SentryLive));
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.

--- a/docs/platforms/javascript/guides/electron/index.mdx
+++ b/docs/platforms/javascript/guides/electron/index.mdx
@@ -266,6 +266,10 @@ init(
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly.

--- a/docs/platforms/javascript/guides/elysia/index.mdx
+++ b/docs/platforms/javascript/guides/elysia/index.mdx
@@ -85,12 +85,6 @@ import { Elysia } from "elysia";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -115,12 +109,6 @@ import { node } from "@elysiajs/node";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/elysia/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -170,6 +158,10 @@ const app = Sentry.withElysia(new Elysia(), {
 ### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/ember/index.mdx
+++ b/docs/platforms/javascript/guides/ember/index.mdx
@@ -67,13 +67,6 @@ import * as Sentry from "@sentry/ember";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/ember/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   // ___PRODUCT_OPTION_START___ session-replay
   integrations: [
     Sentry.replayIntegration(),
@@ -123,6 +116,10 @@ export default class App extends Application {
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/firebase/index.mdx
+++ b/docs/platforms/javascript/guides/firebase/index.mdx
@@ -101,12 +101,6 @@ const Sentry = require("@sentry/node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/firebase/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Add Tracing by setting tracesSampleRate
@@ -169,6 +163,10 @@ exports.onUserCreated = onDocumentCreated("users/{userId}", async (event) => {
 ### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/gatsby/index.mdx
+++ b/docs/platforms/javascript/guides/gatsby/index.mdx
@@ -118,13 +118,6 @@ import * as Sentry from "@sentry/gatsby";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/gatsby/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     Sentry.browserTracingIntegration(),
@@ -171,6 +164,10 @@ Sentry.init({
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/gcp-functions/index.mdx
+++ b/docs/platforms/javascript/guides/gcp-functions/index.mdx
@@ -73,6 +73,10 @@ Make sure to initialize Sentry at the top of your function code and wrap each fu
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.

--- a/docs/platforms/javascript/guides/hono/index.mdx
+++ b/docs/platforms/javascript/guides/hono/index.mdx
@@ -174,12 +174,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],
@@ -253,12 +247,6 @@ app.use(
   sentry(app, {
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -297,12 +285,6 @@ app.use(
   sentry(app, {
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -327,12 +309,6 @@ app.use(
   sentry(app, {
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -390,6 +366,10 @@ To control which errors are captured, use the <PlatformLink to="/features/error-
 ### Add Readable Stack Traces With Source Maps (Optional)
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/nestjs/index.mdx
+++ b/docs/platforms/javascript/guides/nestjs/index.mdx
@@ -132,6 +132,10 @@ export class AppModule {}
 
 If your NestJS app uses background jobs (such as `@Cron()`, `@Interval()`, `@OnEvent()`, or BullMQ), breadcrumbs from those jobs can leak into unrelated HTTP request error events. Wrap your background job handlers with `Sentry.withIsolationScope()` to isolate them. See <PlatformLink to="/features/async-context">Isolate Background Job Scopes</PlatformLink> for details and code examples.
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.

--- a/docs/platforms/javascript/guides/nextjs/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/index.mdx
@@ -61,12 +61,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
@@ -88,12 +82,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
@@ -106,12 +94,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   // ___PRODUCT_OPTION_END___ performance
@@ -270,6 +252,10 @@ app/
 </SplitSection>
 
 </SplitLayout>
+
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/index.mdx
@@ -131,12 +131,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -174,12 +168,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -195,12 +183,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -375,6 +357,10 @@ export default withSentryConfig(nextConfig, {
 </SplitSection>
 
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Error Monitoring
 

--- a/docs/platforms/javascript/guides/nextjs/manual-setup/pages-router.mdx
+++ b/docs/platforms/javascript/guides/nextjs/manual-setup/pages-router.mdx
@@ -155,12 +155,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -188,12 +182,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -209,12 +197,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Capture 100% in dev, 10% in production
@@ -285,6 +267,10 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 </SplitSection>
 
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Error Monitoring
 

--- a/docs/platforms/javascript/guides/nitro/index.mdx
+++ b/docs/platforms/javascript/guides/nitro/index.mdx
@@ -141,12 +141,6 @@ import * as Sentry from "@sentry/nitro";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nitro/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -191,6 +185,10 @@ Load the instrumentation file with Node's `--import` flag before any Nitro comma
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/nuxt/index.mdx
+++ b/docs/platforms/javascript/guides/nuxt/index.mdx
@@ -26,6 +26,10 @@ categories:
 
 <PlatformContent includePath="getting-started-tunneling" />
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 The `sentry init` command checks the integration files it creates or modifies before it finishes. To confirm runtime events are reaching Sentry, start your Nuxt app, exercise the parts of your app that should send events, and then check your Sentry project.

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -86,13 +86,6 @@ import { HydratedRouter } from "react-router/dom";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     // Registers and configures the Tracing integration,
@@ -169,12 +162,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   // Add our Profiling integration
@@ -200,6 +187,10 @@ Sentry.init({
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -125,13 +125,6 @@ The `sentryOnError` handler integrates with React Router's [`onError` hook](http
 +Sentry.init({
 +  dsn: "___PUBLIC_DSN___",
 +
-+  dataCollection: {
-+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-+    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-+    // userInfo: false,
-+    // httpBodies: [],
-+  },
-+
 +  integrations: [
 +    // ___PRODUCT_OPTION_START___ performance
 +    // Registers and configures the Tracing integration,
@@ -221,12 +214,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   // Add our Profiling integration
@@ -538,6 +525,10 @@ export default {
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/react/index.mdx
+++ b/docs/platforms/javascript/guides/react/index.mdx
@@ -76,13 +76,6 @@ import * as Sentry from "@sentry/react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     // If you're using react router, use the integration for your react router version instead.
@@ -323,6 +316,10 @@ Sentry.init({
 
 <SplitSection>
 <SplitSectionText>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/remix/index.mdx
+++ b/docs/platforms/javascript/guides/remix/index.mdx
@@ -106,6 +106,10 @@ export default withSentry(App);
 
 <PlatformContent includePath="getting-started-tunneling" />
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 If you haven't tested your Sentry configuration yet, let's do it now. You can confirm that Sentry is working properly and sending data to your Sentry project by using the example page created by the installation wizard:

--- a/docs/platforms/javascript/guides/solid/index.mdx
+++ b/docs/platforms/javascript/guides/solid/index.mdx
@@ -84,13 +84,6 @@ if (!DEV) {
   Sentry.init({
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
-
     integrations: [
       // ___PRODUCT_OPTION_START___ performance
       solidRouterBrowserTracingIntegration(),
@@ -164,6 +157,10 @@ To automatically report exceptions from inside a component tree to Sentry, wrap 
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -100,12 +100,6 @@ import { mount, StartClient } from "@solidjs/start/client";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     // add solidRouterBrowserTracingIntegration if you're using Solid Router
@@ -165,12 +159,6 @@ import * as Sentry from "@sentry/solidstart";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -405,6 +393,10 @@ SENTRY_AUTH_TOKEN="___ORG_AUTH_TOKEN___"
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/svelte/index.mdx
+++ b/docs/platforms/javascript/guides/svelte/index.mdx
@@ -77,13 +77,6 @@ import * as Sentry from "@sentry/svelte";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/svelte/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     Sentry.browserTracingIntegration(),
@@ -192,6 +185,10 @@ export default app;
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/sveltekit/index.mdx
+++ b/docs/platforms/javascript/guides/sveltekit/index.mdx
@@ -28,6 +28,10 @@ categories:
 
 <PlatformContent includePath="getting-started-tunneling" />
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 The `sentry init` command checks the integration files it creates or modifies before it finishes. To confirm runtime events are reaching Sentry, start your SvelteKit app, exercise the parts of your app that should send events, and then check your Sentry project.

--- a/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/index.mdx
@@ -32,6 +32,10 @@ Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issu
 
 <PlatformContent includePath="sentry-init/framework-wizard" />
 
+## Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 The wizard will have prompted you to select which features to enable. Select the same options here to see the relevant verification steps:

--- a/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
+++ b/docs/platforms/javascript/guides/tanstackstart-react/manual-setup/index.mdx
@@ -87,13 +87,6 @@ import * as Sentry from "@sentry/tanstackstart-react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ session-replay
     Sentry.replayIntegration(),
@@ -208,13 +201,6 @@ import * as Sentry from "@sentry/tanstackstart-react";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
 
   // ___PRODUCT_OPTION_START___ performance
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -566,6 +552,10 @@ export default defineConfig({
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify
 

--- a/docs/platforms/javascript/guides/vue/index.mdx
+++ b/docs/platforms/javascript/guides/vue/index.mdx
@@ -68,7 +68,7 @@ If you're creating more than one Vue 3 app within your application, check out ho
 </SplitSectionText>
 <SplitSectionCode>
 
-```javascript {tabTitle:Vue 3} {filename:main.js} {3, 12-41}
+```javascript {tabTitle:Vue 3} {filename:main.js} {3, 12-34}
 import { createApp } from "vue";
 import { createRouter } from "vue-router";
 import * as Sentry from "@sentry/vue";
@@ -83,13 +83,6 @@ const router = createRouter({
 Sentry.init({
   app,
   dsn: "___PUBLIC_DSN___",
-
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -262,6 +255,10 @@ pinia.use(createSentryPiniaPlugin());
 ### Avoid Ad Blockers With Tunneling (Optional)
 
 <PlatformContent includePath="getting-started-tunneling" />
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/guides/wasm/index.mdx
+++ b/docs/platforms/javascript/guides/wasm/index.mdx
@@ -103,6 +103,10 @@ Sentry.init({
 </SplitSection>
 </SplitLayout>
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data from your WebAssembly modules to your Sentry project.

--- a/platform-includes/getting-started-complete/javascript.astro.mdx
+++ b/platform-includes/getting-started-complete/javascript.astro.mdx
@@ -131,12 +131,6 @@ import handler from "@astrojs/cloudflare/entrypoints/server";
 export default Sentry.withSentry(
   (env) => ({
     dsn: env.SENTRY_DSN,
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
     // Define how likely traces are sampled. Adjust this value in production,
     // or use tracesSampler for greater control.
@@ -222,13 +216,6 @@ import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
 
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
@@ -327,12 +314,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [
@@ -448,6 +429,10 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 <PlatformContent includePath="getting-started-tunneling" />
 
 </PlatformSection>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/platform-includes/getting-started-complete/javascript.mdx
+++ b/platform-includes/getting-started-complete/javascript.mdx
@@ -31,6 +31,10 @@ Choose the features you want to configure, and this guide will show you how:
 
 <PlatformContent includePath="getting-started-tunneling" />
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 <PlatformContent includePath="getting-started-verify" />

--- a/platform-includes/getting-started-complete/javascript.nuxt.mdx
+++ b/platform-includes/getting-started-complete/javascript.nuxt.mdx
@@ -100,12 +100,6 @@ Sentry.init({
   // modify depending on your custom runtime config
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ session-replay
 
   // Replay may only be enabled for the client-side
@@ -398,6 +392,10 @@ export default defineNuxtConfig({
   platform="javascript"
 />
 </PlatformSection>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/platform-includes/getting-started-complete/javascript.remix.mdx
+++ b/platform-includes/getting-started-complete/javascript.remix.mdx
@@ -19,13 +19,6 @@ import { useEffect } from "react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     // ___PRODUCT_OPTION_START___ performance
     Sentry.browserTracingIntegration({
@@ -171,12 +164,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   // Add our Profiling integration
@@ -279,12 +266,6 @@ export const onRequest = [
   Sentry.sentryPagesPlugin((context) => ({
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/remix/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -431,6 +412,10 @@ SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
 <PlatformContent includePath="getting-started-tunneling" />
 
 </PlatformSection>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/platform-includes/getting-started-complete/javascript.sveltekit.mdx
+++ b/platform-includes/getting-started-complete/javascript.sveltekit.mdx
@@ -123,18 +123,12 @@ Create a client hooks file `src/hooks.client.(js|ts)` in your project if you don
 
 <SplitSectionCode>
 
-```javascript {filename:src/hooks.client.(js|ts)} {1, 3-43, 49}
+```javascript {filename:src/hooks.client.(js|ts)} {1, 3-37, 43}
 import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -245,18 +239,12 @@ Create a `src/instrumentation.server.(js|ts)` file (if you don't have one alread
 
 <SplitSectionCode>
 
-```js {filename:src/instrumentation.server.(js|ts)} {1, 3-23}
+```js {filename:src/instrumentation.server.(js|ts)} {1, 3-15}
 import * as Sentry from "@sentry/sveltekit";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ performance
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -332,12 +320,6 @@ export const handle = sequence(
   initCloudflareSentryHandle({
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -497,6 +479,10 @@ export default {
 <PlatformContent includePath="getting-started-tunneling" />
 
 </PlatformSection>
+
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
 
 ## Verify Your Setup
 

--- a/platform-includes/getting-started-config/javascript.aws-lambda.mdx
+++ b/platform-includes/getting-started-config/javascript.aws-lambda.mdx
@@ -7,12 +7,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],
@@ -49,12 +43,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [nodeProfilingIntegration()],

--- a/platform-includes/getting-started-config/javascript.capacitor.mdx
+++ b/platform-includes/getting-started-config/javascript.capacitor.mdx
@@ -6,13 +6,6 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
-
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
@@ -94,13 +87,6 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
-
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
@@ -179,13 +165,6 @@ Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
-
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
@@ -256,13 +235,6 @@ Sentry.init(
       },
     },
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
-
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
@@ -321,13 +293,6 @@ import * as SentryNuxt from "@sentry/nuxt";
 Sentry.init(
   {
     dsn: "___PUBLIC_DSN___",
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
-
     // Set your release version, such as "getsentry@1.0.0"
     release: "my-project-name@<release-name>",
     // Set your dist version, such as "1"
@@ -387,13 +352,6 @@ import { feedbackIntegration } from "@sentry/browser";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
 
   // Set your release version, such as "getsentry@1.0.0"
   release: "my-project-name@<release-name>",

--- a/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.hono.mdx
@@ -20,12 +20,6 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.

--- a/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
+++ b/platform-includes/getting-started-config/javascript.cloudflare.workers.mdx
@@ -14,12 +14,6 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "___PUBLIC_DSN___",
 
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
     // ___PRODUCT_OPTION_START___ performance
 
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.

--- a/platform-includes/getting-started-config/javascript.gcp-functions.mdx
+++ b/platform-includes/getting-started-config/javascript.gcp-functions.mdx
@@ -7,12 +7,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/gcp-functions/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/getting-started-config/javascript.hono.mdx
+++ b/platform-includes/getting-started-config/javascript.hono.mdx
@@ -8,12 +8,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [
@@ -50,12 +44,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/getting-started-config/javascript.mdx
+++ b/platform-includes/getting-started-config/javascript.mdx
@@ -16,13 +16,6 @@ import * as Sentry from "___SDK_PACKAGE___";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   // Alternatively, use `process.env.npm_package_version` for a dynamic release version
   // if your build tool supports it.
   release: "my-project-name@2.3.12",
@@ -74,13 +67,6 @@ Sentry.init({
   window.sentryOnLoad = function () {
     Sentry.init({
       dsn: "___PUBLIC_DSN___",
-
-      dataCollection: {
-        // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-        // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-        // userInfo: false,
-        // httpBodies: [],
-      },
 
       // Alternatively, use `process.env.npm_package_version` for a dynamic release version
       // if your build tool supports it.
@@ -135,13 +121,6 @@ Sentry.init({
 <script>
   Sentry.init({
     dsn: "___PUBLIC_DSN___",
-
-    dataCollection: {
-      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-      // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-      // userInfo: false,
-      // httpBodies: [],
-    },
 
     // Alternatively, use `process.env.npm_package_version` for a dynamic release version
     // if your build tool supports it.

--- a/platform-includes/getting-started-config/javascript.node.mdx
+++ b/platform-includes/getting-started-config/javascript.node.mdx
@@ -8,12 +8,6 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [
@@ -50,12 +44,6 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
   // ___PRODUCT_OPTION_START___ profiling
 
   integrations: [

--- a/platform-includes/getting-started-data-collection/javascript.mdx
+++ b/platform-includes/getting-started-data-collection/javascript.mdx
@@ -19,7 +19,7 @@ Sentry.init({
   dsn: "___PUBLIC_DSN___",
   dataCollection: {
     userInfo: false,
-    // other options
+    // other categories
   },
 });
 ```

--- a/platform-includes/getting-started-data-collection/javascript.mdx
+++ b/platform-includes/getting-started-data-collection/javascript.mdx
@@ -1,0 +1,29 @@
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+By default, the SDK sends user identity data (IP address, ID, and similar) and other data like HTTP bodies and URL query parameters.
+This will give you rich debugging context.
+
+The SDK always filters sensitive values whose keys match a built-in denylist, such as `auth` or `password`, and sends `[Filtered]` instead.
+
+To send less data, turn off the categories you don't need in the `dataCollection` option.
+For the full list of categories and their defaults, <PlatformLink to="/configuration/options/#dataCollection">see the `dataCollection` options</PlatformLink>.
+
+</SplitSectionText>
+
+<SplitSectionCode>
+
+```javascript {3-5}
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  dataCollection: {
+    userInfo: false,
+    // other options
+  },
+});
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>

--- a/platform-includes/getting-started-node/javascript.mdx
+++ b/platform-includes/getting-started-node/javascript.mdx
@@ -105,6 +105,10 @@ node --import ./instrument.mjs app.mjs
 
 <PlatformContent includePath="getting-started-sourcemaps-short-version" />
 
+### Control the Data You Send to Sentry (Optional)
+
+<PlatformContent includePath="getting-started-data-collection" />
+
 ## Verify Your Setup
 
 Let's test your setup and confirm that Sentry is working correctly and sending data to your Sentry project.

--- a/platform-includes/performance/configure-sample-rate/javascript.solid.mdx
+++ b/platform-includes/performance/configure-sample-rate/javascript.solid.mdx
@@ -6,13 +6,6 @@ import { render } from "solid-js/web";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
 
-  dataCollection: {
-    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
-    // userInfo: false,
-    // httpBodies: [],
-  },
-
   integrations: [
     solidRouterBrowserTracingIntegration(),
   ],


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/23696

Removes the commented-out lines in the setup snippet and adds an explicit step instead.

<img width="1025" height="454" alt="image" src="https://github.com/user-attachments/assets/b809a44d-f427-4591-a9cb-b23afda15c19" />
