### PR TITLE
fix: add back Agent workshop banner and improve banner formatting for light and dark mode

### DIFF
--- a/src/components/banner/banner.module.scss
+++ b/src/components/banner/banner.module.scss
@@ -1,7 +1,7 @@
 .promo-banner {
   font-size: 15px;
-  color: #21201c;
-  background: var(--accent-yellow);
+  color: var(--desatPurple1);
+  background: var(--accent-purple-light);
   padding: 0.5rem 1rem;
   display: flex;
   justify-content: center;
@@ -48,7 +48,8 @@
 }
 
 .promo-banner-dismiss {
-  background: var(--flame6);
+  color: var(--desatPurple15);
+  background: var(--desatPurple2);
   height: 1.5rem;
   width: 1.5rem;
   font-size: 1rem;

--- a/src/components/banner/banner.module.scss
+++ b/src/components/banner/banner.module.scss
@@ -72,6 +72,6 @@
 }
 
 :global(.dark) .promo-banner-dismiss {
-  color: #21201c;
-  background: var(--accent-yellow);
+  color: var(--desatPurple2);
+  background: var(--desatPurple15);
 }

--- a/src/components/banner/banner.module.scss
+++ b/src/components/banner/banner.module.scss
@@ -15,6 +15,11 @@
   }
 }
 
+:global(.dark) .promo-banner {
+  color: var(--desatPurple15);
+  background: var(--desatPurple2);
+}
+
 @keyframes slide-down {
   from {
     transform: translateY(-100%);
@@ -64,4 +69,9 @@
     top: 1.5rem;
     right: 1rem;
   }
+}
+
+:global(.dark) .promo-banner-dismiss {
+  color: #21201c;
+  background: var(--accent-yellow);
 }

--- a/src/components/banner/banner.module.scss
+++ b/src/components/banner/banner.module.scss
@@ -49,7 +49,7 @@
 
 .promo-banner-dismiss {
   color: var(--desatPurple15);
-  background: var(--desatPurple2);
+  background: var(--desatPurple4);
   height: 1.5rem;
   width: 1.5rem;
   font-size: 1rem;

--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -65,6 +65,15 @@ const BANNERS: BannerType[] = [
     textAfterLink: ' on Oct. 1.',
     expiresOn: '2026-09-30T23:59:59Z',
   },
+  {
+    appearsOn: ['^/product/agents/$', '^/platforms/.*/agent-tracing/'],
+    text: 'Join our',
+    linkURL: 'https://sentry.io/resources/agent-tracing-series/',
+    linkText: 'Agent debugging series',
+    textAfterLink:
+      ' on October 7th and 14th to learn best practices, including how Sentry debugs their own Agents.',
+    expiresOn: '2026-10-13T23:59:59Z',
+  },
   /// ⚠️ KEEP THIS LAST BANNER ACTIVE FOR DOCUMENTATION
   // check it out on `/contributing/pages/banners/`
   {

--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -67,11 +67,11 @@ const BANNERS: BannerType[] = [
   },
   {
     appearsOn: ['^/product/agents/$', '^/platforms/.*/agent-tracing/'],
-    text: 'Join our',
+    text: "Join Sentry's",
     linkURL: 'https://sentry.io/resources/agent-tracing-series/',
-    linkText: 'Agent debugging series',
+    linkText: 'agent debugging series',
     textAfterLink:
-      ' on October 7th and 14th to learn best practices, including how Sentry debugs their own Agents.',
+      ' on October 7th and 14th to learn best practices, including how the Sentry team debugs their own agents.',
     expiresOn: '2026-10-13T23:59:59Z',
   },
   /// ⚠️ KEEP THIS LAST BANNER ACTIVE FOR DOCUMENTATION


### PR DESCRIPTION
## DESCRIBE YOUR PR

Adds back Agent debugging workshop banner removed in #19352 with updated copy.

Adds a banner-specific dark-mode treatment using the docs desaturated-purple palette, near-white text, and a white dismiss control. Both dark-mode text combinations have approximately 12:1 contrast. 

Also updated light mode treatment to be light purple instead of yellow. 

## IS YOUR CHANGE URGENT?

- [x] Urgent deadline (GA date, etc.): 2026-09-22
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you have supplied a deadline.

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)