### PR TITLE
docs(bun): Document the build plugin in the instrumentation step

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -691,4 +691,38 @@ shamefully-hoist=true
   </Expandable>
 </PlatformSection>
 
+<PlatformSection supported={['javascript.bun']}>
+  <Expandable permalink title="My database client isn't traced in a plugin build">
+    The plugin can only rewrite a package that passes through the bundler. Anything left external is resolved at runtime, never reaches the transform, and publishes no channel events, so it records no spans.
+
+    Build without `external`, which is the configuration to start from:
+
+    ```typescript {filename:build.ts}
+    import { sentryBunPlugin } from "@sentry/bun/plugin";
+
+    await Bun.build({
+      entrypoints: ["./app.ts"],
+      outdir: "./dist",
+      target: "bun",
+      plugins: [sentryBunPlugin()],
+    });
+    ```
+
+    A blanket externalization strategy is the usual cause. Both `packages: "external"` and `"*"` in `external` push your instrumented packages back out of the bundle, and the plugin warns at build time:
+
+    ```typescript {filename:build.ts} {diff}
+     await Bun.build({
+       entrypoints: ["./app.ts"],
+       outdir: "./dist",
+       target: "bun",
+    -  packages: "external",
+       plugins: [sentryBunPlugin()],
+     });
+    ```
+
+    If you do need `external`, list only packages you don't need traced, and keep your database clients, AI SDKs and instrumented frameworks off the list.
+
+  </Expandable>
+</PlatformSection>
+
 If you need additional help, you can [ask on GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose). Customers on a paid plan may also contact support.

--- a/docs/platforms/javascript/guides/bun/index.mdx
+++ b/docs/platforms/javascript/guides/bun/index.mdx
@@ -18,7 +18,7 @@ categories:
 Choose the features you want to configure, and this guide will show you how:
 
 <OnboardingOptionButtons
-  options={["error-monitoring", "performance" ]}
+  options={["error-monitoring", "performance", "logs" ]}
 />
 
 <Include name="quick-start-features-expandable" />
@@ -79,25 +79,51 @@ Sentry.init({
 </SplitSection>
 </SplitLayout>
 
+### Build With the Sentry Plugin (Recommended)
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+We recommend building with the Sentry plugin, because it adds spans from your dependencies, such as database drivers, AI SDKs, and web frameworks like Express, Koa and Hapi. Bun has no runtime hook Sentry can use to instrument those packages, so the plugin rewrites them as `bun build` bundles them.
+
+Add `sentryBunPlugin` from `@sentry/bun/plugin` to your `Bun.build()` call, then run the output the same way, with `--preload`. Errors, the spans you create yourself, and `Bun.serve`, `node:http` and `fetch` spans work either way.
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```typescript {filename:build.ts}
+import { sentryBunPlugin } from "@sentry/bun/plugin";
+
+await Bun.build({
+  entrypoints: ["./app.ts"],
+  outdir: "./dist",
+  target: "bun",
+  plugins: [sentryBunPlugin()],
+});
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
 ### Apply Instrumentation to Your App
 
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>
 
-To make sure that Sentry initializes before any other modules, you need to preload your instrumentation file using the [`--preload`](https://bun.com/docs/runtime#param-preload) flag.
-
-<Alert level="warning" title="Bundled Code Limitation">
-
-Sentry's auto-instrumentation does not work with bundled code, including Bun's single-file executables. This is because auto-instrumentation relies on module loading hooks that are not available when code is bundled. If you need to bundle your application, you'll need to <PlatformLink to="/tracing/instrumentation/">manually instrument your code</PlatformLink> instead of relying on auto-instrumentation.
-
-</Alert>
+Preload your instrumentation file with the [`--preload`](https://bun.com/docs/runtime#param-preload) flag. This is what guarantees that `Sentry.init()` runs before any other module is loaded.
 
 </SplitSectionText>
 <SplitSectionCode>
 
-```bash
+```bash {tabTitle:From source}
 bun --preload ./instrument.js app.js
+```
+
+```bash {tabTitle:Built output}
+bun --preload ./instrument.js dist/app.js
 ```
 
 </SplitSectionCode>


### PR DESCRIPTION


## DESCRIBE YOUR PR

The guide told users to run `bun --preload ./instrument.js app.js` and then warned that auto-instrumentation doesn't work with bundled code, which is backwards: library and framework spans exist only in a build, and `@sentry/bun/plugin` was never named on the page.

The two compose. `--preload` guarantees init order and is always needed; the plugin build adds library and framework spans on top. Verified in the runtime audit repro `quickstarts/bun` variant (c): a `sentryBunPlugin()` bundle run with `--preload` produced errors, route-named `Bun.serve` spans, `http.client` spans carrying `sentry-trace` and `baggage`, and logs.

- Add an optional "Build With the Sentry Plugin" step using `sentryBunPlugin`, before the run step
- Reframe the `--preload` step as what guarantees init order, and show it for both source and built output
- Drop the "Bundled Code Limitation" alert, which claimed the opposite
- Add a troubleshooting entry for an instrumented package left outside the bundle, which is what silences library spans in a plugin build
- Add `logs` to the onboarding options, so the logs verify block already on the page can be selected

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
