### PR TITLE
docs(node): update minimum Node.js version to 20.19.0

### DIFF
--- a/docs/platforms/javascript/common/install/esm.mdx
+++ b/docs/platforms/javascript/common/install/esm.mdx
@@ -37,7 +37,6 @@ Sentry.init({
 Adjust the Node.js call for your application to use the [--import](https://nodejs.org/api/cli.html#--importmodule) parameter and point it at `instrument.js`, which contains your `Sentry.init()` code:
 
 ```bash
-# Note: This is only available for Node v18.19.0 onwards.
 node --import ./instrument.mjs app.mjs
 ```
 
@@ -50,8 +49,6 @@ NODE_OPTIONS="--import ./instrument.mjs" npm run start
 If you're building a Node.js Single Executable Application (SEA) and can't rely
 on `--import` or `NODE_OPTIONS`, use the <PlatformLink to="/install/esm-without-import/#nodejs-single-executable-applications">SEA
 bootstrap setup</PlatformLink> instead.
-
-We do not support ESM in Node versions before 18.19.0.
 
 ## Troubleshooting instrumentation
 

--- a/docs/platforms/javascript/common/install/late-initialization.mdx
+++ b/docs/platforms/javascript/common/install/late-initialization.mdx
@@ -64,7 +64,6 @@ Sentry.init({
 In your ESM application, use the `@sentry/node/preload` hook with `--import` to ensure modules are wrapped early:
 
 ```bash
-# Note: This is only available for Node v18.19.0 onwards.
 node --import @sentry/node/preload app.js
 ```
 

--- a/docs/platforms/javascript/guides/elysia/index.mdx
+++ b/docs/platforms/javascript/guides/elysia/index.mdx
@@ -22,7 +22,7 @@ You need:
 
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - An Elysia application (`v1.4.0+`)
-- Bun or Node.js 18+ (with [@elysiajs/node](https://elysiajs.com/integrations/node) adapter)
+- Bun or Node.js 20.19.0+ (with [@elysiajs/node](https://elysiajs.com/integrations/node) adapter)
 
 <StepConnector selector="h2" showNumbers={true}>
 

--- a/docs/platforms/javascript/guides/nestjs/install/esm.mdx
+++ b/docs/platforms/javascript/guides/nestjs/install/esm.mdx
@@ -31,7 +31,6 @@ Sentry.init({
 **Step 2:** Adjust your application's start command to use the [--import](https://nodejs.org/api/cli.html#--importmodule) parameter:
 
 ```bash
-# Note: This is only available for Node v18.19.0 onwards.
 "start": "--import ./instrument.mjs nest start"
 ```
 
@@ -40,8 +39,6 @@ If you can't pass the `--import` flag to the Node.js binary, you can alternative
 ```bash
 NODE_OPTIONS="--import ./instrument.mjs" npm run start
 ```
-
-<Alert>We do not support ESM in Node versions before 18.19.0.</Alert>
 
 ## Troubleshooting ESM Instrumentation
 

--- a/docs/platforms/javascript/guides/nitro/index.mdx
+++ b/docs/platforms/javascript/guides/nitro/index.mdx
@@ -21,7 +21,7 @@ You need:
 
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - A Nitro application (`3.0.260415-beta` or newer)
-- Node.js 18.19.0+
+- Node.js 20.19.0+
 
 <StepConnector selector="h2" showNumbers={true}>
 

--- a/platform-includes/getting-started-node/javascript.mdx
+++ b/platform-includes/getting-started-node/javascript.mdx
@@ -91,7 +91,6 @@ When running your application in ESM mode, use the [--import](https://nodejs.org
 <SplitSectionCode>
 
 ```bash
-# Note: This is only available for Node v18.19.0 onwards.
 node --import ./instrument.mjs app.mjs
 ```
 

--- a/platform-includes/getting-started-prerequisites/javascript.node.mdx
+++ b/platform-includes/getting-started-prerequisites/javascript.node.mdx
@@ -4,13 +4,4 @@ You need:
 
 - A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
 - Your application up and running
-- Node version `18.0.0` or above (>= `19.9.0` or `18.19.0`  recommended)
-
-<Expandable title="Are you using Node version < 18.19.0 or < 19.9.0?">
-  The required Node version will increase in the next major release of the SDK (v11) to support features that rely on [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel).
-
-  - We strongly recommend upgrading to at least Node `18.19.0` or `19.9.0` to get the best support.
-  - While we may add features relying on `TracingChannel` in v10.x releases, they will have backwards compatibility for older Node versions.
-
-  See the following [issue on GitHub](https://github.com/getsentry/sentry-javascript/issues/17585) for more details.
-</Expandable>
+- Node version `20.19.0` or above. Node.js 22 needs `22.12` or higher, while Node.js 23 needs `23.2` or higher (`>=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0`).

--- a/platform-includes/getting-started-run/javascript.mdx
+++ b/platform-includes/getting-started-run/javascript.mdx
@@ -3,7 +3,6 @@
 node --require ./instrument.js app.js
 
 # If you are using ECMAScript Modules (ESM)
-# Note: This is only available for Node v18.19.0 onwards.
 node --import ./instrument.mjs app.mjs
 ```
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Set the Node.js minimum to 20.19.0 for v11 across the docs: reword the prerequisites with the full supported range, drop the now-moot "only available for Node v18.19.0 onwards" ESM notes (the minimum already guarantees them), and bump the stale Node-18 minimums on the Nitro and Elysia guides.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
