### PR TITLE
docs(react-router): raise minimum version to 7.15

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Router Framework
-description: Learn how to set up and configure Sentry in your React Router application (v7+) using the installation wizard, capture your first errors, and view them in Sentry.
+description: Learn how to set up and configure Sentry in your React Router application (v7.15+) using the installation wizard, capture your first errors, and view them in Sentry.
 sdk: sentry.javascript.react-router
 categories:
   - javascript

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Manual Setup"
 sidebar_order: 1
-description: "Learn how to manually set up Sentry in your React Router app (v7+) and capture your first errors."
+description: "Learn how to manually set up Sentry in your React Router app (v7.15+) and capture your first errors."
 ---
 
 <Alert level="warning" title="Important">
@@ -190,7 +190,7 @@ Sentry's OpenTelemetry-based auto-instrumentation (loaded through `instrument.se
 - **Node 20:** Version \<20.19
 - **Node 22:** Version \<22.12
 
-This restriction **doesn't** affect tracing for loaders, actions, middleware, and request handlers. Those are instrumented through React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) (the `instrumentations` export shown below, React Router 7.15+), which works on all Node versions.
+This restriction **doesn't** affect tracing for loaders, actions, middleware, and request handlers. Those are instrumented through React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) (the `instrumentations` export shown below), which works on all Node versions.
 
 On unsupported Node versions, you'll only lose auto-instrumentation for lower-level operations such as outgoing HTTP requests and database queries.
 
@@ -244,7 +244,7 @@ Sentry.init({
 
 Next, replace the default `handleRequest` and `handleError` functions in your `entry.server.tsx` file with Sentry's wrapped versions, and export `instrumentations` to enable automatic tracing.
 
-Exporting `instrumentations` uses React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) (React Router 7.15+) to automatically create spans for all loaders, actions, middleware, and request handlers — no need to wrap them individually.
+Exporting `instrumentations` uses React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) to automatically create spans for all loaders, actions, middleware, and request handlers — no need to wrap them individually.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -269,7 +269,7 @@ Exporting `instrumentations` uses React Router's [instrumentation API](https://r
 +});
 
 +// Automatically instruments all server loaders, actions, middleware,
-+// and request handlers. Requires React Router 7.15+.
++// and request handlers.
 +export const instrumentations = [Sentry.createSentryServerInstrumentation()];
 
 // ... rest of your server entry

--- a/platform-includes/getting-started-prerequisites/javascript.react-router.mdx
+++ b/platform-includes/getting-started-prerequisites/javascript.react-router.mdx
@@ -1,0 +1,7 @@
+## Prerequisites
+
+You need:
+
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running
+- React Router version `7.15.0` or above (framework mode)


### PR DESCRIPTION
## DESCRIBE YOUR PR

State React Router 7.15 as the framework-mode minimum for v11: bump the "v7+" support labels to "v7.15+", add a prerequisites include with the minimum version, and generalize the previously feature-scoped 7.15 notes now that it's the baseline.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
