### PR TITLE
docs(angular): Fix snippets that fail to compile

### DIFF
--- a/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
+++ b/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
@@ -117,14 +117,14 @@ import * as Sentry from "@sentry/angular";
   selector: "app-user-card",
   templateUrl: "./user-card.component.html",
 })
-@Sentry.TraceClass()
+@Sentry.TraceClass({ name: "UserCard" })
 export class UserCardComponent implements OnChanges, OnDestroy {
   @Input() user!: { name: string };
 
-  @Sentry.TraceMethod()
+  @Sentry.TraceMethod({ name: "UserCard.ngOnChanges" })
   ngOnChanges(changes: SimpleChanges) {}
 
-  @Sentry.TraceMethod()
+  @Sentry.TraceMethod({ name: "UserCard.ngOnDestroy" })
   ngOnDestroy() {}
 }
 ```
@@ -133,10 +133,10 @@ Use the `trace` directive if you only want to track components in certain instan
 
 ```html {filename: user-card.component.html} {2,5}
 <div>
-  <span trace="user-icon">user</span>
+  <app-icon trace="user-icon">user</app-icon>
   <label>{{ user.name }}</label>
   <!--...-->
-  <button trace="save-user">Save</button>
+  <app-button trace="save-user">Save</app-button>
 </div>
 ```
 

--- a/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
+++ b/docs/platforms/javascript/guides/angular/features/component-tracking.mdx
@@ -78,7 +78,7 @@ Note: Due to code minification in production builds, you need to pass a `name` p
 The `TraceMethod` decorator tracks specific component lifecycle hooks as point-in-time spans. The added spans are called **`ui.angular.[methodname]`** (like, `ui.angular.ngOnChanges`). For example, you can use this decorator to track how often component changes are detected:
 
 ```typescript {filename:login.component.ts} {2,9}
-import { Component, OnInit } from "@angular/core";
+import { Component, OnChanges, SimpleChanges } from "@angular/core";
 import * as Sentry from "@sentry/angular";
 
 @Component({
@@ -103,8 +103,14 @@ You can combine our component tracking utilities and track the bootstrapping dur
 
 To get the best insights into your components' performance, you can combine `TraceDirective`, `TraceClassDecorator`, and `TraceMethodDecorator`. This allows you to track component initialization durations as well as arbitrary lifecycle events, such as change and destroy events:
 
-```typescript {filename:user-card.component.ts} {2,8,10,13}
-import { Component, OnInit } from "@angular/core";
+```typescript {filename:user-card.component.ts} {8,14,18,21}
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+} from "@angular/core";
 import * as Sentry from "@sentry/angular";
 
 @Component({
@@ -113,6 +119,8 @@ import * as Sentry from "@sentry/angular";
 })
 @Sentry.TraceClass()
 export class UserCardComponent implements OnChanges, OnDestroy {
+  @Input() user!: { name: string };
+
   @Sentry.TraceMethod()
   ngOnChanges(changes: SimpleChanges) {}
 
@@ -125,10 +133,10 @@ Use the `trace` directive if you only want to track components in certain instan
 
 ```html {filename: user-card.component.html} {2,5}
 <div>
-  <app-icon trace="user-icon">user</app-icon>
+  <span trace="user-icon">user</span>
   <label>{{ user.name }}</label>
   <!--...-->
-  <app-button trace="save-user">Save</app-button>
+  <button trace="save-user">Save</button>
 </div>
 ```
 

--- a/docs/platforms/javascript/guides/angular/features/error-handler.mdx
+++ b/docs/platforms/javascript/guides/angular/features/error-handler.mdx
@@ -73,7 +73,7 @@ export class CustomErrorHandler extends Sentry.SentryErrorHandler {
     super({ logErrors: false });
   }
 
-  handleError(error: any): void {
+  override handleError(error: any): void {
     // Your custom error handling logic
     // Call Sentry's error handler to capture errors:
     super.handleError(error);

--- a/docs/platforms/javascript/guides/angular/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/angular/manual-setup.mdx
@@ -267,7 +267,7 @@ export const appConfig: ApplicationConfig = {
       deps: [Router],
     },
     provideAppInitializer(() => {
-      inject(TraceService);
+      inject(Sentry.TraceService);
     }),
     // ___PRODUCT_OPTION_END___ performance
   ],


### PR DESCRIPTION
## DESCRIBE YOUR PR

closes SDK-1506

Three snippets in the Angular guide don't build under the tsconfig `ng new` generates, from the runtime docs audit (SDK-1506).

- `manual-setup` called `inject(TraceService)` while importing only `Sentry`, so `ng build` failed with `TS2304 Cannot find name 'TraceService'`. Call `inject(Sentry.TraceService)`
- The custom error handler declared `handleError` without `override`, which `noImplicitOverride` rejects with `TS4114`
- The component tracking examples used `OnChanges`, `OnDestroy` and `SimpleChanges` without importing them, and the paired template read a `user` input the class never declared. Import what they use, declare the input, and drop the two child components the example doesn't define

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
