### PR TITLE
docs(js): Replace Mastra community exporter with first-party integration

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/mastra.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/mastra.mdx
@@ -29,9 +29,11 @@ supported:
 <PlatformSection supported={["javascript.nextjs"]}>
   <Alert level="warning">
     With Turbopack, automatic instrumentation requires **Next.js 16 or newer**.
-    On Next.js 15, `next build --turbopack` skips the build-time transform that
-    hooks Mastra, and no spans are created. Build with webpack instead, or use
-    [**Manual Instrumentation**](#manual-instrumentation).
+    Scoping the transform to your server build relies on Turbopack's rule
+    `condition` field, which Next.js 15 doesn't support, so on Next.js 15 the
+    SDK skips it and Mastra produces no spans under `--turbopack` (in `dev` or
+    `build`). Use webpack instead, or [**Manual
+    Instrumentation**](#manual-instrumentation).
   </Alert>
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/agent-tracing/mastra.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/mastra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mastra
 sidebar_title: Mastra
-description: "Learn how to export Mastra AI tracing to Sentry."
+description: "Adds instrumentation for Mastra agents, workflows, and tool calls."
 sidebar_order: 26
 supported:
   - javascript.node
@@ -24,186 +24,219 @@ supported:
   - javascript.tanstackstart-react
 ---
 
-[Mastra](https://mastra.ai/) is a framework for building AI-powered applications and agents with a modern TypeScript stack. The Mastra Sentry Exporter sends tracing data to Sentry using OpenTelemetry semantic conventions, providing insights into model performance, token usage, and tool executions.
+[Mastra](https://mastra.ai/) is a TypeScript framework for building AI agents and workflows. The Sentry SDK captures agent runs, model generations, and tool calls as `gen_ai` spans, so Mastra activity shows up in the [Agents](/product/agents/) dashboards next to the rest of your traces.
 
-## Prerequisites
+<PlatformSection
+  supported={[
+    "javascript.nextjs",
+    "javascript.nuxt",
+    "javascript.solidstart",
+    "javascript.sveltekit",
+    "javascript.remix",
+    "javascript.astro",
+    "javascript.tanstackstart-react",
+  ]}
+>
+  <Alert level="warning">
+    In meta-frameworks, Mastra is usually bundled into the server build, which
+    the SDK can't hook at runtime. Register the exporter yourself using
+    [**Manual Instrumentation**](#manual-instrumentation).
+  </Alert>
+</PlatformSection>
 
-Before you begin, you need:
+## Automatic Instrumentation
 
-- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/). The project's DSN tells the exporter where to send data.
-- A Mastra application using `@mastra/core`.
-- Node.js 22.13.0 or newer. The exporter uses `@sentry/node` internally and does not support browser or edge runtimes.
+_Import name: `Sentry.mastraIntegration`_
 
-Mastra sends agent data as traces. Keep `tracesSampleRate` above `0` to enable tracing.
+The `mastraIntegration` hooks the [`@mastra/core`](https://www.npmjs.com/package/@mastra/core) `Mastra` constructor and registers a Sentry exporter on Mastra's observability pipeline. In Node.js runtimes it's enabled by default (requires Sentry SDK version `11.0.0` or higher).
 
-## Installation
-
-Install the Mastra Sentry exporter and observability packages:
+Mastra routes telemetry through `@mastra/observability`, which `@mastra/core` doesn't depend on. Install it, or Mastra produces no spans for the SDK to export:
 
 ```bash {tabTitle:npm}
-npm install @mastra/sentry@latest @mastra/observability@latest
+npm install @mastra/observability
 ```
 
 ```bash {tabTitle:yarn}
-yarn add @mastra/sentry@latest @mastra/observability@latest
+yarn add @mastra/observability
 ```
 
 ```bash {tabTitle:pnpm}
-pnpm add @mastra/sentry@latest @mastra/observability@latest
+pnpm add @mastra/observability
 ```
 
-You don't need to install or initialize `@sentry/node` separately for this standalone setup. The exporter includes it as a dependency and initializes it for you.
+That's the whole setup. If your app doesn't configure observability itself, the SDK builds the pipeline from the `@mastra/observability` you installed:
+
+```typescript {filename:src/mastra/index.ts}
+import { Mastra } from "@mastra/core";
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+});
+```
+
+If your app does configure observability — because you send Mastra telemetry somewhere else as well — the SDK adds its exporter to your existing config and leaves the rest of it alone:
+
+```typescript {filename:src/mastra/index.ts}
+import { Mastra } from "@mastra/core";
+import { Observability } from "@mastra/observability";
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "my-mastra-app",
+        exporters: [myOtherExporter],
+      },
+    },
+  }),
+});
+```
+
+The SDK never installs `@mastra/observability` for you. When it's missing and you configured no pipeline, the SDK logs a warning at startup and creates no Mastra spans.
+
+To customize what data is captured (such as inputs and outputs), see the [Options](#options) in the Configuration section.
+
+### Migrating From the Community Exporter
+
+The community `@mastra/sentry` exporter is no longer needed — remove it from your Mastra `exporters` and uninstall the package:
+
+```typescript {filename:src/mastra/index.ts} {diff}
+ import { Mastra } from "@mastra/core";
+-import { Observability } from "@mastra/observability";
+-import { SentryExporter } from "@mastra/sentry";
+
+ export const mastra = new Mastra({
+   agents: { weatherAgent },
+-  observability: new Observability({
+-    configs: {
+-      sentry: {
+-        serviceName: "my-mastra-app",
+-        exporters: [new SentryExporter()],
+-      },
+-    },
+-  }),
+ });
+```
+
+`@mastra/sentry` calls `Sentry.init()` itself. Leaving it in place alongside the SDK either replaces the client configured in your `Sentry.init()` — losing your release, environment, integrations, and sampling — or starts a second, independent SDK whose events never reach the first one. The SDK detects the community exporter and warns about it, but can't remove it, because Mastra's exporter API is add-only.
+
+## Manual Instrumentation
+
+_Import name: `Sentry.SentryMastraExporter`_
+
+Register `SentryMastraExporter` yourself when the SDK can't hook the `Mastra` constructor — most often because Mastra is bundled into your server build:
+
+```typescript {filename:src/mastra/index.ts}
+import { SentryMastraExporter } from "___SDK_PACKAGE___";
+import { Mastra } from "@mastra/core";
+import { Observability } from "@mastra/observability";
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "my-mastra-app",
+        exporters: [new SentryMastraExporter()],
+      },
+    },
+  }),
+});
+```
+
+The exporter reports to the client you set up in `Sentry.init()` — it doesn't initialize or close Sentry on its own, so your normal SDK setup still applies. It's also safe to leave automatic instrumentation enabled: the SDK recognizes an exporter you registered yourself and won't add a second one.
+
+To customize what data is captured (such as inputs and outputs), see the [Options](#options) in the Configuration section.
 
 ## Configuration
 
-### Configure With Environment Variables
+### Options
 
-The Sentry exporter can automatically read configuration from environment variables (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`):
+The following options control what data is captured from Mastra operations:
+
+#### `recordInputs`
+
+_Type: `boolean` (optional)_
+
+Records inputs to Mastra operations (agent prompts, system instructions, model messages, and tool call arguments).
+
+Defaults to `true` if `dataCollection.genAI.inputs` is `true` (which is the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`.
+
+#### `recordOutputs`
+
+_Type: `boolean` (optional)_
+
+Records outputs from Mastra operations (model responses, agent output, and tool call results).
+
+Defaults to `true` if `dataCollection.genAI.outputs` is `true` (which is the default when using `dataCollection`), or if the deprecated `sendDefaultPii` is `true`.
+
+#### `bootstrapObservability`
+
+_Type: `boolean` (optional)_
+
+Whether to construct a Mastra observability pipeline when your app hasn't configured one. Defaults to `true`. Set it to `false` to leave apps that opted out of Mastra telemetry untouched — the SDK then only attaches its exporter to an `Observability` you pass to the `Mastra` constructor yourself.
+
+This option applies to automatic instrumentation only; it uses an `@mastra/observability` your app already has and never installs one.
+
+**Usage**
+
+Using the `mastraIntegration` integration for **automatic instrumentation**:
 
 ```javascript
-import { Mastra } from "@mastra/core";
-import { Observability } from "@mastra/observability";
-import { SentryExporter } from "@mastra/sentry";
-
-export const mastra = new Mastra({
-  observability: new Observability({
-    configs: {
-      sentry: {
-        serviceName: "my-service",
-        exporters: [new SentryExporter()],
-      },
-    },
-  }),
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // Tracing must be enabled for agent tracing to work
+  tracesSampleRate: 1.0,
+  integrations: [
+    Sentry.mastraIntegration({
+      // your options here
+    }),
+  ],
 });
 ```
 
-### Explicit Configuration
-
-You can also pass configuration directly:
+Using the `SentryMastraExporter` for **manual instrumentation**:
 
 ```javascript
-import { Mastra } from "@mastra/core";
-import { Observability } from "@mastra/observability";
-import { SentryExporter } from "@mastra/sentry";
-
-export const mastra = new Mastra({
-  observability: new Observability({
-    configs: {
-      sentry: {
-        serviceName: "my-service",
-        exporters: [
-          new SentryExporter({
-            dsn: process.env.SENTRY_DSN,
-            environment: "production",
-            tracesSampleRate: 1.0,
-          }),
-        ],
-      },
-    },
-  }),
+new SentryMastraExporter({
+  // your options here
 });
 ```
 
-<Expandable title="Span Mapping">
-
-Mastra automatically maps its span types to Sentry operations for proper visualization in Sentry's AI monitoring dashboards:
-
-| Mastra Span Type       | Sentry Operation       |
-| ---------------------- | ---------------------- |
-| `AGENT_RUN`            | `gen_ai.invoke_agent`  |
-| `MODEL_GENERATION`     | `gen_ai.chat`          |
-| `TOOL_CALL`            | `gen_ai.execute_tool`  |
-| `MCP_TOOL_CALL`        | `gen_ai.execute_tool`  |
-| `WORKFLOW_RUN`         | `workflow.run`         |
-| `WORKFLOW_STEP`        | `workflow.step`        |
-| `WORKFLOW_CONDITIONAL` | `workflow.conditional` |
-| `WORKFLOW_PARALLEL`    | `workflow.parallel`    |
-| `WORKFLOW_LOOP`        | `workflow.loop`        |
-| `PROCESSOR_RUN`        | `ai.processor`         |
-| `GENERIC`              | `ai.span`              |
-
-**Note:** `MODEL_STEP` and `MODEL_CHUNK` spans are automatically skipped to simplify trace hierarchy. Their data is aggregated into parent `MODEL_GENERATION` spans.
-
-</Expandable>
-
-<Expandable title="Captured Data">
-
-The Sentry exporter captures comprehensive trace data following OpenTelemetry semantic conventions:
-
-#### Common Attributes (All spans)
-
-- `sentry.origin`: `auto.ai.mastra` (identifies spans from Mastra)
-- `ai.span.type`: Mastra span type
-
-#### Model Generation Spans
-
-- `gen_ai.operation.name`: Operation name (e.g., `chat`)
-- `gen_ai.system`: Model provider (e.g., OpenAI, Anthropic)
-- `gen_ai.request.model`: Model identifier
-- `gen_ai.request.messages`: Input messages/prompts (JSON)
-- `gen_ai.response.model`: Response model
-- `gen_ai.response.text`: Output text
-- `gen_ai.response.tool_calls`: Tool calls made during generation
-- `gen_ai.usage.input_tokens`: Input token count
-- `gen_ai.usage.output_tokens`: Output token count
-- `gen_ai.usage.total_tokens`: Total tokens used
-- `gen_ai.request.stream`: Whether streaming was used
-- `gen_ai.request.temperature`: Temperature parameter
-- `gen_ai.completion_start_time`: Time to first token
-
-#### Tool Call Spans
-
-- `gen_ai.operation.name`: `execute_tool`
-- `gen_ai.tool.name`: Tool identifier
-- `gen_ai.tool.type`: `function`
-- `gen_ai.tool.call.id`: Tool call ID
-- `gen_ai.tool.input`: Tool input parameters
-- `gen_ai.tool.output`: Tool output result
-- `tool.success`: Success flag
-
-#### Agent Run Spans
-
-- `gen_ai.operation.name`: `invoke_agent`
-- `gen_ai.agent.name`: Agent identifier
-- `gen_ai.pipeline.name`: Agent name
-- `gen_ai.agent.instructions`: Agent instructions/system prompt
-- `gen_ai.response.model`: Model from child generation
-- `gen_ai.response.text`: Output from child generation
-- `gen_ai.usage.*`: Token usage aggregated from child spans
-
-</Expandable>
-
-## Methods
-
-### `exportTracingEvent()`
-
-Exports a tracing event to Sentry. Handles `SPAN_STARTED`, `SPAN_UPDATED`, and `SPAN_ENDED` events.
+To turn off automatic instrumentation entirely, filter the integration out of the defaults:
 
 ```javascript
-await exporter.exportTracingEvent(event);
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  defaultIntegrations: (integrations) =>
+    integrations.filter((integration) => integration.name !== "Mastra"),
+});
 ```
 
-### `flush()`
+## Supported Operations
 
-Force flushes any pending spans to Sentry without shutting down the exporter. Waits up to 2 seconds for pending data to be sent. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+Mastra span types are mapped onto the `gen_ai` conventions the Agents dashboards read:
 
-```javascript
-await exporter.flush();
-```
+| Mastra Span Type     | Sentry Operation      |
+| -------------------- | --------------------- |
+| `agent_run`          | `gen_ai.invoke_agent` |
+| `workflow_run`       | `gen_ai.invoke_agent` |
+| `model_generation`   | `gen_ai.chat`         |
+| `tool_call`          | `gen_ai.execute_tool` |
+| `mcp_tool_call`      | `gen_ai.execute_tool` |
+| `provider_tool_call` | `gen_ai.execute_tool` |
+| `client_tool_call`   | `gen_ai.execute_tool` |
+| `rag_embedding`      | `gen_ai.embeddings`   |
 
-### `shutdown()`
+Span types with no conventional `gen_ai` equivalent — workflow steps, processors, scorers, and Mastra's internal `model_step` and `model_inference` spans — are dropped, and their children are re-parented onto the nearest exported ancestor. This keeps the trace readable: `model_inference` in particular repeats its parent `model_generation`, which would otherwise show every model call twice.
 
-Ends all active spans, clears internal state, and closes the Sentry connection. Waits up to 2 seconds for pending data to be sent.
+Spans carry `sentry.origin: auto.ai.mastra`. Token usage from model generations is summed onto the agent or workflow span, so a multi-step run reports its total cost in one place.
 
-```javascript
-await exporter.shutdown();
-```
-
-## Learn More
-
-For a standalone setup walkthrough, see the [Sentry guide for Mastra](/platforms/javascript/guides/mastra/). For complete exporter documentation, see the [Mastra Sentry Exporter documentation](https://mastra.ai/integrations/observability/sentry).
+Mastra's conversation ID — or, when that's absent, its `metadata.threadId` — is recorded as `gen_ai.conversation.id`, which groups multi-turn chats in [Conversations](/product/agents/conversations/).
 
 ## Supported Versions
 
-- `@mastra/sentry`: `>=1.0.0`
-- Node.js: `>=22.13.0`
+- `@mastra/core`: `>=1.63.2 <2.0.0`
+- `@mastra/observability`: `>=1.17.4`
+- Node.js: `>=22.13.0` (required by `@mastra/core`)

--- a/docs/platforms/javascript/common/agent-tracing/mastra.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/mastra.mdx
@@ -26,20 +26,11 @@ supported:
 
 [Mastra](https://mastra.ai/) is a TypeScript framework for building AI agents and workflows. The Sentry SDK captures agent runs, model generations, and tool calls as `gen_ai` spans, so Mastra activity shows up in the [Agents](/product/agents/) dashboards next to the rest of your traces.
 
-<PlatformSection
-  supported={[
-    "javascript.nextjs",
-    "javascript.nuxt",
-    "javascript.solidstart",
-    "javascript.sveltekit",
-    "javascript.remix",
-    "javascript.astro",
-    "javascript.tanstackstart-react",
-  ]}
->
+<PlatformSection supported={["javascript.nextjs"]}>
   <Alert level="warning">
-    In meta-frameworks, Mastra is usually bundled into the server build, which
-    the SDK can't hook at runtime. Register the exporter yourself using
+    With Turbopack, automatic instrumentation requires **Next.js 16 or newer**.
+    On Next.js 15, `next build --turbopack` skips the build-time transform that
+    hooks Mastra, and no spans are created. Build with webpack instead, or use
     [**Manual Instrumentation**](#manual-instrumentation).
   </Alert>
 </PlatformSection>
@@ -49,6 +40,8 @@ supported:
 _Import name: `Sentry.mastraIntegration`_
 
 The `mastraIntegration` hooks the [`@mastra/core`](https://www.npmjs.com/package/@mastra/core) `Mastra` constructor and registers a Sentry exporter on Mastra's observability pipeline. In Node.js runtimes it's enabled by default (requires Sentry SDK version `11.0.0` or higher).
+
+This works whether Mastra is loaded from `node_modules` at runtime or bundled into a server build: in meta-frameworks the SDK's build-time code transform rewrites `@mastra/core` as it's bundled. Setting `buildTimeInstrumentation: false` in your framework's Sentry build options turns that transform off, and with it automatic Mastra instrumentation.
 
 Mastra routes telemetry through `@mastra/observability`, which `@mastra/core` doesn't depend on. Install it, or Mastra produces no spans for the SDK to export:
 
@@ -125,7 +118,7 @@ The community `@mastra/sentry` exporter is no longer needed — remove it from y
 
 _Import name: `Sentry.SentryMastraExporter`_
 
-Register `SentryMastraExporter` yourself when the SDK can't hook the `Mastra` constructor — most often because Mastra is bundled into your server build:
+Register `SentryMastraExporter` yourself when the build-time transform doesn't run — on Next.js 15 with Turbopack, or when you've set `buildTimeInstrumentation: false`:
 
 ```typescript {filename:src/mastra/index.ts}
 import { SentryMastraExporter } from "___SDK_PACKAGE___";

--- a/docs/platforms/javascript/common/agent-tracing/mastra.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/mastra.mdx
@@ -30,9 +30,11 @@ supported:
   <Alert level="warning">
     With Turbopack, automatic instrumentation requires **Next.js 16 or newer**.
     Scoping the transform to your server build relies on Turbopack's rule
-    `condition` field, which Next.js 15 doesn't support, so on Next.js 15 the
-    SDK skips it and Mastra produces no spans under `--turbopack` (in `dev` or
-    `build`). Use webpack instead, or [**Manual
+    `condition` field, which earlier versions don't support, so on Next.js 14
+    and 15 the SDK skips it and Mastra produces no spans under `--turbopack` (or
+    `--turbo`), in `dev` as well as `build`. Note that this can differ between
+    environments: a `dev` server on Turbopack produces no spans while a webpack
+    production build of the same app works. Build with webpack, or use [**Manual
     Instrumentation**](#manual-instrumentation).
   </Alert>
 </PlatformSection>

--- a/docs/platforms/javascript/guides/mastra/index.mdx
+++ b/docs/platforms/javascript/guides/mastra/index.mdx
@@ -14,81 +14,119 @@ keywords:
   - agent tracing
 ---
 
-[Mastra](https://mastra.ai/) is a TypeScript framework for building AI applications and agents. This guide configures Mastra's `@mastra/sentry` exporter to send agent runs, model generations, tool calls, and workflows to [Sentry Agent Tracing](/product/agents/).
+[Mastra](https://mastra.ai/) is a TypeScript framework for building AI applications and agents. This guide sets up the Sentry Node.js SDK in a Mastra app so agent runs, model generations, tool calls, and workflows show up in [Sentry Agent Tracing](/product/agents/).
 
-The exporter uses `@sentry/node` internally, so it can send Mastra telemetry directly to a Sentry project without another Sentry SDK.
+Mastra support is built into `@sentry/node` and is on by default — you don't need a separate exporter package.
+
+<Alert title="Already using @mastra/sentry?">
+
+The community `@mastra/sentry` exporter is no longer needed. Follow this guide, then remove `SentryExporter` from your Mastra `exporters` and uninstall `@mastra/sentry`. See [Migrating From the Community Exporter](/platforms/javascript/guides/node/agent-tracing/mastra/#migrating-from-the-community-exporter) for why leaving both in place breaks your Sentry configuration.
+
+</Alert>
 
 ## Prerequisites
 
 Before you begin, you need:
 
-- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/). The project's DSN tells the exporter where to send data.
-- A Mastra application using `@mastra/core`.
-- Node.js 22.13.0 or newer. The Mastra Sentry exporter does not support browser or edge runtimes.
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/). The project's DSN tells the SDK where to send data.
+- A Mastra application using `@mastra/core` 1.63.2 or newer.
+- Node.js 22.13.0 or newer, as required by `@mastra/core`. Mastra tracing isn't supported in browser or edge runtimes.
 
 <StepConnector selector="h2" showNumbers={true}>
 
 ## Install
 
-Install the Mastra Sentry exporter and observability packages:
+Install the Sentry SDK and Mastra's observability package:
 
 ```bash {tabTitle:npm}
-npm install @mastra/sentry@latest @mastra/observability@latest
+npm install @sentry/node @mastra/observability
 ```
 
 ```bash {tabTitle:yarn}
-yarn add @mastra/sentry@latest @mastra/observability@latest
+yarn add @sentry/node @mastra/observability
 ```
 
 ```bash {tabTitle:pnpm}
-pnpm add @mastra/sentry@latest @mastra/observability@latest
+pnpm add @sentry/node @mastra/observability
 ```
 
-You don't need to install or initialize `@sentry/node` separately for this setup. The exporter includes it as a dependency and initializes it for you.
+Mastra routes all telemetry through `@mastra/observability`, which `@mastra/core` doesn't depend on. Without it, Mastra emits nothing for Sentry to export.
 
 ## Configure
 
-Add your Sentry DSN to the environment. You can find it in **Project Settings > Client Keys (DSN)**.
+### Initialize the Sentry SDK
 
-```bash {filename:.env}
-SENTRY_DSN=___PUBLIC_DSN___
+Create a file named `instrument.mjs` in the root directory of your project:
+
+```javascript {filename:instrument.mjs}
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  // Tracing must be enabled for agent tracing to work
+  tracesSampleRate: 1.0,
+  // Send prompts, responses, and tool arguments to Sentry
+  dataCollection: {},
+});
 ```
 
-Add the Sentry exporter to your Mastra observability configuration:
+Mastra sends agent data to Sentry as traces, so keep `tracesSampleRate` above `0`. The example sends every trace so you can verify the setup; lower the value in production if needed.
+
+`dataCollection: {}` opts into Sentry's permissive defaults, which include generative AI prompts and responses. To keep that content out of Sentry, set `dataCollection: { genAI: { inputs: false, outputs: false } }` instead. See [`dataCollection`](/platforms/javascript/guides/node/configuration/options/#dataCollection) for the full list of what it covers.
+
+### Apply Instrumentation to Your App
+
+<Alert level="warning">
+
+Import `instrument.mjs` before any other modules. Sentry hooks Mastra as `@mastra/core` loads, so initializing later means no agent spans.
+
+</Alert>
+
+Use the [`--import`](https://nodejs.org/api/cli.html#--importmodule) flag to load the file before your application starts:
+
+```bash
+node --import ./instrument.mjs src/index.mjs
+```
+
+If your project is CommonJS, name the file `instrument.js` and require it as the first line of your entry point instead:
+
+```javascript {filename:index.js}
+require("./instrument.js");
+```
+
+For other setups — bundlers, `ts-node`, or frameworks with their own entry point — see [alternative installation methods](/platforms/javascript/guides/node/install/).
+
+### Configure Mastra
+
+Nothing to do. Sentry builds Mastra's observability pipeline from the `@mastra/observability` you installed and registers its own exporter on it:
+
+```typescript {filename:src/mastra/index.ts}
+import { Mastra } from "@mastra/core";
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+  workflows: { weatherWorkflow },
+});
+```
+
+If you already configure `Observability` yourself — to send Mastra telemetry to another backend as well — keep your configuration as it is. Sentry adds its exporter alongside yours:
 
 ```typescript {filename:src/mastra/index.ts}
 import { Mastra } from "@mastra/core";
 import { Observability } from "@mastra/observability";
-import { SentryExporter } from "@mastra/sentry";
 
 export const mastra = new Mastra({
-  // agents, workflows, ...
+  agents: { weatherAgent },
   observability: new Observability({
     configs: {
-      sentry: {
-        serviceName: "my-mastra-service",
-        exporters: [
-          new SentryExporter({
-            tracesSampleRate: 1.0,
-          }),
-        ],
+      default: {
+        serviceName: "my-mastra-app",
+        exporters: [myOtherExporter],
       },
     },
   }),
 });
 ```
-
-Mastra sends agent data to Sentry as traces. Keep `tracesSampleRate` above `0` to enable tracing. The example sends every trace so you can verify the setup; lower the value in production if needed.
-
-The exporter also reads `SENTRY_ENVIRONMENT` and `SENTRY_RELEASE` when those environment variables are set. You can instead pass `dsn`, `environment`, and `release` directly to `SentryExporter`.
-
-<Alert title="Using Mastra With a Framework or Different Runtime?">
-
-This setup covers telemetry produced by Mastra. If a frontend or another service communicates with a separate Mastra server, configure that application with its own [JavaScript framework guide](/platforms/javascript/) and use this guide for the Mastra service.
-
-`@mastra/sentry` initializes `@sentry/node` internally. If Mastra runs in the same process as an application that already calls `Sentry.init()`, don't initialize Sentry a second time without first confirming that the two SDK setups are compatible.
-
-</Alert>
 
 ## Verify
 
@@ -96,38 +134,36 @@ Run one of your Mastra agents, then open the **Agents** page in your Sentry proj
 
 If no data appears, confirm that:
 
-- `SENTRY_DSN` belongs to the Sentry project you're viewing.
-- `tracesSampleRate` is greater than `0`.
-- Your application completed at least one agent run after you added the exporter.
+- Sentry initialized before `@mastra/core` loaded (check for a `--import ./instrument.mjs` flag, or a `require("./instrument.js")` on the first line of your entry point).
+- `@mastra/observability` is installed. If it's missing, the SDK logs a warning at startup saying it can't create Mastra spans.
+- `tracesSampleRate` is greater than `0`, and the DSN belongs to the project you're viewing.
+- Your application completed at least one agent run after you added the SDK.
 
 ## Next Steps
 
 - [Name your agents](/product/agents/naming/) so you can identify them in the Agents Dashboard.
-- Add a stable thread ID to group multi-turn chats in [Conversations](/product/agents/conversations/). Mastra maps `metadata.threadId` to `gen_ai.conversation.id`.
-- Review the [Mastra Sentry exporter reference](https://mastra.ai/integrations/observability/sentry).
-- Use the appropriate [JavaScript framework guide](/platforms/javascript/) for application monitoring in a separate frontend or service.
+- Pass a `threadId` on your Mastra calls to group multi-turn chats in [Conversations](/product/agents/conversations/). Sentry records Mastra's conversation or thread ID as `gen_ai.conversation.id`.
+- Read the [Mastra integration reference](/platforms/javascript/guides/node/agent-tracing/mastra/) for the full span mapping and the `recordInputs` / `recordOutputs` options.
+- Finish setting up the [Node.js SDK](/platforms/javascript/guides/node/) for errors, logs, and the rest of your application's traces.
 
 <Expandable permalink={false} title="What gets captured?">
 
-Mastra maps its span types to Sentry operations for the Agents dashboards:
+Mastra span types are mapped onto the `gen_ai` conventions the Agents dashboards read:
 
-| Mastra Span Type       | Sentry Operation       |
-| ---------------------- | ---------------------- |
-| `AGENT_RUN`            | `gen_ai.invoke_agent`  |
-| `MODEL_GENERATION`     | `gen_ai.chat`          |
-| `TOOL_CALL`            | `gen_ai.execute_tool`  |
-| `MCP_TOOL_CALL`        | `gen_ai.execute_tool`  |
-| `WORKFLOW_RUN`         | `workflow.run`         |
-| `WORKFLOW_STEP`        | `workflow.step`        |
-| `WORKFLOW_CONDITIONAL` | `workflow.conditional` |
-| `WORKFLOW_PARALLEL`    | `workflow.parallel`    |
-| `WORKFLOW_LOOP`        | `workflow.loop`        |
-| `PROCESSOR_RUN`        | `ai.processor`         |
-| `GENERIC`              | `ai.span`              |
+| Mastra Span Type     | Sentry Operation      |
+| -------------------- | --------------------- |
+| `agent_run`          | `gen_ai.invoke_agent` |
+| `workflow_run`       | `gen_ai.invoke_agent` |
+| `model_generation`   | `gen_ai.chat`         |
+| `tool_call`          | `gen_ai.execute_tool` |
+| `mcp_tool_call`      | `gen_ai.execute_tool` |
+| `provider_tool_call` | `gen_ai.execute_tool` |
+| `client_tool_call`   | `gen_ai.execute_tool` |
+| `rag_embedding`      | `gen_ai.embeddings`   |
 
-`MODEL_STEP` and `MODEL_CHUNK` spans are skipped. Their data is aggregated into parent `MODEL_GENERATION` spans.
+Span types with no conventional `gen_ai` equivalent — workflow steps, processors, scorers, and Mastra's internal model steps — are dropped, and their children are re-parented onto the nearest exported ancestor.
 
-Spans are tagged with `sentry.origin: auto.ai.mastra`.
+Spans carry `sentry.origin: auto.ai.mastra`. Token usage from model generations is summed onto the agent or workflow span, so a multi-step run reports its total cost in one place.
 
 </Expandable>
 
@@ -135,5 +171,7 @@ Spans are tagged with `sentry.origin: auto.ai.mastra`.
 
 ## Supported Versions
 
-- `@mastra/sentry`: `>=1.0.0`
+- `@sentry/node`: `>=11.0.0`
+- `@mastra/core`: `>=1.63.2 <2.0.0`
+- `@mastra/observability`: `>=1.17.4`
 - Node.js: `>=22.13.0`

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -169,7 +169,7 @@ export async function Home() {
             <AgentQuickLink
               to="/agent-tracing/mastra/"
               title="Mastra"
-              desc="Export Mastra AI tracing to Sentry."
+              desc="Trace Mastra agents, workflows, and tool calls."
               icon={<PlatformIcon platform="mastra" />}
             />
             <AgentQuickLink


### PR DESCRIPTION
## DESCRIBE YOUR PR

The JavaScript SDK now instruments Mastra natively ([sentry-javascript#23823](https://github.com/getsentry/sentry-javascript/pull/23823)). `mastraIntegration` is a default integration in Node runtimes and registers a Sentry exporter on Mastra's observability pipeline. Both Mastra docs pages still described the community `@mastra/sentry` exporter, which calls `Sentry.init()` itself, so this replaces them.

**`/platforms/javascript/guides/node/agent-tracing/mastra/`**

- Restructured to the LangGraph/LangChain integration-page pattern: Automatic Instrumentation, Manual Instrumentation, Configuration/Options, Supported Operations, Supported Versions.
- Automatic setup is now just installing `@mastra/observability` — the SDK bootstraps the pipeline when the app configured none, and attaches its exporter to an existing `Observability` when it did.
- Added `SentryMastraExporter` as the manual escape hatch for bundled server builds, with a `<PlatformSection>` warning on the meta-framework guides.
- Corrected the span mapping table to what the SDK actually emits. The old table listed `workflow.run`, `workflow.step`, `ai.processor` and `ai.span`, none of which are produced; added `provider_tool_call`, `client_tool_call` and `rag_embedding`, and explained why unmapped types are dropped and their children re-parented.
- Documented `recordInputs`, `recordOutputs` and `bootstrapObservability`, plus how to disable the integration.
- Added a migration section: why leaving `@mastra/sentry` in place either replaces the configured client (losing release, environment, integrations, sampling) or starts a second SDK.

**`/platforms/javascript/guides/mastra/`**

- Rewritten as a `@sentry/node` setup guide instead of a standalone-exporter walkthrough: install `@sentry/node` + `@mastra/observability`, `instrument.mjs` with `--import`, then nothing to change on the Mastra side. Same URL and `StepConnector` structure.

**Also**

- Updated the Mastra card copy on the home page (`src/components/home.tsx`).

 Note: both pages cite Sentry SDK `11.0.0` as the minimum. This should go with v11 release. 

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy8ky8AVsY8dxgUNzWQMMT
