### PR TITLE
docs(usageStats): Document `callback_error` client discard reason

### DIFF
--- a/docs/product/stats/index.mdx
+++ b/docs/product/stats/index.mdx
@@ -96,6 +96,7 @@ Events and attachments discarded by the SDK. The following reasons are currently
 - **Invalid**: An event was dropped because it contained invalid data (e.g. replay session exceeded maximum allowed length).
 - **Ignored**: An event was ignored by the SDK (for example, a span was ignored by `ignore_spans`).
 - **No Parent Span**: A span was not started or dropped because no parent span was present at span start (for example, auto-instrumented request spans suppressed when the request happens outside an active span).
+- **Callback Error**: An event was dropped because a callback (e.g., `before_send`, `traces_sampler`) threw an error.
 
 For more details, please consult the [Client Reports](https://develop.sentry.dev/sdk/telemetry/client-reports/#envelope-item-payload) documentation.
 


### PR DESCRIPTION
Adds the new `callback_error` client discard reason to usage stats product docs.

ref https://github.com/getsentry/sentry/pull/123316
ref https://github.com/getsentry/snuba/pull/8422
ref https://linear.app/getsentry/project/wrap-all-sdk-user-callbacks-in-a-try-catch-6bfdbe9f7268/overview