### PR TITLE
docs(react-router): Update framework guides for v11

### DIFF
--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Router Framework
-description: Learn how to set up and configure Sentry in your React Router application (v7+) using the installation wizard, capture your first errors, and view them in Sentry.
+description: Learn how to set up and configure Sentry in your React Router application (v7.15+) using the installation wizard, capture your first errors, and view them in Sentry.
 sdk: sentry.javascript.react-router
 categories:
   - javascript

--- a/docs/platforms/javascript/guides/react-router/index.mdx
+++ b/docs/platforms/javascript/guides/react-router/index.mdx
@@ -14,13 +14,6 @@ categories:
   platformName="React Router"
 />
 
-<Alert level="warning" title="Important">
-  This SDK is currently in **beta**. Beta features are still in progress and may
-  have bugs. Please reach out on
-  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if
-  you have any feedback or concerns.
-</Alert>
-
 <Alert title='Looking for data/declarative mode?' level='info'>
 
 If you're using React Router in data or declarative mode, follow the instructions in our [React guide for v7](/platforms/javascript/guides/react/features/react-router/v7) or [v8](/platforms/javascript/guides/react/features/react-router/v8).

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -4,13 +4,6 @@ sidebar_order: 1
 description: "Learn how to manually set up Sentry in your React Router app (v7.15+) and capture your first errors."
 ---
 
-<Alert level="warning" title="Important">
-  This SDK is currently in **beta**. Beta features are still in progress and may
-  have bugs. Please reach out on
-  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if
-  you have any feedback or concerns.
-</Alert>
-
 <PlatformContent includePath="sentry-init/manual-setup-callout" />
 
 <PlatformContent includePath="getting-started-prerequisites" />

--- a/docs/platforms/javascript/guides/react-router/manual-setup.mdx
+++ b/docs/platforms/javascript/guides/react-router/manual-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Manual Setup"
 sidebar_order: 1
-description: "Learn how to manually set up Sentry in your React Router app (v7+) and capture your first errors."
+description: "Learn how to manually set up Sentry in your React Router app (v7.15+) and capture your first errors."
 ---
 
 <Alert level="warning" title="Important">
@@ -190,7 +190,7 @@ Sentry's OpenTelemetry-based auto-instrumentation (loaded through `instrument.se
 - **Node 20:** Version \<20.19
 - **Node 22:** Version \<22.12
 
-This restriction **doesn't** affect tracing for loaders, actions, middleware, and request handlers. Those are instrumented through React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) (the `instrumentations` export shown below, React Router 7.15+), which works on all Node versions.
+This restriction **doesn't** affect tracing for loaders, actions, middleware, and request handlers. Those are instrumented through React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) (the `instrumentations` export shown below), which works on all Node versions.
 
 On unsupported Node versions, you'll only lose auto-instrumentation for lower-level operations such as outgoing HTTP requests and database queries.
 
@@ -244,7 +244,7 @@ Sentry.init({
 
 Next, replace the default `handleRequest` and `handleError` functions in your `entry.server.tsx` file with Sentry's wrapped versions, and export `instrumentations` to enable automatic tracing.
 
-Exporting `instrumentations` uses React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) (React Router 7.15+) to automatically create spans for all loaders, actions, middleware, and request handlers — no need to wrap them individually.
+Exporting `instrumentations` uses React Router's [instrumentation API](https://reactrouter.com/how-to/instrumentation) to automatically create spans for all loaders, actions, middleware, and request handlers — no need to wrap them individually.
 
 </SplitSectionText>
 <SplitSectionCode>
@@ -269,7 +269,7 @@ Exporting `instrumentations` uses React Router's [instrumentation API](https://r
 +});
 
 +// Automatically instruments all server loaders, actions, middleware,
-+// and request handlers. Requires React Router 7.15+.
++// and request handlers.
 +export const instrumentations = [Sentry.createSentryServerInstrumentation()];
 
 // ... rest of your server entry

--- a/platform-includes/getting-started-prerequisites/javascript.react-router.mdx
+++ b/platform-includes/getting-started-prerequisites/javascript.react-router.mdx
@@ -1,0 +1,7 @@
+## Prerequisites
+
+You need:
+
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running
+- React Router version `7.15.0` or above (framework mode)


### PR DESCRIPTION
## DESCRIBE YOUR PR

Updates the React Router Framework docs for SDK v11: state the new 7.15 framework-mode minimum, drop the beta warnings, only describe the instrumentation API for server-side tracing, and fix the snippets that no longer build against v11.

- Change the stated support in the page descriptions from "v7+" to "v7.15+"
- Add a `getting-started-prerequisites` include for React Router that lists the `7.15.0` minimum (framework mode)
- Drop the feature-scoped "React Router 7.15+" notes around the `instrumentations` export, since 7.15 is now the baseline
- Remove the "This SDK is currently in beta" alerts from the getting started and manual setup pages
- Import `sentryReactRouter`, `SentryReactRouterBuildOptions`, and `sentryOnBuildEnd` from `@sentry/react-router/vite` on the manual setup and Hydrogen pages
- Fix the `entry.server.tsx` snippet to import `../instrument.server` (the file lives in the project root, the entry in `app/`)
- Move the misplaced `+` diff marker in the `react-router.config.ts` snippet so it no longer renders as a unary plus

The removed `wrapServerLoader` / `wrapServerAction` wrappers are already covered by the v10-to-v11 migration guide and aren't referenced anywhere else in the docs.

Supersedes #19314.

> **⚠️ Do not merge until v11 is released as stable.**

Fixes https://linear.app/getsentry/issue/SDK-1466/update-react-router-minimum-version-to-715-in-docs
Fixes https://linear.app/getsentry/issue/SDK-1486/update-react-router-vite-plugin-imports-for-v11-in-docs
Fixes https://linear.app/getsentry/issue/SDK-1516/react-router-getting-started-manual-setup

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01833WEY4kqAQNfbtu9Z8JLr