### PR TITLE
ref(devdocs): Add recommendation to flush buffer on segment end

### DIFF
--- a/develop-docs/sdk/telemetry/spans/span-buffer.mdx
+++ b/develop-docs/sdk/telemetry/spans/span-buffer.mdx
@@ -26,6 +26,7 @@ as long as the core requirements adquately are met.
    - Flush when the trace bucket has reached a size of 5MB (SDKs MAY choose a different value based on platform-specific needs, but the value MUST NOT exceed 10MB)
    - Flush when `SentrySDK.flush()` is called
    - Flush and stop further flushes when `SentrySDK.close()` is called. The buffer MUST stop accepting new spans at this time to prevent infinite memory consumption.
+6. The buffer MAY flush the trace bucket with the corresponding trace ID when a segment span ends. This is encouraged in backend SDKs to reduce memory pressure under many concurrent requests.
 
 ### Buckets per Trace ID
 


### PR DESCRIPTION
<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

Document the flush condition added in `sentry-python`.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
