### PR TITLE
docs(cloudflare): Move AI pages under Agent Tracing

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -67,15 +67,13 @@ Pick your AI stack. Some libraries auto-instrument; others need a short setup â€
     {
       to: "/agent-tracing/workers-ai/",
       href: "/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai/",
-      title: "Cloudflare Workers AI",
-      description: "Cloudflare guide",
+      title: "Workers AI",
       icon: "cloudflare",
     },
     {
       to: "/agent-tracing/agents-sdk/",
       href: "/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/",
-      title: "Cloudflare Agents SDK",
-      description: "Cloudflare guide",
+      title: "Agents SDK",
       icon: "cloudflare",
     },
     { to: "/agent-tracing/vercelai/", title: "Vercel AI SDK", icon: "vercel" },

--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -13,6 +13,29 @@ With <Link to="/product/agents/dashboards/">Sentry Agent Tracing</Link>, you can
 
 <AgentSetupCallout skill="sentry-setup-ai-monitoring" />
 
+## Cloudflare Agent Tracing
+
+Deploying agents to Cloudflare? Open the Cloudflare guide for Workers AI and the Agents SDK.
+
+<IntegrationGrid
+  integrations={[
+    {
+      to: "/agent-tracing/workers-ai/",
+      href: "/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai/",
+      title: "Cloudflare Workers AI",
+      description: "Cloudflare guide",
+      icon: "cloudflare",
+    },
+    {
+      to: "/agent-tracing/agents-sdk/",
+      href: "/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/",
+      title: "Cloudflare Agents SDK",
+      description: "Cloudflare guide",
+      icon: "cloudflare",
+    },
+  ]}
+/>
+
 <PlatformSection supported={["javascript.node", "javascript.aws-lambda", "javascript.azure-functions", "javascript.bun", "javascript.cloudflare", "javascript.connect", "javascript.deno", "javascript.effect", "javascript.electron", "javascript.elysia", "javascript.express", "javascript.fastify", "javascript.firebase", "javascript.gcp-functions", "javascript.hapi", "javascript.hono", "javascript.koa", "javascript.nestjs", "javascript.nitro", "javascript.astro", "javascript.nextjs", "javascript.nuxt", "javascript.react-router", "javascript.remix", "javascript.solidstart", "javascript.sveltekit", "javascript.tanstackstart-react"]}>
 
 ## Getting Started
@@ -62,32 +85,39 @@ Durable Objects / <PlatformLink to="/agent-tracing/agents-sdk/">Agents SDK</Plat
 
 Pick your AI stack. Some libraries auto-instrument; others need a short setup â€” each page has the details.
 
-<PlatformSection notSupported={["javascript.deno"]}>
-
 <IntegrationGrid
   integrations={[
-    {
-      to: "/agent-tracing/workers-ai/",
-      title: "Workers AI",
-      icon: "cloudflare",
-      supported: ["javascript.cloudflare"],
-    },
-    {
-      to: "/agent-tracing/agents-sdk/",
-      title: "Agents SDK",
-      icon: "cloudflare",
-      supported: ["javascript.cloudflare"],
-    },
     { to: "/agent-tracing/vercelai/", title: "Vercel AI SDK", icon: "vercel" },
-    { to: "/agent-tracing/openai/", title: "OpenAI", icon: "openai" },
-    { to: "/agent-tracing/anthropic/", title: "Anthropic", icon: "anthropic" },
+    {
+      to: "/agent-tracing/openai/",
+      title: "OpenAI",
+      icon: "openai",
+      notSupported: ["javascript.deno"],
+    },
+    {
+      to: "/agent-tracing/anthropic/",
+      title: "Anthropic",
+      icon: "anthropic",
+      notSupported: ["javascript.deno"],
+    },
     {
       to: "/agent-tracing/google-genai/",
       title: "Google Gen AI SDK",
       icon: "google-genai",
+      notSupported: ["javascript.deno"],
     },
-    { to: "/agent-tracing/langchain/", title: "LangChain", icon: "langchain" },
-    { to: "/agent-tracing/langgraph/", title: "LangGraph", icon: "langgraph" },
+    {
+      to: "/agent-tracing/langchain/",
+      title: "LangChain",
+      icon: "langchain",
+      notSupported: ["javascript.deno"],
+    },
+    {
+      to: "/agent-tracing/langgraph/",
+      title: "LangGraph",
+      icon: "langgraph",
+      notSupported: ["javascript.deno"],
+    },
     {
       to: "/agent-tracing/mastra/",
       title: "Mastra",
@@ -127,14 +157,6 @@ Pick your AI stack. Some libraries auto-instrument; others need a short setup â€
     },
   ]}
 />
-
-</PlatformSection>
-
-<PlatformSection supported={["javascript.deno"]}>
-
-- <PlatformLink to="/agent-tracing/vercelai/">Vercel AI SDK</PlatformLink>
-
-</PlatformSection>
 
 ## Tracking Conversations
 

--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -54,7 +54,7 @@ export default Sentry.withSentry(
 );
 ```
 
-Durable Objects / <PlatformLink to="/features/agents-sdk/">Agents SDK</PlatformLink>: use <PlatformLink to="/features/durableobject/">`instrumentDurableObjectWithSentry`</PlatformLink> with the same options.
+Durable Objects / <PlatformLink to="/agent-tracing/agents-sdk/">Agents SDK</PlatformLink>: use <PlatformLink to="/features/durableobject/">`instrumentDurableObjectWithSentry`</PlatformLink> with the same options.
 
 </PlatformSection>
 
@@ -67,13 +67,13 @@ Pick your AI stack. Some libraries auto-instrument; others need a short setup â€
 <IntegrationGrid
   integrations={[
     {
-      to: "/features/workers-ai/",
+      to: "/agent-tracing/workers-ai/",
       title: "Workers AI",
       icon: "cloudflare",
       supported: ["javascript.cloudflare"],
     },
     {
-      to: "/features/agents-sdk/",
+      to: "/agent-tracing/agents-sdk/",
       title: "Agents SDK",
       icon: "cloudflare",
       supported: ["javascript.cloudflare"],

--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -13,29 +13,6 @@ With <Link to="/product/agents/dashboards/">Sentry Agent Tracing</Link>, you can
 
 <AgentSetupCallout skill="sentry-setup-ai-monitoring" />
 
-## Cloudflare Agent Tracing
-
-Deploying agents to Cloudflare? Open the Cloudflare guide for Workers AI and the Agents SDK.
-
-<IntegrationGrid
-  integrations={[
-    {
-      to: "/agent-tracing/workers-ai/",
-      href: "/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai/",
-      title: "Cloudflare Workers AI",
-      description: "Cloudflare guide",
-      icon: "cloudflare",
-    },
-    {
-      to: "/agent-tracing/agents-sdk/",
-      href: "/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/",
-      title: "Cloudflare Agents SDK",
-      description: "Cloudflare guide",
-      icon: "cloudflare",
-    },
-  ]}
-/>
-
 <PlatformSection supported={["javascript.node", "javascript.aws-lambda", "javascript.azure-functions", "javascript.bun", "javascript.cloudflare", "javascript.connect", "javascript.deno", "javascript.effect", "javascript.electron", "javascript.elysia", "javascript.express", "javascript.fastify", "javascript.firebase", "javascript.gcp-functions", "javascript.hapi", "javascript.hono", "javascript.koa", "javascript.nestjs", "javascript.nitro", "javascript.astro", "javascript.nextjs", "javascript.nuxt", "javascript.react-router", "javascript.remix", "javascript.solidstart", "javascript.sveltekit", "javascript.tanstackstart-react"]}>
 
 ## Getting Started
@@ -87,6 +64,20 @@ Pick your AI stack. Some libraries auto-instrument; others need a short setup â€
 
 <IntegrationGrid
   integrations={[
+    {
+      to: "/agent-tracing/workers-ai/",
+      href: "/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai/",
+      title: "Cloudflare Workers AI",
+      description: "Cloudflare guide",
+      icon: "cloudflare",
+    },
+    {
+      to: "/agent-tracing/agents-sdk/",
+      href: "/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/",
+      title: "Cloudflare Agents SDK",
+      description: "Cloudflare guide",
+      icon: "cloudflare",
+    },
     { to: "/agent-tracing/vercelai/", title: "Vercel AI SDK", icon: "vercel" },
     {
       to: "/agent-tracing/openai/",

--- a/docs/platforms/javascript/common/mcp-monitoring/index.mdx
+++ b/docs/platforms/javascript/common/mcp-monitoring/index.mdx
@@ -82,7 +82,7 @@ export default Sentry.withSentry(
 
 Stream mode sends span records instead of assembling one transaction event with embedded spans. `beforeSendTransaction` and `ignoreTransactions` don't apply to streamed spans. See <PlatformLink to="/tracing/streamed-spans/">Streamed Spans</PlatformLink> for the `beforeSendSpan` and `ignoreSpans` configuration.
 
-If you use `McpAgent`, wrap the `McpServer` returned by its `server` getter, and wrap the Agent class separately with `instrumentAgentWithSentry` to preserve request and RPC context. Agent instrumentation, MCP server wrapping, and span streaming solve different parts of the setup; none replaces the others. See <PlatformLink to="/features/agents-sdk/">Agents SDK</PlatformLink>.
+If you use `McpAgent`, wrap the `McpServer` returned by its `server` getter, and wrap the Agent class separately with `instrumentAgentWithSentry` to preserve request and RPC context. Agent instrumentation, MCP server wrapping, and span streaming solve different parts of the setup; none replaces the others. See <PlatformLink to="/agent-tracing/agents-sdk/">Agents SDK</PlatformLink>.
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk.mdx
@@ -87,7 +87,7 @@ Populate the Conversations **User** column with `Sentry.setUser` on every reques
 
 ## Related
 
-- <PlatformLink to="/features/workers-ai/">Workers AI</PlatformLink>
+- <PlatformLink to="/agent-tracing/workers-ai/">Workers AI</PlatformLink>
 - <PlatformLink to="/features/durableobject/">Durable Objects</PlatformLink>
 - <PlatformLink to="/features/vite-plugin/">Vite Plugin</PlatformLink>
 - <PlatformLink to="/agent-tracing/#tracking-conversations">

--- a/docs/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cloudflare Agents SDK
+sidebar_title: Agents SDK
 description: "Instrument Cloudflare Agents SDK classes with Sentry and link chats to the Conversations view."
 ---
 

--- a/docs/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai.mdx
@@ -39,4 +39,4 @@ You can browse the full list of available models in the [Cloudflare Workers AI m
 ## Next Steps
 
 - Group multi-turn chats with <PlatformLink to="/agent-tracing/#tracking-conversations">`setConversationId()`</PlatformLink>
-- If you use the <PlatformLink to="/features/agents-sdk/">Cloudflare Agents SDK</PlatformLink>, follow that guide
+- If you use the <PlatformLink to="/agent-tracing/agents-sdk/">Cloudflare Agents SDK</PlatformLink>, follow that guide

--- a/docs/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cloudflare Workers AI
+sidebar_title: Workers AI
 description: "Learn how Sentry instruments Cloudflare Workers AI to capture gen_ai spans."
 ---
 

--- a/docs/platforms/javascript/guides/cloudflare/features/durableobject.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/durableobject.mdx
@@ -28,7 +28,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 
 `instrumentDurableObjectWithSentry` works with any class that extends `DurableObject`, not only those that extend it directly. This includes classes built on top of Durable Objects by other libraries.
 
-For classes built on the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/) (`Agent`, `AIChatAgent`, `McpAgent`), use the dedicated `instrumentAgentWithSentry` wrapper instead (SDK version 10.69.0 or higher). It applies the same Durable Object instrumentation and adds spans for `@callable()` RPC methods as well as automatic conversation IDs. See <PlatformLink to="/features/agents-sdk/">Cloudflare Agents SDK</PlatformLink>.
+For classes built on the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/) (`Agent`, `AIChatAgent`, `McpAgent`), use the dedicated `instrumentAgentWithSentry` wrapper instead (SDK version 10.69.0 or higher). It applies the same Durable Object instrumentation and adds spans for `@callable()` RPC methods as well as automatic conversation IDs. See <PlatformLink to="/agent-tracing/agents-sdk/">Cloudflare Agents SDK</PlatformLink>.
 
 ## Durable Object Storage Spans
 

--- a/docs/platforms/javascript/guides/cloudflare/features/index.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/index.mdx
@@ -5,4 +5,9 @@ description: "Learn how Sentry's Cloudflare SDK exposes features for first class
 
 The Sentry Cloudflare SDK offers Cloudflare-specific features for first class integration with Cloudflare products and the Cloudflare workers runtime.
 
-<PageGrid />
+<PageGrid
+  additionalPages={[
+    "/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/",
+    "/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai/",
+  ]}
+/>

--- a/docs/platforms/javascript/guides/cloudflare/features/vite-plugin.mdx
+++ b/docs/platforms/javascript/guides/cloudflare/features/vite-plugin.mdx
@@ -65,7 +65,7 @@ export default Sentry.withSentry(
 
 ### Auto-instrumentation (Experimental)
 
-Alternatively, the plugin can wrap your Worker for you at build time, so you don't need `withSentry` in your code. Enable `autoInstrumentation` and the plugin reads your wrangler config (probing `wrangler.json`, `wrangler.jsonc`, and `wrangler.toml` at the Vite root, or the file set with [`wranglerConfigPath`](#options)) to find the entry point, Durable Objects, workflows, and Agents SDK classes. The plugin wraps Agents SDK classes (`Agent`, `AIChatAgent`, `McpAgent`) with `instrumentAgentWithSentry` (SDK version 10.69.0 or higher), which also gives them automatic conversation IDs (see <PlatformLink to="/features/agents-sdk/">Cloudflare Agents SDK</PlatformLink>).
+Alternatively, the plugin can wrap your Worker for you at build time, so you don't need `withSentry` in your code. Enable `autoInstrumentation` and the plugin reads your wrangler config (probing `wrangler.json`, `wrangler.jsonc`, and `wrangler.toml` at the Vite root, or the file set with [`wranglerConfigPath`](#options)) to find the entry point, Durable Objects, workflows, and Agents SDK classes. The plugin wraps Agents SDK classes (`Agent`, `AIChatAgent`, `McpAgent`) with `instrumentAgentWithSentry` (SDK version 10.69.0 or higher), which also gives them automatic conversation IDs (see <PlatformLink to="/agent-tracing/agents-sdk/">Cloudflare Agents SDK</PlatformLink>).
 
 ```typescript {filename:vite.config.ts}
 import { cloudflare } from "@cloudflare/vite-plugin";

--- a/docs/product/agents/conversations/index.mdx
+++ b/docs/product/agents/conversations/index.mdx
@@ -39,7 +39,7 @@ Some SDK integrations (such as OpenAI Agents SDK for Python and OpenAI SDK for N
 
 - [JavaScript/Node](/platforms/javascript/guides/node/agent-tracing/#tracking-conversations)
 - [Cloudflare](/platforms/javascript/guides/cloudflare/agent-tracing/#tracking-conversations)
-- [Cloudflare Agents SDK](/platforms/javascript/guides/cloudflare/features/agents-sdk/)
+- [Cloudflare Agents SDK](/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/)
 - [Python](/platforms/python/agent-tracing/#tracking-conversations)
 - [Laravel](/platforms/php/guides/laravel/agent-tracing/#conversations)
 

--- a/includes/docs-changelog.mdx
+++ b/includes/docs-changelog.mdx
@@ -16,7 +16,7 @@
 - [Set Up Tracing](/platforms/javascript/tracing/)
 - [Instrument MCP Servers](/platforms/javascript/guides/node/tracing/instrumentation/mcp-module/)
 - [Example Instrumentation](/platforms/javascript/tracing/span-metrics/examples/)
-- [Cloudflare Agents SDK](/platforms/javascript/guides/cloudflare/features/agents-sdk/)
+- [Cloudflare Agents SDK](/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/)
 - [Next.js](/platforms/javascript/guides/nextjs/)
 - [Manual Setup](/platforms/javascript/guides/nextjs/manual-setup/)
 - [Pages Router Setup](/platforms/javascript/guides/nextjs/manual-setup/pages-router/)

--- a/redirects.js
+++ b/redirects.js
@@ -2280,6 +2280,29 @@ const userDocsRedirects = [
     source: '/product/insights/:path*',
     destination: '/product/dashboards/sentry-dashboards/',
   },
+  // Cloudflare AI pages moved from Features to Agent Tracing.
+  {
+    source: '/platforms/javascript/guides/cloudflare/features/agents-sdk.md',
+    destination:
+      '/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk.md',
+  },
+  {
+    source:
+      '/platforms/javascript/guides/cloudflare/features/agents-sdk/:path*',
+    destination:
+      '/platforms/javascript/guides/cloudflare/agent-tracing/agents-sdk/:path*',
+  },
+  {
+    source: '/platforms/javascript/guides/cloudflare/features/workers-ai.md',
+    destination:
+      '/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai.md',
+  },
+  {
+    source:
+      '/platforms/javascript/guides/cloudflare/features/workers-ai/:path*',
+    destination:
+      '/platforms/javascript/guides/cloudflare/agent-tracing/workers-ai/:path*',
+  },
   // Mastra lives under Agent Tracing alongside the other AI library pages.
   // Map older names directly to avoid redirect chains.
   {

--- a/src/components/integrationGrid.tsx
+++ b/src/components/integrationGrid.tsx
@@ -10,6 +10,8 @@ type Integration = {
   icon: string;
   /** Display name of the integration. */
   title: string;
+  /** Absolute path for links that target a different platform or guide. */
+  href?: string;
   /** Platform-relative path, e.g. "/integrations/anthropic/". */
   to: string;
   /** Optional one-line description shown under the title. */
@@ -39,10 +41,11 @@ export function IntegrationGrid({integrations}: Props) {
   const {rootNode, path} = serverContext();
   const currentPlatformOrGuide = getCurrentPlatformOrGuide(rootNode, path);
 
-  const hrefFor = (to: string) =>
-    currentPlatformOrGuide
+  const hrefFor = (to: string, href?: string) =>
+    href ??
+    (currentPlatformOrGuide
       ? currentPlatformOrGuide.url + to.slice(1)
-      : `/platform-redirect/?next=${encodeURIComponent(to)}`;
+      : `/platform-redirect/?next=${encodeURIComponent(to)}`);
 
   const visibleIntegrations = currentPlatformOrGuide
     ? integrations.filter(({supported, notSupported}) =>
@@ -56,10 +59,10 @@ export function IntegrationGrid({integrations}: Props) {
 
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3 not-prose mt-4 mb-6">
-      {visibleIntegrations.map(({icon, title, to, description}) => (
+      {visibleIntegrations.map(({icon, title, href, to, description}) => (
         <Link
-          key={to}
-          href={hrefFor(to)}
+          key={href ?? to}
+          href={hrefFor(to, href)}
           className="no-underline group flex flex-row items-center gap-3 px-4 py-2 rounded-lg shadow border border-[var(--gray-5)] dark:bg-[var(--gray-4)] text-[var(--foreground)] transition-shadow hover:shadow-md"
         >
           <PlatformIcon

--- a/src/components/pageGrid.tsx
+++ b/src/components/pageGrid.tsx
@@ -6,23 +6,37 @@ import {isNotNil, sortPages} from 'sentry-docs/utils';
 import {isVersioned} from 'sentry-docs/versioning';
 
 type Props = {
+  /** Root-relative pages to include alongside the current page's children. */
+  additionalPages?: string[];
   exclude?: string[];
   header?: string;
 };
 
-export function PageGrid({header, exclude}: Props) {
+export function PageGrid({additionalPages = [], header, exclude}: Props) {
   const {rootNode, path: nodePath} = serverContext();
 
   const parentNode = nodeForPath(rootNode, nodePath);
-  if (!parentNode || parentNode.children.length === 0) {
+  if (!parentNode) {
     return null;
   }
 
-  const children: DocNode[] = parentNode.frontmatter.next_steps?.length
+  const childPages: DocNode[] = parentNode.frontmatter.next_steps?.length
     ? (parentNode.frontmatter.next_steps
         .map(p => nodeForPath(rootNode, path.join(parentNode.path, p)))
         .filter(isNotNil) ?? [])
     : parentNode.children;
+  const additionalPageNodes = additionalPages
+    .map(pagePath => nodeForPath(rootNode, pagePath.split('/').filter(Boolean)))
+    .filter(isNotNil);
+  const children = [
+    ...new Map(
+      [...childPages, ...additionalPageNodes].map(child => [child.path, child])
+    ).values(),
+  ];
+
+  if (children.length === 0) {
+    return null;
+  }
 
   return (
     <nav>

--- a/src/components/sidebar/dynamicNav.tsx
+++ b/src/components/sidebar/dynamicNav.tsx
@@ -40,9 +40,8 @@ type Node = {
     [key: string]: any;
     beta?: boolean;
     /**
-     * Link target, when it differs from the node's position in the tree. Used for
-     * pages that belong in more than one sidebar section (the AI library pages are
-     * listed under both Agent Tracing and Configuration > Integrations).
+     * Link target when it differs from the node's position in the tree. Used for
+     * pages that belong in more than one sidebar section.
      */
     href?: string;
     new?: boolean;

--- a/src/components/sidebar/platformSidebar.tsx
+++ b/src/components/sidebar/platformSidebar.tsx
@@ -5,17 +5,22 @@ import {PlatformSidebarProps} from './types';
 import {getNavNodes} from './utils';
 
 /**
- * Platforms whose AI library pages live under agent-tracing, mapped to where that
- * platform keeps its integrations list. The library pages are mirrored into that
- * list so they stay discoverable from both places.
+ * Platforms whose AI pages live under agent-tracing, mapped to where those pages
+ * are mirrored in the sidebar by default.
  */
 const INTEGRATIONS_PATH_BY_PLATFORM: Record<string, string> = {
   javascript: 'configuration/integrations',
   python: 'integrations',
 };
 
-/** Pages under agent-tracing that document the feature rather than a library. */
-const NON_LIBRARY_AGENT_TRACING_PAGES = new Set(['manual-instrumentation']);
+const AGENT_TRACING_ALIAS_PATH_OVERRIDES: Record<string, Record<string, string>> = {
+  'javascript.cloudflare': {
+    'agents-sdk': 'features',
+    'workers-ai': 'features',
+  },
+};
+
+const UNALIASED_AGENT_TRACING_PAGES = new Set(['manual-instrumentation']);
 
 export function PlatformSidebar({
   rootNode,
@@ -60,37 +65,38 @@ export function PlatformSidebar({
     ? `platforms/${platformName}/guides/${guideName}`
     : `platforms/${platformName}`;
 
-  // The AI library pages live under agent-tracing, but they're also integrations,
-  // so mirror them into the integrations list. These are link-only entries: they
-  // sit under the integrations path but point at the real agent-tracing page.
-  // The list is derived from whatever pages exist under agent-tracing for this
-  // platform or guide, so it needs no maintenance as libraries come and go.
+  // Mirror Agent Tracing pages elsewhere in the sidebar as link-only entries.
+  // Most are integrations; guide-specific overrides can place pages in a more
+  // appropriate section while keeping Agent Tracing as their canonical location.
   const integrationsPath = INTEGRATIONS_PATH_BY_PLATFORM[platformName];
+  const aliasPathOverrides = guideName
+    ? AGENT_TRACING_ALIAS_PATH_OVERRIDES[`${platformName}.${guideName}`]
+    : undefined;
   const agentTracingNode =
     integrationsPath && nodeForPath(rootNode, [...pathRoot.split('/'), 'agent-tracing']);
 
-  const aiIntegrationAliases = !agentTracingNode
+  const agentTracingAliases = !agentTracingNode
     ? []
     : agentTracingNode.children
         .filter(
           child =>
             !child.missing &&
             !child.frontmatter.draft &&
-            !NON_LIBRARY_AGENT_TRACING_PAGES.has(child.slug)
+            !UNALIASED_AGENT_TRACING_PAGES.has(child.slug)
         )
         .map(child => ({
           context: {
             platform: {platformName},
             title: child.frontmatter.title,
             sidebar_title: child.frontmatter.sidebar_title,
-            // Deliberately no sidebar_order: these sort alphabetically among the
-            // other integrations rather than carrying their agent-tracing ordering.
+            // Deliberately no sidebar_order: aliases sort alphabetically in their
+            // secondary location instead of using their Agent Tracing order.
             href: '/' + child.path + '/',
           },
-          path: `/${pathRoot}/${integrationsPath}/${child.slug}/`,
+          path: `/${pathRoot}/${aliasPathOverrides?.[child.slug] ?? integrationsPath}/${child.slug}/`,
         }));
 
-  const tree = toTree([...nodes, ...aiIntegrationAliases].filter(n => !!n.context));
+  const tree = toTree([...nodes, ...agentTracingAliases].filter(n => !!n.context));
 
   // Use "Getting Started" for Next.js, default title for other platforms
   const isNextJs = platformName === 'javascript' && guideName === 'nextjs';

--- a/src/components/sidebar/platformSidebar.tsx
+++ b/src/components/sidebar/platformSidebar.tsx
@@ -21,6 +21,7 @@ const AGENT_TRACING_ALIAS_PATH_OVERRIDES: Record<string, Record<string, string>>
 };
 
 const UNALIASED_AGENT_TRACING_PAGES = new Set(['manual-instrumentation']);
+const CLOUDFLARE_AGENT_TRACING_PAGE_SLUGS = ['agents-sdk', 'workers-ai'];
 
 export function PlatformSidebar({
   rootNode,
@@ -96,7 +97,40 @@ export function PlatformSidebar({
           path: `/${pathRoot}/${aliasPathOverrides?.[child.slug] ?? integrationsPath}/${child.slug}/`,
         }));
 
-  const tree = toTree([...nodes, ...agentTracingAliases].filter(n => !!n.context));
+  // Expose Cloudflare-only pages from every JavaScript Agent Tracing sidebar.
+  // Their links navigate to the canonical Cloudflare guide instead of creating
+  // unsupported copies under the current guide.
+  const cloudflareAgentTracingAliases =
+    platformName !== 'javascript' || guideName === 'cloudflare' || !agentTracingNode
+      ? []
+      : CLOUDFLARE_AGENT_TRACING_PAGE_SLUGS.map(slug => {
+          const target = nodeForPath(rootNode, [
+            'platforms',
+            'javascript',
+            'guides',
+            'cloudflare',
+            'agent-tracing',
+            slug,
+          ]);
+          if (!target || target.missing || target.frontmatter.draft) {
+            return undefined;
+          }
+          return {
+            context: {
+              platform: {platformName},
+              title: target.frontmatter.title,
+              sidebar_title: target.frontmatter.sidebar_title,
+              href: '/' + target.path + '/',
+            },
+            path: `/${pathRoot}/agent-tracing/${slug}/`,
+          };
+        }).filter(alias => alias !== undefined);
+
+  const tree = toTree(
+    [...nodes, ...agentTracingAliases, ...cloudflareAgentTracingAliases].filter(
+      n => !!n.context
+    )
+  );
 
   // Use "Getting Started" for Next.js, default title for other platforms
   const isNextJs = platformName === 'javascript' && guideName === 'nextjs';


### PR DESCRIPTION
## DESCRIBE YOUR PR

Cloudflare Workers AI and Agents SDK now live under Agent Tracing, while link-only entries keep them discoverable under Cloudflare Features. Supported JavaScript Agent Tracing pages show both in the existing Instrumentation grid, and Agent Tracing sidebars link directly to the Cloudflare guide.

The Cloudflare Features page grid and Markdown export retain both canonical links. Their old URLs redirect to the new pages, and neither page appears under Configuration > Integrations.

Refs TET-2939

## IS YOUR CHANGE URGENT?

- [ ] No deadline: Not urgent, can wait up to 1 week+