### PR TITLE
docs(php): fix Monolog logs handler example

### DIFF
--- a/platform-includes/logs/setup/php.mdx
+++ b/platform-includes/logs/setup/php.mdx
@@ -25,10 +25,7 @@ use Monolog\Logger;
 ]);
 
 $log = new Logger('app');
-$log->pushHandler(new \Sentry\Monolog\LogsHandler(
-    hub: \Sentry\SentrySdk::getCurrentHub(),
-    level: Level::Info,
-));
+$log->pushHandler(new \Sentry\Monolog\LogsHandler(Level::Info));
 
 // Your existing Monolog usage will now send logs to Sentry
 $log->info('Application started');


### PR DESCRIPTION
## DESCRIBE YOUR PR

Fixes #19177

Updates the PHP Monolog logs example to use the current `LogsHandler` constructor signature.

## IS YOUR CHANGE URGENT?

- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Please give the docs team up to 1 week to review this change.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
