### PR TITLE
docs(astro): update minimum Astro version to 4

### DIFF
--- a/docs/platforms/javascript/common/configuration/apis.mdx
+++ b/docs/platforms/javascript/common/configuration/apis.mdx
@@ -1461,9 +1461,9 @@ export const GET = wrapServerRouteWithSentry(async () => {
 <PlatformSection supported={["javascript.astro"]}>
 ## Server Request Instrumentation
 
-Astro server requests are automatically instrumented starting from Astro version `3.5.2`.
+Astro server requests are automatically instrumented.
 
-If you're below Astro version `3.5.2` or want to customize instrumentation, you can use `Sentry.handleRequest()` as an Astro middleware.
+If you want to customize instrumentation, you can use `Sentry.handleRequest()` as an Astro middleware.
 
 <SdkApi
   name="handleRequest"
@@ -1484,7 +1484,7 @@ If you have multiple request handlers, make sure to add the Sentry middleware as
 
 <Alert>
 
-If you're using Astro version `>=3.5.2`, you must <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#disable-automatic-instrumentation">disable automatic instrumentation</PlatformLink> before adding this middleware manually.
+You must <PlatformLink to="/tracing/instrumentation/automatic-instrumentation/#disable-automatic-instrumentation">disable automatic instrumentation</PlatformLink> before adding this middleware manually.
 
 </Alert>
 

--- a/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
+++ b/docs/platforms/javascript/common/tracing/instrumentation/automatic-instrumentation.mdx
@@ -42,7 +42,7 @@ Once you enable tracing, the SDK automatically captures performance data without
 
 ## Disable Automatic Instrumentation
 
-For Astro version `3.5.2` and up, you can optionally disable the automatic server instrumentation by turning off the `requestHandler` auto instrumentation option:
+You can optionally disable the automatic server instrumentation by turning off the `requestHandler` auto instrumentation option:
 
 ```javascript {filename:astro.config.mjs}
 import { defineConfig } from "astro/config";

--- a/docs/platforms/javascript/guides/astro/index.mdx
+++ b/docs/platforms/javascript/guides/astro/index.mdx
@@ -15,7 +15,7 @@ You need:
 
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - Your application up and running
-- Astro `3.0.0` or above
+- Astro `4.0.0` or above
 - If you're using Astro's Netlify adapter (`@astrojs/netlify`), you need version `5.0.0` or above
 
 <Alert level="warning" title="What runtime do you use?">


### PR DESCRIPTION
## DESCRIBE YOUR PR

Set the Astro minimum to 4.0.0 for v11 and drop the now-moot `3.5.2` version qualifiers from the server-instrumentation notes.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
