### PR TITLE
feat(elixir): document diagnostics logging

### DIFF
--- a/docs/platforms/elixir/configuration/options.mdx
+++ b/docs/platforms/elixir/configuration/options.mdx
@@ -58,6 +58,12 @@ Most SDKs will attempt to auto-discover this value.
 
 </SdkOption>
 
+<SdkOption name="log_level" type='atom' defaultValue=':warning'>
+
+The level the SDK logs at when it fails to send data to Sentry, such as an API failure or an active rate limit. Lower it to `:debug` to keep these messages out of your warning stream. See <PlatformLink to="/configuration/sdk-diagnostics/">SDK Diagnostics</PlatformLink>.
+
+</SdkOption>
+
 ## Hooks
 
 These options can be used to hook the SDK in various ways to customize the reporting of events.

--- a/docs/platforms/elixir/configuration/sdk-diagnostics.mdx
+++ b/docs/platforms/elixir/configuration/sdk-diagnostics.mdx
@@ -1,0 +1,26 @@
+---
+title: SDK Diagnostics
+description: "Learn how to control the diagnostic messages the Sentry Elixir SDK writes to your own logs."
+sidebar_order: 20
+---
+
+When data doesn't reach Sentry — an API failure, a network error, an active rate limit, or an event the SDK can't process — the SDK says so through Elixir's [`Logger`](https://hexdocs.pm/logger/Logger.html) rather than failing silently.
+
+## Setting the Level
+
+The SDK reports these problems by default. The `:log_level` option controls how loudly they arrive, and defaults to `:warning`:
+
+```elixir {filename:config/prod.exs}
+config :sentry,
+  log_level: :debug
+```
+
+`:log_level` applies to messages about data that didn't make it to Sentry — an event dropped as empty or duplicate, a full transport queue, a failed send. Diagnostics about your own code misbehaving — a `before_send_log` callback raising, a `traces_sampler` crashing — log at their own fixed level and ignore `:log_level`, so lowering it won't quiet them. That's deliberate: those point at a bug to fix, not noise to tune out.
+
+## Rate Limits
+
+Rate limits are the one case the SDK deliberately doesn't announce per event. When your organization exceeds its quota, the SDK logs the rate limit **once per rate-limit window**, and logs each event dropped while that limit is active at `:debug`.
+
+<Alert>
+  Per-window rate-limit logging is available since version `13.5.1`.
+</Alert>


### PR DESCRIPTION
<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

Follow-up after https://github.com/getsentry/sentry-elixir/issues/1179 - new section called "SDK Diagnostics" under Configuration added to explain how to tune out logging about failed deliveries or rate-limited event drops. Also - adds `log_level` option to the Options section as it was missing.

## Preview

<img width="1410" height="1165" alt="image" src="https://github.com/user-attachments/assets/a00488a6-da11-4259-86fe-6e99493ee000" />


## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
