### PR TITLE
docs: De-duplicate Troubleshooting and Custom Instrumentation page titles

### DIFF
--- a/docs/platforms/android/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/android/profiling/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Profiling Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/android/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/android/profiling/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Profiling Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/android/session-replay/troubleshooting.mdx
+++ b/docs/platforms/android/session-replay/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Session Replay Troubleshooting"
 sidebar_order: 5503
 notSupported:
 description: "Troubleshooting issues with Session Replay"

--- a/docs/platforms/android/session-replay/troubleshooting.mdx
+++ b/docs/platforms/android/session-replay/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Session Replay Troubleshooting"
+sidebar_title: "Troubleshooting"
 sidebar_order: 5503
 notSupported:
 description: "Troubleshooting issues with Session Replay"

--- a/docs/platforms/android/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/android/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/android/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/android/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/android/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/android/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/apple/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/profiling/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Profiling Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/apple/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/apple/common/profiling/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Profiling Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/apple/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/apple/common/session-replay/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Session Replay Troubleshooting"
 sidebar_order: 5504
 description: "Troubleshoot and resolve common issues with the iOS Session Replay."
 notSupported:

--- a/docs/platforms/apple/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/apple/common/session-replay/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Session Replay Troubleshooting"
+sidebar_title: "Troubleshooting"
 sidebar_order: 5504
 description: "Troubleshoot and resolve common issues with the iOS Session Replay."
 notSupported:

--- a/docs/platforms/dart/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/dart/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/dart/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/dart/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/dart/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/dart/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/dart/guides/flutter/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/dart/guides/flutter/profiling/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Profiling Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/dart/guides/flutter/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/dart/guides/flutter/profiling/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Profiling Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Profiling Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 notSupported:

--- a/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/dotnet/common/profiling/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Profiling Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 notSupported:

--- a/docs/platforms/dotnet/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/dotnet/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/dotnet/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/dotnet/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/dotnet/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/dotnet/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/dotnet/guides/aspnet/tracing/troubleshooting.mdx
+++ b/docs/platforms/dotnet/guides/aspnet/tracing/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 sidebar_order: 9000
 description: "Learn more about how to troubleshoot performance issues with the ASP.NET SDK."
 ---

--- a/docs/platforms/dotnet/guides/aspnet/tracing/troubleshooting.mdx
+++ b/docs/platforms/dotnet/guides/aspnet/tracing/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 sidebar_order: 9000
 description: "Learn more about how to troubleshoot performance issues with the ASP.NET SDK."
 ---

--- a/docs/platforms/elixir/crons/troubleshooting.mdx
+++ b/docs/platforms/elixir/crons/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Crons Troubleshooting"
 description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/elixir/crons/troubleshooting.mdx
+++ b/docs/platforms/elixir/crons/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Crons Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/go/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/go/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/go/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/go/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/go/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/go/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/go/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/go/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/go/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/go/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/java/common/crons/troubleshooting.mdx
+++ b/docs/platforms/java/common/crons/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Crons Troubleshooting"
 description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/java/common/crons/troubleshooting.mdx
+++ b/docs/platforms/java/common/crons/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Crons Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/java/common/opentelemetry/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/opentelemetry/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "OpenTelemetry Troubleshooting"
 sdk: sentry.java.opentelemetry-agentless
 description: "Troubleshoot Java OpenTelemetry problems."
 sidebar_order: 400

--- a/docs/platforms/java/common/opentelemetry/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/opentelemetry/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OpenTelemetry Troubleshooting"
+sidebar_title: "Troubleshooting"
 sdk: sentry.java.opentelemetry-agentless
 description: "Troubleshoot Java OpenTelemetry problems."
 sidebar_order: 400

--- a/docs/platforms/java/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/java/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/java/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/java/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/java/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/java/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/java/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/java/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/java/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/javascript/common/crons/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/crons/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Crons Troubleshooting"
 description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 9000
 supported:

--- a/docs/platforms/javascript/common/crons/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/crons/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Crons Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your Cron Monitoring setup."
 sidebar_order: 9000
 supported:

--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Session Replay Troubleshooting"
+sidebar_title: "Troubleshooting"
 sidebar_order: 9000
 notSupported:
   - javascript.cordova

--- a/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
+++ b/docs/platforms/javascript/common/session-replay/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Session Replay Troubleshooting"
 sidebar_order: 9000
 notSupported:
   - javascript.cordova

--- a/docs/platforms/javascript/common/tracing/distributed-tracing/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/distributed-tracing/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Trace Propagation
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 notSupported:
   - javascript.cordova

--- a/docs/platforms/javascript/common/tracing/distributed-tracing/custom-instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/distributed-tracing/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 notSupported:
   - javascript.cordova

--- a/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/index.mdx
@@ -163,7 +163,7 @@ See <PlatformLink to="/apis/#tracing-utilities">Tracing Utility APIs</PlatformLi
 <PlatformSection notSupported={['javascript.cordova']}>
 ## Distributed Tracing
 
-See <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">Custom Trace Propagation</PlatformLink> for details on how to manually set up distributed tracing.
+See <PlatformLink to="/tracing/trace-propagation/custom-instrumentation/">custom instrumentation</PlatformLink> for details on how to manually set up distributed tracing.
 
 </PlatformSection>
 

--- a/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/javascript/common/tracing/streamed-spans/index.mdx
@@ -437,7 +437,7 @@ If you're auto-instrumenting and don't know what the initial name of a span is w
 ## Distributed Tracing (Optional)
 
 Distributed tracing works out of the box when tracing is enabled and works the same way in stream mode. If you need to manually propagate trace context, for example,
-when the SDK can't instrument automatically, see <PlatformLink to="/tracing/distributed-tracing/custom-instrumentation/">Custom Trace Propagation</PlatformLink>.
+when the SDK can't instrument automatically, see <PlatformLink to="/tracing/distributed-tracing/custom-instrumentation/">custom instrumentation for distributed tracing</PlatformLink>.
 
 ## Verify Your Setup
 

--- a/docs/platforms/javascript/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/javascript/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/native/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/native/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/native/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/native/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/native/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/native/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/php/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/php/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/php/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/php/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/php/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/php/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/powershell/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/powershell/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/powershell/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/powershell/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/python/tracing/distributed-tracing/custom-trace-propagation/index.mdx
+++ b/docs/platforms/python/tracing/distributed-tracing/custom-trace-propagation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 10
 ---
 

--- a/docs/platforms/python/tracing/distributed-tracing/custom-trace-propagation/index.mdx
+++ b/docs/platforms/python/tracing/distributed-tracing/custom-trace-propagation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Trace Propagation
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 10
 ---
 

--- a/docs/platforms/python/tracing/streamed-spans/index.mdx
+++ b/docs/platforms/python/tracing/streamed-spans/index.mdx
@@ -306,7 +306,7 @@ with sentry_sdk.traces.start_span(name="span in trace 2"):
 </SplitSection>
 </SplitLayout>
 
-See <PlatformLink to="/tracing/distributed-tracing/custom-trace-propagation/">Custom Trace Propagation</PlatformLink> for more information on distributed tracing.
+See <PlatformLink to="/tracing/distributed-tracing/custom-trace-propagation/">custom instrumentation</PlatformLink> for more information on distributed tracing.
 
 ## Extended Configuration (Optional)
 

--- a/docs/platforms/python/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/python/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 60
 ---

--- a/docs/platforms/python/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/python/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 60
 ---

--- a/docs/platforms/react-native/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/common/profiling/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Profiling Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/react-native/common/profiling/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/common/profiling/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Profiling Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your profiling setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/react-native/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Tracing Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/react-native/common/tracing/troubleshooting/index.mdx
+++ b/docs/platforms/react-native/common/tracing/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tracing Troubleshooting"
+sidebar_title: "Troubleshooting"
 description: "Learn how to troubleshoot your tracing setup."
 sidebar_order: 9000
 ---

--- a/docs/platforms/ruby/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/ruby/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/ruby/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/ruby/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/ruby/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/ruby/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/rust/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/rust/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/rust/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/rust/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/rust/common/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/rust/common/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/unity/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/unity/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/unity/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/unity/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/unity/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/unity/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/unreal/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/unreal/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Instrumentation
+title: "Custom Trace Propagation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/unreal/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/unreal/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Instrumentation for Distributed Tracing"
+sidebar_title: "Custom Instrumentation"
 sidebar_order: 40
 ---
 

--- a/docs/platforms/unreal/tracing/trace-propagation/custom-instrumentation/index.mdx
+++ b/docs/platforms/unreal/tracing/trace-propagation/custom-instrumentation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Trace Propagation"
+title: "Custom Instrumentation for Distributed Tracing"
 sidebar_order: 40
 ---
 

--- a/docs/product/monitors-and-alerts/monitors/crons/troubleshooting.mdx
+++ b/docs/product/monitors-and-alerts/monitors/crons/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Crons Troubleshooting"
+sidebar_title: "Troubleshooting"
 sidebar_order: 3
 description: "Troubleshoot common issues with cron monitoring."
 ---

--- a/docs/product/monitors-and-alerts/monitors/crons/troubleshooting.mdx
+++ b/docs/product/monitors-and-alerts/monitors/crons/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Crons Troubleshooting"
 sidebar_order: 3
 description: "Troubleshoot common issues with cron monitoring."
 ---

--- a/docs/product/monitors-and-alerts/monitors/uptime-monitoring/troubleshooting.mdx
+++ b/docs/product/monitors-and-alerts/monitors/uptime-monitoring/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Uptime Monitoring Troubleshooting"
+sidebar_title: "Troubleshooting"
 sidebar_order: 53
 description: "Learn how to troubleshoot potential Uptime Monitoring problems."
 ---

--- a/docs/product/monitors-and-alerts/monitors/uptime-monitoring/troubleshooting.mdx
+++ b/docs/product/monitors-and-alerts/monitors/uptime-monitoring/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: "Uptime Monitoring Troubleshooting"
 sidebar_order: 53
 description: "Learn how to troubleshoot potential Uptime Monitoring problems."
 ---


### PR DESCRIPTION
## DESCRIBE YOUR PR

De-duplicates page titles that collide in the rendered `<title>` tag. Two systematic families where multiple pages on the same platform rendered an identical title (e.g. Java had four pages all showing `Troubleshooting | Sentry for Java`):

- **Troubleshooting family** — section-specific troubleshooting pages now carry their section name (Tracing Troubleshooting, Crons Troubleshooting, Profiling Troubleshooting, Session Replay Troubleshooting, OpenTelemetry Troubleshooting, Uptime Monitoring Troubleshooting). Each platform's top-level "Troubleshooting" page is unchanged.
- **Custom Instrumentation family** — the `tracing/trace-propagation/custom-instrumentation` pages are renamed to "Custom Trace Propagation" to distinguish them from the performance-oriented `tracing/instrumentation/custom-instrumentation` pages.

Covers 33 pages. Note: the site already appends `| Sentry for {Platform}` to platform page titles, so cross-platform repeats (e.g. "Configuration") are already unique and were intentionally left alone; this PR only targets genuine within-platform collisions.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
