### PR TITLE
docs(ruby): Document attempt_threshold for sentry-sidekiq

### DIFF
--- a/docs/platforms/ruby/common/configuration/integration_options.mdx
+++ b/docs/platforms/ruby/common/configuration/integration_options.mdx
@@ -75,3 +75,12 @@ config.delayed_job.report_after_job_retries = true
 ```
 config.sidekiq.report_after_job_retries = true
 ```
+
+`attempt_threshold`
+
+`sentry-sidekiq` skips error reporting until a job reaches the given attempt. Set it in the job's `sidekiq_options`. The threshold is capped at the job's final attempt. Not set by default.
+
+```ruby
+# Report only the last of 5 attempts (1 initial execution + 4 retries)
+sidekiq_options retry: 4, attempt_threshold: 5
+```


### PR DESCRIPTION
## DESCRIBE YOUR PR

`attempt_threshold` is only mentioned in the changelog, so there's no reference for it in the docs. Someone asked about it on the PR that added it, and the maintainer said it should be documented:

> good point, we should definitely document this and related features as it's kinda tricky 😅 I'll make sure we get it done!
>
> — [getsentry/sentry-ruby#2503 (comment)](https://github.com/getsentry/sentry-ruby/pull/2503#issuecomment-3245720177)

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
