### PR TITLE
feat(docs): promote agent integrations on home page

### DIFF
--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -15,6 +15,8 @@ import {Header} from './header';
 import styles from './home.module.scss';
 import {HomeAiSetupCard} from './homeAiSetupCard';
 import {PlatformFilter} from './platformFilter';
+import {PlatformIcon} from './platformIcon';
+import {PreferredPlatformLink} from './preferredPlatformLink';
 import {SentryWordmarkLogo} from './wordmarkLogo';
 
 export async function Home() {
@@ -156,6 +158,45 @@ export async function Home() {
               icon={<Cursor width={20} height={20} aria-hidden />}
             />
           </div>
+          <p className="mt-8 mb-4">
+            Start{' '}
+            <Link href="/product/agents/" className={styles.seeAllLink}>
+              debugging your agents
+            </Link>{' '}
+            with one of these agent integrations.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+            <AgentQuickLink
+              to="/agent-tracing/mastra/"
+              title="Mastra"
+              desc="Export Mastra AI tracing to Sentry."
+              icon={<PlatformIcon platform="mastra" />}
+            />
+            <AgentQuickLink
+              to="/agent-tracing/eve/"
+              title="Eve"
+              desc="Send Eve agent traces to Sentry over OTLP."
+              icon={<PlatformIcon platform="eve" />}
+            />
+            <AgentQuickLink
+              to="/agent-tracing/flue/"
+              title="Flue"
+              desc="Send Flue traces, logs, and errors to Sentry."
+              icon={<PlatformIcon platform="flue" />}
+            />
+            <AgentQuickLink
+              to="/agent-tracing/vercelai/"
+              title="Vercel AI"
+              desc="Instrument the Vercel AI SDK."
+              icon={<PlatformIcon platform="vercel" />}
+            />
+            <AgentQuickLink
+              to="/agent-tracing/openai/"
+              title="OpenAI"
+              desc="Instrument the OpenAI SDK."
+              icon={<PlatformIcon platform="openai" />}
+            />
+          </div>
         </section>
 
         <section className="max-w-screen-lg mx-auto px-4 sm:px-8 pb-16">
@@ -249,6 +290,28 @@ function QuickLink({
       </div>
       <div className="text-sm text-[var(--gray-11)] leading-snug">{desc}</div>
     </Link>
+  );
+}
+
+function AgentQuickLink({
+  to,
+  title,
+  desc,
+  icon,
+}: {
+  desc: string;
+  icon: ReactNode;
+  title: string;
+  to: string;
+}) {
+  return (
+    <PreferredPlatformLink to={to} className={`${styles.quickLink} no-underline`}>
+      <div className={styles.quickLinkTitle}>
+        {icon}
+        {title}
+      </div>
+      <div className="text-sm text-[var(--gray-11)] leading-snug">{desc}</div>
+    </PreferredPlatformLink>
   );
 }
 

--- a/src/components/preferredPlatformLink.tsx
+++ b/src/components/preferredPlatformLink.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Link from 'next/link';
+import {ComponentProps, useEffect, useState} from 'react';
+import {isLocalStorageAvailable} from 'sentry-docs/utils';
+
+type Props = Omit<ComponentProps<typeof Link>, 'href'> & {
+  to: string;
+};
+
+function getRedirectHref(to: string, platform?: string) {
+  const params = new URLSearchParams({next: to});
+  if (platform) {
+    params.set('platform', platform);
+  }
+  return `/platform-redirect/?${params.toString()}`;
+}
+
+export function PreferredPlatformLink({to, ...props}: Props) {
+  const [href, setHref] = useState(() => getRedirectHref(to));
+
+  useEffect(() => {
+    if (!isLocalStorageAvailable()) {
+      return;
+    }
+
+    const platform = localStorage.getItem('active-platform');
+    if (platform) {
+      setHref(getRedirectHref(to, platform));
+    }
+  }, [to]);
+
+  return <Link href={href} {...props} />;
+}


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds a second row to the home page Integrations section promoting Mastra, Eve, Flue, Vercel AI, and OpenAI Agent Tracing integrations.

The tiles use the existing product icons and route through the platform redirect flow. A supported stored platform preference goes directly to the matching guide; missing or unsupported preferences fall back to a picker containing only valid destinations.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## TESTING

- `pnpm lint:ts`
- `pnpm test:ci` (348 tests)
- `pnpm exec eslint src/components/home.tsx src/components/preferredPlatformLink.tsx`
- `pnpm exec prettier --check src/components/home.tsx src/components/preferredPlatformLink.tsx`

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)