### PR TITLE
docs(dotnet): document trace propagation targets

### DIFF
--- a/docs/platforms/dotnet/common/configuration/options.mdx
+++ b/docs/platforms/dotnet/common/configuration/options.mdx
@@ -370,6 +370,14 @@ This option was added in SDK version 5.1.0.
 
 </SdkOption>
 
+<SdkOption name="TracePropagationTargets" type="List&lt;StringOrRegex&gt;">
+
+Controls which outgoing HTTP requests receive the `sentry-trace` and `baggage` headers for distributed tracing. Provide URL substrings or regular expression patterns that match the request URLs.
+
+By default, the SDK matches every outgoing request. Adding a target replaces that default, so include every destination that should receive trace headers. Set the collection to empty to disable trace propagation.
+
+</SdkOption>
+
 <SdkOption name="PropagateTraceparent" type="bool" defaultValue="false" availableSince="6.0.0">
 
 If set to `true`, the SDK adds the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/) to outgoing HTTP requests, in addition to the `sentry-trace` and `baggage` headers. Enable this when your backend services are instrumented with a W3C Trace Context compatible library, such as OpenTelemetry, and you want to continue the trace from the client.


### PR DESCRIPTION
## DESCRIBE YOUR PR
Documents the .NET `TracePropagationTargets` option so users can control which outgoing requests receive Sentry trace headers.

- Describes the default all-target behavior.
- Explains how adding targets replaces that default and how to disable propagation.

## IS YOUR CHANGE URGENT?
- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA
- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

## PRE-MERGE CHECKLIST
- [ ] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the Sentry docs team

Closes #13582