### PR TITLE
docs(agent-tracing): remove the streamGenAiSpans option

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/flue.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/flue.mdx
@@ -108,7 +108,6 @@ Sentry.init({
   enabled: Boolean(process.env.SENTRY_DSN),
   tracesSampleRate,
   traceLifecycle: "stream",
-  streamGenAiSpans: true,
   enableLogs: true,
   // Flue already emits one `chat` span per model call, so Sentry's
   // AI provider integrations are removed to avoid double counting.
@@ -165,7 +164,6 @@ export const cloudflare = extend({
         release: env.SENTRY_RELEASE,
         tracesSampleRate: clampRate(env.SENTRY_TRACES_SAMPLE_RATE, 0),
         traceLifecycle: "stream",
-        streamGenAiSpans: true,
         enableLogs: true,
         integrations: (defaults) =>
           defaults.filter((i) => !SENTRY_AI_PROVIDER_INTEGRATIONS.has(i.name)),

--- a/docs/platforms/javascript/common/agent-tracing/index.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/index.mdx
@@ -215,38 +215,6 @@ On the default CF entrypoint, control Vercel AI I/O with `experimental_telemetry
 
 From SDK `10.61.0`, `gen_ai` spans are sent as standalone envelope items (avoids large-payload drops; required for <Link to="/product/agents/conversations/">Conversations</Link>).
 
-Self-hosted Sentry users should set `streamGenAiSpans: false` if standalone `gen_ai` spans may not be ingested.
-
-<PlatformSection notSupported={["javascript.cloudflare"]}>
-
-```javascript
-Sentry.init({
-  dsn: "___PUBLIC_DSN___",
-  streamGenAiSpans: false,
-});
-```
-
-</PlatformSection>
-
-<PlatformSection supported={["javascript.cloudflare"]}>
-
-```javascript
-export default Sentry.withSentry(
-  (env) => ({
-    dsn: "___PUBLIC_DSN___",
-    tracesSampleRate: 1.0,
-    streamGenAiSpans: false,
-  }),
-  {
-    async fetch(request, env, ctx) {
-      /* ... */
-    },
-  }
-);
-```
-
-</PlatformSection>
-
 ## Manual Instrumentation
 
 You can also instrument agent spans yourself. See <PlatformLink to="/agent-tracing/manual-instrumentation/">manual instrumentation</PlatformLink>.

--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -742,16 +742,6 @@ See <PlatformLink to="/tracing/distributed-tracing/dealing-with-cors-issues/">De
 
 </SdkOption>
 
-<SdkOption name="streamGenAiSpans" type='boolean' defaultValue='true' defaultNote='since version 10.61.0' availableSince='10.53.0'>
-
-When enabled, `gen_ai` spans are sent as standalone envelope items instead of being bundled in the transaction payload. This prevents AI spans with large inputs and outputs from being dropped due to transaction payload size limits.
-
-This is enabled by default starting with SDK version `10.61.0` (before that, it defaulted to `false`). Set it to `false` to send `gen_ai` spans as part of the transaction instead.
-
-Self-hosted Sentry users should set this option to `false`, as standalone `gen_ai` spans may not be ingested by their Sentry instance.
-
-</SdkOption>
-
 <SdkOption name="traceLifecycle" type="'static' | 'stream'" defaultValue="'static'" availableSince='10.53.1'>
 
 Controls how spans are sent to Sentry:


### PR DESCRIPTION
## DESCRIBE YOUR PR

Remove the `streamGenAiSpans` option from the docs, since v11 always streams gen AI spans and the flag no longer exists.

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
