### PR TITLE
fix(apple): Update broken Foundation doc links

### DIFF
--- a/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/apple/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -704,9 +704,9 @@ SentrySDK.start { options in
 Starting with iOS 18, tvOS 18, and macOS 15 the Swift classes `Data` and `FileManager` are no longer backed by their Objective-C counterparts `NSData` and `NSFileManager` and therefore cannot be instrumented automatically anymore. Instead, please use [Manual File I/O Tracing](#manual-fileio-tracing).
 
 [NSData]: https://developer.apple.com/documentation/foundation/nsdata
-[NSFileManager]: https://developer.apple.com/documentation/foundation/nsfilemanager
+[NSFileManager]: https://developer.apple.com/documentation/foundation/filemanager
 [NSString]: https://developer.apple.com/documentation/foundation/nsstring
-[NSBundle]: https://developer.apple.com/documentation/foundation/nsbundle
+[NSBundle]: https://developer.apple.com/documentation/foundation/bundle
 
 ### Manual File/IO Tracing
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fix two broken external links in the Apple SDK automatic instrumentation docs. Apple renamed the `NSFileManager` and `NSBundle` Foundation documentation pages, so the old lowercased `ns*` URLs now return 404 and fail the "Check external links" (lychee) CI job whenever the file is included in a PR's scan set.

- `foundation/nsfilemanager` → `foundation/filemanager`
- `foundation/nsbundle` → `foundation/bundle`

This came up while checking https://github.com/getsentry/sentry-docs/pull/19123#pullrequestreview-5078260990

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
