### PR TITLE
feat: add targeted workshop banners

### DIFF
--- a/docs/contributing/pages/banners.mdx
+++ b/docs/contributing/pages/banners.mdx
@@ -17,6 +17,8 @@ type BannerType = {
   linkURL: string;
   /** The main text of the banner */
   text: string;
+  /** Optional text after the link; when set, the link is rendered inline */
+  textAfterLink?: string;
   /** Optional ISO Date string that will hide the banner after this date without the need for a rebuild */
   expiresOn?: string;
 };

--- a/src/components/banner/banner.module.scss
+++ b/src/components/banner/banner.module.scss
@@ -36,6 +36,10 @@
     text-decoration: underline;
     margin-left: 0.5rem;
   }
+
+  > span.promo-banner-inline-link a {
+    margin-left: 0;
+  }
 }
 
 .promo-banner-dismiss {

--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 
 import styles from './banner.module.scss';
 
@@ -13,6 +13,8 @@ type BannerType = {
   linkURL: string;
   /** The main text of the banner */
   text: string;
+  /** Optional text after the link; when set, the link is rendered inline */
+  textAfterLink?: string;
   /** Optional ISO Date string that will hide the banner after this date without the need for a rebuild */
   expiresOn?: string;
 };
@@ -46,6 +48,31 @@ type BannerType = {
 // ];
 
 const BANNERS: BannerType[] = [
+  {
+    appearsOn: ['^/integrations/feature-flag/launchdarkly/$'],
+    text: 'Join a workshop on September 23rd about',
+    linkURL: 'https://sentry.io/resources/launchdarkly-workshop/',
+    linkText: 'protecting releases and fixing bugs with Sentry & LaunchDarkly',
+    textAfterLink: '.',
+    expiresOn: '2026-09-22T23:59:59Z',
+  },
+  {
+    appearsOn: ['^/product/logs/$', '^/platforms/.*/logs/'],
+    text: 'Go deeper with Logs.',
+    linkURL: 'https://sentry.io/resources/beyond-logs-basics-workshop/',
+    linkText: 'Join the workshop',
+    textAfterLink: ' on Oct. 1.',
+    expiresOn: '2026-09-30T23:59:59Z',
+  },
+  {
+    appearsOn: ['^/product/agents/$', '^/platforms/.*/agent-tracing/'],
+    text: 'Join our',
+    linkURL: 'https://sentry.io/resources/agent-tracing-series/',
+    linkText: 'Agent debugging series',
+    textAfterLink:
+      ' on October 7th and 14th to learn best practices, including how Sentry debugs our own Agents.',
+    expiresOn: '2026-10-13T23:59:59Z',
+  },
   /// ⚠️ KEEP THIS LAST BANNER ACTIVE FOR DOCUMENTATION
   // check it out on `/contributing/pages/banners/`
   {
@@ -121,14 +148,34 @@ export function Banner() {
   if (!banner) {
     return null;
   }
+
+  const hasInlineLink = banner.textAfterLink !== undefined;
+
   return (
     <div className={[styles['promo-banner']].filter(Boolean).join(' ')}>
       <div className={styles['promo-banner-message']}>
-        <span className="flex flex-col md:flex-row gap-4">
-          {banner.text}
-          <a href={banner.linkURL} className="min-w-max">
-            {banner.linkText}
-          </a>
+        <span
+          className={
+            hasInlineLink
+              ? styles['promo-banner-inline-link']
+              : 'flex flex-col md:flex-row gap-4'
+          }
+        >
+          {hasInlineLink ? (
+            <Fragment>
+              {banner.text}
+              {banner.text && ' '}
+              <a href={banner.linkURL}>{banner.linkText}</a>
+              {banner.textAfterLink}
+            </Fragment>
+          ) : (
+            <Fragment>
+              {banner.text}
+              <a href={banner.linkURL} className="min-w-max">
+                {banner.linkText}
+              </a>
+            </Fragment>
+          )}
         </span>
       </div>
       <button

--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -50,10 +50,11 @@ type BannerType = {
 const BANNERS: BannerType[] = [
   {
     appearsOn: ['^/integrations/feature-flag/launchdarkly/$'],
-    text: 'Join a workshop on September 23rd about',
+    text: '',
     linkURL: 'https://sentry.io/resources/launchdarkly-workshop/',
-    linkText: 'protecting releases and fixing bugs with Sentry & LaunchDarkly',
-    textAfterLink: '.',
+    linkText: 'Join a workshop',
+    textAfterLink:
+      ' on September 23rd about protecting releases and fixing bugs with Sentry & LaunchDarkly.',
     expiresOn: '2026-09-22T23:59:59Z',
   },
   {


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds three targeted workshop promotion banners:

- LaunchDarkly workshop on the LaunchDarkly integration page
- Logs workshop on the Logs product page and SDK Logs guides
- Agent debugging series on the Agents product page and SDK Agent Tracing guides

Adds inline banner links so promotional copy can link text within a sentence while preserving the existing CTA layout for other banners. Each promotion has independent dismissal state shared across its targeted pages and expires automatically before its event date.

Validation: `pnpm lint` and `pnpm test:ci` (369 tests).

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [x] Other deadline: 2026-09-22
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you have supplied a deadline.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)