### PR TITLE
feat(react-native): Document enableMemoryIntrospection iOS option

### DIFF
--- a/docs/platforms/react-native/common/configuration/options.mdx
+++ b/docs/platforms/react-native/common/configuration/options.mdx
@@ -452,6 +452,16 @@ Learn more in the <PlatformLink to="/configuration/metric-kit/">MetricKit</Platf
 
 </SdkOption>
 
+<SdkOption name="enableMemoryIntrospection" type="boolean" defaultValue="false" availableSince="8.26.0">
+
+When enabled, `SentryCrash` reads memory near the crash site while capturing a native crash on iOS (for example, `EXC_BAD_ACCESS`) and embeds string-based stack contents in the event under `exception.value`. This can help with debugging, but may also expose sensitive information (such as user IDs or personal data), which can even surface in the issue title.
+
+Set this boolean to `true` to include memory introspection data, or leave it disabled to keep native crash reporting while omitting memory contents. This option has no effect on Android.
+
+Learn more about managing sensitive data in the <PlatformLink to="/data-management/sensitive-data/">Scrubbing Sensitive Data</PlatformLink> documentation.
+
+</SdkOption>
+
 <SdkOption name="onReady" type="function">
 
 Set this callback, which is called after the Sentry React Native SDK initializes its Native SDKs (Android and iOS).


### PR DESCRIPTION
## DESCRIBE YOUR PR

⚠️ Should be merged after https://github.com/getsentry/sentry-react-native/pull/6674 is released

Documents the new iOS-only `enableMemoryIntrospection` option in the React Native configuration reference (Hybrid SDK Options).

When the SDK captures a native crash on iOS (e.g. `EXC_BAD_ACCESS`), `SentryCrash` reads memory near the crash site and embeds string-based stack contents in the event, which can expose sensitive information. This option lets privacy-sensitive apps keep native crash reporting while omitting memory contents.

Companion SDK change: getsentry/sentry-react-native#6674 (resolves getsentry/sentry-react-native#6547). The option ships in React Native SDK `8.26.0`, so the `availableSince` reflects that — please hold merge until that release is out.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the Sentry docs team
