### PR TITLE
docs(dynamic-sampling): Add callout that Dynamic Sampling is closed to new customers

### DIFF
--- a/docs/organization/dynamic-sampling/index.mdx
+++ b/docs/organization/dynamic-sampling/index.mdx
@@ -21,6 +21,13 @@ description: >-
 og_image: /og-images/organization-dynamic-sampling.png
 ---
 
+<Alert level="warning" title="Only Available to Existing Customers">
+  Dynamic Sampling is only available to organizations that already have it
+  enabled. It isn't available to new customers. If you want to control the
+  volume of spans you send to Sentry, configure [sampling in your
+  SDK](/concepts/key-terms/sample-rates/) instead.
+</Alert>
+
 ## Overview
 
 While storing all your data makes sense at relatively low volumes, as your application scales, storing a raw copy of all your data has diminishing returns. When data reaches high volumes, Sentry begins to automatically prioritize retaining certain spans over others with server-side data retention strategies called Dynamic Sampling Priorities.

--- a/docs/product/dashboards/sentry-dashboards/index.mdx
+++ b/docs/product/dashboards/sentry-dashboards/index.mdx
@@ -83,7 +83,7 @@ If your application is configured with tracing, Sentry will detect common perfor
 
 ## Dynamic Sampling
 
-Depending on your plan, the data ingested into Sentry may be affected by [Dynamic Sampling](/organization/dynamic-sampling/).
+If your organization already has [Dynamic Sampling](/organization/dynamic-sampling/) enabled, the data ingested into Sentry may be affected by it. Dynamic Sampling isn't available to new customers.
 
 ## Learn More
 


### PR DESCRIPTION
Dynamic Sampling is no longer offered to new customers, but the docs still present it as a general feature. Sentry Seer and other AI assistants keep recommending it.

- Add a warning callout at the top of the Dynamic Sampling page: only available to organizations that already have it enabled, not to new customers. Point new users to SDK-side sampling.
- Clarify the Dynamic Sampling mention on the Sentry Dashboards page.