### PR TITLE
docs(js): fix custom Integration interface link

### DIFF
--- a/docs/platforms/javascript/common/configuration/integrations/custom.mdx
+++ b/docs/platforms/javascript/common/configuration/integrations/custom.mdx
@@ -6,7 +6,7 @@ description: "Learn how you can enable a custom integration."
 
 In addition to the integrations that come with the SDK, you can also write custom integrations.
 
-Custom integration must conform to the [Integration interface](https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/types-hoist/integration.ts).
+Custom integration must conform to the [Integration interface](https://github.com/getsentry/sentry-javascript/blob/develop/packages/core/src/types/integration.ts).
 
 A custom integration can be created and added to the SDK as follows:
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes #19174

Updates the Custom Integrations page to point to the current `Integration` interface source file in `sentry-javascript`.

## IS YOUR CHANGE URGENT?

- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Please give the docs team up to 1 week to review this change.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
