### PR TITLE
ref(sentry.io): Mirror IP changes in ip-ranges.mdx

### DIFF
--- a/docs/security-legal-pii/security/ip-ranges.mdx
+++ b/docs/security-legal-pii/security/ip-ranges.mdx
@@ -99,10 +99,16 @@ To allow access to source maps with Nginx for instance, you can use this locatio
 location ~ ^/static/dist/(.+)\.map$ {
     alias /your/path/site/static/dist/$1.map;
 
+    allow 35.222.255.47/32;
+    allow 34.61.215.243/32;
+    allow 34.71.103.17/32;
     allow 35.184.238.160/32;
     allow 104.155.159.182/32;
     allow 104.155.149.19/32;
     allow 130.211.230.102/32;
+    allow 34.141.31.19/32;
+    allow 34.141.4.162/32;
+    allow 35.234.78.236/32;
     deny all;
 }
 ```
@@ -115,10 +121,16 @@ To allow access to source maps with Apache you can use this example. It can eith
 <FilesMatch "\.map$">
     Order deny,allow
     Deny from all
+    Allow from 35.222.255.47/32
+    Allow from 34.61.215.243/32
+    Allow from 34.71.103.17/32
     Allow from 35.184.238.160/32
     Allow from 104.155.159.182/32
     Allow from 104.155.149.19/32
     Allow from 130.211.230.102/32
+    Allow from 34.141.31.19/32
+    Allow from 34.141.4.162/32
+    Allow from 35.234.78.236/32
 </FilesMatch>
 ```
 

--- a/docs/security-legal-pii/security/ip-ranges.mdx
+++ b/docs/security-legal-pii/security/ip-ranges.mdx
@@ -23,7 +23,7 @@ Sentry's dashboard and API are both served from different domains, depending
 on your organization's data storage location. The IP addresses are:
 
 ```plaintext
-sentry.io     35.186.247.156/32
+sentry.io     34.8.226.60/32, 34.111.148.117/32
 us.sentry.io  35.186.247.156/32
 de.sentry.io  34.36.122.224/32, 34.36.87.148/32
 ```
@@ -65,6 +65,14 @@ Organizations in the EU Data Storage Location are unable to ingest events via
 In some circumstances the Hosted Sentry infrastructure might send HTTP requests your way. Primarily this is relevant to [_JavaScript Source Maps_](/platforms/javascript/sourcemaps/), but also affects things like webhooks and other integrations.
 
 Sentry uses the following IP addresses to make outbound requests:
+
+Control Silo
+
+```plaintext
+35.222.255.47/32
+34.61.215.243/32
+34.71.103.17/32
+```
 
 US Data Storage Location
 


### PR DESCRIPTION
## DESCRIBE YOUR PR

Mirrors the IP updates from #19374 (which updated `app/api/ip-ranges/ip-ranges.json`) into the corresponding docs page `docs/security-legal-pii/security/ip-ranges.mdx`. The two files are intended to be copies of each other; the JSON was updated but the MDX was not, so customers reading the docs page still see stale IPs.

Addresses the review comment at https://github.com/getsentry/sentry-docs/pull/19374#discussion_r3990566546.

Changes:
- Dashboard/API `sentry.io`: replace `35.186.247.156/32` with `34.8.226.60/32, 34.111.148.117/32`
- Outbound Requests: add new "Control Silo" section with `35.222.255.47/32`, `34.61.215.243/32`, `34.71.103.17/32`

Not changed:
- `us.sentry.io` / `de.sentry.io` dashboard rows (unchanged in JSON)
- Event-ingestion apex IP (line 41) — `event_ingestion.apex_domain` in the JSON is still `35.186.247.156/32`; if that field is itself stale (per Cursor bugbot on #19374), that should be fixed in the JSON first and then mirrored here in a follow-up.

## IS YOUR CHANGE URGENT?

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [x] No deadline: Not urgent, can wait up to 1 week+

## PRE-MERGE CHECKLIST

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)