### PR TITLE
docs(javascript): Fix browser tracing verification

### DIFF
--- a/platform-includes/getting-started-verify/javascript.mdx
+++ b/platform-includes/getting-started-verify/javascript.mdx
@@ -42,9 +42,9 @@ To verify that Sentry captures errors and creates issues in your Sentry project,
 <SplitSection>
 
 <SplitSectionText>
-To test your tracing configuration, update the previous code to simulate a longer operation and start a trace.
+To test your tracing configuration, update the previous code to measure a simulated operation with a span.
 
-Open the page in a browser and click the button to throw an error and create a trace.
+Open the page in a browser and click the button. In Sentry, look for the `Sentry Test Error` issue and the `Example Frontend Span` span in the trace.
 
 </SplitSectionText>
 
@@ -52,16 +52,16 @@ Open the page in a browser and click the button to throw an error and create a t
 
 ```html
 <script>
-  function triggerError() {
-       await Sentry.startSpan(
-        { name: "Example Frontend Span", op: "test" },
-        async () => {
-          await new Promise(resolve => setTimeout(resolve, 200));
+  async function triggerError() {
+    await Sentry.startSpan(
+      { name: "Example Frontend Span", op: "test" },
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
 
-          throw new Error("Sentry Test Error");
-        },
-      );
-     }
+        throw new Error("Sentry Test Error");
+      },
+    );
+  }
 </script>
 
 <button onclick="triggerError()">Break the World</button>


### PR DESCRIPTION
Make the browser tracing verification handler async so the example runs instead of failing to parse at `await`. Clarify which error and span to look for in Sentry.

Fixes SDK-1503

## IS YOUR CHANGE URGENT?

- [x] No deadline: Not urgent, can wait up to 1 week+
