### PR TITLE
docs(browser): drop Safari 14 from supported browsers

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/supported-browsers.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/supported-browsers.mdx
@@ -22,7 +22,7 @@ Sentry's latest JavaScript SDKs require ES2020 compatibility. The minimum suppor
 
 - Chrome 80
 - Edge 80
-- Safari 14, iOS Safari 14.4
+- Safari 15, iOS Safari 15
 - Firefox 74
 - Opera 67
 - Samsung Internet 13.0


### PR DESCRIPTION
## DESCRIBE YOUR PR

Raise the minimum supported Safari to 15 (Safari 15 / iOS Safari 15) in the v11 browser support matrix, since v11 drops Safari 14.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
