### PR TITLE
docs(javascript): Document custom AI span costs

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/manual-instrumentation.mdx
@@ -393,4 +393,18 @@ async function callLLMStreaming(model, messages) {
 
 <Include name="tracing/ai-agents-module/token-cost-gotchas" />
 
-Sentry derives [model cost](/product/agents/costs/) from the model name and token counts. You do not need to set `gen_ai.cost.*` attributes. Pass the raw provider model string unchanged so pricing can resolve.
+By default, Sentry derives [model cost](/product/agents/costs/) from the model name and token counts. Pass the raw provider model string unchanged so pricing can resolve.
+
+## Provide Custom Costs
+
+If your provider reports costs or you use custom pricing, set costs as numeric USD values on each AI span. Always set `gen_ai.cost.total_tokens`, even when you provide a breakdown:
+
+```javascript
+span.setAttributes({
+  "gen_ai.cost.input_tokens": result.cost.input,
+  "gen_ai.cost.output_tokens": result.cost.output,
+  "gen_ai.cost.total_tokens": result.cost.total,
+});
+```
+
+A numeric total tells Sentry to preserve your cost attributes instead of replacing them with estimates. See [Model Costs](/product/agents/costs/#send-custom-costs) for all supported breakdown attributes.


### PR DESCRIPTION
JavaScript manual Agent Tracing guidance now explains how to provide numeric USD costs on `gen_ai` spans. It identifies required total cost, shows an optional input/output breakdown, and clarifies that numeric total prevents Sentry estimates from replacing provided values.

Closes [TET-2927](https://linear.app/getsentry/issue/TET-2927/document-how-to-provide-your-own-costs-for-tokens)
