### PR TITLE
docs(develop-docs): Document `callback_error` discard reason

### DIFF
--- a/develop-docs/sdk/telemetry/client-reports.mdx
+++ b/develop-docs/sdk/telemetry/client-reports.mdx
@@ -2,12 +2,15 @@
 title: Client Reports
 description: SDK self-reporting protocol for tracking discarded events and their discard reasons.
 spec_id: sdk/telemetry/client-reports
-spec_version: 1.23.0
+spec_version: 1.24.0
 spec_status: stable
 spec_depends_on:
   - id: sdk/foundations/transport/envelopes
     version: ">=1.0.0"
 spec_changelog:
+  - version: 1.24.0
+    date: 2026-09-01
+    summary: Added `callback_error` discard reason
   - version: 1.23.0
     date: 2026-06-22
     summary: Added metric byte outcomes for tracking discarded metric data size
@@ -369,6 +372,7 @@ The following discard reasons are defined for `discarded_events`:
 | `ignored` | 1.16.0 | Telemetry item was ignored by the SDK (e.g., a span was ignored by `ignore_spans`; can also be used by other deny-list mechanisms). |
 | `invalid` | 1.17.0 | Failed validation (e.g., replay session exceeded maximum allowed length). |
 | `no_parent_span` | 1.22.0 | Span was not started or dropped because no parent span was present at span start (for example, auto-instrumented spans suppressed when the request happens outside an active span). |
+| `callback_error` | 1.24.0 | A user-provided callback (e.g., `before_send`, `traces_sampler`) threw an error. |
 
 #### Adding a new discard reason:
 


### PR DESCRIPTION
Adds the new `callback_error` discard reason to the spec.

ref https://github.com/getsentry/snuba/pull/8422
ref https://linear.app/getsentry/project/wrap-all-sdk-user-callbacks-in-a-try-catch-6bfdbe9f7268/overview