### PR TITLE
docs(native): Use per-event level setter

### DIFF
--- a/platform-includes/set-level/native.mdx
+++ b/platform-includes/set-level/native.mdx
@@ -1,7 +1,10 @@
+Set an event's level to match its severity. For example, report a recoverable exception as a warning:
+
 ```c
 #include <sentry.h>
 
 sentry_value_t event = sentry_value_new_event();
 sentry_event_set_level(event, SENTRY_LEVEL_WARNING);
+sentry_event_add_exception(event, sentry_value_new_exception("Timeout", "Request timed out"));
 sentry_capture_event(event);
 ```

--- a/platform-includes/set-level/native.mdx
+++ b/platform-includes/set-level/native.mdx
@@ -1,5 +1,7 @@
 ```c
 #include <sentry.h>
 
-sentry_set_level(SENTRY_LEVEL_WARNING);
+sentry_value_t event = sentry_value_new_event();
+sentry_event_set_level(event, SENTRY_LEVEL_WARNING);
+sentry_capture_event(event);
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

The "Set the Level" guide says an event level can be overridden, but its example called `sentry_set_level`, which only sets a default on the scope. Native crash events already have an explicit fatal level, so the example does not demonstrate the advertised per-event workflow.

Use `sentry_event_set_level` from getsentry/sentry-native#2038 to create an event, assign its level explicitly, and capture it. This matches the per-event flow demonstrated by the respective [Godot guide](https://docs.sentry.io/platforms/godot/usage/set-level/).

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
