### PR TITLE
docs(solidstart): Document the SolidStart 2 setup

### DIFF
--- a/docs/platforms/javascript/guides/solidstart/features/middleware.mdx
+++ b/docs/platforms/javascript/guides/solidstart/features/middleware.mdx
@@ -8,8 +8,8 @@ The Sentry middleware enhances the data collected by Sentry on the server side b
 Add the Sentry middleware to your `middleware.ts` file. If you don't have a `middleware.ts` file yet, create one:
 
 ```typescript {filename:middleware.ts}
-import { sentryBeforeResponseMiddleware } from '@sentry/solidstart/middleware';
-import { createMiddleware } from '@solidjs/start/middleware';
+import { sentryBeforeResponseMiddleware } from "@sentry/solidstart";
+import { createMiddleware } from "@solidjs/start/middleware";
 
 export default createMiddleware({
   onBeforeResponse: [
@@ -22,10 +22,10 @@ export default createMiddleware({
 And specify `middleware.ts` in `app.config.ts`:
 
 ```typescript {filename:app.config.ts}
-import { defineConfig } from '@solidjs/start/config';
+import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
   // ...
-  middleware: './src/middleware.ts',
+  middleware: "./src/middleware.ts",
 });
 ```

--- a/docs/platforms/javascript/guides/solidstart/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/index.mdx
@@ -149,12 +149,32 @@ mount(() => <StartClient />, document.getElementById("app"));
 <SplitSection>
 <SplitSectionText>
 
-Create a file named `instrument.server.ts` in your `src` folder. In this file, initialize and import Sentry for your server:
+Initialize Sentry on the server. On SolidStart 2, do this in a Nitro startup plugin, which runs once when the server starts. On SolidStart 1, create an `instrument.server.ts` file in your `src` folder.
 
 </SplitSectionText>
 <SplitSectionCode>
 
-```javascript {filename:src/instrument.server.ts}
+```typescript {tabTitle:SolidStart 2} {filename:server/plugins/sentry.ts} {mdExpandTabs}
+import * as Sentry from "@sentry/solidstart";
+import { definePlugin } from "nitro";
+
+export default definePlugin(() => {
+  Sentry.init({
+    dsn: "___PUBLIC_DSN___",
+    // ___PRODUCT_OPTION_START___ performance
+
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for tracing.
+    // We recommend adjusting this value in production
+    // Learn more at
+    // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
+    tracesSampleRate: 1.0,
+    // ___PRODUCT_OPTION_END___ performance
+  });
+});
+```
+
+```javascript {tabTitle:SolidStart 1} {filename:src/instrument.server.ts}
 import * as Sentry from "@sentry/solidstart";
 
 Sentry.init({
@@ -205,13 +225,29 @@ export default createMiddleware({
 <SplitSection>
 <SplitSectionText>
 
-Wrap your SolidStart config in `app.config.ts` with `withSentry` so that the instrumentation file gets included in your build output.
-Then, specify the middleware that you've just created:
+Add the Sentry plugin to your build config and register the middleware you just created. On SolidStart 2, add `sentrySolidStart` to `vite.config.ts`. On SolidStart 1, wrap your `app.config.ts` with `withSentry` so that the instrumentation file gets included in your build output.
 
 </SplitSectionText>
 <SplitSectionCode>
 
-```javascript {filename:app.config.ts} {5-15}
+```typescript {tabTitle:SolidStart 2} {filename:vite.config.ts} {mdExpandTabs}
+import { sentrySolidStart } from "@sentry/solidstart/vite";
+import { solidStart } from "@solidjs/start/config";
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    solidStart({
+      middleware: "./src/middleware.ts",
+    }),
+    sentrySolidStart(),
+    nitro(),
+  ],
+});
+```
+
+```javascript {tabTitle:SolidStart 1} {filename:app.config.ts} {5-15}
 import { withSentry } from "@sentry/solidstart";
 import { defineConfig } from "@solidjs/start/config";
 
@@ -274,24 +310,35 @@ export default function App() {
 <SplitSection>
 <SplitSectionText>
 
-Instrumentation needs to happen as early as possible to make sure Sentry works as intended. To do this, add an `--import` flag to the `NODE_OPTIONS` environment variable when you run your application and set it to import the instrumentation file created by the build output: `.output/server/instrument.server.mjs`.
+On SolidStart 2, the Vite plugin instruments your dependencies at build time, so the server needs no preload flag. Build with `vite build` and start the output directly.
+
+On SolidStart 1, instrumentation has to happen as early as possible, so add an `--import` flag pointing at the instrumentation file that the build output creates: `.output/server/instrument.server.mjs`.
 
 <Alert>
 
-Run your build command to generate the `instrument.server.mjs` file before running your app. Depending on your build preset, the location of the file can differ. To find out where the file is located, monitor the build log output for:
+On SolidStart 1, run your build command to generate the `instrument.server.mjs` file before running your app. Depending on your build preset, the location of the file can differ. To find out where the file is located, monitor the build log output for:
 
 `[Sentry SolidStart withSentry] Successfully created /my/project/path/.output/server/instrument.server.mjs.`
 
 </Alert>
 
-If you're not able to use the `--import` flag, check the alternative <PlatformLink to="/install">installation methods</PlatformLink>.
+If you're not able to use the `--import` flag on SolidStart 1, check the alternative <PlatformLink to="/install">installation methods</PlatformLink>.
 
 </SplitSectionText>
 <SplitSectionCode>
 
 For example, update your scripts in `package.json`:
 
-```json {filename:package.json}
+```json {tabTitle:SolidStart 2} {filename:package.json} {mdExpandTabs}
+{
+  "scripts": {
+    "build": "vite build",
+    "start": "node .output/server/index.mjs"
+  }
+}
+```
+
+```json {tabTitle:SolidStart 1} {filename:package.json}
 {
   "scripts": {
     "start:vinxi": "NODE_OPTIONS='--import ./.output/server/instrument.server.mjs ' vinxi start",
@@ -327,12 +374,32 @@ To automatically report exceptions from inside a component tree to Sentry, wrap 
 <SplitSection>
 <SplitSectionText>
 
-To upload source maps for clear error stack traces, add your Sentry auth token, organization, and project slug in your SolidStart configuration:
+To upload source maps for clear error stack traces, add your Sentry auth token, organization, and project slug to the Sentry plugin in your build config:
 
 </SplitSectionText>
 <SplitSectionCode>
 
-```TypeScript {filename:app.config.ts}
+```typescript {tabTitle:SolidStart 2} {filename:vite.config.ts} {mdExpandTabs}
+import { sentrySolidStart } from "@sentry/solidstart/vite";
+import { solidStart } from "@solidjs/start/config";
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    solidStart(),
+    sentrySolidStart({
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
+      // store your auth token in an environment variable
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+    nitro(),
+  ],
+});
+```
+
+```TypeScript {tabTitle:SolidStart 1} {filename:app.config.ts}
 import { withSentry } from '@sentry/solidstart';
 import { defineConfig } from '@solidjs/start/config';
 

--- a/docs/platforms/javascript/guides/solidstart/install/cli-import.mdx
+++ b/docs/platforms/javascript/guides/solidstart/install/cli-import.mdx
@@ -4,6 +4,12 @@ sidebar_order: 1
 description: "Learn how to use the node --import CLI flag."
 ---
 
+<Alert>
+
+This installation method applies to SolidStart 1. On SolidStart 2, the Sentry Vite plugin instruments your dependencies at build time, so no preload is needed. See the <PlatformLink to="/">SolidStart guide</PlatformLink>.
+
+</Alert>
+
 ## Understanding the `--import` CLI Flag
 
 The [`--import` CLI flag](https://nodejs.org/api/cli.html#--importmodule) in Node is the default way in ESM to preload a specified module at startup.
@@ -54,11 +60,13 @@ Consult your hosting provider's documentation for specific implementation detail
 Most deployment platforms support this through two primary methods:
 
 #### Option 1: Direct CLI Flag
+
 ```bash
 node --import ./.output/server/instrument.server.mjs your-server-entry.mjs
 ```
 
 #### Option 2: Environment Variable
+
 ```bash
 NODE_OPTIONS='--import ./.output/server/instrument.server.mjs'
 ```

--- a/docs/platforms/javascript/guides/solidstart/install/dynamic-import.mdx
+++ b/docs/platforms/javascript/guides/solidstart/install/dynamic-import.mdx
@@ -4,12 +4,19 @@ sidebar_order: 3
 description: "Learn about how the SolidStart SDK leverages dynamic input() in the build output."
 ---
 
+<Alert>
+
+This installation method applies to SolidStart 1. On SolidStart 2, the Sentry Vite plugin instruments your dependencies at build time, so no preload is needed. See the <PlatformLink to="/">SolidStart guide</PlatformLink>.
+
+</Alert>
+
 ## Understanding the `import()` expression
 
 <Alert level='warning'>
   This setting is experimental as it is not guaranteed to work with every setup and the underlying functionality could change.
 
-  We recommend reading the guide for installing the SDK with the <PlatformLink to="/install/cli-import">CLI flag `--import`</PlatformLink> or <PlatformLink to="/install/limited-server-tracing">limited server tracing</PlatformLink>
+We recommend reading the guide for installing the SDK with the <PlatformLink to="/install/cli-import">CLI flag `--import`</PlatformLink> or <PlatformLink to="/install/limited-server-tracing">limited server tracing</PlatformLink>
+
 </Alert>
 
 The `import()` expression, or dynamic import, enables flexible, conditional module loading in ESM.
@@ -31,15 +38,17 @@ You can also check out the guide for installing the SDK with the <PlatformLink t
 Enable the dynamic `import()` by setting `autoInjectServerSentry`:
 
 ```typescript {filename:app.config.ts} {8}
-import { defineConfig } from '@solidjs/start/config';
-import { withSentry } from '@sentry/solidstart';
+import { defineConfig } from "@solidjs/start/config";
+import { withSentry } from "@sentry/solidstart";
 
-export default defineConfig(withSentry(
+export default defineConfig(
+  withSentry(
     {},
     {
-      autoInjectServerSentry: 'experimental_dynamic-import'
-    })
- );
+      autoInjectServerSentry: "experimental_dynamic-import",
+    }
+  )
+);
 ```
 
 After setting this, the Sentry SolidStart SDK will add build-time configuration so that your app will be wrapped with `import()`,
@@ -50,10 +59,12 @@ The SolidStart server entry file will look something like this:
 ```javascript {filename:.output/server/index.mjs}
 // Note: The file may have some imports and code, related to debug IDs
 Sentry.init({
-  dsn: "..."
+  dsn: "...",
 });
 
-import('./chunks/nitro/nitro.mjs').then(function (n) { return n.r; });
+import("./chunks/nitro/nitro.mjs").then(function (n) {
+  return n.r;
+});
 ```
 
 ## Re-exporting serverless handler functions
@@ -64,17 +75,18 @@ By default, Sentry re-exports functions named `handler`, `server`, and `default`
 If your serverless function has a custom name, you can override it with `experimental_entrypointWrappedFunctions`:
 
 ```javascript {filename: app.config.ts} {11}
+import { defineConfig } from "@solidjs/start/config";
+import { withSentry } from "@sentry/solidstart";
 
-import { defineConfig } from '@solidjs/start/config';
-import { withSentry } from '@sentry/solidstart';
-
-export default defineConfig(withSentry(
+export default defineConfig(
+  withSentry(
     {},
     {
-      autoInjectServerSentry: 'experimental_dynamic-import',
+      autoInjectServerSentry: "experimental_dynamic-import",
       // Customize detected function names
       // Default value: ['default', 'handler', 'server']
-      experimental_entrypointWrappedFunctions: ['customFunctionName']
-    })
- );
+      experimental_entrypointWrappedFunctions: ["customFunctionName"],
+    }
+  )
+);
 ```

--- a/docs/platforms/javascript/guides/solidstart/install/index.mdx
+++ b/docs/platforms/javascript/guides/solidstart/install/index.mdx
@@ -4,7 +4,9 @@ sidebar_order: 1.5
 description: "Review our alternate installation methods."
 ---
 
-SolidStart uses ES Modules for server-side builds, which requires Sentry to register Node [customization hooks](https://nodejs.org/api/module.html#customization-hooks).
+These installation methods apply to SolidStart 1. On SolidStart 2, the Sentry Vite plugin instruments your dependencies at build time, so the server needs no preload.
+
+SolidStart 1 uses ES Modules for server-side builds, which requires Sentry to register Node [customization hooks](https://nodejs.org/api/module.html#customization-hooks).
 Those customization hooks need to be registered before the rest of the application.
 
 To be able to run Sentry before the rest of the application and fully monitor the server-side, Sentry can be initialized using one of those two approaches:

--- a/docs/platforms/javascript/guides/solidstart/install/limited-server-tracing.mdx
+++ b/docs/platforms/javascript/guides/solidstart/install/limited-server-tracing.mdx
@@ -4,6 +4,12 @@ sidebar_order: 2
 description: "Learn how to set up the SolidStart SDK with limited server tracing by adding a top-level import to the build output."
 ---
 
+<Alert>
+
+This installation method applies to SolidStart 1. On SolidStart 2, the Sentry Vite plugin instruments your dependencies at build time, so no preload is needed. See the <PlatformLink to="/">SolidStart guide</PlatformLink>.
+
+</Alert>
+
 ## Understanding Limited Server Tracing
 
 Sentry needs to be initialized before the rest of the application runs.

--- a/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
+++ b/platform-includes/distributed-tracing/how-to-use/javascript.solidstart.mdx
@@ -3,8 +3,8 @@ To set up distributed tracing, use Sentry's middleware to inject tracing informa
 Create or modify the `middleware.ts` file and import and add `sentryBeforeResponseMiddleware`
 
 ```typescript {filename: middleware.ts}
-import { sentryBeforeResponseMiddleware } from '@sentry/solidstart/middleware';
-import { createMiddleware } from '@solidjs/start/middleware';
+import { sentryBeforeResponseMiddleware } from "@sentry/solidstart";
+import { createMiddleware } from "@solidjs/start/middleware";
 
 export default createMiddleware({
   onBeforeResponse: [
@@ -12,16 +12,16 @@ export default createMiddleware({
     // Add your other middleware handlers after `sentryBeforeResponseMiddleware`
   ],
 });
-````
+```
 
 If you didn't use a middleware before, don't forget to specify it in `app.config.ts`
 
 ```typescript {filename: app.config.ts}
-import { defineConfig } from '@solidjs/start/config';
+import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
   // ...
-  middleware: './src/middleware.ts',
+  middleware: "./src/middleware.ts",
 });
 ```
 
@@ -66,8 +66,8 @@ Sentry.init({
 
 This tells Sentry to pass trace headers across the following paths:
 
-* Your main API server (where product data comes from)
-* Your authentication server (where logins happen)
+- Your main API server (where product data comes from)
+- Your authentication server (where logins happen)
 
 This way, if a customer experiences an error during checkout, or you want to check the performance of a specific endpoint, you can see the complete path their request took across these different services.
 
@@ -81,16 +81,16 @@ Sentry.init({
   tracePropagationTargets: [
     "https://api.myapp.com",
     "https://media.myapp.com",
-    /^\/local-api\//
+    /^\/local-api\//,
   ],
 });
 ```
 
 This configuration lets your app track user actions across:
 
-* Your main API server (handles most app functions)
-* Your media server (handles images, videos, etc.)
-* Any local API endpoints in your app
+- Your main API server (handles most app functions)
+- Your media server (handles images, videos, etc.)
+- Any local API endpoints in your app
 
 If your app crashes while a user is uploading a photo, you can trace exactly where the problem occurred - in the app itself, the main API, or the media service.
 

--- a/platform-includes/getting-started-prerequisites/javascript.solidstart.mdx
+++ b/platform-includes/getting-started-prerequisites/javascript.solidstart.mdx
@@ -1,0 +1,15 @@
+## Prerequisites
+
+You need:
+
+- A Sentry [account](https://sentry.io/signup/) and [project](/product/projects/)
+- Your application up and running
+- SolidStart version `1.0.0`+ or `2.0.0`+
+
+<Expandable title="Are you using SolidStart 1?">
+
+SolidStart 2 dropped vinxi and `app.config.ts`, so the two versions are set up differently. Check the `@solidjs/start` version in your `package.json`; a new project installs SolidStart 2.
+
+Where this guide shows **SolidStart 2** and **SolidStart 1** tabs, pick the one that matches your version. The <PlatformLink to="/install">installation methods</PlatformLink> apply to SolidStart 1 only.
+
+</Expandable>


### PR DESCRIPTION
## DESCRIBE YOUR PR

closes SDK-1515

`npm install @solidjs/start` gives SolidStart 2 today, and the guide described SolidStart 1 only. On SolidStart 2 there is no `app.config.ts`, `@solidjs/start/config` exports no `defineConfig`, the build emits no `.output/server/instrument.server.mjs`, and vinxi is not installed, so the documented config was ignored and the documented start command exited with `ERR_MODULE_NOT_FOUND`.

Give each affected step a SolidStart 2 tab next to the SolidStart 1 one:

- Server init moves to a Nitro startup plugin, `server/plugins/sentry.ts`.
- The build config moves to `vite.config.ts` with `sentrySolidStart` from `@sentry/solidstart/vite`.
- The server starts with a plain `node .output/server/index.mjs`. The Vite plugin instruments dependencies at build time, so no preload is needed.
- Source map options move into `sentrySolidStart()`.

Add a SolidStart prerequisites include naming the supported versions, so readers know which set of tabs applies to them. The guide fell back to the default include, which names no framework version at all.

Scope the `--import`, limited server tracing and dynamic import installation methods to SolidStart 1, since all three configure `withSentry` in `app.config.ts`.

Import `sentryBeforeResponseMiddleware` from `@sentry/solidstart`. The package exports `.`, `./solidrouter` and `./vite`, so the documented `@sentry/solidstart/middleware` path failed with
`ERR_PACKAGE_PATH_NOT_EXPORTED`.

## IS YOUR CHANGE URGENT?

Help us prioritize incoming PRs by letting us know when the change needs to go live.
Select exactly one option. For deadlines, replace `YYYY-MM-DD` with the due date. You can update this information later by editing the PR description.

- [ ] Urgent deadline (GA date, etc.): YYYY-MM-DD
- [ ] Other deadline: YYYY-MM-DD
- [ ] No deadline: Not urgent, can wait up to 1 week+

## SLA

- Teamwork makes the dream work, so please add a reviewer to your PRs.
- Please give the docs team up to 1 week to review your PR unless you've supplied a deadline.

Thanks in advance for your help!

## PRE-MERGE CHECKLIST

_Make sure you've checked the following before merging your changes:_

- [ ] Checked Vercel preview for correctness, including links
- [ ] PR was reviewed and approved by any necessary SMEs (subject matter experts)
- [ ] PR was reviewed and approved by a member of the [Sentry docs team](https://github.com/orgs/getsentry/teams/docs)

## LEGAL BOILERPLATE

<!-- Sentry employees and contractors can delete or ignore this section. -->

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

## EXTRA RESOURCES

- [Sentry Docs contributor guide](https://docs.sentry.io/contributing/)
