### PR TITLE
feat(react-native): Document anrProfilingSampleRate for Android

### DIFF
--- a/docs/platforms/react-native/common/configuration/app-hangs.mdx
+++ b/docs/platforms/react-native/common/configuration/app-hangs.mdx
@@ -55,6 +55,29 @@ Sentry.init({
 });
 ```
 
+### ANR Profiling on Android
+
+When a foreground ANR is detected on Android, the SDK can capture a stack profile of the main thread and attach it to the ANR event on the next app start. This gives you a flamegraph on the issue details page, showing what the main thread was doing at the time of the ANR. This is independent of the JVM-based ANR detection (which is always on by default) and of UI/transaction profiling configured via `profilesSampleRate`.
+
+<Alert>
+
+ANR profiles are powered by the Profiling platform and require a plan with profiling enabled. They're billed as UI Profile Hours. See the [pricing page](https://sentry.io/pricing/) for more details.
+
+</Alert>
+
+ANR profiling is disabled by default. To enable it, set the `anrProfilingSampleRate` option to a value between `0.0` and `1.0`. This controls the probability that a profile is collected for each detected foreground ANR (`0.0` represents 0% while `1.0` represents 100%):
+
+```javascript
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "DSN",
+  anrProfilingSampleRate: 1.0,
+});
+```
+
+To read more about how ANR profiles are captured, check out the `sentry-java` [documentation](/platforms/android/configuration/app-not-respond/#anr-profiling).
+
 ### Pause and Resume App Hang Tracking (iOS only)
 
 Starting with version 8.13.0, you can pause and resume app hang tracking at runtime. This is useful when showing system dialogs (for example, permission prompts) that block the main thread but aren't real app hangs.


### PR DESCRIPTION
## DESCRIBE YOUR PR

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/6674 is released

Documents the new `anrProfilingSampleRate` option for the React Native SDK on Android. When set, the SDK profiles the main thread during a detected foreground ANR and attaches the resulting flamegraph to the ANR event on the next app start.

Adds an **ANR Profiling on Android** section to the React Native [App Hangs](https://docs.sentry.io/platforms/react-native/configuration/app-hangs/) page, alongside the existing NDK app-hang tracking docs. It includes the billing note (powered by the Profiling platform, billed as UI Profile Hours) and links to the `sentry-java` ANR profiling docs for deeper detail.

Accompanies the SDK change: getsentry/sentry-react-native#6673. ANR profiling graduated out of experimental in sentry-java 8.55.0 (getsentry/sentry-java#6042), which the RN SDK now bundles.

> [!NOTE]
> This should merge once/after the SDK release that ships `anrProfilingSampleRate` (the accompanying SDK PR) is out.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)