### PR TITLE
docs(deno): update minimum Deno version to 2.8.3

### DIFF
--- a/platform-includes/getting-started-prerequisites/javascript.deno.mdx
+++ b/platform-includes/getting-started-prerequisites/javascript.deno.mdx
@@ -4,4 +4,4 @@ You need:
 
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - Your application up and running
-- Deno version >= `2.0.0`
+- Deno version >= `2.8.3`


### PR DESCRIPTION
## DESCRIBE YOUR PR

Raise the documented Deno minimum version to 2.8.3 for the Sentry JavaScript SDK v11.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
