### PR TITLE
docs(apple): Add maxFeatureFlags option

### DIFF
--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -84,6 +84,16 @@ The maximum number of [envelopes](https://develop.sentry.dev/sdk/data-model/enve
 
 </SdkOption>
 
+<SdkOption name="maxFeatureFlags" type="int" defaultValue="100">
+
+The maximum number of unique feature flag evaluations to keep in memory on the scope. Events record the most recent, unique feature flag evaluations. When the limit is exceeded, the SDK drops the oldest evaluations. Increase this if your app evaluates a large number of flags and you want more of them attached to your events. Set it to `0` to stop recording feature flag evaluations on the scope.
+
+This option does not affect span-level feature flag tracking, which independently records up to 10 evaluations per span.
+
+Learn more in the <PlatformLink to="/feature-flags/">Feature Flags</PlatformLink> documentation.
+
+</SdkOption>
+
 <SdkOption name="attachStacktrace" type="bool" defaultValue="true">
 
 When enabled, stack traces are automatically attached to all messages logged. Stack traces are always attached to exceptions; however, when this option is set, stack traces are also sent with messages. This option, for instance, means that stack traces appear next to all log messages.

--- a/platform-includes/feature-flags/evaluation-tracking-index/apple.mdx
+++ b/platform-includes/feature-flags/evaluation-tracking-index/apple.mdx
@@ -70,6 +70,6 @@ SentrySDK.configureScope { scope in
 
 `clearFeatureFlags()` removes evaluations from the current scope. It doesn't remove evaluations already recorded on an active span or transaction.
 
-Scope evaluations are attached to error and message events. The current scope keeps the latest evaluation for up to 100 flag names. Re-evaluating a flag updates its stored value and makes it the most recent evaluation.
+Scope evaluations are attached to error and message events. The current scope keeps the latest evaluation for up to <PlatformLink to="/configuration/options/#maxFeatureFlags">`maxFeatureFlags`</PlatformLink> flag names (default 100). Re-evaluating a flag updates its stored value and makes it the most recent evaluation.
 
 Active spans and transactions record evaluations for up to 10 flag names as span attributes using the `flag.evaluation.<name>` key. Re-evaluating a recorded flag updates its value. After 10 flag names are recorded, evaluations for new flag names are ignored. Spans don't inherit evaluations from their parent span.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document the new `maxFeatureFlags` configuration option for the sentry-cocoa SDK.

- Add `maxFeatureFlags` to the Apple SDK options page (type `int`, default `100`)
- Update the feature flags evaluation tracking text to link to the configurable option instead of hardcoding "100"

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)