### PR TITLE
docs(agent-tracing): update gen_ai attribute names and rename instrumentLangGraph

### DIFF
--- a/docs/platforms/javascript/common/agent-tracing/langgraph.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/langgraph.mdx
@@ -37,7 +37,7 @@ supported:
 
 <PlatformSection supported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react"]}>
   <Alert level="warning">
-    For meta-framework applications running on both client and server, we recommend **setting up the integration manually** using the [`instrumentLangGraph` wrapper](#manual-instrumentation) to ensure consistent instrumentation across all runtimes.
+    For meta-framework applications running on both client and server, we recommend **setting up the integration manually** using the [`instrumentStateGraph` wrapper](#manual-instrumentation) to ensure consistent instrumentation across all runtimes.
   </Alert>
 </PlatformSection>
 
@@ -65,9 +65,9 @@ supported:
 
   ## Manual Instrumentation
 
-  _Import name: `Sentry.instrumentLangGraph`_
+  _Import name: `Sentry.instrumentStateGraph`_
 
-  The `instrumentLangGraph` helper adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) to capture spans by wrapping a `StateGraph` before compilation and recording agent interactions with configurable input/output recording. You need to call this helper on the graph **before** calling `.compile()`.
+  The `instrumentStateGraph` helper adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) to capture spans by wrapping a `StateGraph` before compilation and recording agent interactions with configurable input/output recording. You need to call this helper on the graph **before** calling `.compile()`.
 
   See example below:
 
@@ -97,7 +97,7 @@ supported:
     .addEdge('agent', END);
 
   // Instrument the graph before compiling
-  Sentry.instrumentLangGraph(agent, {
+  Sentry.instrumentStateGraph(agent, {
     recordInputs: true,
     recordOutputs: true,
   });
@@ -162,10 +162,10 @@ Sentry.init({
 
 <PlatformSection notSupported={["javascript.node", "javascript.connect", "javascript.hapi", "javascript.koa"]}>
 
-Using the `instrumentLangGraph` wrapper for **manual instrumentation**:
+Using the `instrumentStateGraph` wrapper for **manual instrumentation**:
 
 ```javascript
-Sentry.instrumentLangGraph(graph, {
+Sentry.instrumentStateGraph(graph, {
   // your options here
 });
 ```

--- a/docs/platforms/javascript/common/agent-tracing/langgraph.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/langgraph.mdx
@@ -37,7 +37,7 @@ supported:
 
 <PlatformSection supported={["javascript.nextjs", "javascript.nuxt", "javascript.solidstart", "javascript.sveltekit", "javascript.react-router", "javascript.remix", "javascript.astro", "javascript.tanstackstart-react"]}>
   <Alert level="warning">
-    For meta-framework applications running on both client and server, we recommend **setting up the integration manually** using the [`instrumentStateGraph` wrapper](#manual-instrumentation) to ensure consistent instrumentation across all runtimes.
+    For meta-framework applications running on both client and server, we recommend **setting up the integration manually** using the [`instrumentStateGraph` or `instrumentCreateReactAgent` wrapper](#manual-instrumentation) to ensure consistent instrumentation across all runtimes.
   </Alert>
 </PlatformSection>
 
@@ -65,11 +65,16 @@ supported:
 
   ## Manual Instrumentation
 
-  _Import name: `Sentry.instrumentStateGraph`_
+  _Import names: `Sentry.instrumentStateGraph`, `Sentry.instrumentCreateReactAgent`_
 
-  The `instrumentStateGraph` helper adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) to capture spans by wrapping a `StateGraph` before compilation and recording agent interactions with configurable input/output recording. You need to call this helper on the graph **before** calling `.compile()`.
+  There are two manual instrumentation helpers, depending on how you build your agent:
 
-  See example below:
+  - **`instrumentStateGraph`** — for graphs you build yourself with `StateGraph`. Call it on the graph **before** calling `.compile()`.
+  - **`instrumentCreateReactAgent`** — for LangGraph's prebuilt `createReactAgent`. Wrap the factory, then use the wrapped version exactly like `createReactAgent`. This also captures the model and wraps tools, so you get `execute_tool` spans as well.
+
+  Both accept the same input/output recording options.
+
+  Instrumenting a `StateGraph`:
 
   ```javascript
   import { ChatOpenAI } from "@langchain/openai";
@@ -111,6 +116,17 @@ supported:
       new HumanMessage("Hello!"),
     ],
   });
+  ```
+
+  Instrumenting a prebuilt `createReactAgent`:
+
+  ```javascript
+  import { createReactAgent } from "@langchain/langgraph/prebuilt";
+
+  // Instrument createReactAgent, then use the wrapped version in its place
+  const instrumentedCreateReactAgent = Sentry.instrumentCreateReactAgent(createReactAgent);
+
+  const agent = instrumentedCreateReactAgent({ llm, tools });
   ```
 
   To customize what data is captured (such as inputs and outputs), see the [Options](#options) in the Configuration section.

--- a/docs/platforms/javascript/common/agent-tracing/mastra.mdx
+++ b/docs/platforms/javascript/common/agent-tracing/mastra.mdx
@@ -138,7 +138,7 @@ The Sentry exporter captures comprehensive trace data following OpenTelemetry se
 #### Model Generation Spans
 
 - `gen_ai.operation.name`: Operation name (e.g., `chat`)
-- `gen_ai.system`: Model provider (e.g., OpenAI, Anthropic)
+- `gen_ai.provider.name`: Model provider (e.g., OpenAI, Anthropic)
 - `gen_ai.request.model`: Model identifier
 - `gen_ai.request.messages`: Input messages/prompts (JSON)
 - `gen_ai.response.model`: Response model
@@ -155,10 +155,9 @@ The Sentry exporter captures comprehensive trace data following OpenTelemetry se
 
 - `gen_ai.operation.name`: `execute_tool`
 - `gen_ai.tool.name`: Tool identifier
-- `gen_ai.tool.type`: `function`
 - `gen_ai.tool.call.id`: Tool call ID
-- `gen_ai.tool.input`: Tool input parameters
-- `gen_ai.tool.output`: Tool output result
+- `gen_ai.tool.call.arguments`: Tool input parameters
+- `gen_ai.tool.call.result`: Tool output result
 - `tool.success`: Success flag
 
 #### Agent Run Spans

--- a/docs/platforms/javascript/common/tracing/span-metrics/examples.mdx
+++ b/docs/platforms/javascript/common/tracing/span-metrics/examples.mdx
@@ -811,7 +811,6 @@ app.post("/api/ai/chat", async (req: Request, res: Response) => {
                 attributes: {
                   "gen_ai.operation.name": "execute_tool",
                   "gen_ai.tool.name": toolCall.function.name,
-                  "gen_ai.tool.type": "function",
                   "gen_ai.tool.call.arguments": toolCall.function.arguments,
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: "manual.ai.custom-llm",
                 },

--- a/docs/platforms/react-native/common/integrations/langgraph.mdx
+++ b/docs/platforms/react-native/common/integrations/langgraph.mdx
@@ -3,9 +3,9 @@ title: LangGraph
 description: "Manually instrument LangGraph in React Native to capture spans for agent compilation and invocation."
 ---
 
-_Import name: `Sentry.instrumentLangGraph`_
+_Import name: `Sentry.instrumentStateGraph`_
 
-The `instrumentLangGraph` helper adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) by wrapping a `StateGraph` before compilation and recording agent interactions with configurable input/output capture. The OpenTelemetry-based automatic integration available for Node.js does not work in React Native, so calling `instrumentLangGraph` on the graph **before** `.compile()` is the only supported path.
+The `instrumentStateGraph` helper adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) by wrapping a `StateGraph` before compilation and recording agent interactions with configurable input/output capture. The OpenTelemetry-based automatic integration available for Node.js does not work in React Native, so calling `instrumentStateGraph` on the graph **before** `.compile()` is the only supported path.
 
 ## Usage
 
@@ -35,7 +35,7 @@ const agent = new StateGraph(MessagesAnnotation)
   .addEdge("agent", END);
 
 // Instrument the graph BEFORE compiling
-Sentry.instrumentLangGraph(agent, {
+Sentry.instrumentStateGraph(agent, {
   recordInputs: true,
   recordOutputs: true,
 });

--- a/docs/platforms/react-native/common/integrations/langgraph.mdx
+++ b/docs/platforms/react-native/common/integrations/langgraph.mdx
@@ -3,9 +3,14 @@ title: LangGraph
 description: "Manually instrument LangGraph in React Native to capture spans for agent compilation and invocation."
 ---
 
-_Import name: `Sentry.instrumentStateGraph`_
+_Import names: `Sentry.instrumentStateGraph`, `Sentry.instrumentCreateReactAgent`_
 
-The `instrumentStateGraph` helper adds instrumentation for [`@langchain/langgraph`](https://www.npmjs.com/package/@langchain/langgraph) by wrapping a `StateGraph` before compilation and recording agent interactions with configurable input/output capture. The OpenTelemetry-based automatic integration available for Node.js does not work in React Native, so calling `instrumentStateGraph` on the graph **before** `.compile()` is the only supported path.
+The OpenTelemetry-based automatic integration available for Node.js does not work in React Native, so manual instrumentation is the only supported path. Two helpers are available, depending on how you build your agent:
+
+- **`instrumentStateGraph`** — for graphs you build yourself with `StateGraph`. Call it on the graph **before** calling `.compile()`.
+- **`instrumentCreateReactAgent`** — for LangGraph's prebuilt `createReactAgent`. Wrap the factory, then use the wrapped version exactly like `createReactAgent`. This also captures the model and wraps tools, so you get `execute_tool` spans as well.
+
+Both accept the same input/output recording options.
 
 ## Usage
 
@@ -48,6 +53,18 @@ const result = await graph.invoke({
     new HumanMessage("Hello!"),
   ],
 });
+```
+
+Or, instrument LangGraph's prebuilt `createReactAgent`:
+
+```javascript
+import * as Sentry from "@sentry/react-native";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+
+// Instrument createReactAgent, then use the wrapped version in its place
+const instrumentedCreateReactAgent = Sentry.instrumentCreateReactAgent(createReactAgent);
+
+const agent = instrumentedCreateReactAgent({ llm, tools });
 ```
 
 Make sure <PlatformLink to="/tracing/">tracing is enabled</PlatformLink> for the spans produced by this integration to be captured.


### PR DESCRIPTION
## DESCRIBE YOUR PR

Apply the v11 `gen_ai.*` attribute renames (Mastra page + manual span-metrics example), rename `instrumentLangGraph` to `instrumentStateGraph`, and document the separate `instrumentCreateReactAgent` manual helper on the LangGraph pages (JavaScript and React Native).

> **⚠️ Do not merge until v11 is released as stable.**

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
