### PR TITLE
docs(js): Update Deno guide for v11

### DIFF
--- a/docs/platforms/javascript/common/troubleshooting/index.mdx
+++ b/docs/platforms/javascript/common/troubleshooting/index.mdx
@@ -691,4 +691,28 @@ shamefully-hoist=true
   </Expandable>
 </PlatformSection>
 
+<PlatformSection supported={["javascript.deno"]}>
+
+<Expandable permalink title="The app stops at startup with `SyntaxError: Unexpected token ':'`">
+
+Your app imports a dependency that calls `require()` on a JSON file, and the `@sentry/deno/import` hook is active. Deno compiles the JSON as JavaScript instead, and the process stops before your code runs:
+
+```
+error: Uncaught SyntaxError: Unexpected token ':'
+```
+
+This is a Deno bug ([denoland/deno#36240](https://github.com/denoland/deno/issues/36240)): while any module hook is registered, Deno loads `.json` files with the wrong format. Express, Fastify, Hapi, Koa and mysql2 all read a JSON file this way.
+
+Remove the `@sentry/deno/import` line from your entry file to start your app again:
+
+```javascript {filename: main.ts}
+import * as Sentry from "npm:@sentry/deno";
+```
+
+Errors, `Deno.serve` and `node:http` spans, logs and metrics all keep working without the hook. You lose the integrations that depend on it, such as `mysql` 2.x and `pg`. Drivers that publish their own diagnostics channels, among them `mysql2` 3.20.0 and later and `ioredis` 5.11.0 and later, are instrumented either way.
+
+</Expandable>
+
+</PlatformSection>
+
 If you need additional help, you can [ask on GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose). Customers on a paid plan may also contact support.

--- a/docs/platforms/javascript/guides/deno/index.mdx
+++ b/docs/platforms/javascript/guides/deno/index.mdx
@@ -35,14 +35,37 @@ Choose the features you want to configure, and this guide will show you how:
 <SplitSection>
 <SplitSectionText>
 
-Import the Sentry Deno SDK directly from the npm registry, before importing any other modules:
+Import the Sentry Deno SDK directly from the npm registry, before importing any other modules. The first line registers the hook that instruments your database drivers, message queues, AI libraries and web frameworks. It only works as the first import of your entry file:
 
 </SplitSectionText>
 <SplitSectionCode>
 
 ```javascript {filename: main.ts}
+import "___SDK_PACKAGE___/import";
 import * as Sentry from "___SDK_PACKAGE___";
 // your other imports
+```
+
+</SplitSectionCode>
+</SplitSection>
+</SplitLayout>
+
+<SplitLayout>
+<SplitSection>
+<SplitSectionText>
+
+The hook reads your dependencies from a local `node_modules` directory, not from Deno's global npm cache. Set `nodeModulesDir` in your `deno.json`:
+
+</SplitSectionText>
+<SplitSectionCode>
+
+```json {filename: deno.json}
+{
+  "imports": {
+    "@sentry/deno": "npm:@sentry/deno"
+  },
+  "nodeModulesDir": "auto"
+}
 ```
 
 </SplitSectionCode>
@@ -63,6 +86,7 @@ Initialize Sentry as early as possible in your app:
 <SplitSectionCode>
 
 ```javascript {filename: main.ts}
+import "___SDK_PACKAGE___/import";
 import * as Sentry from "___SDK_PACKAGE___";
 // your other imports
 
@@ -85,43 +109,42 @@ Sentry.init({
 </SplitSection>
 </SplitLayout>
 
-### Enable Network Access
+### Grant Permissions
 
 <SplitLayout>
 <SplitSection>
 <SplitSectionText>
 
-To make sure the SDK can send events, enable network access for your Sentry ingestion domain:
+Deno blocks access to the network, the file system and system information until you grant it. Start your app with all four permissions so that the SDK can send complete events. Add the other hosts your app talks to, separated by commas:
 
 </SplitSectionText>
 <SplitSectionCode>
 
 ```bash
-deno run --allow-net=___ORG_INGEST_DOMAIN___ index.ts
+deno run \
+  --allow-net=___ORG_INGEST_DOMAIN___ \
+  --allow-env \
+  --allow-read=. \
+  --allow-sys=hostname,osRelease \
+  main.ts
 ```
 
 </SplitSectionCode>
 </SplitSection>
 </SplitLayout>
 
-### Allow Access to Source Files
+<Expandable permalink={false} title="What each permission gives you">
 
-<SplitLayout>
-<SplitSection>
-<SplitSectionText>
+| Flag                             | What it gives you                                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------------- |
+| `--allow-net=<host>`             | Delivery of events to Sentry. If a host is missing, Deno names it in the error.              |
+| `--allow-env`                    | The import hook. Without it, your app stops at start with `NotCapable: Requires env access`. |
+| `--allow-read=.`                 | Source code in stack traces, and `app:///` paths instead of absolute paths.                  |
+| `--allow-sys=hostname,osRelease` | The server name and the operating system version on events.                                  |
 
-Grant read access to your source files so that the SDK can include your source code in stack traces:
+If you omit `--allow-read` or `--allow-sys`, the SDK sends events without that data and prints no warning.
 
-</SplitSectionText>
-<SplitSectionCode>
-
-```bash
-deno run --allow-read=./src index.ts
-```
-
-</SplitSectionCode>
-</SplitSection>
-</SplitLayout>
+</Expandable>
 
 ### Add Readable Stack Traces With Source Maps (Optional)
 

--- a/platform-includes/crons/setup/javascript.deno.mdx
+++ b/platform-includes/crons/setup/javascript.deno.mdx
@@ -1,8 +1,24 @@
-## Automatic Check-Ins (Recommended)
+## Job Monitoring
 
-_requires SDK version 7.88.0 or higher_
+<Include name="javascript-crons-job-monitoring.mdx" />
+
+## Check-Ins
+
+<Include name="javascript-crons-checkins.mdx" />
+
+## Automatic Check-Ins With `Deno.cron`
+
+<Alert level="warning">
+
+The `DenoCron` integration does not work on Deno 2.9.0 and later. On these versions `Deno.cron` is a read-only property, so `Sentry.init` stops with `TypeError: Cannot set property cron of #<Object> which has only a getter` and your app does not start. Use `Sentry.withMonitor` or `Sentry.captureCheckIn` instead.
+
+</Alert>
+
+_requires SDK version 7.88.0 or higher, and Deno 2.8.3 or earlier_
 
 Use the `DenoCron` integration to monitor your [`Deno.cron`](https://deno.com/blog/cron) calls and get notified when a schedule job is missed (or doesn't start when expected), if it fails due to a problem in the runtime (such as an error), or if it fails by exceeding its maximum runtime.
+
+The integration is not part of the default set, so you must add it to `integrations` yourself:
 
 ```TypeScript
 import * as Sentry from "___SDK_PACKAGE___";
@@ -12,14 +28,6 @@ Sentry.init({
   integrations: [Sentry.denoCronIntegration()],
 });
 ```
-
-## Job Monitoring
-
-<Include name="javascript-crons-job-monitoring.mdx" />
-
-## Check-Ins
-
-<Include name="javascript-crons-checkins.mdx" />
 
 ## Upserting Cron Monitors
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

closes SDK-1502

Rework the Deno getting-started path so a new user reaches a first event without hitting the gaps found in the runtime docs audit.

- Document the `@sentry/deno/import` hook as the first import, with the `nodeModulesDir` setting it needs to resolve. Without it the database, messaging, AI and framework integrations never instrument anything, and the SDK gives no warning.
- Replace the two separate permission commands with one `deno run` line covering all four flags, and explain what each one unlocks. The previous `--allow-net` only command crashed or silently dropped `server_name`, the OS version, context lines and app-relative frame paths.
- Widen `--allow-read` from `./src` to `.`, which is what path normalization queries. A subdirectory grant loses context lines on the entry file and all `app:///` rewriting.
- Stop recommending `denoCronIntegration()`. It throws inside `Sentry.init` on Deno 2.9.0 and later, is not in the Deno default integration set, and does nothing without `--unstable-cron`.
- Add a troubleshooting entry for the startup crash that the import hook triggers on Deno (denoland/deno#36240).

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
