### PR TITLE
docs(alerts): Document Alert and Metric Monitor limits

### DIFF
--- a/docs/product/monitors-and-alerts/alerts/index.mdx
+++ b/docs/product/monitors-and-alerts/alerts/index.mdx
@@ -70,6 +70,20 @@ Here are some quick tips:
 - Select only the triggers that matter for Alerting actions. For example, you may want to create a Jira ticket any time an issue is created, but only be notified in Slack when an issue is a certain severity.
 - Consider how your team works in terms of triaging. For example, do you want individual alerts routing to specific project, or service channels, or one alert to catch them all in a team channel? 
 
+## Alert Limits
+
+Sentry caps how many Alerts you can create so that alert evaluation stays fast. If you hit one of these limits, Sentry rejects the new Alert with an error naming the limit that you exceeded.
+
+| Scope                                        | Limit |
+| -------------------------------------------- | ----- |
+| Alerts per organization                      | 1,000 |
+| Alerts per project, using a frequency filter | 100   |
+| Alerts per project, using any other filter   | 500   |
+
+Frequency filters are the ones that count events over a time window, such as "The issue is seen more than 100 times in one hour" or "The issue affects more than 5 percent of sessions in one day." They're more expensive to evaluate, so they get a lower ceiling.
+
+To stay under the limits, delete or turn off the Alerts you're not using, and consolidate several narrow Alerts into one Alert with broader filters and multiple actions. If your organization genuinely needs more, [contact support](https://sentry.io/support/)—all three ceilings can be raised for an organization.
+
 ## Sentry Notifications
 
 Besides Alerts, Sentry sends you notifications about various things like [issue state changes](/product/issues/states-triage/), [release deploys](/product/releases/), and [quota usage](/pricing/quotas/). You can fine-tune these notifications, as well as your personal alert settings, in **User Settings > Notifications**. Learn more about notifications and adjusting their associated settings in [the full documentation](/product/notifications/).

--- a/docs/product/monitors-and-alerts/monitors/index.mdx
+++ b/docs/product/monitors-and-alerts/monitors/index.mdx
@@ -128,3 +128,14 @@ Monitors are a Project-level feature, but the permission set is organization-lev
 By clicking on a Monitor, you can view the details, edit the Monitor, or disable it.
 
 The details page will show a high level chart of the Monitor's performance, the configuration, created issue, and connected automations.
+
+## Metric Monitor Limits
+
+Two separate limits apply to Metric Monitors, and both are counted across your whole organization rather than per project:
+
+- **Your plan's Metric Monitor allowance.** How many Metric Monitors you can create depends on your organization's plan. When you reach it, Sentry rejects the new Monitor with an error telling you that you may not exceed that number of metric alerts on your current plan.
+- **1,000 concurrent monitoring queries.** Every Metric Monitor runs a background query against your event data, and an organization can run at most 1,000 of them at a time.
+
+If you need more, delete or disable the Metric Monitors you're no longer acting on, or [contact support](https://sentry.io/support/) to have the ceiling raised.
+
+Cron and Uptime Monitors aren't subject to these limits. They're metered through your [pay-as-you-go budget](/pricing/quotas/manage-cron-monitors/) instead.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Sentry enforces hard caps on how many Alerts and Metric Monitors an organization can create, but none of those limits are documented. Today the only way a customer finds out is by hitting a `400` with "You may not exceed N ..." — or by opening a support ticket. This adds the numbers to the two pages that already own these products.

- `docs/product/monitors-and-alerts/alerts/index.mdx` — new **Alert Limits** section: 1,000 Alerts per organization, plus the per-project caps of 100 (Alerts using a frequency filter) and 500 (any other filter), what a frequency filter is and why it's cheaper to evaluate, and what to do when you hit a limit.
- `docs/product/monitors-and-alerts/monitors/index.mdx` — new **Metric Monitor Limits** section: the plan-based Metric Monitor allowance and the 1,000 concurrent monitoring queries per organization, plus a note that Cron and Uptime Monitors are metered through PAYG instead.

### Where the numbers come from

All values were read out of `getsentry/sentry` rather than from a support macro:

| Doc statement | Source |
| --- | --- |
| 1,000 Alerts per org | `workflow_engine.max_workflows_per_org` option (default `1000`), enforced in `workflow_engine/endpoints/validators/base/workflow.py` |
| 100 / 500 per project | `MAX_SLOW_CONDITION_ISSUE_ALERTS` / `MAX_FAST_CONDITION_ISSUE_ALERTS` in `conf/server.py`, enforced in `api/endpoints/project_rules.py` |
| "frequency filter" = the slow conditions | `SLOW_CONDITION_MATCHES = ["event_frequency"]` in `rules/processing/processor.py` |
| Plan-based Metric Monitor allowance | `quotas.backend.get_metric_detector_limit()`, enforced in `incidents/endpoints/organization_alert_rule_index.py` |
| 1,000 concurrent monitoring queries | `MAX_QUERY_SUBSCRIPTIONS_PER_ORG` in `conf/server.py`, enforced in `incidents/serializers/alert_rule.py` |
| Cron/Uptime metered via PAYG | Existing `/pricing/quotas/manage-cron-monitors/` page |

### Questions for SMEs

Flagging three judgment calls rather than deciding them unilaterally:

1. **Raised ceilings.** Each limit has a higher tier (10,000 Alerts per org, 400/1,000 per project) gated behind an internal org feature flag. I described these as "contact support" rather than naming the flags. Happy to be more or less specific.
2. **The plan-based Metric Monitor number.** `get_metric_detector_limit()` returns `-1` in the open-source backend and the check sits behind `organizations:workflow-engine-metric-detector-limit`, so I deliberately didn't publish a number. If this is fully rolled out and the per-plan values are stable, we should list them.
3. **On-demand metric extraction specs (omitted).** Alerts that filter on custom transaction attributes are also capped at 50 on-demand metric specs per org (`on_demand.max_alert_specs`, raised to 750 case-by-case). Past that, extraction silently stops, which is a genuinely user-visible failure. I left it out because "on-demand metric extraction" isn't a documented concept anywhere in the docs, so the limit has nothing to hang off. Worth a follow-up if we want to explain the underlying mechanism first.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
