### PR TITLE
docs(apple): Document App Hang removal in v10

### DIFF
--- a/docs/platforms/apple/common/configuration/app-hangs.mdx
+++ b/docs/platforms/apple/common/configuration/app-hangs.mdx
@@ -5,6 +5,12 @@ description: Learn about how to add app hang detection reporting.
 og_image: /og-images/platforms-apple-common-configuration-app-hangs.png
 ---
 
+<Alert level="warning">
+
+App Hang tracking can produce less relevant stack traces and false positives. Migrate to the <PlatformLink to="/configuration/metric-kit/">MetricKit integration</PlatformLink> for system-provided hang diagnostics. We will remove the current App Hang tracking integration in the next major release, version 10 of the Sentry Apple SDK.
+
+</Alert>
+
 <Alert>
 
 We recommend disabling this feature for Widgets and Live Activities because it might detect false positives.

--- a/docs/platforms/apple/common/configuration/options.mdx
+++ b/docs/platforms/apple/common/configuration/options.mdx
@@ -289,9 +289,11 @@ This feature is not available in `DebugWithoutUIKit` and `ReleaseWithoutUIKit` c
 
 </SdkOption>
 
-<SdkOption name="enableReportNonFullyBlockingAppHangs" type="bool" defaultValue="true">
+<SdkOption name="enableReportNonFullyBlockingAppHangs" type="bool" defaultValue="true" removedSince="10.0.0">
 
 When enabled, the SDK reports non-fully-blocking app hangs. Non-fully-blocking app hangs occur when the app appears stuck to the user but can still render a few frames. Fully-blocking app hangs are when the main thread is stuck completely and the app can't render a single frame.
+
+App Hang tracking can produce less relevant stack traces and false positives. Migrate to the <PlatformLink to="/configuration/metric-kit/">MetricKit integration</PlatformLink> for system-provided hang diagnostics. We will remove this option and the current App Hang tracking integration in the next major release, version 10 of the Sentry Apple SDK.
 
 Learn more in the <PlatformLink to="/configuration/app-hangs/">App Hangs</PlatformLink> documentation.
 
@@ -1141,7 +1143,13 @@ This feature is currently experimental and disabled by default. Learn more in th
 
 ## App Hang Options
 
-<SdkOption name="enableAppHangTracking" type="bool" defaultValue="true">
+<Alert level="warning">
+
+App Hang tracking can produce less relevant stack traces and false positives. Migrate to the <PlatformLink to="/configuration/metric-kit/">MetricKit integration</PlatformLink> for system-provided hang diagnostics. We will remove the current App Hang tracking integration and the `enableAppHangTracking` option in the next major release, version 10 of the Sentry Apple SDK.
+
+</Alert>
+
+<SdkOption name="enableAppHangTracking" type="bool" defaultValue="true" removedSince="10.0.0">
 
 When enabled, the SDK tracks when the application stops responding for a specific amount of time defined by the `appHangTimeoutInterval` option.
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Warns Apple SDK users that the current App Hang tracking integration can produce less relevant stack traces and false positives and will be removed in version 10. Recommends migrating to MetricKit for system-provided hang diagnostics and marks the removed App Hang options with `removedSince="10.0.0"`.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [x] Checked Vercel preview for correctness, including links
- [x] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
