### PR TITLE
docs(js): Add data collection docs for `databaseQueryData` and `queues`

### DIFF
--- a/docs/platforms/javascript/common/configuration/options.mdx
+++ b/docs/platforms/javascript/common/configuration/options.mdx
@@ -123,6 +123,8 @@ Sentry.init({
   dataCollection: {
     userInfo: false,
     genAI: { inputs: false, outputs: false },
+    databaseQueryData: false,
+    queues: false,
     httpBodies: [],
     httpHeaders: { deny: ["forwarded", "-ip", "remote-", "via", "-user"] },
     cookies: { deny: ["forwarded", "-ip", "remote-", "via", "-user"] },
@@ -151,6 +153,8 @@ For more on what data Sentry collects and how to control it, see <PlatformLink t
 | `httpBodies`          | `HttpBodyCollectionTarget[]` | all types  | Body types to collect: `"incomingRequest"`, `"outgoingRequest"`, `"incomingResponse"`, `"outgoingResponse"`. Set to `[]` to disable.    |
 | `urlQueryParams`      | `CollectBehavior`            | `true`     | Collect URL query parameters.                                                                                                            |
 | `genAI`               | `{ inputs?, outputs? }`      | both `true`| Collect generative AI input/output content. Metadata is always collected.                                                                |
+| `databaseQueryData`   | `boolean`                    | `true`     | Collect the data inside database queries: bound query parameters, write payloads, and returned rows. The parameterized query text and structural metadata are always collected. |
+| `queues`              | `boolean`                    | `true`     | Collect the data passed to tasks within queues. For Kafka, this is the message key. Structural metadata, such as the messaging system, the topic, and the partition, is always collected. |
 | `stackFrameVariables` | `boolean`                    | `true`     | Capture local variable values in stack frames.                                                                                           |
 | `frameContextLines`   | `number`                     | `5`        | Source code lines captured around each stack frame.                                                                                      |
 
@@ -839,8 +843,8 @@ The sample rate for replays that are recorded when an error happens. This type o
 
 <SdkOption name="profileSessionSampleRate" type='number' availableSince="7.4.0" defaultValue="0">
 
-A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none. 
-The sampling decision is made once at the beginning of a session. 
+A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none.
+The sampling decision is made once at the beginning of a session.
 This option is required to enable profiling (default is `0`).
 
 </SdkOption>
@@ -868,8 +872,8 @@ A number between `0` and `1`, controlling the percentage chance a given sampled 
 
 <SdkOption name="profileSessionSampleRate" type='number' availableSince="10.27.0" defaultValue="0">
 
-A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none. 
-The sampling decision is made once at the beginning of a session. 
+A number between `0` and `1` that sets the percentage of how many sessions should have profiling enabled. `1.0` enables profiling in every session, `0.5` enables profiling for 50% of the sessions, and `0` enables it for none.
+The sampling decision is made once at the beginning of a session.
 This option is required to enable profiling (default is `0`).
 
 <PlatformCategorySection categorySupported={["server", "serverless"]}>

--- a/docs/platforms/javascript/common/data-management/data-collected/index.mdx
+++ b/docs/platforms/javascript/common/data-management/data-collected/index.mdx
@@ -185,9 +185,40 @@ By default, the Sentry SDK sends information about the device and runtime to Sen
   <PlatformSection notSupported={["javascript.deno"]}>
     ## Database Queries
 
-    By default, the Sentry SDK sends SQL queries to Sentry. The SQL queries can include PII information if the statement is not parametrized.
+    By default, the Sentry SDK sends database queries to Sentry. The query text is parameterized: literal data values are replaced with placeholders. This applies to SQL and MongoDB queries.
 
-    MongoDB queries are sent as well, but the Sentry SDK will not send the full MongoDB query. Instead, it will send a parameterized version of the query.
+    The SDK also sends the data inside those queries by default: bound query parameters, write payloads, and returned rows. This data can include PII. Use the `dataCollection.databaseQueryData` option to control it. Set it to `false` to stop sending this data:
+
+    ```JavaScript
+    Sentry.init({
+      dsn: "___PUBLIC_DSN___",
+      dataCollection: {
+        databaseQueryData: false,
+      },
+    });
+    ```
+
+    The parameterized query text and structural metadata, such as the database system, the operation, and the table, are always sent. If you turn this option off, you keep the query performance data.
+
+  </PlatformSection>
+
+  <PlatformSection notSupported={["javascript.deno"]}>
+    ## Queue Message Data
+
+    By default, the Sentry SDK sends the data passed to tasks within queues. For Kafka, this is the message key. Producers often use a user ID or a tenant ID as the message key, so this value can include PII.
+
+    Use the `dataCollection.queues` option to control this. Set it to `false` to stop sending the message key:
+
+    ```JavaScript
+    Sentry.init({
+      dsn: "___PUBLIC_DSN___",
+      dataCollection: {
+        queues: false,
+      },
+    });
+    ```
+
+    Structural metadata, such as the messaging system, the topic, the partition, and the offset, is always sent. If you turn this option off, you keep the queue performance data.
 
   </PlatformSection>
 


### PR DESCRIPTION
Linear: https://linear.app/getsentry/issue/SDK-1522/update-data-collection-docs-with-the-new-queues-and-databasequery