### PR TITLE
docs(godot): Document minimum macOS and iOS versions

### DIFF
--- a/platform-includes/getting-started-primer/godot.mdx
+++ b/platform-includes/getting-started-primer/godot.mdx
@@ -4,8 +4,8 @@ Our SDK for Godot Engine builds on top of existing Sentry SDKs, extending them w
 
 - Native support for automatic crash and error reporting for:
   - Windows and Linux using the [Native SDK](/platforms/native/) to support C and C++ with minidumps
-  - macOS using the [macOS SDK](/platforms/apple/guides/macos/) to support Objective-C, Swift, C and C++
-  - iOS using the [iOS SDK](/platforms/apple/guides/ios/) to support Objective-C, Swift, C and C++
+  - macOS 12 Monterey or later using the [macOS SDK](/platforms/apple/guides/macos/) to support Objective-C, Swift, C and C++
+  - iOS 15 or later using the [iOS SDK](/platforms/apple/guides/ios/) to support Objective-C, Swift, C and C++
   - Android using the [Android SDK](/platforms/android/) to support Java, Kotlin, C and C++
   - Web using the [JavaScript SDK](/platforms/javascript/) to support WebAssembly and JavaScript
 - Automatically capture Godot runtime errors, such as script and shader errors


### PR DESCRIPTION
## DESCRIBE YOUR PR

Document macOS 12 Monterey and iOS 15 as the minimum supported versions in the Godot platform list so developers can check compatibility before installing the SDK. These match the SDK's build requirements.

The macOS minimum increases in the unreleased Godot SDK 2.2.0; publish with that release. The iOS minimum is already in effect.

- Godot SDK PR: https://github.com/getsentry/sentry-godot/pull/899

## IS YOUR CHANGE URGENT?

- [x] No deadline: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)
