### PR TITLE
ref(mdx): Read image dimensions with sharp instead of image-size

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "hast-util-to-jsx-runtime": "^2.3.2",
     "hast-util-to-string": "^3.0.1",
     "hastscript": "^8.0.0",
-    "image-size": "^1.2.1",
     "js-cookie": "^3.0.7",
     "js-yaml": "^4.3.1",
     "match-sorter": "^6.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       hastscript:
         specifier: ^8.0.0
         version: 8.0.0
-      image-size:
-        specifier: ^1.2.1
-        version: 1.2.1
       js-cookie:
         specifier: ^3.0.7
         version: 3.0.8
@@ -5078,11 +5075,6 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
-    engines: {node: '>=16.x'}
-    hasBin: true
-
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
@@ -6217,9 +6209,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -13118,10 +13107,6 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
-
   immutable@5.1.5: {}
 
   import-fresh@3.3.1:
@@ -14725,10 +14710,6 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   radix-ui@1.4.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/src/remark-image-processing.js
+++ b/src/remark-image-processing.js
@@ -1,8 +1,8 @@
 import {createHash} from 'node:crypto';
 import {readFileSync} from 'node:fs';
 
-import getImageSize from 'image-size';
 import path from 'path';
+import sharp from 'sharp';
 import {visit} from 'unist-util-visit';
 
 /**
@@ -16,24 +16,37 @@ import {visit} from 'unist-util-visit';
  * The content hash (?v=xxx) ensures browsers/CDN fetch fresh images when content changes.
  */
 export default function remarkImageProcessing(options) {
-  return tree =>
+  return async tree => {
+    // sharp only exposes an async metadata API, so collect the nodes first and
+    // resolve their dimensions together.
+    const imageNodes = [];
     visit(tree, 'image', node => {
       // don't process external images
       if (node.url.startsWith('http') || node.url.startsWith('//')) {
         return;
       }
-      const fullImagePath = path.join(
-        // if the path starts with / it's a public asset, otherwise it's a relative path
-        node.url.startsWith('/') ? options.publicFolder : options.sourceFolder,
-        node.url
-      );
-
-      // Read file buffer once for both operations to avoid redundant disk I/O
-      const imageBuffer = readFileSync(fullImagePath);
-      const imageSize = getImageSize(imageBuffer);
-      const contentHash = createHash('md5').update(imageBuffer).digest('hex').slice(0, 8);
-
-      // Add content hash as query param (for CDN cache busting) and size as hash
-      node.url += `?v=${contentHash}#${imageSize.width}x${imageSize.height}`;
+      imageNodes.push(node);
     });
+
+    await Promise.all(
+      imageNodes.map(async node => {
+        const fullImagePath = path.join(
+          // if the path starts with / it's a public asset, otherwise it's a relative path
+          node.url.startsWith('/') ? options.publicFolder : options.sourceFolder,
+          node.url
+        );
+
+        // Read file buffer once for both operations to avoid redundant disk I/O
+        const imageBuffer = readFileSync(fullImagePath);
+        const {width, height} = await sharp(imageBuffer).metadata();
+        const contentHash = createHash('md5')
+          .update(imageBuffer)
+          .digest('hex')
+          .slice(0, 8);
+
+        // Add content hash as query param (for CDN cache busting) and size as hash
+        node.url += `?v=${contentHash}#${width}x${height}`;
+      })
+    );
+  };
 }

--- a/src/remark-image-processing.spec.js
+++ b/src/remark-image-processing.spec.js
@@ -1,0 +1,102 @@
+import {createHash} from 'node:crypto';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+
+import sharp from 'sharp';
+import {beforeAll, describe, expect, it} from 'vitest';
+
+import remarkImageProcessing from './remark-image-processing';
+
+const createImage = (width, height, format) => {
+  const image = sharp({
+    create: {width, height, channels: 3, background: {r: 12, g: 34, b: 56}},
+  });
+  return image[format]().toBuffer();
+};
+
+const imageNode = url => ({type: 'image', url});
+
+const tree = (...nodes) => ({type: 'root', children: nodes});
+
+const md5 = buffer => createHash('md5').update(buffer).digest('hex').slice(0, 8);
+
+describe('remarkImageProcessing', () => {
+  let publicFolder;
+  let sourceFolder;
+  let transform;
+  const hashes = {};
+
+  beforeAll(async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'remark-image-processing-'));
+    publicFolder = path.join(root, 'public');
+    sourceFolder = path.join(root, 'source');
+    mkdirSync(path.join(publicFolder, 'img'), {recursive: true});
+    mkdirSync(sourceFolder, {recursive: true});
+
+    const fixtures = [
+      [path.join(publicFolder, 'img', 'public.png'), await createImage(120, 80, 'png')],
+      [path.join(sourceFolder, 'relative.png'), await createImage(200, 150, 'png')],
+      [path.join(sourceFolder, 'photo.jpg'), await createImage(64, 48, 'jpeg')],
+      [path.join(sourceFolder, 'animation.gif'), await createImage(30, 20, 'gif')],
+      [
+        path.join(sourceFolder, 'icon.svg'),
+        Buffer.from(
+          '<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16"/></svg>'
+        ),
+      ],
+    ];
+
+    for (const [filePath, buffer] of fixtures) {
+      writeFileSync(filePath, buffer);
+      hashes[path.basename(filePath)] = md5(buffer);
+    }
+
+    transform = remarkImageProcessing({publicFolder, sourceFolder});
+
+    return () => rmSync(root, {recursive: true, force: true});
+  });
+
+  it.each([
+    ['./relative.png', 'relative.png', '200x150'],
+    ['./photo.jpg', 'photo.jpg', '64x48'],
+    ['./animation.gif', 'animation.gif', '30x20'],
+    ['./icon.svg', 'icon.svg', '16x16'],
+  ])('appends the hash and dimensions for %s', async (url, fixture, size) => {
+    const node = imageNode(url);
+    await transform(tree(node));
+
+    expect(node.url).toBe(`${url}?v=${hashes[fixture]}#${size}`);
+  });
+
+  it('resolves absolute urls against the public folder', async () => {
+    const node = imageNode('/img/public.png');
+    await transform(tree(node));
+
+    expect(node.url).toBe(`/img/public.png?v=${hashes['public.png']}#120x80`);
+  });
+
+  it.each(['https://example.com/img.png', 'http://example.com/img.png', '//cdn/img.png'])(
+    'leaves the external image %s untouched',
+    async url => {
+      const node = imageNode(url);
+      await transform(tree(node));
+
+      expect(node.url).toBe(url);
+    }
+  );
+
+  it('processes every image in the tree', async () => {
+    const nodes = [imageNode('./photo.jpg'), imageNode('./icon.svg')];
+    await transform(tree(...nodes, {type: 'paragraph', children: []}));
+
+    expect(nodes.map(node => node.url)).toEqual([
+      `./photo.jpg?v=${hashes['photo.jpg']}#64x48`,
+      `./icon.svg?v=${hashes['icon.svg']}#16x16`,
+    ]);
+  });
+
+  it('rejects when the image is missing', async () => {
+    await expect(transform(tree(imageNode('./nope.png')))).rejects.toThrow(/ENOENT/);
+  });
+});


### PR DESCRIPTION
## DESCRIBE YOUR PR

Drops the `image-size` dependency and reads doc image dimensions with `sharp` instead.

`image-size` has three unpatched infinite-loop DoS advisories against its ICNS, JXL and HEIF parsers ([GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq)). There is nothing to upgrade to — the advisories cover every version through 2.0.2, which is the latest release, and upstream has been dormant since April 2025. The fix PR the advisory points at no longer exists on GitHub.

Our only call site is `src/remark-image-processing.js`, the build-time remark plugin that stamps `?v=<hash>#<W>x<H>` onto doc image URLs. It only ever sees files committed to this repo, so there is no request path an attacker can reach, and the practical exposure was a crafted image in a pull request hanging the docs build until CI times out. Rather than accept that indefinitely, this removes the package: `sharp` is already a direct dependency (required by `next/image`) and reads the same headers.

This closes Dependabot alerts 396, 397, 403 and 404 by removing the package rather than dismissing them as accepted risk.

### Changes

- Remove `image-size` from `package.json` (and `queue`, its only dependency, from the lockfile)
- Rewrite the remark transformer to use `sharp(buffer).metadata()`
- Add tests for the plugin, which previously had none

### Notes for reviewers

**Output is unchanged.** Every image in the repo — 1015 files across `public/`, `docs/`, `develop-docs/`, `includes/` and `platform-includes/` — was compared across both libraries, with **zero differences**. That includes all 10 SVGs and one with fractional dimensions (`1071.046875 × 507.42999629748056` → `1071x507` from both), so the SVG special case I expected to need turned out to be unnecessary. Re-verified against `sharp` 0.35.0 after it landed on master.

**The transformer is now async.** `sharp` has no sync metadata API, so it collects the image nodes during `visit` and resolves them with `Promise.all`. Async remark transformers already work in this pipeline (`src/remark-variables.js:30`), and I confirmed it end-to-end through real `bundleMDX` rather than relying on that precedent.

**Small perf cost.** Reading all 1015 images takes 91ms with `sharp` versus 4ms with `image-size` (~0.09ms per image). Immaterial against a full docs build, and it's now parallel per page where it used to be serial — but flagging it rather than burying it.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

---

Fixes VULN-2750
Fixes VULN-2753

🤖 Generated with [Claude Code](https://claude.com/claude-code)