### PR TITLE
docs(js): Create the router the Koa verify step relies on

### DIFF
--- a/platform-includes/getting-started-install/javascript.koa.mdx
+++ b/platform-includes/getting-started-install/javascript.koa.mdx
@@ -1,0 +1,37 @@
+<OnboardingOption optionId="profiling" hideForThisOption>
+
+```bash {tabTitle:npm}
+npm install @sentry/node @koa/router
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/node @koa/router
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @koa/router
+```
+
+</OnboardingOption>
+
+<OnboardingOption optionId="profiling">
+
+```bash {tabTitle:npm}
+npm install @sentry/node @sentry/profiling-node @koa/router --save
+```
+
+```bash {tabTitle:yarn}
+yarn add @sentry/node @sentry/profiling-node @koa/router
+```
+
+```bash {tabTitle:pnpm}
+pnpm add @sentry/node @sentry/profiling-node @koa/router
+```
+
+</OnboardingOption>
+
+<Alert>
+
+The examples in this guide route requests with [`@koa/router`](https://www.npmjs.com/package/@koa/router). If your app already has a router, keep yours and skip that package.
+
+</Alert>

--- a/platform-includes/getting-started-use/javascript.koa.mdx
+++ b/platform-includes/getting-started-use/javascript.koa.mdx
@@ -4,13 +4,18 @@ require("./instrument");
 
 // Now require other modules
 const Koa = require("koa");
+const Router = require("@koa/router");
 const Sentry = require("@sentry/node");
 
 const app = new Koa();
+const router = new Router();
 
 Sentry.setupKoaErrorHandler(app);
 
 // Add your routes, etc.
+
+app.use(router.routes());
+app.use(router.allowedMethods());
 
 app.listen(3030);
 ```
@@ -21,13 +26,18 @@ import "./instrument";
 
 // Now import other modules
 import Koa from "koa";
+import Router from "@koa/router";
 import * as Sentry from "@sentry/node";
 
 const app = new Koa();
+const router = new Router();
 
 Sentry.setupKoaErrorHandler(app);
 
 // Add your routes, etc.
+
+app.use(router.routes());
+app.use(router.allowedMethods());
 
 app.listen(3030);
 ```


### PR DESCRIPTION
## DESCRIBE YOUR PR

(not v11 relevant)

closes SDK-1497

The Koa verify step tells the reader to add `router.get("/debug-sentry",...)` to their main application file, but the application file the guide shows creates no router, and no step installs one. Pasted as instructed, the app stops at startup with `ReferenceError: router is not defined`.

Create the router in both getting-started tabs and mount it, and add `@koa/router` to the Koa install step.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
