### PR TITLE
docs: Note that breadcrumbs are no longer sent with streamed spans

### DIFF
--- a/docs/platforms/dart/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/dart/common/tracing/streamed-spans/index.mdx
@@ -399,6 +399,11 @@ await Sentry.startSpan('sync', (span) async {
 });
 ```
 
+## Breadcrumbs
+
+In stream mode, breadcrumbs are no longer sent with spans.
+They remain attached to errors, so you don't need to change how you record them.
+
 ## Extended Configuration (Optional)
 
 You can shape what ends up in Sentry by filtering span data or dropping spans entirely.

--- a/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
@@ -257,6 +257,11 @@ Sentry.withScope((scope) => {
 </SplitSection>
 </SplitLayout>
 
+## Breadcrumbs
+
+In stream mode, breadcrumbs are no longer sent with spans.
+They remain attached to errors, so you don't need to change how you record them.
+
 ## Extended Configuration (Optional)
 
 ### Filter Spans

--- a/docs/platforms/python/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/python/tracing/streamed-spans/index.mdx
@@ -242,6 +242,11 @@ with sentry_sdk.traces.start_span(name="handle-request") as span:
 
 Find more examples in our <PlatformLink to="/tracing/span-metrics/">Sending Span Metrics</PlatformLink> documentation.
 
+## Breadcrumbs
+
+In stream mode, breadcrumbs are no longer sent with spans.
+They remain attached to errors, so you don't need to change how you record them.
+
 ## Distributed Tracing (Optional)
 
 ### Continue a Trace


### PR DESCRIPTION
## DESCRIBE YOUR PR

Notes in the Streamed Spans docs that breadcrumbs are no longer sent with spans in stream mode (the span v2 protocol has no breadcrumbs field), and that they're still attached to errors. Added as a short `## Breadcrumbs` section on the JavaScript, Dart/Flutter, and Python pages.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
