### PR TITLE
Update migration notes for `sendDefaultPii` in SDK

### DIFF
--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -2,7 +2,7 @@
 title: Data Collection
 description: Configuration for what data SDKs collect by default, including technical context, PII, and sensitive data.
 spec_id: sdk/foundations/client/data-collection
-spec_version: 0.13.0
+spec_version: 0.14.0
 spec_status: candidate
 spec_depends_on:
   - id: sdk/foundations/client

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -761,7 +761,7 @@ If the SDK can not cleanly map `sendDefaultPii` behavior to data collection opti
 This prevents breaking changes in PII filtering and allows customers to migrate to data collection at their own pace. Customers may keep using `sendDefaultPii` without changes to SDK behavior as long as they don't opt into data collection.
 
 Examples of not cleanly mapping:
-- mixed behavior between integrations (e.g. one integration sends cookies even with `sendDefaultPii` = `false` while another does not)
+- mixed behavior between integrations (e.g. one integration sent cookies even with `sendDefaultPii` = `false` while another did not)
 - hard coded filter terms that don't match the ones defined in data collection spec (e.g. sensitive http header names)
 - sensitive values were omitted and are now attached as `[Filtered]`
 

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -757,7 +757,7 @@ init({
 });
 ```
 
-If the SDK can not cleanly map `sendDefaultPii` behavior to data collection options, it **MUST NOT** backfill data collection options from the configured `sendDefaultPii` value and instead **MUST** ignore the value of `sendDefaultPii` if any data collection options is set explicitly.
+If the SDK can not cleanly map `sendDefaultPii` behavior to data collection options, it **MUST NOT** backfill data collection options from the configured `sendDefaultPii` value. Instead the SDK **MUST** ignore the value of `sendDefaultPii` if any data collection options is set explicitly and instead use the default data collection options where no explicit value has been set.
 This prevents breaking changes in PII filtering and allows customers to migrate to data collection at their own pace. Customers may keep using `sendDefaultPii` without changes to SDK behavior as long as they don't opt into data collection.
 
 Examples of not cleanly mapping:

--- a/develop-docs/sdk/foundations/client/data-collection/index.mdx
+++ b/develop-docs/sdk/foundations/client/data-collection/index.mdx
@@ -8,6 +8,9 @@ spec_depends_on:
   - id: sdk/foundations/client
     version: ">=1.0.0"
 spec_changelog:
+  - version: 0.14.0
+    date: 2026-09-10
+    summary: Explain migration from `sendDefaultPii` for SDKs that can't cleanly map previous behavior to data collection.
   - version: 0.13.0
     date: 2026-09-08
     summary: Add `filePaths`, defaulting to `true`, to control automatic collection of file and directory paths.
@@ -724,6 +727,7 @@ init({
 
 ### Migration from `sendDefaultPii`
 
+If the SDK can cleanly map what `sendDefaultPii` did to data collection options, it **MAY** backfill data collection options from the configured `sendDefaultPii` value:
 - **`sendDefaultPii: true`** (legacy) → omit `dataCollection` entirely; the new defaults already populate `user.*` and collect HTTP bodies. Add overrides only to restrict collection.
 - **`sendDefaultPii: false`** (legacy) → opt out of the categories the new defaults collect.
 
@@ -752,6 +756,14 @@ init({
   },
 });
 ```
+
+If the SDK can not cleanly map `sendDefaultPii` behavior to data collection options, it **MUST NOT** backfill data collection options from the configured `sendDefaultPii` value and instead **MUST** ignore the value of `sendDefaultPii` if any data collection options is set explicitly.
+This prevents breaking changes in PII filtering and allows customers to migrate to data collection at their own pace. Customers may keep using `sendDefaultPii` without changes to SDK behavior as long as they don't opt into data collection.
+
+Examples of not cleanly mapping:
+- mixed behavior between integrations (e.g. one integration sends cookies even with `sendDefaultPii` = `false` while another does not)
+- hard coded filter terms that don't match the ones defined in data collection spec (e.g. sensitive http header names)
+- sensitive values were omitted and are now attached as `[Filtered]`
 
 ---
 


### PR DESCRIPTION
Added migration details for `sendDefaultPii` behavior in data collection options, clarifying backfill conditions and implications for SDKs.

<!-- Keep the urgency section so automation can prioritize this PR. You may delete other sections you don't need. -->

## DESCRIBE YOUR PR

_Tell us what you're changing and why. If your PR **resolves an issue**, please link it so it closes automatically._

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
