### PR TITLE
docs(js): update attachStacktrace default to true

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -172,7 +172,7 @@ This variable controls the total amount of breadcrumbs that should be captured. 
 
 </SdkOption>
 
-<SdkOption name="attachStacktrace" type='boolean' defaultValue='false'>
+<SdkOption name="attachStacktrace" type='boolean' defaultValue='true'>
 
 <PlatformSection supported={["javascript.electron"]}>
   Enabled per Electron process.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Update the documented default for `attachStacktrace` to `true` for v11.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
