### PR TITLE
docs(js): Add browser AI integrations to SDK tables

### DIFF
--- a/platform-includes/configuration/integrations/javascript.astro.mdx
+++ b/platform-includes/configuration/integrations/javascript.astro.mdx
@@ -29,13 +29,18 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.gatsby.mdx
+++ b/platform-includes/configuration/integrations/javascript.gatsby.mdx
@@ -10,15 +10,20 @@
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
 | [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
 | [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`browserSessionIntegration`](./browsersession)       |        ✓         |            |             |            |           ✓            |
 | [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
 | [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`rewriteFramesIntegration`](./rewriteframes)         |                  |     ✓      |             |            |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |

--- a/platform-includes/configuration/integrations/javascript.nextjs.mdx
+++ b/platform-includes/configuration/integrations/javascript.nextjs.mdx
@@ -29,13 +29,18 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.nuxt.mdx
+++ b/platform-includes/configuration/integrations/javascript.nuxt.mdx
@@ -28,13 +28,18 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.remix.mdx
+++ b/platform-includes/configuration/integrations/javascript.remix.mdx
@@ -28,13 +28,18 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.solidstart.mdx
+++ b/platform-includes/configuration/integrations/javascript.solidstart.mdx
@@ -28,13 +28,18 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.sveltekit.mdx
+++ b/platform-includes/configuration/integrations/javascript.sveltekit.mdx
@@ -28,13 +28,18 @@ Depending on whether an integration enhances the functionality of a particular r
 | [`browserTracingIntegration`](./browsertracing)       |        ✓         |            |      ✓      |            |           ✓            |
 | [`globalHandlersIntegration`](./globalhandlers)       |        ✓         |     ✓      |             |            |                        |
 | [`httpContextIntegration`](./httpcontext)             |        ✓         |            |             |            |           ✓            |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |

--- a/platform-includes/configuration/integrations/javascript.vue.mdx
+++ b/platform-includes/configuration/integrations/javascript.vue.mdx
@@ -12,16 +12,21 @@
 | [`inboundFiltersIntegration`](./inboundfilters)       |        ✓         |     ✓      |             |            |                        |
 | [`linkedErrorsIntegration`](./linkederrors)           |        ✓         |     ✓      |             |            |                        |
 | [`vueIntegration`](./vue)                             |        ✓         |     ✓      |      ✓      |            |                        |
+| [`anthropicAIIntegration`](../../agent-tracing/anthropic)               |                  |            |      ✓      |            |           ✓            |
 | [`browserProfilingIntegration`](./browserprofiling)   |                  |            |      ✓      |            |                        |
 | [`browserTracingIntegration`](./browsertracing)       |                  |            |      ✓      |            |           ✓            |
 | [`captureConsoleIntegration`](./captureconsole)       |                  |            |             |            |           ✓            |
 | [`contextLinesIntegration`](./contextlines)           |                  |     ✓      |             |            |                        |
 | [`extraErrorDataIntegration`](./extraerrordata)       |                  |            |             |            |           ✓            |
 | [`featureFlagsIntegration`](./featureflags)           |                  |            |             |            |           ✓            |
+| [`googleGenAIIntegration`](../../agent-tracing/google-genai)            |                  |            |      ✓      |            |           ✓            |
 | [`graphqlClientIntegration`](./graphqlclient)         |                  |            |             |            |           ✓            |
 | [`httpClientIntegration`](./httpclient)               |                  |     ✓      |             |            |                        |
+| [`langChainIntegration`](../../agent-tracing/langchain)                 |                  |            |      ✓      |            |           ✓            |
+| [`langGraphIntegration`](../../agent-tracing/langgraph)                 |                  |            |      ✓      |            |           ✓            |
 | [`launchDarklyIntegration`](./launchdarkly)           |                  |            |             |            |           ✓            |
 | [`moduleMetadataIntegration`](./modulemetadata)       |                  |            |             |            |           ✓            |
+| [`openAIIntegration`](../../agent-tracing/openai)                       |                  |            |      ✓      |            |           ✓            |
 | [`openFeatureIntegration`](./openfeature)             |                  |            |             |            |           ✓            |
 | [`replayCanvasIntegration`](./replaycanvas)           |                  |            |             |     ✓      |                        |
 | [`replayIntegration`](./replay)                       |                  |            |             |     ✓      |           ✓            |


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds Anthropic, Google Gen AI, LangChain, LangGraph, and OpenAI to the browser integration tables for Astro, Gatsby, Next.js, Nuxt, Remix, SolidStart, SvelteKit, and Vue.

These SDK-specific tables override the generic JavaScript table, so they did not inherit the browser AI integration entries added in getsentry/sentry-docs#15736. The new rows link to the existing Agent Tracing guides and identify these integrations as opt-in tracing and additional-context integrations in browser runtimes.

Fixes getsentry/sentry-javascript#18799

AI assistance disclosure: OpenAI Codex assisted with repository inspection, implementation, and validation. The commit includes the corresponding co-author attribution.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
