### PR TITLE
docs(integrations): Add Modem third-party integration

### DIFF
--- a/docs/integrations/third-party-integrations/index.mdx
+++ b/docs/integrations/third-party-integrations/index.mdx
@@ -31,6 +31,7 @@ To build and publish your own, see the [Integration Platform docs](/integrations
 - [Leroy](https://useleroy.com/sentry) {/* leroy */}
 - [LogBrew](https://docs.logbrew.co) {/* logbrew */}
 - [Mendral](https://mendral.com/) {/* mendral */}
+- [Modem](https://modem.dev/integrations/sentry) {/* modem */}
 - [NotiLens](https://www.notilens.com/docs/sentry) {/* notilens */}
 - [Offloop](https://docs.offloop.org/get-started/introduction) {/* offloop */}
 - [Oneleet](https://docs.oneleet.com) {/* oneleet */}

--- a/docs/integrations/third-party-integrations/index.mdx
+++ b/docs/integrations/third-party-integrations/index.mdx
@@ -33,9 +33,9 @@ To build and publish your own, see the [Integration Platform docs](/integrations
 - [Mendral](https://mendral.com/) {/* mendral */}
 - [Modem](https://modem.dev/integrations/sentry) {/* modem */}
 - [NotiLens](https://www.notilens.com/docs/sentry) {/* notilens */}
-- [Offloop](https://docs.offloop.org/get-started/introduction) {/* offloop */}
+- [Offloop](https://offloop.org/) {/* offloop */}
 - [Oneleet](https://docs.oneleet.com) {/* oneleet */}
-- [OpenBlock](https://www.openblocklabs.com/manual) {/* work-os */}
+- [OpenBlock](https://docs.openblocklabs.com/) {/* work-os */}
 - [OpsBrief](https://opsbrief.io/docs/integrations/sentry) {/* opsbrief */}
 - [Phoenix Alerts](https://help.phoenixincidents.com/en/articles/15808434-connect-sentry-to-phoenix-alerts) {/* phoenix-alerts */}
 - [Ploxir](https://ploxir.com/docs) {/* ploxir */}

--- a/redirects.js
+++ b/redirects.js
@@ -1172,6 +1172,10 @@ const userDocsRedirects = [
     source: '/organization/integrations/superlog-responder/',
     destination: '/integrations/third-party-integrations/',
   },
+  {
+    source: '/organization/integrations/modem/',
+    destination: '/integrations/third-party-integrations/',
+  },
   // DOCS-2426: WorkOS is an SSO provider; no dedicated page exists
   {
     source: '/organization/integrations/workos/',
@@ -1365,6 +1369,10 @@ const userDocsRedirects = [
   },
   {
     source: '/integrations/superlog-responder/',
+    destination: '/integrations/third-party-integrations/',
+  },
+  {
+    source: '/integrations/modem/',
     destination: '/integrations/third-party-integrations/',
   },
   {


### PR DESCRIPTION
Adds Modem to the consolidated third-party integrations list, linking to its Sentry setup guide at modem.dev.

Adds redirects for the `modem` slug from both `/organization/integrations/` and `/integrations/` to the consolidated page.

---

The external link check was failing on two pre-existing 404s unrelated to the Modem addition:

- Offloop: the docs.offloop.org subdomain is gone entirely (its root 404s too), so point at the offloop.org homepage.
- OpenBlock: /manual no longer exists, so point at the docs.openblocklabs.com root.